### PR TITLE
fix: fix zac http client not dealing with pathParams

### DIFF
--- a/src/main/app/src/app/identity/identity.service.ts
+++ b/src/main/app/src/app/identity/identity.service.ts
@@ -36,7 +36,7 @@ export class IdentityService {
   listUsersInGroup(groupId: string): Observable<User[]> {
     return this.zacHttp
       .GET("/rest/identity/groups/{groupId}/users", {
-        params: { path: { groupId } },
+        pathParams: { path: { groupId } },
       })
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),

--- a/src/main/app/src/app/shared/http/zac-http-client.ts
+++ b/src/main/app/src/app/shared/http/zac-http-client.ts
@@ -33,26 +33,6 @@ type Response<
     : never
 >["data"];
 
-function replacePathParams(
-  urlTemplate: string,
-  pathParams: Record<string, string | number | boolean>,
-): string {
-  let url = urlTemplate;
-  Object.keys(pathParams).forEach((key) => {
-    url = url.replace(new RegExp(`{${key}}`, "g"), pathParams[key].toString());
-  });
-  return url;
-}
-
-function prepareUrl(url: string, init?: any) {
-  const pathParams = init?.pathParams;
-  let newUrl = url as string;
-  if (pathParams && "path" in pathParams) {
-    newUrl = replacePathParams(url, pathParams.path);
-  }
-  return newUrl;
-}
-
 @Injectable({
   providedIn: "root",
 })
@@ -66,7 +46,10 @@ export class ZacHttpClient {
     },
   ) {
     const { pathParams, ...restInit } = { pathParams: {}, ...init };
-    return this.http.get<Response<P, "get">>(prepareUrl(url, init), restInit);
+    return this.http.get<Response<P, "get">>(
+      this.prepareUrl(url, init),
+      restInit,
+    );
   }
 
   public POST<P extends PathsWithMethod<Paths, "post">>(
@@ -78,7 +61,7 @@ export class ZacHttpClient {
   ) {
     const { pathParams, ...restInit } = { pathParams: {}, ...init };
     return this.http.post<Response<P, "post">>(
-      prepareUrl(url, init),
+      this.prepareUrl(url, init),
       body,
       init,
     );
@@ -93,7 +76,7 @@ export class ZacHttpClient {
   ) {
     const { pathParams, ...restInit } = { pathParams: {}, ...init };
     return this.http.put<Response<P, "put">>(
-      prepareUrl(url, init),
+      this.prepareUrl(url, init),
       body,
       restInit,
     );
@@ -107,7 +90,7 @@ export class ZacHttpClient {
   ) {
     const { pathParams, ...restInit } = { pathParams: {}, ...init };
     return this.http.delete<Response<P, "delete">>(
-      prepareUrl(url, restInit),
+      this.prepareUrl(url, restInit),
       restInit,
     );
   }
@@ -121,9 +104,32 @@ export class ZacHttpClient {
   ) {
     const { pathParams, ...restInit } = { pathParams: {}, ...init };
     return this.http.patch<Response<P, "patch">>(
-      prepareUrl(url, init),
+      this.prepareUrl(url, init),
       body,
       restInit,
     );
+  }
+
+  private replacePathParams(
+    urlTemplate: string,
+    pathParams: Record<string, string | number | boolean>,
+  ): string {
+    let url = urlTemplate;
+    Object.keys(pathParams).forEach((key) => {
+      url = url.replace(
+        new RegExp(`{${key}}`, "g"),
+        pathParams[key].toString(),
+      );
+    });
+    return url;
+  }
+
+  private prepareUrl(url: string, init?: any) {
+    const pathParams = init?.pathParams;
+    let newUrl = url as string;
+    if (pathParams && "path" in pathParams) {
+      newUrl = this.replacePathParams(url, pathParams.path);
+    }
+    return newUrl;
   }
 }

--- a/src/main/app/src/app/shared/http/zac-http-client.ts
+++ b/src/main/app/src/app/shared/http/zac-http-client.ts
@@ -41,27 +41,25 @@ export class ZacHttpClient {
 
   public GET<P extends PathsWithMethod<Paths, "get">>(
     url: P,
-    init?: Omit<Parameters<HttpClient["get"]>[1], "params"> & {
+    init?: Parameters<HttpClient["get"]>[1] & {
       pathParams: FetchOptions<FilterKeys<Paths[P], "get">>["params"];
     },
   ) {
-    const { pathParams, ...restInit } = { pathParams: {}, ...init };
     return this.http.get<Response<P, "get">>(
-      this.prepareUrl(url, init),
-      restInit,
+      this.prepareUrl(url, init?.pathParams),
+      init,
     );
   }
 
   public POST<P extends PathsWithMethod<Paths, "post">>(
     url: P,
     body: FetchOptions<FilterKeys<Paths[P], "post">>["body"],
-    init?: Omit<Parameters<HttpClient["post"]>[2], "params"> & {
+    init?: Parameters<HttpClient["post"]>[2] & {
       pathParams: FetchOptions<FilterKeys<Paths[P], "post">>["params"];
     },
   ) {
-    const { pathParams, ...restInit } = { pathParams: {}, ...init };
     return this.http.post<Response<P, "post">>(
-      this.prepareUrl(url, init),
+      this.prepareUrl(url, init?.pathParams),
       body,
       init,
     );
@@ -70,43 +68,40 @@ export class ZacHttpClient {
   public PUT<P extends PathsWithMethod<Paths, "put">>(
     url: P,
     body: FetchOptions<FilterKeys<Paths[P], "put">>["body"],
-    init?: Omit<Parameters<HttpClient["put"]>[2], "params"> & {
+    init?: Parameters<HttpClient["put"]>[2] & {
       pathParams: FetchOptions<FilterKeys<Paths[P], "put">>["params"];
     },
   ) {
-    const { pathParams, ...restInit } = { pathParams: {}, ...init };
     return this.http.put<Response<P, "put">>(
-      this.prepareUrl(url, init),
+      this.prepareUrl(url, init?.pathParams),
       body,
-      restInit,
+      init,
     );
   }
 
   public DELETE<P extends PathsWithMethod<Paths, "delete">>(
     url: P,
-    init?: Omit<Parameters<HttpClient["delete"]>[1], "params"> & {
+    init?: Parameters<HttpClient["delete"]>[1] & {
       pathParams: FetchOptions<FilterKeys<Paths[P], "delete">>["params"];
     },
   ) {
-    const { pathParams, ...restInit } = { pathParams: {}, ...init };
     return this.http.delete<Response<P, "delete">>(
-      this.prepareUrl(url, restInit),
-      restInit,
+      this.prepareUrl(url, init?.pathParams),
+      init,
     );
   }
 
   public PATCH<P extends PathsWithMethod<Paths, "patch">>(
     url: P,
     body: FetchOptions<FilterKeys<Paths[P], "patch">>["body"],
-    init?: Omit<Parameters<HttpClient["patch"]>[2], "params"> & {
+    init?: Parameters<HttpClient["patch"]>[2] & {
       pathParams: FetchOptions<FilterKeys<Paths[P], "patch">>["params"];
     },
   ) {
-    const { pathParams, ...restInit } = { pathParams: {}, ...init };
     return this.http.patch<Response<P, "patch">>(
-      this.prepareUrl(url, init),
+      this.prepareUrl(url, init?.pathParams),
       body,
-      restInit,
+      init,
     );
   }
 
@@ -124,10 +119,9 @@ export class ZacHttpClient {
     return url;
   }
 
-  private prepareUrl(url: string, init?: any) {
-    const pathParams = init?.pathParams;
-    let newUrl = url as string;
-    if (pathParams && "path" in pathParams) {
+  private prepareUrl(url: string, pathParams?: any) {
+    let newUrl = url;
+    if (pathParams) {
       newUrl = this.replacePathParams(url, pathParams.path);
     }
     return newUrl;


### PR DESCRIPTION
Angular httpclient does not handle pathParams when you pass it to params. this was a missconception and was not tested correctly when ZacHttpClient was implemented. This pr will add some utility functions so the httpclient can deal with pathParams

Solves PZ-762