### PR TITLE
chore: fix Docker Compose without ZAC start script 

### DIFF
--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -5,9 +5,6 @@
 # SPDX-License-Identifier: EUPL-1.2+
 #
 
-# Do a pull first to make sure we use the latest ZAC Docker Image
-docker compose pull zac
-
 # Uses the 1Password CLI tools to set up the environment variables for running Docker Compose and ZAC in IntelliJ.
 # Please see docs/INSTALL.md for details on how to use this script.
 export APP_ENV=devlocal && op run --env-file="./.env.tpl" -- docker compose --project-name zac up -d


### PR DESCRIPTION
Docker Compose without ZAC start script should not pull ZAC Docker image.

Solves PZ-574