### PR TITLE
fix(codeql): Combine java and kotlin languages for codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["java", "kotlin", "javascript"]
+        language: ["java-kotlin", "javascript"]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
CodeQL does not support java and kotlin individually. We need to combine these into a single language in it's matrix as java-kotlin.