### PR TITLE
chore: set Dependabot workflow schedule time earlier 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "08:00"
+      time: "04:00"
       timezone: "Europe/Amsterdam"
     reviewers:
       - "infonl/dimpact"
@@ -19,7 +19,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "08:00"
+      time: "04:00"
       timezone: "Europe/Amsterdam"
     reviewers:
       - "infonl/dimpact"
@@ -39,7 +39,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "08:00"
+      time: "04:00"
       timezone: "Europe/Amsterdam"
     reviewers:
     - "infonl/dimpact"


### PR DESCRIPTION
So that the Dependabot PRs do not interfere with our own PRs.

Solves PZ-733.