### PR TITLE
feat: use the Keycloak --hostname-url startup option

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -135,6 +135,11 @@ jobs:
       BAG_API_CLIENT_MP_REST_URL: $${{ vars.BAG_API_CLIENT_MP_REST_URL }}
       BAG_API_KEY: ${{ secrets.BAG_API_KEY }}
     steps:
+        # workaround to avoid 'No space left on device' error
+        # see: https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
+      - name: Delete unnecessary tools folder to make space on disk
+        run: rm -rf /opt/hostedtoolcache
+
       - uses: actions/checkout@v4
 
       - name: Setup JDK

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
     command:
       - "start-dev"
       - "--import-realm"
+      - "--hostname-url=http://localhost:8081"
 
   keycloak-database:
     image: postgres:15.4
@@ -352,7 +353,7 @@ services:
       - AUTH_REALM=zaakafhandelcomponent
       - AUTH_RESOURCE=zaakafhandelcomponent
       - AUTH_SECRET=keycloakZaakafhandelcomponentClientSecret
-      - AUTH_SERVER=http://host.docker.internal:8081
+      - AUTH_SERVER=http://keycloak:8080
       - BAG_API_CLIENT_MP_REST_URL=https://api.bag.acceptatie.kadaster.nl/lvbag/individuelebevragingen/v2/
       - BAG_API_KEY=${BAG_API_KEY}
       - BRP_API_CLIENT_MP_REST_URL=http://brpproxy:5000/haalcentraal/api/brp


### PR DESCRIPTION
Use the Keycloak --hostname-url startup option so that Keycloak uses a different frontend URL vs backend URL and we do not need to change our /etc/hosts file for the connection to Keycloak in our Docker Compose set-up.

Solves PZ-645.