### PR TITLE
chore: run unit tests and itests in parallel

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -68,6 +68,13 @@ jobs:
             build/
           key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
+      - name: Cache generated Java clients
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            src/generated/
+          key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
       - name: Cache Maven build artefacts
         uses: actions/cache/save@v3
         with:
@@ -97,6 +104,13 @@ jobs:
           path: |
             build/
           key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
+      - name: Restore generated Java clients
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            src/generated/
+          key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Run unit tests
         run: ./gradlew test --info

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -113,7 +113,7 @@ jobs:
           key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Run unit tests
-        run: ./gradlew test --info
+        run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes test --info
 
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -58,8 +58,34 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       # The Gradle build also executes a Maven command to build the WildFly bootable JAR.
-      - name: Gradle build and test
-        run: ./gradlew build --info
+      - name: Gradle build
+        run: ./gradlew build -x test --info
+
+      - name: Cache Maven build artefacts
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            target/
+          key: maven-build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
+  run-unit-tests:
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Run unit tests
+        run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes test --info
 
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -69,13 +95,6 @@ jobs:
           files: |
             build/test-results/**/*.xml
             src/main/app/reports/*.xml
-
-      - name: Cache Maven build artefacts
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            target/
-          key: maven-build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   build-docker-image-and-run-itests:
     needs: [build]
@@ -141,7 +160,7 @@ jobs:
           key: docker-image-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   push-docker-image:
-    needs: [build, build-docker-image-and-run-itests]
+    needs: [build, run-unit-tests, build-docker-image-and-run-itests]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -85,7 +85,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Run unit tests
-        run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes test --info
+        run: ./gradlew test --info
 
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Gradle build
         run: ./gradlew build -x test --info
 
+      - name: Cache Gradle build artefacts
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            build/
+          key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
       - name: Cache Maven build artefacts
         uses: actions/cache/save@v3
         with:
@@ -83,6 +90,13 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+
+      - name: Restore Gradle build artefacts
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            build/
+          key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Run unit tests
         run: ./gradlew test --info

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: |
-            src/generated/
+            src/generated/java
           key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Cache Maven build artefacts
@@ -98,19 +98,19 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Restore generated Java clients
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            src/generated/java
+          key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
       - name: Restore Gradle build artefacts
         uses: actions/cache/restore@v3
         with:
           path: |
             build/
           key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
-
-      - name: Restore generated Java clients
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            src/generated/
-          key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Run unit tests
         run: ./gradlew test --info


### PR DESCRIPTION
Run the unit and integration tests in parallel in GitHub to improve performance a little bit (especially once we get more unit tests).

Solves PZ-617.