### PR TITLE
fix: do not run the conventional commit GitHub Action on the main branch

### DIFF
--- a/.github/workflows/check-for-conventional-commits.yml
+++ b/.github/workflows/check-for-conventional-commits.yml
@@ -6,9 +6,7 @@ name: Check for conventional commits
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
+    types: [opened, edited, synchronize]
 
 jobs:
   check-for-conventional-commits:


### PR DESCRIPTION
Do not run the conventional commit GitHub Action on the main branch.

Solves PZ-443