### PR TITLE
chore: added missing dependency from npmRunBuild Gradle task and generateOpenApiSpec

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -243,47 +243,31 @@ tasks {
     }
 
     register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("generateKvkZoekenClient") {
-        // these openapi generate tasks cannot be run in parallel because they generate files in the same directory
         inputSpec.set("$rootDir/src/main/resources/api-specs/kvk/zoeken-openapi.yaml")
         modelPackage.set("net.atos.client.kvk.zoeken.model")
     }
 
     register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("generateKvkBasisProfielClient") {
-        // these openapi generate tasks cannot be run in parallel because they generate files in the same directory
-        mustRunAfter("generateKvkZoekenClient")
-
         inputSpec.set("$rootDir/src/main/resources/api-specs/kvk/basisprofiel-openapi.yaml")
         modelPackage.set("net.atos.client.kvk.basisprofiel.model")
     }
 
     register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("generateKvkVestigingsProfielClient") {
-        // these openapi generate tasks cannot be run in parallel because they generate files in the same directory
-        mustRunAfter("generateKvkBasisProfielClient")
-
         inputSpec.set("$rootDir/src/main/resources/api-specs/kvk/vestigingsprofiel-openapi.yaml")
         modelPackage.set("net.atos.client.kvk.vestigingsprofiel.model")
     }
 
     register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("generateBrpClient") {
-        // these openapi generate tasks cannot be run in parallel because they generate files in the same directory
-        mustRunAfter("generateKvkVestigingsProfielClient")
-
         inputSpec.set("$rootDir/src/main/resources/api-specs/brp/openapi.yaml")
         modelPackage.set("net.atos.client.brp.model")
     }
 
     register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("generateVrlClient") {
-        // these openapi generate tasks cannot be run in parallel because they generate files in the same directory
-        mustRunAfter("generateBrpClient")
-
         inputSpec.set("$rootDir/src/main/resources/api-specs/vrl/openapi.yaml")
         modelPackage.set("net.atos.client.vrl.model")
     }
 
     register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("generateBagClient") {
-        // these openapi generate tasks cannot be run in parallel because they generate files in the same directory
-        mustRunAfter("generateVrlClient")
-
         inputSpec.set("$rootDir/src/main/resources/api-specs/bag/openapi.yaml")
         modelPackage.set("net.atos.client.bag.model")
         // we use a different date library for this client
@@ -303,17 +287,11 @@ tasks {
         // this task was not enabled in the original Maven build either; these model files were added to the code base manually instead
         isEnabled = false
 
-        // these openapi generate tasks cannot be run in parallel because they generate files in the same directory
-        mustRunAfter("generateBagClient")
-
         inputSpec.set("$rootDir/src/main/resources/api-specs/klanten/openapi.yaml")
         modelPackage.set("net.atos.client.klanten.model")
     }
 
     register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("generateContactMomentenClient") {
-        // these openapi generate tasks cannot be run in parallel because they generate files in the same directory
-        mustRunAfter("generateKlantenClient")
-
         inputSpec.set("$rootDir/src/main/resources/api-specs/contactmomenten/openapi.yaml")
         modelPackage.set("net.atos.client.contactmomenten.model")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -334,6 +334,7 @@ tasks {
 
     register<NpmTask>("npmRunBuild") {
         dependsOn("npmInstall")
+        dependsOn("generateOpenApiSpec")
         npmCommand.set(listOf("run", "build"))
 
         // avoid running this task when there are no changes in the input or output files

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -234,7 +234,6 @@ tasks {
             mapOf(
                 "library" to "microprofile",
                 "microprofileRestClientVersion" to "2.0",
-                //"sourceFolder" to "src/generated/java",
                 "sourceFolder" to "",
                 "dateLibrary" to "java8",
                 "disallowAdditionalPropertiesIfNotPresent" to "false",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
Added dependsOn from npmRunBuild to generateOpenApiSpec Gradle task so  that "./gradlew clean test" succeeds.

Solves PZ-454