### PR TITLE
fix(build): change token and pass correct branch

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -137,14 +137,14 @@ jobs:
     steps:
       - uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROVISION_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'infonl',
               repo: 'dimpact-provisioning',
               workflow_id: 'azure-provision-zaakafhandelcomponent.yml',
               inputs: {
-                tag: '${{ needs.build.outputs.docker_image_tag }}',
+                tag: '${{ steps.gen_branch_name.outputs.BRANCH_NAME }}-${{ github.run_number }}',
               },
               ref: 'main'
             })


### PR DESCRIPTION
This should fix the new build step (again).

For now I added a secret token to the repository settings. You should be able to use the GITHUB_TOKEN but it doesn't work.

It also now passes the correct tag to the hook.