### PR TITLE
fix: fix crash of WildFly in IntelliJ when debug logging is enabled in WildFly

### DIFF
--- a/startupwithenv.sh
+++ b/startupwithenv.sh
@@ -8,4 +8,8 @@
 # Uses the 1Password CLI tools to set up the environment variables for running ZAC in IntelliJ.
 # Please see docs/development/INSTALL.md for details on how to use this script.
 
-op run --env-file="./.env.tpl" -- ./wildfly-30.0.0.Final/bin/standalone.sh
+# Note that we do not use masking as this does not work well in our context and will result in
+# crashes of WildFly/ZAC when running in IntelliJ when you have configured DEBUG logging in WildFly
+# with errors such as: "fatal error: concurrent map read and map write goroutine 2013 [running]:
+# go.1password.io/op/op-cli/command/subprocess/masking.matches.add(...)"
+op run --env-file="./.env.tpl" --no-masking -- ./wildfly-30.0.0.Final/bin/standalone.sh


### PR DESCRIPTION
Fixed crashing of WildFly when debug logging was enabled by disabling masking in the 1Password CLI tool which we use to run WildFly in IntelliJ. Also see: https://developer.1password.com/docs/cli/reference/commands/run

Solves PZ-847
