### PR TITLE
feat: use Gradle up-to-date checking in OpenAPI plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -164,7 +164,7 @@ tasks {
 
     withType<org.openapitools.generator.gradle.plugin.tasks.GenerateTask> {
         generatorName.set("java")
-        outputDir.set("$rootDir")
+        outputDir.set("$rootDir/src/generated/java")
         generateApiTests.set(false)
         generateApiDocumentation.set(false)
         generateModelTests.set(false)
@@ -181,7 +181,8 @@ tasks {
             mapOf(
                 "library" to "microprofile",
                 "microprofileRestClientVersion" to "2.0",
-                "sourceFolder" to "src/generated/java",
+                //"sourceFolder" to "src/generated/java",
+                "sourceFolder" to "",
                 "dateLibrary" to "java8",
                 "disallowAdditionalPropertiesIfNotPresent" to "false",
                 "openApiNullable" to "false"
@@ -238,7 +239,7 @@ tasks {
             mapOf(
                 "library" to "microprofile",
                 "microprofileRestClientVersion" to "2.0",
-                "sourceFolder" to "src/generated/java",
+                "sourceFolder" to "",
                 "dateLibrary" to "java8-localdatetime",
                 "disallowAdditionalPropertiesIfNotPresent" to "false",
                 "openApiNullable" to "false"


### PR DESCRIPTION
The trick was to set the outputDir in the OpenAPI Gradle plugin to the folder where the clients are generated. Before it would check the entire root folder of the project to see if things are up to data which of course they never were. Now it works like a charm.