### PR TITLE
chore: added missing SPDX headers for backend unit tests

### DIFF
--- a/src/test/kotlin/net/atos/zac/aanvraag/AanvraagFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/aanvraag/AanvraagFixtures.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.zac.aanvraag
 
 import java.net.URI

--- a/src/test/kotlin/net/atos/zac/app/zaken/ZakenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaken/ZakenRESTServiceTest.kt
@@ -17,9 +17,6 @@ import io.mockk.slot
 import io.mockk.verify
 import net.atos.client.or.`object`.ObjectsClientService
 import net.atos.client.or.`object`.model.createObjectRegistratieObject
-import net.atos.client.vrl.VRLClientService
-import net.atos.client.zgw.brc.BRCClientService
-import net.atos.client.zgw.drc.DRCClientService
 import net.atos.client.zgw.shared.ZGWApiService
 import net.atos.client.zgw.zrc.ZRCClientService
 import net.atos.client.zgw.zrc.model.BetrokkeneType
@@ -38,76 +35,35 @@ import net.atos.client.zgw.ztc.model.createZaakType
 import net.atos.zac.aanvraag.InboxProductaanvraagService
 import net.atos.zac.aanvraag.ProductaanvraagService
 import net.atos.zac.aanvraag.createProductaanvraagDenhaag
-import net.atos.zac.app.admin.converter.RESTZaakAfzenderConverter
-import net.atos.zac.app.audit.converter.RESTHistorieRegelConverter
 import net.atos.zac.app.bag.converter.RESTBAGConverter
-import net.atos.zac.app.zaken.converter.RESTBesluitConverter
-import net.atos.zac.app.zaken.converter.RESTBesluittypeConverter
-import net.atos.zac.app.zaken.converter.RESTCommunicatiekanaalConverter
-import net.atos.zac.app.zaken.converter.RESTGeometryConverter
-import net.atos.zac.app.zaken.converter.RESTResultaattypeConverter
-import net.atos.zac.app.zaken.converter.RESTZaakBetrokkeneConverter
 import net.atos.zac.app.zaken.converter.RESTZaakConverter
-import net.atos.zac.app.zaken.converter.RESTZaakOverzichtConverter
-import net.atos.zac.app.zaken.converter.RESTZaaktypeConverter
 import net.atos.zac.app.zaken.model.createRESTZaak
 import net.atos.zac.app.zaken.model.createRESTZaakAanmaakGegevens
 import net.atos.zac.authentication.LoggedInUser
 import net.atos.zac.authentication.createLoggedInUser
-import net.atos.zac.configuratie.ConfiguratieService
-import net.atos.zac.documenten.OntkoppeldeDocumentenService
-import net.atos.zac.event.EventingService
-import net.atos.zac.flowable.BPMNService
 import net.atos.zac.flowable.CMMNService
-import net.atos.zac.flowable.TakenService
 import net.atos.zac.flowable.ZaakVariabelenService
-import net.atos.zac.healthcheck.HealthCheckService
 import net.atos.zac.identity.IdentityService
 import net.atos.zac.identity.model.createGroup
 import net.atos.zac.policy.PolicyService
 import net.atos.zac.policy.output.OverigeRechten
 import net.atos.zac.policy.output.createZaakRechten
-import net.atos.zac.shared.helper.OpschortenZaakHelper
-import net.atos.zac.signalering.SignaleringenService
 import net.atos.zac.zaaksturing.ZaakafhandelParameterService
 import net.atos.zac.zaaksturing.model.createZaakafhandelParameters
-import net.atos.zac.zoeken.IndexeerService
 import org.junit.jupiter.api.Assertions.assertEquals
 import javax.enterprise.inject.Instance
 
 class ZakenRESTServiceTest : BehaviorSpec() {
-    val bpmnService = mockk<BPMNService>()
-    val brcClientService = mockk<BRCClientService>()
     val cmmnService = mockk<CMMNService>()
-    val communicatiekanaalConverter = mockk<RESTCommunicatiekanaalConverter>()
-    val configuratieService = mockk<ConfiguratieService>()
-    val drcClientService = mockk<DRCClientService>()
-    val eventingService = mockk<EventingService>()
-    val healthCheckService = mockk<HealthCheckService>()
     val identityService = mockk<IdentityService>()
     val inboxProductaanvraagService = mockk<InboxProductaanvraagService>()
-    val indexeerService = mockk<IndexeerService>()
     val loggedInUserInstance = mockk<Instance<LoggedInUser>>()
     val objectsClientService = mockk<ObjectsClientService>()
-    val ontkoppeldeDocumentenService = mockk<OntkoppeldeDocumentenService>()
-    val opschortenZaakHelper = mockk<OpschortenZaakHelper>()
     val policyService = mockk<PolicyService>()
     val productaanvraagService = mockk<ProductaanvraagService>()
     val restBagConverter = mockk<RESTBAGConverter>()
-    val restBesluitConverter = mockk<RESTBesluitConverter>()
-    val restBesluittypeConverter = mockk<RESTBesluittypeConverter>()
-    val restGeometryConverter = mockk<RESTGeometryConverter>()
-    val restHistorieRegelConverter = mockk<RESTHistorieRegelConverter>()
-    val restZaakBetrokkeneConverter = mockk<RESTZaakBetrokkeneConverter>()
     val restZaakConverter = mockk<RESTZaakConverter>()
-    val restZaaktypeConverter = mockk<RESTZaaktypeConverter>()
-    val resultaattypeConverter = mockk<RESTResultaattypeConverter>()
-    val signaleringenService = mockk<SignaleringenService>()
-    val takenService = mockk<TakenService>()
-    val vrlClientService = mockk<VRLClientService>()
     val zaakafhandelParameterService = mockk<ZaakafhandelParameterService>()
-    val zaakAfzenderConverter = mockk<RESTZaakAfzenderConverter>()
-    val zaakOverzichtConverter = mockk<RESTZaakOverzichtConverter>()
     val zaakVariabelenService = mockk<ZaakVariabelenService>()
     val zgwApiService = mockk<ZGWApiService>()
     val zrcClientService = mockk<ZRCClientService>()

--- a/src/test/kotlin/net/atos/zac/app/zaken/model/RESTZakenFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaken/model/RESTZakenFixtures.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.zac.app.zaken.model
 
 import net.atos.client.zgw.shared.model.Vertrouwelijkheidaanduiding

--- a/src/test/kotlin/net/atos/zac/authentication/AuthenticationFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/authentication/AuthenticationFixtures.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.zac.authentication
 
 import net.atos.zac.app.zaken.model.ZAAK_TYPE_1_OMSCHRIJVING

--- a/src/test/kotlin/net/atos/zac/authentication/UserPrincipalFilterTest.kt
+++ b/src/test/kotlin/net/atos/zac/authentication/UserPrincipalFilterTest.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.zac.authentication
 
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/net/atos/zac/identity/model/IdentityFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/identity/model/IdentityFixtures.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.zac.identity.model
 
 fun createGroup(

--- a/src/test/kotlin/net/atos/zac/policy/output/PolicyOutputFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/policy/output/PolicyOutputFixtures.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.zac.policy.output
 
 fun createZaakRechten() = ZaakRechten(

--- a/src/test/kotlin/net/atos/zac/util/JsonbConfigurationTest.kt
+++ b/src/test/kotlin/net/atos/zac/util/JsonbConfigurationTest.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.zac.util
 
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/net/atos/zac/zaaksturing/model/ZaaksturingFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/zaaksturing/model/ZaaksturingFixtures.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.zac.zaaksturing.model
 
 import java.util.UUID


### PR DESCRIPTION
Added missing SPDX copyright headers for the newly added Kotlin backend unit tests.

Solves PZ-452