### PR TITLE
feat: no longer use container names in Docker Compose 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,19 +1,17 @@
 version: "3.9"
 services:
-  # Keycloak
-  zac-keycloak:
+  keycloak:
     image: quay.io/keycloak/keycloak:22.0.1
-    container_name: zac-keycloak
     depends_on:
-      zac-keycloak-database:
-          condition: service_healthy
+      keycloak-database:
+        condition: service_healthy
     ports:
       - "8081:8080"
     environment:
       - KEYCLOAK_ADMIN=admin
       - KEYCLOAK_ADMIN_PASSWORD=admin
       - DB_VENDOR=postgres
-      - DB_ADDR=zac-keycloak-database
+      - DB_ADDR=keycloak-database
       - DB_USER=keycloak
       - DB_NAME=keycloak
       - DB_PASSWORD=keycloak
@@ -24,9 +22,8 @@ services:
       - "start-dev"
       - "--import-realm"
 
-  zac-keycloak-database:
+  keycloak-database:
     image: postgres:15.4
-    container_name: zac-keycloak-database
     ports:
       - "54326:5432"
     healthcheck:
@@ -42,10 +39,8 @@ services:
     volumes:
       - ./scripts/docker-compose/volume-data/zac-keycloak-database-data:/var/lib/postgresql/data
 
-  # ZAC database
   zac-database:
     image: postgres:15.4
-    container_name: zac-database
     ports:
       - "54320:5432"
     healthcheck:
@@ -64,7 +59,6 @@ services:
 
   openzaak-database:
     image: postgis/postgis:15-3.4
-    container_name: openzaak-database
     ports:
       - "54322:5432"
     platform: linux/amd64
@@ -86,7 +80,6 @@ services:
 
   openzaak:
     image: openzaak/open-zaak:1.8.2
-    container_name: openzaak
     platform: linux/amd64
     environment:
       - DB_HOST=openzaak-database
@@ -114,11 +107,9 @@ services:
 
   redis:
     image: redis:6.2.6
-    container_name: redis
 
   objecten-api:
     image: maykinmedia/objects-api:2.1.1
-    container_name: objecten-api
     platform: linux/amd64
     ports:
       - "8010:8000"
@@ -136,7 +127,6 @@ services:
 
   objecten-api-database:
     image: postgis/postgis:15-3.4
-    container_name: objecten-api-database
     ports:
       - "54323:5432"
     platform: linux/amd64
@@ -153,7 +143,6 @@ services:
 
   objecten-api-import:
     image: maykinmedia/objects-api:2.1.1
-    container_name: objects-api-import
     platform: linux/amd64
     environment: *objects-env
     # in the current version of django it is not possible to create a new user with password without user interaction by using the createsuperuser command
@@ -166,7 +155,6 @@ services:
 
   objecttypen-api:
     image: maykinmedia/objecttypes-api:2.1.0
-    container_name: objecttypen-api
     platform: linux/amd64
     ports:
       - "8011:8000"
@@ -184,7 +172,6 @@ services:
 
   objecttypen-api-database:
     image: postgres:15.4
-    container_name: objecttypen-api-database
     ports:
       - "54324:5432"
     healthcheck:
@@ -200,7 +187,6 @@ services:
 
   objecttypen-api-import:
     image: maykinmedia/objecttypes-api:2.1.0
-    container_name: objecttypen-api-import
     platform: linux/amd64
     environment: *objecttypes-env
     command: sh init/init.sh
@@ -210,10 +196,8 @@ services:
     depends_on:
       - objecttypen-api
 
-  # Solr
-  zac-solr:
+  solr:
     image: solr:9.2.1
-    container_name: zac-solr
     ports:
       - "8983:8983"
     volumes:
@@ -224,16 +208,14 @@ services:
       - "precreate-core zac; exec solr -f"
 
   # Open Policy Agent (OPA)
-  zac-opa:
+  opa:
     image: openpolicyagent/opa:edge-static
-    container_name: zac-opa
     command: run --server --log-level debug
     ports:
       - "8181:8181"
 
   openldap:
     image: bitnami/openldap:2.6.6
-    container_name: openldap
     ports:
       - "1389:1389"
       - "1636:1636"
@@ -255,7 +237,6 @@ services:
   # VNG ZGW referentielijsten ('VRL') (see: https://github.com/VNG-Realisatie/VNG-referentielijsten)
   zgw-referentielijsten-database:
     image: postgres:15.4
-    container_name: zgw-referentielijsten-database
     ports:
       - "54321:5432"
     environment:
@@ -267,7 +248,6 @@ services:
 
   zgw-referentielijsten:
     image: ghcr.io/infonl/vng-referentielijsten:0.6.1
-    container_name: zgw-referentielijsten
     environment:
       - DB_HOST=zgw-referentielijsten-database
       - DB_NAME=vrl
@@ -289,7 +269,6 @@ services:
   # Insert required test data into the VRL database after the VRL application has started up and finished initializing the database
   zgw-referentielijsten-database-init:
     image: postgres:15.4
-    container_name: zgw-referentielijsten-database-init
     volumes:
       - ./scripts/docker-compose/imports/zgw-referentielijsten/init-zgw-referentielijsten-database.sql:/tmp/init-zgw-referentielijsten-database.sql
     command: bash -c "psql postgresql://vrl:vrl@zgw-referentielijsten-database/vrl < /tmp/init-zgw-referentielijsten-database.sql"
@@ -301,7 +280,6 @@ services:
   gbamock:
     image: ghcr.io/brp-api/haal-centraal-brp-bevragen-gba-mock:2.0.8
     platform: linux/amd64
-    container_name: gbamock
     environment:
       - ASPNETCORE_ENVIRONMENT=Release
       - ASPNETCORE_URLS=http://+:5010
@@ -311,7 +289,6 @@ services:
   brpproxy:
     image: ghcr.io/brp-api/haal-centraal-brp-bevragen-proxy:2.1.0
     platform: linux/amd64
-    container_name: brpproxy
     environment:
       - ASPNETCORE_ENVIRONMENT=Release
       - ASPNETCORE_URLS=http://+:5000
@@ -322,7 +299,6 @@ services:
 
   openklant-database:
     image: postgres:15.4
-    container_name: openklant-database
     ports:
       - "54325:5432"
     healthcheck:
@@ -341,7 +317,6 @@ services:
 
   openklant:
     image: docker.io/maykinmedia/open-klant:latest
-    container_name: openklant
     platform: linux/amd64
     environment:
       - ALLOWED_HOSTS=localhost,host.docker.internal,172.17.0.1,openklant
@@ -364,15 +339,13 @@ services:
         condition: service_started
 
   zac:
-    # By default we use the latest ZAC Docker Image. Change this if you wish to use a specific version.
+    # By default, we use the latest ZAC Docker Image. Change this if you wish to use a specific version.
     # See: https://github.com/infonl/dimpact-zaakafhandelcomponent/pkgs/container/zaakafhandelcomponent
     image: ghcr.io/infonl/zaakafhandelcomponent:latest
-    container_name: zac
-    platform: linux/amd64
     environment:
-    # Some of these environment variables use 'host.docker.internal' as hostname.
-    # To be able to use this you need an entry in your /etc/hosts file.
-    # Please see docs/INSTALL-DOCKER-COMPOSE.md for details.
+      # Some of these environment variables use 'host.docker.internal' as hostname.
+      # To be able to use this you need an entry in your /etc/hosts file.
+      # Please see docs/INSTALL-DOCKER-COMPOSE.md for details.
       - AUTH_REALM=zaakafhandelcomponent
       - AUTH_RESOURCE=zaakafhandelcomponent
       - AUTH_SECRET=keycloakZaakafhandelcomponentClientSecret
@@ -407,12 +380,12 @@ services:
       - OFFICE_CONVERTER_CLIENT_MP_REST_URL=http://localhost:9999 # dummy for now
       - OBJECTS_API_TOKEN=1 # dummy for now
       - OBJECTTYPES_API_TOKEN=1 # dummy for now
-      - OPA_API_CLIENT_MP_REST_URL=http://zac-opa:8181
+      - OPA_API_CLIENT_MP_REST_URL=http://opa:8181
       - OPEN_FORMS_URL=http://localhost:9999 # dummy for now
       - OPEN_NOTIFICATIONS_API_SECRET_KEY=opennotificaties
       - SD_AUTHENTICATION=${SD_AUTHENTICATION}
       - SD_CLIENT_MP_REST_URL=${SD_CLIENT_MP_REST_URL}
-      - SOLR_URL=http://zac-solr:8983
+      - SOLR_URL=http://solr:8983
       - VRL_API_CLIENT_MP_REST_URL=http://host.docker.internal:8020/
       - ZGW_API_CLIENT_MP_REST_URL=http://host.docker.internal:8001/
       - ZGW_API_CLIENTID=zac_client
@@ -420,6 +393,7 @@ services:
       - ZGW_API_URL_EXTERN=http://localhost:8001/
     ports:
       - "8080:8080"
+      - "9990:9990"
     depends_on:
       zac-database:
         condition: service_healthy

--- a/start-docker-compose-with-zac.sh
+++ b/start-docker-compose-with-zac.sh
@@ -10,4 +10,4 @@ docker compose pull zac
 
 # Uses the 1Password CLI tools to set up the environment variables for running Docker Compose and ZAC in IntelliJ.
 # Please see docs/INSTALL.md for details on how to use this script.
-export APP_ENV=devlocal && op run --env-file="./.env.tpl" -- docker compose --profile zac up -d
+export APP_ENV=devlocal && op run --env-file="./.env.tpl" -- docker compose --profile zac --project-name zac up -d

--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -10,4 +10,4 @@ docker compose pull zac
 
 # Uses the 1Password CLI tools to set up the environment variables for running Docker Compose and ZAC in IntelliJ.
 # Please see docs/INSTALL.md for details on how to use this script.
-export APP_ENV=devlocal && op run --env-file="./.env.tpl" -- docker compose up -d
+export APP_ENV=devlocal && op run --env-file="./.env.tpl" -- docker compose --project-name zac up -d


### PR DESCRIPTION
No longer use container names in Docker Compose because for example the TestContainers framework does not support this. Use project name instead when starting up Docker Compose for more flexibility but still have fixed container names.

Solves PZ-569.