### PR TITLE
feat: wait until zac is ready before starting integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ import java.util.Locale
 
 plugins {
     java
-    kotlin("jvm") version "1.9.10"
+    kotlin("jvm") version "1.9.20"
     war
     jacoco
 
@@ -114,6 +114,7 @@ dependencies {
     "itestImplementation"("org.slf4j:slf4j-simple:2.0.9")
     "itestImplementation"("io.github.oshai:kotlin-logging-jvm:5.1.0")
     "itestImplementation"("org.danilopianini:khttp:1.4.0")
+    "itestImplementation"("org.awaitility:awaitility-kotlin:4.2.0")
 }
 
 detekt {

--- a/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -32,9 +32,9 @@ import java.util.concurrent.TimeUnit
 
 private val logger = KotlinLogging.logger {}
 
+@Suppress("MagicNumber")
 object ProjectConfig : AbstractProjectConfig() {
-    private const val THREE_MINUTES = 3L
-    private const val TEN_SECONDS = 10L
+    private val THREE_MINUTES = Duration.ofMinutes(3)
 
     private lateinit var dockerComposeContainer: ComposeContainer
 
@@ -72,17 +72,17 @@ object ProjectConfig : AbstractProjectConfig() {
                 .waitingFor(
                     "openzaak.local",
                     Wait.forLogMessage(".*spawned uWSGI worker 2.*", 1)
-                        .withStartupTimeout(Duration.ofMinutes(THREE_MINUTES))
+                        .withStartupTimeout(THREE_MINUTES)
                 )
                 .waitingFor(
                     "zac",
                     Wait.forLogMessage(".* WildFly Full .* started .*", 1)
-                        .withStartupTimeout(Duration.ofMinutes(THREE_MINUTES))
+                        .withStartupTimeout(THREE_MINUTES)
                 )
             dockerComposeContainer.start()
             logger.info { "Started ZAC Docker Compose containers" }
             logger.info { "Waiting until ZAC is healthy by calling the health endpoint and checking the response" }
-            await.atMost(TEN_SECONDS, TimeUnit.SECONDS)
+            await.atMost(10, TimeUnit.SECONDS)
                 .until {
                     khttp.get(
                         url = "${ZAC_MANAGEMENT_URI}/health/ready",

--- a/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -28,13 +28,15 @@ import org.testcontainers.containers.output.Slf4jLogConsumer
 import org.testcontainers.containers.wait.strategy.Wait
 import java.io.File
 import java.time.Duration
-import java.util.concurrent.TimeUnit
 
 private val logger = KotlinLogging.logger {}
 
-@Suppress("MagicNumber")
 object ProjectConfig : AbstractProjectConfig() {
+    @Suppress("MagicNumber")
     private val THREE_MINUTES = Duration.ofMinutes(3)
+
+    @Suppress("MagicNumber")
+    private val TEN_SECONDS = Duration.ofSeconds(10)
 
     private lateinit var dockerComposeContainer: ComposeContainer
 
@@ -82,7 +84,7 @@ object ProjectConfig : AbstractProjectConfig() {
             dockerComposeContainer.start()
             logger.info { "Started ZAC Docker Compose containers" }
             logger.info { "Waiting until ZAC is healthy by calling the health endpoint and checking the response" }
-            await.atMost(10, TimeUnit.SECONDS)
+            await.atMost(TEN_SECONDS)
                 .until {
                     khttp.get(
                         url = "${ZAC_MANAGEMENT_URI}/health/ready",


### PR DESCRIPTION
Wait until ZAC is healthy before starting the integration tests to fix the issue that on fast machines the integration tests started before ZAC and/or Open Zaak were healthy. Note that the ZAC healthpoint also checks Open Zaak.

Solves PZ-712.