### PR TITLE
chore: always request a new access token from Keycloak

### DIFF
--- a/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -10,8 +10,7 @@ import io.github.oshai.kotlinlogging.DelegatingKLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.config.AbstractProjectConfig
 import nl.lifely.zac.itest.client.KeycloakClient
-import nl.lifely.zac.itest.client.ZacClient
-import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
+import nl.lifely.zac.itest.client.createZaakAfhandelParameters
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_MANAGEMENT_URI
 import org.awaitility.kotlin.await
 import org.slf4j.Logger
@@ -33,7 +32,7 @@ object ProjectConfig : AbstractProjectConfig() {
 
     private lateinit var dockerComposeContainer: ComposeContainer
 
-    lateinit var accessToken: String
+    lateinit var keycloakClient: KeycloakClient
 
     @Suppress("UNCHECKED_CAST")
     override suspend fun beforeProject() {
@@ -88,9 +87,9 @@ object ProjectConfig : AbstractProjectConfig() {
                         it.statusCode == HttpStatus.SC_OK && it.jsonObject.getString("status") == "UP"
                     }
                 }
-            accessToken = KeycloakClient().requestAccessTokenFromKeycloak()
-            val zacClient = ZacClient(ZAC_API_URI, accessToken)
-            zacClient.createZaakAfhandelParameters()
+            keycloakClient = KeycloakClient()
+            keycloakClient.authenticate()
+            createZaakAfhandelParameters()
         } catch (exception: ContainerLaunchException) {
             logger.error(exception) { "Failed to start Docker containers" }
             dockerComposeContainer.stop()

--- a/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -32,8 +32,6 @@ object ProjectConfig : AbstractProjectConfig() {
 
     private lateinit var dockerComposeContainer: ComposeContainer
 
-    lateinit var keycloakClient: KeycloakClient
-
     @Suppress("UNCHECKED_CAST")
     override suspend fun beforeProject() {
         try {
@@ -87,8 +85,7 @@ object ProjectConfig : AbstractProjectConfig() {
                         it.statusCode == HttpStatus.SC_OK && it.jsonObject.getString("status") == "UP"
                     }
                 }
-            keycloakClient = KeycloakClient()
-            keycloakClient.authenticate()
+            KeycloakClient.authenticate()
             createZaakAfhandelParameters()
         } catch (exception: ContainerLaunchException) {
             logger.error(exception) { "Failed to start Docker containers" }

--- a/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -9,15 +9,8 @@ import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus
 import io.github.oshai.kotlinlogging.DelegatingKLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.config.AbstractProjectConfig
-import io.kotest.matchers.shouldBe
-import khttp.requests.GenericRequest.Companion.DEFAULT_FORM_HEADERS
-import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_CLIENT
-import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_CLIENT_SECRET
-import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_HOSTNAME_URL
-import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_REALM
-import nl.lifely.zac.itest.config.ItestConfiguration.PRODUCT_AANVRAAG_TYPE
-import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE
-import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
+import nl.lifely.zac.itest.client.KeycloakClient
+import nl.lifely.zac.itest.client.ZacClient
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_MANAGEMENT_URI
 import org.awaitility.kotlin.await
@@ -95,8 +88,9 @@ object ProjectConfig : AbstractProjectConfig() {
                         it.statusCode == HttpStatus.SC_OK && it.jsonObject.getString("status") == "UP"
                     }
                 }
-            accessToken = requestAccessTokenFromKeycloak()
-            createZaakAfhandelParameters()
+            accessToken = KeycloakClient().requestAccessTokenFromKeycloak()
+            val zacClient = ZacClient(ZAC_API_URI, accessToken)
+            zacClient.createZaakAfhandelParameters()
         } catch (exception: ContainerLaunchException) {
             logger.error(exception) { "Failed to start Docker containers" }
             dockerComposeContainer.stop()
@@ -125,214 +119,6 @@ object ProjectConfig : AbstractProjectConfig() {
                     logger.error { "Failed to delete folder '$file'" }
                 }
             }
-        }
-    }
-
-    private fun requestAccessTokenFromKeycloak() =
-        khttp.post(
-            url = "$KEYCLOAK_HOSTNAME_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token",
-            headers = DEFAULT_FORM_HEADERS,
-            data = mapOf(
-                "client_id" to KEYCLOAK_CLIENT,
-                "grant_type" to "password",
-                "username" to "testuser1",
-                "password" to "testuser1",
-                "client_secret" to KEYCLOAK_CLIENT_SECRET
-            )
-        ).jsonObject.getString("access_token")
-
-    @Suppress("LongMethod")
-    private fun createZaakAfhandelParameters() {
-        logger.info {
-            "Creating zaakafhandelparameters in ZAC for zaaktype with UUID: $ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID"
-        }
-
-        khttp.put(
-            url = "${ZAC_API_URI}/zaakafhandelParameters",
-            headers = mapOf(
-                "Content-Type" to "application/json",
-                "Authorization" to "Bearer $accessToken"
-            ),
-            data = "{\n" +
-                "  \"humanTaskParameters\": [\n" +
-                "    {\n" +
-                "      \"planItemDefinition\": {\n" +
-                "        \"defaultFormulierDefinitie\": \"AANVULLENDE_INFORMATIE\",\n" +
-                "        \"id\": \"AANVULLENDE_INFORMATIE\",\n" +
-                "        \"naam\": \"Aanvullende informatie\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      \"defaultGroepId\": null,\n" +
-                "      \"formulierDefinitieId\": \"AANVULLENDE_INFORMATIE\",\n" +
-                "      \"referentieTabellen\": [],\n" +
-                "      \"actief\": true,\n" +
-                "      \"doorlooptijd\": null\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"planItemDefinition\": {\n" +
-                "        \"defaultFormulierDefinitie\": \"GOEDKEUREN\",\n" +
-                "        \"id\": \"GOEDKEUREN\",\n" +
-                "        \"naam\": \"Goedkeuren\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      \"defaultGroepId\": null,\n" +
-                "      \"formulierDefinitieId\": \"GOEDKEUREN\",\n" +
-                "      \"referentieTabellen\": [],\n" +
-                "      \"actief\": true,\n" +
-                "      \"doorlooptijd\": null\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"planItemDefinition\": {\n" +
-                "        \"defaultFormulierDefinitie\": \"ADVIES\",\n" +
-                "        \"id\": \"ADVIES_INTERN\",\n" +
-                "        \"naam\": \"Advies intern\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      \"defaultGroepId\": null,\n" +
-                "      \"formulierDefinitieId\": \"ADVIES\",\n" +
-                "      \"referentieTabellen\": [\n" +
-                "        {\n" +
-                "          \"veld\": \"ADVIES\",\n" +
-                "          \"tabel\": {\n" +
-                "            \"aantalWaarden\": 5,\n" +
-                "            \"code\": \"ADVIES\",\n" +
-                "            \"id\": 1,\n" +
-                "            \"naam\": \"Advies\",\n" +
-                "            \"systeem\": true\n" +
-                "          }\n" +
-                "        }\n" +
-                "      ],\n" +
-                "      \"actief\": true,\n" +
-                "      \"doorlooptijd\": null\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"planItemDefinition\": {\n" +
-                "        \"defaultFormulierDefinitie\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
-                "        \"id\": \"ADVIES_EXTERN\",\n" +
-                "        \"naam\": \"Advies extern\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      \"defaultGroepId\": null,\n" +
-                "      \"formulierDefinitieId\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
-                "      \"referentieTabellen\": [],\n" +
-                "      \"actief\": true,\n" +
-                "      \"doorlooptijd\": null\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"planItemDefinition\": {\n" +
-                "        \"defaultFormulierDefinitie\": \"DOCUMENT_VERZENDEN_POST\",\n" +
-                "        \"id\": \"DOCUMENT_VERZENDEN_POST\",\n" +
-                "        \"naam\": \"Document verzenden\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      \"defaultGroepId\": null,\n" +
-                "      \"formulierDefinitieId\": \"DOCUMENT_VERZENDEN_POST\",\n" +
-                "      \"referentieTabellen\": [],\n" +
-                "      \"actief\": true,\n" +
-                "      \"doorlooptijd\": null\n" +
-                "    }\n" +
-                "  ],\n" +
-                "  \"mailtemplateKoppelingen\": [],\n" +
-                "  \"userEventListenerParameters\": [\n" +
-                "    {\n" +
-                "      \"id\": \"INTAKE_AFRONDEN\",\n" +
-                "      \"naam\": \"Intake afronden\",\n" +
-                "      \"toelichting\": null\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"id\": \"ZAAK_AFHANDELEN\",\n" +
-                "      \"naam\": \"Zaak afhandelen\",\n" +
-                "      \"toelichting\": null\n" +
-                "    }\n" +
-                "  ],\n" +
-                "  \"valide\": false,\n" +
-                "  \"zaakAfzenders\": [],\n" +
-                "  \"zaakbeeindigParameters\": [],\n" +
-                "  \"zaaktype\": {\n" +
-                "    \"beginGeldigheid\": \"2023-09-21\",\n" +
-                "    \"doel\": \"Melding evenement organiseren behandelen\",\n" +
-                "    \"identificatie\": \"$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE\",\n" +
-                "    \"nuGeldig\": true,\n" +
-                "    \"omschrijving\": \"Melding evenement organiseren behandelen\",\n" +
-                "    \"servicenorm\": false,\n" +
-                "    \"uuid\": \"448356ff-dcfb-4504-9501-7fe929077c4f\",\n" +
-                "    \"versiedatum\": \"2023-09-21\",\n" +
-                "    \"vertrouwelijkheidaanduiding\": \"openbaar\"\n" +
-                "  },\n" +
-                "  \"intakeMail\": \"BESCHIKBAAR_UIT\",\n" +
-                "  \"afrondenMail\": \"BESCHIKBAAR_UIT\",\n" +
-                "  \"caseDefinition\": {\n" +
-                "    \"humanTaskDefinitions\": [\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"AANVULLENDE_INFORMATIE\",\n" +
-                "        \"id\": \"AANVULLENDE_INFORMATIE\",\n" +
-                "        \"naam\": \"Aanvullende informatie\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"GOEDKEUREN\",\n" +
-                "        \"id\": \"GOEDKEUREN\",\n" +
-                "        \"naam\": \"Goedkeuren\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"ADVIES\",\n" +
-                "        \"id\": \"ADVIES_INTERN\",\n" +
-                "        \"naam\": \"Advies intern\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
-                "        \"id\": \"ADVIES_EXTERN\",\n" +
-                "        \"naam\": \"Advies extern\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"DOCUMENT_VERZENDEN_POST\",\n" +
-                "        \"id\": \"DOCUMENT_VERZENDEN_POST\",\n" +
-                "        \"naam\": \"Document verzenden\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      }\n" +
-                "    ],\n" +
-                "    \"key\": \"melding-klein-evenement\",\n" +
-                "    \"naam\": \"Melding klein evenement\",\n" +
-                "    \"userEventListenerDefinitions\": [\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"DEFAULT_TAAKFORMULIER\",\n" +
-                "        \"id\": \"INTAKE_AFRONDEN\",\n" +
-                "        \"naam\": \"Intake afronden\",\n" +
-                "        \"type\": \"USER_EVENT_LISTENER\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"DEFAULT_TAAKFORMULIER\",\n" +
-                "        \"id\": \"ZAAK_AFHANDELEN\",\n" +
-                "        \"naam\": \"Zaak afhandelen\",\n" +
-                "        \"type\": \"USER_EVENT_LISTENER\"\n" +
-                "      }\n" +
-                "    ]\n" +
-                "  },\n" +
-                "  \"domein\": null,\n" +
-                "  \"defaultGroepId\": \"test-group-a\",\n" +
-                "  \"defaultBehandelaarId\": null,\n" +
-                "  \"einddatumGeplandWaarschuwing\": null,\n" +
-                "  \"uiterlijkeEinddatumAfdoeningWaarschuwing\": null,\n" +
-                "  \"productaanvraagtype\": \"$PRODUCT_AANVRAAG_TYPE\",\n" +
-                "  \"zaakNietOntvankelijkResultaattype\": {\n" +
-                "    \"archiefNominatie\": \"VERNIETIGEN\",\n" +
-                "    \"archiefTermijn\": \"5 jaren\",\n" +
-                "    \"besluitVerplicht\": false,\n" +
-                "    \"id\": \"dd2bcd87-ed7e-4b23-a8e3-ea7fe7ef00c6\",\n" +
-                "    \"naam\": \"Geweigerd\",\n" +
-                "    \"naamGeneriek\": \"Geweigerd\",\n" +
-                "    \"toelichting\": \"Het door het orgaan behandelen van een aanvraag, melding of verzoek om " +
-                "toestemming voor het doen of laten van een derde waar het orgaan bevoegd is om over te beslissen\",\n" +
-                "    \"vervaldatumBesluitVerplicht\": false\n" +
-                "  }\n" +
-                "}\n"
-        ).apply {
-            logger.info { "response: $text" }
-            // check contents
-            statusCode shouldBe HttpStatus.SC_OK
         }
     }
 }

--- a/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
@@ -9,7 +9,7 @@ import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.provided.ProjectConfig
+import nl.lifely.zac.itest.client.KeycloakClient
 import nl.lifely.zac.itest.config.ItestConfiguration.OBJECTS_API_HOSTNAME_URL
 import nl.lifely.zac.itest.config.ItestConfiguration.OBJECTTYPE_UUID_PRODUCTAANVRAAG_DENHAAG
 import nl.lifely.zac.itest.config.ItestConfiguration.OBJECT_PRODUCTAANVRAAG_UUID
@@ -79,7 +79,7 @@ class NotificationsTest : BehaviorSpec({
                         url = "${ZAC_API_URI}/zaken/zaak/id/$ZAAK_1_IDENTIFICATION",
                         headers = mapOf(
                             "Content-Type" to "application/json",
-                            "Authorization" to "Bearer ${ProjectConfig.keycloakClient.requestAccessToken()}"
+                            "Authorization" to "Bearer ${KeycloakClient.requestAccessToken()}"
                         ),
                     ).apply {
                         logger.info { "Response: $text" }
@@ -87,13 +87,15 @@ class NotificationsTest : BehaviorSpec({
                         statusCode shouldBe HttpStatus.SC_OK
                         val zaak = JSONObject(text)
                         zaak.getString("identificatie") shouldBe ZAAK_1_IDENTIFICATION
-                        zaak.getJSONObject("zaaktype").getString("uuid") shouldBe ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
+                        zaak.getJSONObject("zaaktype")
+                            .getString("uuid") shouldBe ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
                         zaak.getJSONObject("status").getString("naam") shouldBe "Intake"
                         zaak.getJSONObject("groep").getString("id") shouldBe "test-group-a"
                         // 'proces gestuurd' is true when a BPMN rather than a CMMN proces has been started
                         // since we have defined zaakafhandelparameters for this zaaktype a CMMN proces should be started
                         zaak.getBoolean("isProcesGestuurd") shouldBe false
-                        zaak.getJSONObject("communicatiekanaal").getString("naam") shouldBe "E-formulier"
+                        zaak.getJSONObject("communicatiekanaal")
+                            .getString("naam") shouldBe "E-formulier"
                     }
                 }
             }

--- a/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
@@ -79,7 +79,7 @@ class NotificationsTest : BehaviorSpec({
                         url = "${ZAC_API_URI}/zaken/zaak/id/$ZAAK_1_IDENTIFICATION",
                         headers = mapOf(
                             "Content-Type" to "application/json",
-                            "Authorization" to "Bearer ${ProjectConfig.accessToken}"
+                            "Authorization" to "Bearer ${ProjectConfig.keycloakClient.requestAccessToken()}"
                         ),
                     ).apply {
                         logger.info { "Response: $text" }

--- a/src/itest/kotlin/nl/lifely/zac/itest/ZaakafhandelParametersTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZaakafhandelParametersTest.kt
@@ -23,7 +23,7 @@ class ZaakafhandelParametersTest : BehaviorSpec({
             then("the response should be ok and it should return the zaakafhandelparameters") {
                 khttp.get(
                     url = "${ZAC_API_URI}/zaakafhandelParameters/$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID",
-                    headers = mapOf("Authorization" to "Bearer ${ProjectConfig.accessToken}")
+                    headers = mapOf("Authorization" to "Bearer ${ProjectConfig.keycloakClient.requestAccessToken()}")
                 ).apply {
                     logger.info { "Zaakafhandelparameters response: $text" }
                     val zaakafhandelparameters = JSONObject(text)

--- a/src/itest/kotlin/nl/lifely/zac/itest/ZaakafhandelParametersTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZaakafhandelParametersTest.kt
@@ -9,7 +9,7 @@ import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.provided.ProjectConfig
+import nl.lifely.zac.itest.client.KeycloakClient
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
@@ -23,7 +23,7 @@ class ZaakafhandelParametersTest : BehaviorSpec({
             then("the response should be ok and it should return the zaakafhandelparameters") {
                 khttp.get(
                     url = "${ZAC_API_URI}/zaakafhandelParameters/$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID",
-                    headers = mapOf("Authorization" to "Bearer ${ProjectConfig.keycloakClient.requestAccessToken()}")
+                    headers = mapOf("Authorization" to "Bearer ${KeycloakClient.requestAccessToken()}")
                 ).apply {
                     logger.info { "Zaakafhandelparameters response: $text" }
                     val zaakafhandelparameters = JSONObject(text)

--- a/src/itest/kotlin/nl/lifely/zac/itest/client/KeycloakClient.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/client/KeycloakClient.kt
@@ -30,12 +30,12 @@ class KeycloakClient {
         }
 
     /**
-     * Always request a new access token using the refresh token to make sure we remain
+     * Always request a new access token using the current refresh token to make sure we remain
      * authenticated and our access token does not expire.
      * Note that this assumes that subsequent calls to this method are done quickly enough so that the
      * refresh token does not expire in the meantime.
      */
-    fun requestAccessToken(): String =
+    fun requestAccessToken(): String {
         khttp.post(
             url = "$KEYCLOAK_HOSTNAME_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token",
             headers = GenericRequest.DEFAULT_FORM_HEADERS,
@@ -45,6 +45,12 @@ class KeycloakClient {
                 "refresh_token" to refreshToken,
                 "client_secret" to KEYCLOAK_CLIENT_SECRET
             )
-        ).jsonObject.getString("access_token")
+        ).apply {
+            // a new refresh token is optional, so only update it if it is present
+            if (jsonObject.has("refresh_token"))
+                refreshToken = jsonObject.getString("refresh_token")
+            return jsonObject.getString("access_token")
+        }
+    }
 }
 

--- a/src/itest/kotlin/nl/lifely/zac/itest/client/KeycloakClient.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/client/KeycloakClient.kt
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+package nl.lifely.zac.itest.client
+
+import khttp.requests.GenericRequest
+import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_CLIENT
+import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_CLIENT_SECRET
+import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_HOSTNAME_URL
+import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_REALM
+
+class KeycloakClient {
+    fun requestAccessTokenFromKeycloak() =
+        khttp.post(
+            url = "$KEYCLOAK_HOSTNAME_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token",
+            headers = GenericRequest.DEFAULT_FORM_HEADERS,
+            data = mapOf(
+                "client_id" to KEYCLOAK_CLIENT,
+                "grant_type" to "password",
+                "username" to "testuser1",
+                "password" to "testuser1",
+                "client_secret" to KEYCLOAK_CLIENT_SECRET
+            )
+        ).jsonObject.getString("access_token")
+}

--- a/src/itest/kotlin/nl/lifely/zac/itest/client/KeycloakClient.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/client/KeycloakClient.kt
@@ -12,7 +12,9 @@ import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_HOSTNAME_URL
 import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_REALM
 
 class KeycloakClient {
-    fun requestAccessTokenFromKeycloak() =
+    private lateinit var refreshToken: String
+
+    fun authenticate() =
         khttp.post(
             url = "$KEYCLOAK_HOSTNAME_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token",
             headers = GenericRequest.DEFAULT_FORM_HEADERS,
@@ -23,5 +25,26 @@ class KeycloakClient {
                 "password" to "testuser1",
                 "client_secret" to KEYCLOAK_CLIENT_SECRET
             )
+        ).apply {
+            refreshToken = jsonObject.getString("refresh_token")
+        }
+
+    /**
+     * Always request a new access token using the refresh token to make sure we remain
+     * authenticated and our access token does not expire.
+     * Note that this assumes that subsequent calls to this method are done quickly enough so that the
+     * refresh token does not expire in the meantime.
+     */
+    fun requestAccessToken(): String =
+        khttp.post(
+            url = "$KEYCLOAK_HOSTNAME_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token",
+            headers = GenericRequest.DEFAULT_FORM_HEADERS,
+            data = mapOf(
+                "client_id" to KEYCLOAK_CLIENT,
+                "grant_type" to "refresh_token",
+                "refresh_token" to refreshToken,
+                "client_secret" to KEYCLOAK_CLIENT_SECRET
+            )
         ).jsonObject.getString("access_token")
 }
+

--- a/src/itest/kotlin/nl/lifely/zac/itest/client/KeycloakClient.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/client/KeycloakClient.kt
@@ -11,7 +11,7 @@ import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_CLIENT_SECRET
 import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_HOSTNAME_URL
 import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_REALM
 
-class KeycloakClient {
+object KeycloakClient {
     private lateinit var refreshToken: String
 
     fun authenticate() =
@@ -47,10 +47,10 @@ class KeycloakClient {
             )
         ).apply {
             // a new refresh token is optional, so only update it if it is present
-            if (jsonObject.has("refresh_token"))
+            if (jsonObject.has("refresh_token")) {
                 refreshToken = jsonObject.getString("refresh_token")
+            }
             return jsonObject.getString("access_token")
         }
     }
 }
-

--- a/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+package nl.lifely.zac.itest.client
+
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.matchers.shouldBe
+import nl.lifely.zac.itest.config.ItestConfiguration.PRODUCT_AANVRAAG_TYPE
+import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE
+import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
+
+private val logger = KotlinLogging.logger {}
+
+class ZacClient(
+    private val zacApiUri: String,
+    private val accessToken: String
+) {
+    @Suppress("LongMethod")
+    fun createZaakAfhandelParameters() {
+        logger.info {
+            "Creating zaakafhandelparameters in ZAC for zaaktype with UUID: $ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID"
+        }
+
+        khttp.put(
+            url = "$zacApiUri/zaakafhandelParameters",
+            headers = mapOf(
+                "Content-Type" to "application/json",
+                "Authorization" to "Bearer $accessToken"
+            ),
+            data = "{\n" +
+                "  \"humanTaskParameters\": [\n" +
+                "    {\n" +
+                "      \"planItemDefinition\": {\n" +
+                "        \"defaultFormulierDefinitie\": \"AANVULLENDE_INFORMATIE\",\n" +
+                "        \"id\": \"AANVULLENDE_INFORMATIE\",\n" +
+                "        \"naam\": \"Aanvullende informatie\",\n" +
+                "        \"type\": \"HUMAN_TASK\"\n" +
+                "      },\n" +
+                "      \"defaultGroepId\": null,\n" +
+                "      \"formulierDefinitieId\": \"AANVULLENDE_INFORMATIE\",\n" +
+                "      \"referentieTabellen\": [],\n" +
+                "      \"actief\": true,\n" +
+                "      \"doorlooptijd\": null\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"planItemDefinition\": {\n" +
+                "        \"defaultFormulierDefinitie\": \"GOEDKEUREN\",\n" +
+                "        \"id\": \"GOEDKEUREN\",\n" +
+                "        \"naam\": \"Goedkeuren\",\n" +
+                "        \"type\": \"HUMAN_TASK\"\n" +
+                "      },\n" +
+                "      \"defaultGroepId\": null,\n" +
+                "      \"formulierDefinitieId\": \"GOEDKEUREN\",\n" +
+                "      \"referentieTabellen\": [],\n" +
+                "      \"actief\": true,\n" +
+                "      \"doorlooptijd\": null\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"planItemDefinition\": {\n" +
+                "        \"defaultFormulierDefinitie\": \"ADVIES\",\n" +
+                "        \"id\": \"ADVIES_INTERN\",\n" +
+                "        \"naam\": \"Advies intern\",\n" +
+                "        \"type\": \"HUMAN_TASK\"\n" +
+                "      },\n" +
+                "      \"defaultGroepId\": null,\n" +
+                "      \"formulierDefinitieId\": \"ADVIES\",\n" +
+                "      \"referentieTabellen\": [\n" +
+                "        {\n" +
+                "          \"veld\": \"ADVIES\",\n" +
+                "          \"tabel\": {\n" +
+                "            \"aantalWaarden\": 5,\n" +
+                "            \"code\": \"ADVIES\",\n" +
+                "            \"id\": 1,\n" +
+                "            \"naam\": \"Advies\",\n" +
+                "            \"systeem\": true\n" +
+                "          }\n" +
+                "        }\n" +
+                "      ],\n" +
+                "      \"actief\": true,\n" +
+                "      \"doorlooptijd\": null\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"planItemDefinition\": {\n" +
+                "        \"defaultFormulierDefinitie\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
+                "        \"id\": \"ADVIES_EXTERN\",\n" +
+                "        \"naam\": \"Advies extern\",\n" +
+                "        \"type\": \"HUMAN_TASK\"\n" +
+                "      },\n" +
+                "      \"defaultGroepId\": null,\n" +
+                "      \"formulierDefinitieId\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
+                "      \"referentieTabellen\": [],\n" +
+                "      \"actief\": true,\n" +
+                "      \"doorlooptijd\": null\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"planItemDefinition\": {\n" +
+                "        \"defaultFormulierDefinitie\": \"DOCUMENT_VERZENDEN_POST\",\n" +
+                "        \"id\": \"DOCUMENT_VERZENDEN_POST\",\n" +
+                "        \"naam\": \"Document verzenden\",\n" +
+                "        \"type\": \"HUMAN_TASK\"\n" +
+                "      },\n" +
+                "      \"defaultGroepId\": null,\n" +
+                "      \"formulierDefinitieId\": \"DOCUMENT_VERZENDEN_POST\",\n" +
+                "      \"referentieTabellen\": [],\n" +
+                "      \"actief\": true,\n" +
+                "      \"doorlooptijd\": null\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"mailtemplateKoppelingen\": [],\n" +
+                "  \"userEventListenerParameters\": [\n" +
+                "    {\n" +
+                "      \"id\": \"INTAKE_AFRONDEN\",\n" +
+                "      \"naam\": \"Intake afronden\",\n" +
+                "      \"toelichting\": null\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"id\": \"ZAAK_AFHANDELEN\",\n" +
+                "      \"naam\": \"Zaak afhandelen\",\n" +
+                "      \"toelichting\": null\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"valide\": false,\n" +
+                "  \"zaakAfzenders\": [],\n" +
+                "  \"zaakbeeindigParameters\": [],\n" +
+                "  \"zaaktype\": {\n" +
+                "    \"beginGeldigheid\": \"2023-09-21\",\n" +
+                "    \"doel\": \"Melding evenement organiseren behandelen\",\n" +
+                "    \"identificatie\": \"$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE\",\n" +
+                "    \"nuGeldig\": true,\n" +
+                "    \"omschrijving\": \"Melding evenement organiseren behandelen\",\n" +
+                "    \"servicenorm\": false,\n" +
+                "    \"uuid\": \"448356ff-dcfb-4504-9501-7fe929077c4f\",\n" +
+                "    \"versiedatum\": \"2023-09-21\",\n" +
+                "    \"vertrouwelijkheidaanduiding\": \"openbaar\"\n" +
+                "  },\n" +
+                "  \"intakeMail\": \"BESCHIKBAAR_UIT\",\n" +
+                "  \"afrondenMail\": \"BESCHIKBAAR_UIT\",\n" +
+                "  \"caseDefinition\": {\n" +
+                "    \"humanTaskDefinitions\": [\n" +
+                "      {\n" +
+                "        \"defaultFormulierDefinitie\": \"AANVULLENDE_INFORMATIE\",\n" +
+                "        \"id\": \"AANVULLENDE_INFORMATIE\",\n" +
+                "        \"naam\": \"Aanvullende informatie\",\n" +
+                "        \"type\": \"HUMAN_TASK\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"defaultFormulierDefinitie\": \"GOEDKEUREN\",\n" +
+                "        \"id\": \"GOEDKEUREN\",\n" +
+                "        \"naam\": \"Goedkeuren\",\n" +
+                "        \"type\": \"HUMAN_TASK\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"defaultFormulierDefinitie\": \"ADVIES\",\n" +
+                "        \"id\": \"ADVIES_INTERN\",\n" +
+                "        \"naam\": \"Advies intern\",\n" +
+                "        \"type\": \"HUMAN_TASK\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"defaultFormulierDefinitie\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
+                "        \"id\": \"ADVIES_EXTERN\",\n" +
+                "        \"naam\": \"Advies extern\",\n" +
+                "        \"type\": \"HUMAN_TASK\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"defaultFormulierDefinitie\": \"DOCUMENT_VERZENDEN_POST\",\n" +
+                "        \"id\": \"DOCUMENT_VERZENDEN_POST\",\n" +
+                "        \"naam\": \"Document verzenden\",\n" +
+                "        \"type\": \"HUMAN_TASK\"\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"key\": \"melding-klein-evenement\",\n" +
+                "    \"naam\": \"Melding klein evenement\",\n" +
+                "    \"userEventListenerDefinitions\": [\n" +
+                "      {\n" +
+                "        \"defaultFormulierDefinitie\": \"DEFAULT_TAAKFORMULIER\",\n" +
+                "        \"id\": \"INTAKE_AFRONDEN\",\n" +
+                "        \"naam\": \"Intake afronden\",\n" +
+                "        \"type\": \"USER_EVENT_LISTENER\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"defaultFormulierDefinitie\": \"DEFAULT_TAAKFORMULIER\",\n" +
+                "        \"id\": \"ZAAK_AFHANDELEN\",\n" +
+                "        \"naam\": \"Zaak afhandelen\",\n" +
+                "        \"type\": \"USER_EVENT_LISTENER\"\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"domein\": null,\n" +
+                "  \"defaultGroepId\": \"test-group-a\",\n" +
+                "  \"defaultBehandelaarId\": null,\n" +
+                "  \"einddatumGeplandWaarschuwing\": null,\n" +
+                "  \"uiterlijkeEinddatumAfdoeningWaarschuwing\": null,\n" +
+                "  \"productaanvraagtype\": \"$PRODUCT_AANVRAAG_TYPE\",\n" +
+                "  \"zaakNietOntvankelijkResultaattype\": {\n" +
+                "    \"archiefNominatie\": \"VERNIETIGEN\",\n" +
+                "    \"archiefTermijn\": \"5 jaren\",\n" +
+                "    \"besluitVerplicht\": false,\n" +
+                "    \"id\": \"dd2bcd87-ed7e-4b23-a8e3-ea7fe7ef00c6\",\n" +
+                "    \"naam\": \"Geweigerd\",\n" +
+                "    \"naamGeneriek\": \"Geweigerd\",\n" +
+                "    \"toelichting\": \"Het door het orgaan behandelen van een aanvraag, melding of verzoek om " +
+                "toestemming voor het doen of laten van een derde waar het orgaan bevoegd is om over te beslissen\",\n" +
+                "    \"vervaldatumBesluitVerplicht\": false\n" +
+                "  }\n" +
+                "}\n"
+        ).apply {
+            logger.info { "PUT zaakafhandelParameters response: $text" }
+            // check contents
+            statusCode shouldBe HttpStatus.SC_OK
+        }
+    }
+}

--- a/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
@@ -8,7 +8,6 @@ package nl.lifely.zac.itest.client
 import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.matchers.shouldBe
-import io.kotest.provided.ProjectConfig
 import nl.lifely.zac.itest.config.ItestConfiguration.PRODUCT_AANVRAAG_TYPE
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
@@ -26,184 +25,184 @@ fun createZaakAfhandelParameters() {
         url = "$ZAC_API_URI/zaakafhandelParameters",
         headers = mapOf(
             "Content-Type" to "application/json",
-            "Authorization" to "Bearer ${ProjectConfig.keycloakClient.requestAccessToken()}"
+            "Authorization" to "Bearer ${KeycloakClient.requestAccessToken()}"
         ),
         data = "{\n" +
-                "  \"humanTaskParameters\": [\n" +
-                "    {\n" +
-                "      \"planItemDefinition\": {\n" +
-                "        \"defaultFormulierDefinitie\": \"AANVULLENDE_INFORMATIE\",\n" +
-                "        \"id\": \"AANVULLENDE_INFORMATIE\",\n" +
-                "        \"naam\": \"Aanvullende informatie\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      \"defaultGroepId\": null,\n" +
-                "      \"formulierDefinitieId\": \"AANVULLENDE_INFORMATIE\",\n" +
-                "      \"referentieTabellen\": [],\n" +
-                "      \"actief\": true,\n" +
-                "      \"doorlooptijd\": null\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"planItemDefinition\": {\n" +
-                "        \"defaultFormulierDefinitie\": \"GOEDKEUREN\",\n" +
-                "        \"id\": \"GOEDKEUREN\",\n" +
-                "        \"naam\": \"Goedkeuren\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      \"defaultGroepId\": null,\n" +
-                "      \"formulierDefinitieId\": \"GOEDKEUREN\",\n" +
-                "      \"referentieTabellen\": [],\n" +
-                "      \"actief\": true,\n" +
-                "      \"doorlooptijd\": null\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"planItemDefinition\": {\n" +
-                "        \"defaultFormulierDefinitie\": \"ADVIES\",\n" +
-                "        \"id\": \"ADVIES_INTERN\",\n" +
-                "        \"naam\": \"Advies intern\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      \"defaultGroepId\": null,\n" +
-                "      \"formulierDefinitieId\": \"ADVIES\",\n" +
-                "      \"referentieTabellen\": [\n" +
-                "        {\n" +
-                "          \"veld\": \"ADVIES\",\n" +
-                "          \"tabel\": {\n" +
-                "            \"aantalWaarden\": 5,\n" +
-                "            \"code\": \"ADVIES\",\n" +
-                "            \"id\": 1,\n" +
-                "            \"naam\": \"Advies\",\n" +
-                "            \"systeem\": true\n" +
-                "          }\n" +
-                "        }\n" +
-                "      ],\n" +
-                "      \"actief\": true,\n" +
-                "      \"doorlooptijd\": null\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"planItemDefinition\": {\n" +
-                "        \"defaultFormulierDefinitie\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
-                "        \"id\": \"ADVIES_EXTERN\",\n" +
-                "        \"naam\": \"Advies extern\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      \"defaultGroepId\": null,\n" +
-                "      \"formulierDefinitieId\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
-                "      \"referentieTabellen\": [],\n" +
-                "      \"actief\": true,\n" +
-                "      \"doorlooptijd\": null\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"planItemDefinition\": {\n" +
-                "        \"defaultFormulierDefinitie\": \"DOCUMENT_VERZENDEN_POST\",\n" +
-                "        \"id\": \"DOCUMENT_VERZENDEN_POST\",\n" +
-                "        \"naam\": \"Document verzenden\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      \"defaultGroepId\": null,\n" +
-                "      \"formulierDefinitieId\": \"DOCUMENT_VERZENDEN_POST\",\n" +
-                "      \"referentieTabellen\": [],\n" +
-                "      \"actief\": true,\n" +
-                "      \"doorlooptijd\": null\n" +
-                "    }\n" +
-                "  ],\n" +
-                "  \"mailtemplateKoppelingen\": [],\n" +
-                "  \"userEventListenerParameters\": [\n" +
-                "    {\n" +
-                "      \"id\": \"INTAKE_AFRONDEN\",\n" +
-                "      \"naam\": \"Intake afronden\",\n" +
-                "      \"toelichting\": null\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"id\": \"ZAAK_AFHANDELEN\",\n" +
-                "      \"naam\": \"Zaak afhandelen\",\n" +
-                "      \"toelichting\": null\n" +
-                "    }\n" +
-                "  ],\n" +
-                "  \"valide\": false,\n" +
-                "  \"zaakAfzenders\": [],\n" +
-                "  \"zaakbeeindigParameters\": [],\n" +
-                "  \"zaaktype\": {\n" +
-                "    \"beginGeldigheid\": \"2023-09-21\",\n" +
-                "    \"doel\": \"Melding evenement organiseren behandelen\",\n" +
-                "    \"identificatie\": \"$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE\",\n" +
-                "    \"nuGeldig\": true,\n" +
-                "    \"omschrijving\": \"Melding evenement organiseren behandelen\",\n" +
-                "    \"servicenorm\": false,\n" +
-                "    \"uuid\": \"448356ff-dcfb-4504-9501-7fe929077c4f\",\n" +
-                "    \"versiedatum\": \"2023-09-21\",\n" +
-                "    \"vertrouwelijkheidaanduiding\": \"openbaar\"\n" +
-                "  },\n" +
-                "  \"intakeMail\": \"BESCHIKBAAR_UIT\",\n" +
-                "  \"afrondenMail\": \"BESCHIKBAAR_UIT\",\n" +
-                "  \"caseDefinition\": {\n" +
-                "    \"humanTaskDefinitions\": [\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"AANVULLENDE_INFORMATIE\",\n" +
-                "        \"id\": \"AANVULLENDE_INFORMATIE\",\n" +
-                "        \"naam\": \"Aanvullende informatie\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"GOEDKEUREN\",\n" +
-                "        \"id\": \"GOEDKEUREN\",\n" +
-                "        \"naam\": \"Goedkeuren\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"ADVIES\",\n" +
-                "        \"id\": \"ADVIES_INTERN\",\n" +
-                "        \"naam\": \"Advies intern\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
-                "        \"id\": \"ADVIES_EXTERN\",\n" +
-                "        \"naam\": \"Advies extern\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"DOCUMENT_VERZENDEN_POST\",\n" +
-                "        \"id\": \"DOCUMENT_VERZENDEN_POST\",\n" +
-                "        \"naam\": \"Document verzenden\",\n" +
-                "        \"type\": \"HUMAN_TASK\"\n" +
-                "      }\n" +
-                "    ],\n" +
-                "    \"key\": \"melding-klein-evenement\",\n" +
-                "    \"naam\": \"Melding klein evenement\",\n" +
-                "    \"userEventListenerDefinitions\": [\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"DEFAULT_TAAKFORMULIER\",\n" +
-                "        \"id\": \"INTAKE_AFRONDEN\",\n" +
-                "        \"naam\": \"Intake afronden\",\n" +
-                "        \"type\": \"USER_EVENT_LISTENER\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"defaultFormulierDefinitie\": \"DEFAULT_TAAKFORMULIER\",\n" +
-                "        \"id\": \"ZAAK_AFHANDELEN\",\n" +
-                "        \"naam\": \"Zaak afhandelen\",\n" +
-                "        \"type\": \"USER_EVENT_LISTENER\"\n" +
-                "      }\n" +
-                "    ]\n" +
-                "  },\n" +
-                "  \"domein\": null,\n" +
-                "  \"defaultGroepId\": \"test-group-a\",\n" +
-                "  \"defaultBehandelaarId\": null,\n" +
-                "  \"einddatumGeplandWaarschuwing\": null,\n" +
-                "  \"uiterlijkeEinddatumAfdoeningWaarschuwing\": null,\n" +
-                "  \"productaanvraagtype\": \"$PRODUCT_AANVRAAG_TYPE\",\n" +
-                "  \"zaakNietOntvankelijkResultaattype\": {\n" +
-                "    \"archiefNominatie\": \"VERNIETIGEN\",\n" +
-                "    \"archiefTermijn\": \"5 jaren\",\n" +
-                "    \"besluitVerplicht\": false,\n" +
-                "    \"id\": \"dd2bcd87-ed7e-4b23-a8e3-ea7fe7ef00c6\",\n" +
-                "    \"naam\": \"Geweigerd\",\n" +
-                "    \"naamGeneriek\": \"Geweigerd\",\n" +
-                "    \"toelichting\": \"Het door het orgaan behandelen van een aanvraag, melding of verzoek om " +
-                "toestemming voor het doen of laten van een derde waar het orgaan bevoegd is om over te beslissen\",\n" +
-                "    \"vervaldatumBesluitVerplicht\": false\n" +
-                "  }\n" +
-                "}\n"
+            "  \"humanTaskParameters\": [\n" +
+            "    {\n" +
+            "      \"planItemDefinition\": {\n" +
+            "        \"defaultFormulierDefinitie\": \"AANVULLENDE_INFORMATIE\",\n" +
+            "        \"id\": \"AANVULLENDE_INFORMATIE\",\n" +
+            "        \"naam\": \"Aanvullende informatie\",\n" +
+            "        \"type\": \"HUMAN_TASK\"\n" +
+            "      },\n" +
+            "      \"defaultGroepId\": null,\n" +
+            "      \"formulierDefinitieId\": \"AANVULLENDE_INFORMATIE\",\n" +
+            "      \"referentieTabellen\": [],\n" +
+            "      \"actief\": true,\n" +
+            "      \"doorlooptijd\": null\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"planItemDefinition\": {\n" +
+            "        \"defaultFormulierDefinitie\": \"GOEDKEUREN\",\n" +
+            "        \"id\": \"GOEDKEUREN\",\n" +
+            "        \"naam\": \"Goedkeuren\",\n" +
+            "        \"type\": \"HUMAN_TASK\"\n" +
+            "      },\n" +
+            "      \"defaultGroepId\": null,\n" +
+            "      \"formulierDefinitieId\": \"GOEDKEUREN\",\n" +
+            "      \"referentieTabellen\": [],\n" +
+            "      \"actief\": true,\n" +
+            "      \"doorlooptijd\": null\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"planItemDefinition\": {\n" +
+            "        \"defaultFormulierDefinitie\": \"ADVIES\",\n" +
+            "        \"id\": \"ADVIES_INTERN\",\n" +
+            "        \"naam\": \"Advies intern\",\n" +
+            "        \"type\": \"HUMAN_TASK\"\n" +
+            "      },\n" +
+            "      \"defaultGroepId\": null,\n" +
+            "      \"formulierDefinitieId\": \"ADVIES\",\n" +
+            "      \"referentieTabellen\": [\n" +
+            "        {\n" +
+            "          \"veld\": \"ADVIES\",\n" +
+            "          \"tabel\": {\n" +
+            "            \"aantalWaarden\": 5,\n" +
+            "            \"code\": \"ADVIES\",\n" +
+            "            \"id\": 1,\n" +
+            "            \"naam\": \"Advies\",\n" +
+            "            \"systeem\": true\n" +
+            "          }\n" +
+            "        }\n" +
+            "      ],\n" +
+            "      \"actief\": true,\n" +
+            "      \"doorlooptijd\": null\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"planItemDefinition\": {\n" +
+            "        \"defaultFormulierDefinitie\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
+            "        \"id\": \"ADVIES_EXTERN\",\n" +
+            "        \"naam\": \"Advies extern\",\n" +
+            "        \"type\": \"HUMAN_TASK\"\n" +
+            "      },\n" +
+            "      \"defaultGroepId\": null,\n" +
+            "      \"formulierDefinitieId\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
+            "      \"referentieTabellen\": [],\n" +
+            "      \"actief\": true,\n" +
+            "      \"doorlooptijd\": null\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"planItemDefinition\": {\n" +
+            "        \"defaultFormulierDefinitie\": \"DOCUMENT_VERZENDEN_POST\",\n" +
+            "        \"id\": \"DOCUMENT_VERZENDEN_POST\",\n" +
+            "        \"naam\": \"Document verzenden\",\n" +
+            "        \"type\": \"HUMAN_TASK\"\n" +
+            "      },\n" +
+            "      \"defaultGroepId\": null,\n" +
+            "      \"formulierDefinitieId\": \"DOCUMENT_VERZENDEN_POST\",\n" +
+            "      \"referentieTabellen\": [],\n" +
+            "      \"actief\": true,\n" +
+            "      \"doorlooptijd\": null\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"mailtemplateKoppelingen\": [],\n" +
+            "  \"userEventListenerParameters\": [\n" +
+            "    {\n" +
+            "      \"id\": \"INTAKE_AFRONDEN\",\n" +
+            "      \"naam\": \"Intake afronden\",\n" +
+            "      \"toelichting\": null\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"id\": \"ZAAK_AFHANDELEN\",\n" +
+            "      \"naam\": \"Zaak afhandelen\",\n" +
+            "      \"toelichting\": null\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"valide\": false,\n" +
+            "  \"zaakAfzenders\": [],\n" +
+            "  \"zaakbeeindigParameters\": [],\n" +
+            "  \"zaaktype\": {\n" +
+            "    \"beginGeldigheid\": \"2023-09-21\",\n" +
+            "    \"doel\": \"Melding evenement organiseren behandelen\",\n" +
+            "    \"identificatie\": \"$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE\",\n" +
+            "    \"nuGeldig\": true,\n" +
+            "    \"omschrijving\": \"Melding evenement organiseren behandelen\",\n" +
+            "    \"servicenorm\": false,\n" +
+            "    \"uuid\": \"448356ff-dcfb-4504-9501-7fe929077c4f\",\n" +
+            "    \"versiedatum\": \"2023-09-21\",\n" +
+            "    \"vertrouwelijkheidaanduiding\": \"openbaar\"\n" +
+            "  },\n" +
+            "  \"intakeMail\": \"BESCHIKBAAR_UIT\",\n" +
+            "  \"afrondenMail\": \"BESCHIKBAAR_UIT\",\n" +
+            "  \"caseDefinition\": {\n" +
+            "    \"humanTaskDefinitions\": [\n" +
+            "      {\n" +
+            "        \"defaultFormulierDefinitie\": \"AANVULLENDE_INFORMATIE\",\n" +
+            "        \"id\": \"AANVULLENDE_INFORMATIE\",\n" +
+            "        \"naam\": \"Aanvullende informatie\",\n" +
+            "        \"type\": \"HUMAN_TASK\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"defaultFormulierDefinitie\": \"GOEDKEUREN\",\n" +
+            "        \"id\": \"GOEDKEUREN\",\n" +
+            "        \"naam\": \"Goedkeuren\",\n" +
+            "        \"type\": \"HUMAN_TASK\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"defaultFormulierDefinitie\": \"ADVIES\",\n" +
+            "        \"id\": \"ADVIES_INTERN\",\n" +
+            "        \"naam\": \"Advies intern\",\n" +
+            "        \"type\": \"HUMAN_TASK\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"defaultFormulierDefinitie\": \"EXTERN_ADVIES_VASTLEGGEN\",\n" +
+            "        \"id\": \"ADVIES_EXTERN\",\n" +
+            "        \"naam\": \"Advies extern\",\n" +
+            "        \"type\": \"HUMAN_TASK\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"defaultFormulierDefinitie\": \"DOCUMENT_VERZENDEN_POST\",\n" +
+            "        \"id\": \"DOCUMENT_VERZENDEN_POST\",\n" +
+            "        \"naam\": \"Document verzenden\",\n" +
+            "        \"type\": \"HUMAN_TASK\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"key\": \"melding-klein-evenement\",\n" +
+            "    \"naam\": \"Melding klein evenement\",\n" +
+            "    \"userEventListenerDefinitions\": [\n" +
+            "      {\n" +
+            "        \"defaultFormulierDefinitie\": \"DEFAULT_TAAKFORMULIER\",\n" +
+            "        \"id\": \"INTAKE_AFRONDEN\",\n" +
+            "        \"naam\": \"Intake afronden\",\n" +
+            "        \"type\": \"USER_EVENT_LISTENER\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"defaultFormulierDefinitie\": \"DEFAULT_TAAKFORMULIER\",\n" +
+            "        \"id\": \"ZAAK_AFHANDELEN\",\n" +
+            "        \"naam\": \"Zaak afhandelen\",\n" +
+            "        \"type\": \"USER_EVENT_LISTENER\"\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"domein\": null,\n" +
+            "  \"defaultGroepId\": \"test-group-a\",\n" +
+            "  \"defaultBehandelaarId\": null,\n" +
+            "  \"einddatumGeplandWaarschuwing\": null,\n" +
+            "  \"uiterlijkeEinddatumAfdoeningWaarschuwing\": null,\n" +
+            "  \"productaanvraagtype\": \"$PRODUCT_AANVRAAG_TYPE\",\n" +
+            "  \"zaakNietOntvankelijkResultaattype\": {\n" +
+            "    \"archiefNominatie\": \"VERNIETIGEN\",\n" +
+            "    \"archiefTermijn\": \"5 jaren\",\n" +
+            "    \"besluitVerplicht\": false,\n" +
+            "    \"id\": \"dd2bcd87-ed7e-4b23-a8e3-ea7fe7ef00c6\",\n" +
+            "    \"naam\": \"Geweigerd\",\n" +
+            "    \"naamGeneriek\": \"Geweigerd\",\n" +
+            "    \"toelichting\": \"Het door het orgaan behandelen van een aanvraag, melding of verzoek om " +
+            "toestemming voor het doen of laten van een derde waar het orgaan bevoegd is om over te beslissen\",\n" +
+            "    \"vervaldatumBesluitVerplicht\": false\n" +
+            "  }\n" +
+            "}\n"
     ).apply {
         logger.info { "PUT zaakafhandelParameters response: $text" }
         // check contents

--- a/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
@@ -8,29 +8,27 @@ package nl.lifely.zac.itest.client
 import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.matchers.shouldBe
+import io.kotest.provided.ProjectConfig
 import nl.lifely.zac.itest.config.ItestConfiguration.PRODUCT_AANVRAAG_TYPE
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
+import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
 
 private val logger = KotlinLogging.logger {}
 
-class ZacClient(
-    private val zacApiUri: String,
-    private val accessToken: String
-) {
-    @Suppress("LongMethod")
-    fun createZaakAfhandelParameters() {
-        logger.info {
-            "Creating zaakafhandelparameters in ZAC for zaaktype with UUID: $ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID"
-        }
+@Suppress("LongMethod")
+fun createZaakAfhandelParameters() {
+    logger.info {
+        "Creating zaakafhandelparameters in ZAC for zaaktype with UUID: $ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID"
+    }
 
-        khttp.put(
-            url = "$zacApiUri/zaakafhandelParameters",
-            headers = mapOf(
-                "Content-Type" to "application/json",
-                "Authorization" to "Bearer $accessToken"
-            ),
-            data = "{\n" +
+    khttp.put(
+        url = "$ZAC_API_URI/zaakafhandelParameters",
+        headers = mapOf(
+            "Content-Type" to "application/json",
+            "Authorization" to "Bearer ${ProjectConfig.keycloakClient.requestAccessToken()}"
+        ),
+        data = "{\n" +
                 "  \"humanTaskParameters\": [\n" +
                 "    {\n" +
                 "      \"planItemDefinition\": {\n" +
@@ -206,10 +204,9 @@ class ZacClient(
                 "    \"vervaldatumBesluitVerplicht\": false\n" +
                 "  }\n" +
                 "}\n"
-        ).apply {
-            logger.info { "PUT zaakafhandelParameters response: $text" }
-            // check contents
-            statusCode shouldBe HttpStatus.SC_OK
-        }
+    ).apply {
+        logger.info { "PUT zaakafhandelParameters response: $text" }
+        // check contents
+        statusCode shouldBe HttpStatus.SC_OK
     }
 }


### PR DESCRIPTION
In our integration tests always request a new access token from Keycloak using the refresh token to make sure the access token does not expire.

Solves PZ-692