### PR TITLE
Ops/build and push docker image

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Docker Login
         run: echo $CR_PAT | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build the Nestjs Docker image
-        run: docker build . --file Containerfile --tag ghcr.io/infonl/dimpact-zac:${{ github.sha }}
+      - name: Build ZAC Docker image
+        run: docker build . --file Containerfile --tag ghcr.io/infonl/dimpact-zaakafhandelcomonent:${{ github.sha }}
       - name: Push Docker image to registry
         run: docker push ghcr.io/infonl/dimpact-zac:${{ github.sha }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,23 @@
+name: Build ZAC Docker image
+
+on:
+  push:
+    # Trigger on specific build- tag
+    tags:
+      - 'build-*'
+
+env:
+  CR_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Docker Login
+        run: echo $CR_PAT | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build the Nestjs Docker image
+        run: docker build . --file Containerfile --tag ghcr.io/infonl/dimpact-zac:${{ github.sha }}
+      - name: Push Docker image to registry
+        run: docker push ghcr.io/infonl/dimpact-zac:${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 wildfly-*
 src/generated
 /.openapi-generator/*
+.DS_Store


### PR DESCRIPTION
This will currently only trigger build when you create a tag called `build-*`. We can change it to build on push to main (or whatever) when we start using this image more.