### PR TITLE
fix: make informatieobjecttype field for Smartdocuments lowercase

### DIFF
--- a/src/main/java/net/atos/zac/documentcreatie/DocumentCreatieService.java
+++ b/src/main/java/net/atos/zac/documentcreatie/DocumentCreatieService.java
@@ -12,13 +12,14 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.rest.client.inject.RestClient;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.UriBuilder;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
 import net.atos.client.sd.SmartDocumentsClient;
 import net.atos.client.sd.exception.BadRequestException;
 import net.atos.client.sd.model.Selection;
@@ -105,7 +106,7 @@ public class DocumentCreatieService {
         registratie.bronorganisatie = BRON_ORGANISATIE;
         registratie.zaak = zrcClientService.createUrlExternToZaak(documentCreatieGegevens.getZaak().getUuid());
         registratie.informatieobjectStatus = documentCreatieGegevens.getInformatieobjectStatus();
-        registratie.informatieobjectType = documentCreatieGegevens.getInformatieobjecttype().getUrl();
+        registratie.informatieobjecttype = documentCreatieGegevens.getInformatieobjecttype().getUrl();
         registratie.creatiedatum = LocalDate.now();
         registratie.auditToelichting = AUDIT_TOELICHTING;
         return registratie;

--- a/src/main/java/net/atos/zac/documentcreatie/model/Registratie.java
+++ b/src/main/java/net/atos/zac/documentcreatie/model/Registratie.java
@@ -16,7 +16,7 @@ public class Registratie {
 
     public InformatieobjectStatus informatieobjectStatus;
 
-    public URI informatieobjectType;
+    public URI informatieobjecttype;
 
     public String bronorganisatie;
 


### PR DESCRIPTION
Make informatieobjecttype field for Smartdocuments create document request lowercase because Smartdocuments expects this.

Solves PZ-863