### PR TITLE
feat: send objectinformatietype to Smartdocuments 

### DIFF
--- a/src/main/java/net/atos/client/zgw/ztc/model/Informatieobjecttype.java
+++ b/src/main/java/net/atos/client/zgw/ztc/model/Informatieobjecttype.java
@@ -69,8 +69,12 @@ public class Informatieobjecttype {
     /**
      * Constructor with required attributes for POST and PUT requests
      */
-    public Informatieobjecttype(final URI catalogus, final String omschrijving, final Vertrouwelijkheidaanduiding vertrouwelijkheidaanduiding,
-            final LocalDate beginGeldigheid) {
+    public Informatieobjecttype(
+            final URI catalogus,
+            final String omschrijving,
+            final Vertrouwelijkheidaanduiding vertrouwelijkheidaanduiding,
+            final LocalDate beginGeldigheid)
+    {
         this.catalogus = catalogus;
         this.omschrijving = omschrijving;
         this.vertrouwelijkheidaanduiding = vertrouwelijkheidaanduiding;
@@ -78,11 +82,13 @@ public class Informatieobjecttype {
     }
 
     /**
-     * Constructor with readOnly attribures for GET response
+     * Constructor with readOnly attributes for GET response
      */
     @JsonbCreator
-    public Informatieobjecttype(@JsonbProperty("url") final URI url,
-            @JsonbProperty("concept") final Boolean concept) {
+    public Informatieobjecttype(
+            @JsonbProperty("url") final URI url,
+            @JsonbProperty("concept") final Boolean concept
+    ) {
         this.url = url;
         this.concept = concept;
     }

--- a/src/main/java/net/atos/zac/configuratie/ConfiguratieService.java
+++ b/src/main/java/net/atos/zac/configuratie/ConfiguratieService.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -21,9 +23,6 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.core.UriBuilder;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 import net.atos.client.zgw.ztc.ZTCClientService;
 import net.atos.client.zgw.ztc.model.CatalogusListParameters;
 import net.atos.zac.configuratie.model.Taal;
@@ -101,6 +100,8 @@ public class ConfiguratieService {
     public static final String COMMUNICATIEKANAAL_EFORMULIER = "E-formulier";
 
     public static final String INFORMATIEOBJECTTYPE_OMSCHRIJVING_EMAIL = "e-mail";
+
+    public static final String INFORMATIEOBJECTTYPE_OMSCHRIJVING_BIJLAGE = "bijlage";
 
     // Base URL of the zaakafhandelcomponent: protocol, host, port and context (no trailing slash)
     @Inject

--- a/src/main/java/net/atos/zac/documentcreatie/DocumentCreatieService.java
+++ b/src/main/java/net/atos/zac/documentcreatie/DocumentCreatieService.java
@@ -12,14 +12,13 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.logging.Logger;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.UriBuilder;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.rest.client.inject.RestClient;
-
 import net.atos.client.sd.SmartDocumentsClient;
 import net.atos.client.sd.exception.BadRequestException;
 import net.atos.client.sd.model.Selection;
@@ -106,6 +105,7 @@ public class DocumentCreatieService {
         registratie.bronorganisatie = BRON_ORGANISATIE;
         registratie.zaak = zrcClientService.createUrlExternToZaak(documentCreatieGegevens.getZaak().getUuid());
         registratie.informatieobjectStatus = documentCreatieGegevens.getInformatieobjectStatus();
+        registratie.informatieobjectType = documentCreatieGegevens.getInformatieobjecttype().getUrl();
         registratie.creatiedatum = LocalDate.now();
         registratie.auditToelichting = AUDIT_TOELICHTING;
         return registratie;

--- a/src/main/java/net/atos/zac/documentcreatie/model/DocumentCreatieGegevens.java
+++ b/src/main/java/net/atos/zac/documentcreatie/model/DocumentCreatieGegevens.java
@@ -7,6 +7,7 @@ package net.atos.zac.documentcreatie.model;
 
 import net.atos.client.zgw.drc.model.InformatieobjectStatus;
 import net.atos.client.zgw.zrc.model.Zaak;
+import net.atos.client.zgw.ztc.model.Informatieobjecttype;
 
 public class DocumentCreatieGegevens {
 
@@ -16,9 +17,16 @@ public class DocumentCreatieGegevens {
 
     private InformatieobjectStatus informatieobjectStatus = InformatieobjectStatus.TER_VASTSTELLING;
 
-    public DocumentCreatieGegevens(final Zaak zaak, final String taskId) {
+    private Informatieobjecttype informatieobjecttype;
+
+    public DocumentCreatieGegevens(
+            final Zaak zaak,
+            final String taskId,
+            final Informatieobjecttype informatieobjecttype
+    ) {
         this.zaak = zaak;
         this.taskId = taskId;
+        this.informatieobjecttype = informatieobjecttype;
     }
 
     public Zaak getZaak() {
@@ -28,6 +36,8 @@ public class DocumentCreatieGegevens {
     public InformatieobjectStatus getInformatieobjectStatus() {
         return informatieobjectStatus;
     }
+
+    public Informatieobjecttype getInformatieobjecttype() { return informatieobjecttype; }
 
     public String getTaskId() {
         return taskId;

--- a/src/main/java/net/atos/zac/documentcreatie/model/Registratie.java
+++ b/src/main/java/net/atos/zac/documentcreatie/model/Registratie.java
@@ -16,6 +16,8 @@ public class Registratie {
 
     public InformatieobjectStatus informatieobjectStatus;
 
+    public URI informatieobjectType;
+
     public String bronorganisatie;
 
     public LocalDate creatiedatum;

--- a/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
@@ -37,7 +37,7 @@ fun createRolNatuurlijkPersoon(
     natuurlijkPersoon
 )
 
-fun createZaak(zaaktypeURI: URI = URI("http://example.com/${UUID.randomUUID()}}")) =
+fun createZaak(zaaktypeURI: URI = URI("http://example.com/${UUID.randomUUID()}")) =
     Zaak(
         zaaktypeURI,
         LocalDate.now(),

--- a/src/test/kotlin/net/atos/client/zgw/ztc/model/ZtcFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/ztc/model/ZtcFixtures.kt
@@ -1,7 +1,9 @@
 package net.atos.client.zgw.ztc.model
 
+import net.atos.client.zgw.shared.model.Vertrouwelijkheidaanduiding
 import java.net.URI
-import java.util.*
+import java.time.LocalDate
+import java.util.UUID
 
 fun createRolType(
     zaakTypeURI: URI = URI("http://example.com/${UUID.randomUUID()}"),
@@ -21,4 +23,16 @@ fun createZaakType() = Zaaktype(
     setOf(URI("dummyInformatieObjectType1"), URI("dummyInformatieObjectType2")),
     setOf(URI("dummyRolType1"), URI("dummyRolType2")),
     false
+)
+
+fun createInformatieObjectType(
+    catalogusURI: URI = URI("http://example.com/catalogus/${UUID.randomUUID()}"),
+    omschrijving: String = "dummyOmschrijving",
+    vertrouwelijkheidaanduiding: Vertrouwelijkheidaanduiding = Vertrouwelijkheidaanduiding.OPENBAAR,
+    beginGeldigheid: LocalDate = LocalDate.now()
+) = Informatieobjecttype(
+    catalogusURI,
+    omschrijving,
+    vertrouwelijkheidaanduiding,
+    beginGeldigheid
 )

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/InformatieObjectenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/InformatieObjectenRESTServiceTest.kt
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+package net.atos.zac.app.informatieobjecten
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.test.TestCase
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.mockk
+import io.mockk.slot
+import net.atos.client.zgw.zrc.ZRCClientService
+import net.atos.client.zgw.zrc.model.createZaak
+import net.atos.client.zgw.ztc.ZTCClientService
+import net.atos.client.zgw.ztc.model.createInformatieObjectType
+import net.atos.zac.app.informatieobjecten.model.RESTDocumentCreatieGegevens
+import net.atos.zac.documentcreatie.DocumentCreatieService
+import net.atos.zac.documentcreatie.model.DocumentCreatieGegevens
+import net.atos.zac.documentcreatie.model.createDocumentCreatieResponse
+import net.atos.zac.policy.PolicyService
+import net.atos.zac.policy.output.ZaakRechten
+
+class InformatieObjectenRESTServiceTest : BehaviorSpec() {
+    val documentCreatieService = mockk<DocumentCreatieService>()
+    val policyService = mockk<PolicyService>()
+    val zrcClientService = mockk<ZRCClientService>()
+    val ztcClientService = mockk<ZTCClientService>()
+
+    // We have to use @InjectMockKs since the class under test uses field injection instead of constructor injection.
+    // This is because WildFly does not support constructor injection for JAX-RS REST services completely.
+    @InjectMockKs
+    lateinit var informatieObjectenRESTService: InformatieObjectenRESTService
+
+    override suspend fun beforeTest(testCase: TestCase) {
+        MockKAnnotations.init(this)
+    }
+
+    init {
+        given("document creation data is provided and zaaktype can use the 'bijlage' informatieobjecttype") {
+            When("createDocument is called") {
+                then("the document creation service is called to create the document") {
+                    val zaak = createZaak()
+                    val zaakRechten =
+                        ZaakRechten(false, true, false, false, false, false, false, false)
+                    val restDocumentCreatieGegevens = RESTDocumentCreatieGegevens().apply {
+                        zaakUUID = zaak.uuid
+                        taskId = "dummyTaskId"
+                    }
+                    val documentCreatieResponse = createDocumentCreatieResponse()
+                    val documentCreatieGegevens = slot<DocumentCreatieGegevens>()
+
+                    every { zrcClientService.readZaak(zaak.uuid) } returns zaak
+                    every { policyService.readZaakRechten(zaak) } returns zaakRechten
+                    every { ztcClientService.readInformatieobjecttypen(zaak.zaaktype) } returns listOf(
+                        createInformatieObjectType(omschrijving = "bijlage")
+                    )
+                    every {
+                        documentCreatieService.creeerDocumentAttendedSD(capture(documentCreatieGegevens))
+                    } returns documentCreatieResponse
+
+                    val restDocumentCreatieResponse =
+                        informatieObjectenRESTService.createDocument(restDocumentCreatieGegevens)
+
+                    restDocumentCreatieResponse.message shouldBe null
+                    restDocumentCreatieResponse.redirectURL shouldBe documentCreatieResponse.redirectUrl
+                    with(documentCreatieGegevens.captured) {
+                        this.zaak shouldBe zaak
+                        this.taskId shouldBe restDocumentCreatieGegevens.taskId
+                        this.informatieobjecttype.omschrijving shouldBe "bijlage"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/net/atos/zac/authentication/UserPrincipalFilterTest.kt
+++ b/src/test/kotlin/net/atos/zac/authentication/UserPrincipalFilterTest.kt
@@ -112,13 +112,13 @@ class UserPrincipalFilterTest : BehaviorSpec({
                     httpSession.setAttribute("logged-in-user", capture(loggedInUserSlot))
                 }
                 with(loggedInUserSlot.captured) {
-                    id shouldBe userName
-                    firstName shouldBe givenName
-                    lastName shouldBe familyName
-                    fullName shouldBe fullName
-                    email shouldBe email
-                    roles shouldContainAll roles
-                    groupIds shouldContainAll groups
+                    this.id shouldBe userName
+                    this.firstName shouldBe givenName
+                    this.lastName shouldBe familyName
+                    this.fullName shouldBe fullName
+                    this.email shouldBe email
+                    this.roles shouldContainAll roles
+                    this.groupIds shouldContainAll groups
                 }
             }
         }

--- a/src/test/kotlin/net/atos/zac/documentcreatie/model/DocumentCreatieFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/documentcreatie/model/DocumentCreatieFixtures.kt
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+package net.atos.zac.documentcreatie.model
+
+import java.net.URI
+
+fun createDocumentCreatieResponse(
+    redirectURI: URI = URI.create("http://example.com/dummyRedirectURI")
+) = DocumentCreatieResponse(
+    redirectURI
+)


### PR DESCRIPTION
Send objectinformatietype to Smartdocuments when creating a new document because without this Smartdocuments cannot create the document in Open Zaak.

Solves PZ-856