### PR TITLE
chore: only pull ZAC Docker Image when starting Docker Compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -232,7 +232,7 @@ services:
       - "8181:8181"
 
   openldap:
-    image: bitnami/openldap:2.6.4
+    image: bitnami/openldap:2.6.6
     container_name: openldap
     ports:
       - "1389:1389"

--- a/start-docker-compose-with-zac.sh
+++ b/start-docker-compose-with-zac.sh
@@ -6,7 +6,7 @@
 #
 
 # Do a pull first to make sure we use the latest ZAC Docker Image
-docker compose pull
+docker compose pull zac
 
 # Uses the 1Password CLI tools to set up the environment variables for running Docker Compose and ZAC in IntelliJ.
 # Please see docs/INSTALL.md for details on how to use this script.

--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -6,7 +6,7 @@
 #
 
 # Do a pull first to make sure we use the latest ZAC Docker Image
-docker compose pull
+docker compose pull zac
 
 # Uses the 1Password CLI tools to set up the environment variables for running Docker Compose and ZAC in IntelliJ.
 # Please see docs/INSTALL.md for details on how to use this script.


### PR DESCRIPTION
Only pull ZAC Docker Image when starting Docker Compose since this is not needed for the other Docker images. Also upgraded OpenLDAP Docker Image.

Solves PZ-556.