### PR TITLE
fix: fixed Docker push step by renaming Docker image 

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@ on:
 env:
   JAVA_VERSION: '17'
   CONTAINER_REGISTRY_URL: 'ghcr.io/infonl'
-  APPLICATION_NAME: 'zaakafhandelcomponent'
+  APPLICATION_NAME: 'dimpact-zac'
 
 permissions:
   contents: write


### PR DESCRIPTION
We currently have a GitHub Container registry with the name 'dimpact-zac'. Hence this is how we need to name our Docker image for now. Later on we should rename this to 'zaakafhandelcomponent'. Dimpact has no role to play in this. :-)