### PR TITLE
PZ-602 fix(codeowners): add Rick and Joran

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*   @infonl/dimpact
+*   @infonl/dimpact @RickWoltheus @Jorann
+


### PR DESCRIPTION
This will add Rick and Joran explicitly to codeowners

Because they are not in the team