### PR TITLE
fix: Open Zaak client secret in Docker Compose file is incorrect

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -367,7 +367,7 @@ services:
       - BRP_API_KEY=dummyKey # not used when using the BRP proxy
       - CONTACTMOMENTEN_API_CLIENT_MP_REST_URL=http://openklant:8000/contactmomenten
       - CONTACTMOMENTEN_API_CLIENTID=zac_client
-      - CONTACTMOMENTEN_API_SECRET=openklantZaakhandelcomponentClientSecret
+      - CONTACTMOMENTEN_API_SECRET=openklantZaakafhandelcomponentClientSecret
       - CONTEXT_URL=http://localhost:8080
       - DB_HOST=zac-database
       - DB_NAME=zac
@@ -378,7 +378,7 @@ services:
       - GEMEENTE_NAAM=${GEMEENTE_NAAM:-DummyZacGemeente}
       - KLANTEN_API_CLIENT_MP_REST_URL=http://openklant:8000/klanten
       - KLANTEN_API_CLIENTID=zac_client
-      - KLANTEN_API_SECRET=openklantZaakhandelcomponentClientSecret
+      - KLANTEN_API_SECRET=openklantZaakafhandelcomponentClientSecret
       - KVK_API_CLIENT_MP_REST_URL=${KVK_API_CLIENT_MP_REST_URL:-dummyKvkApiUrl}
       - KVK_API_KEY=${KVK_API_KEY:-dummyKvkApiKey}
       - LDAP_DN="ou=people,dc=example,dc=org"


### PR DESCRIPTION
Fixed Open Zaak client secret in Docker Compose file.

Solves PZ-800.