### PR TITLE
fix: fix overflowing tables

### DIFF
--- a/src/main/app/src/app/shared/material-form-builder/form/form/form.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form/form/form.component.html
@@ -3,10 +3,10 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-<form [formGroup]="formGroup" (ngSubmit)="submit()">
+<form [formGroup]="formGroup" (ngSubmit)="submit()" >
     <ng-container *ngFor="let row of data">
         <div class="flex-row flex-col-md flex-wrap gap-5 flex-fill">
-            <div class="flex-1" [ngClass]="tile.fieldType | lowercase" *ngFor="let tile of row">
+            <div class="flex-1 mfb-wrapper" [ngClass]="tile.fieldType | lowercase" *ngFor="let tile of row">
                 <mfb-form-field [field]="tile"></mfb-form-field>
             </div>
         </div>

--- a/src/main/app/src/app/shared/material-form-builder/form/form/form.component.less
+++ b/src/main/app/src/app/shared/material-form-builder/form/form/form.component.less
@@ -4,7 +4,7 @@
  */
 @import "/variables";
 
-.documenten_lijst {
+.mfb-wrapper {
+  position: relative; 
   width: 100%;
-  flex-basis: 100%;
 }


### PR DESCRIPTION
Tables were overflowing from their parents, there was a fix in place for one table but not for the other. These changes should apply it to all tables that are build with the formbuilder

Solves PZ-893