### PR TITLE
fix: add type to tsconfig.types

### DIFF
--- a/src/main/app/tsconfig.spec.json
+++ b/src/main/app/tsconfig.spec.json
@@ -4,7 +4,8 @@
     "outDir": "./out-tsc/spec",
     "types": [
       "jest",
-      "node"
+      "node",
+      "@angular/google-maps"
     ]
   },
   "include": [


### PR DESCRIPTION
This pr will add missing types in the tsconfig.spec file. tests were failing because the google global was missing in the test environment

Solves: PZ-474