### PR TITLE
fix: fix CodeQL security finding: "LDAP query built from user-controlled sources"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,12 +152,12 @@ dependencies {
     "itestImplementation"("org.testcontainers:mockserver:1.19.3")
     "itestImplementation"("org.testcontainers:postgresql:1.19.3")
     "itestImplementation"("io.kotest:kotest-runner-junit5:5.8.0")
+    "itestImplementation"("io.kotest:kotest-assertions-json:5.8.0")
     "itestImplementation"("org.slf4j:slf4j-simple:2.0.9")
     "itestImplementation"("io.github.oshai:kotlin-logging-jvm:5.1.1")
     "itestImplementation"("org.danilopianini:khttp:1.4.2")
     "itestImplementation"("org.awaitility:awaitility-kotlin:4.2.0")
     "itestImplementation"("org.mock-server:mockserver-client-java:5.15.0")
-    "itestImplementation"("io.kotest:kotest-assertions-json:5.8.0")
 }
 
 detekt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
     implementation("com.itextpdf:itextpdf:5.5.13.3")
     implementation("com.itextpdf.tool:xmlworker:5.5.13.3")
     implementation("net.sourceforge.htmlcleaner:htmlcleaner:2.29")
+    implementation("com.unboundid:unboundid-ldapsdk:6.0.11")
 
     swaggerUI("org.webjars:swagger-ui:5.10.3")
 
@@ -156,6 +157,7 @@ dependencies {
     "itestImplementation"("org.danilopianini:khttp:1.4.2")
     "itestImplementation"("org.awaitility:awaitility-kotlin:4.2.0")
     "itestImplementation"("org.mock-server:mockserver-client-java:5.15.0")
+    "itestImplementation"("io.kotest:kotest-assertions-json:5.8.0")
 }
 
 detekt {

--- a/src/itest/kotlin/nl/lifely/zac/itest/IdentityServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/IdentityServiceTest.kt
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+package nl.lifely.zac.itest
+
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import nl.lifely.zac.itest.client.KeycloakClient
+import nl.lifely.zac.itest.config.ItestConfiguration
+
+class IdentityServiceTest : BehaviorSpec() {
+    companion object {
+        const val TEST_GROUP_A_ID = "test-group-a"
+        const val TEST_GROUP_A_DESCRIPTION = "Test groep A"
+    }
+
+    init {
+        given(
+            "Keycloak contains 'test group a' and 'test group b'"
+        ) {
+            When("the 'list groups' endpoint is called") {
+                then(
+                    "'test group a' and 'test group b' are returned"
+                ) {
+                    khttp.get(
+                        url = "${ItestConfiguration.ZAC_API_URI}/identity/groups",
+                        headers = mapOf(
+                            "Content-Type" to "application/json",
+                            "Authorization" to "Bearer ${KeycloakClient.requestAccessToken()}"
+                        )
+                    ).apply {
+                        statusCode shouldBe HttpStatus.SC_OK
+                        text shouldEqualJson """
+                            [
+                                {
+                                    "id": "$TEST_GROUP_A_ID",
+                                    "naam": "$TEST_GROUP_A_DESCRIPTION"
+                                }
+                            ]
+                        """.trimIndent()
+                    }
+                }
+            }
+        }
+        given(
+            "Keycloak contains 'test user 1' and 'test user 2'"
+        ) {
+            When("the 'list users' endpoint is called") {
+                then(
+                    "'test user 1' and 'test user 2' are returned"
+                ) {
+                    khttp.get(
+                        url = "${ItestConfiguration.ZAC_API_URI}/identity/users",
+                        headers = mapOf(
+                            "Content-Type" to "application/json",
+                            "Authorization" to "Bearer ${KeycloakClient.requestAccessToken()}"
+                        )
+                    ).apply {
+                        statusCode shouldBe HttpStatus.SC_OK
+                        text shouldEqualJson """
+                            [
+                                {
+                                    "id": "testuser1",
+                                    "naam": "Test User1"
+                                },
+                                {
+                                    "id": "testuser2",
+                                    "naam": "Test User2"
+                                }
+                            ]
+                        """.trimIndent()
+                    }
+                }
+            }
+        }
+        given(
+            "Keycloak contains 'test group a' with 'test user 1' and 'test user 2' as members"
+        ) {
+            When("the 'list users in group' endpoint is called for 'test group a'") {
+                then(
+                    "'testuser 1' and 'testuser 2'"
+                ) {
+                    khttp.get(
+                        url = "${ItestConfiguration.ZAC_API_URI}/identity/groups/$TEST_GROUP_A_ID/users",
+                        headers = mapOf(
+                            "Content-Type" to "application/json",
+                            "Authorization" to "Bearer ${KeycloakClient.requestAccessToken()}"
+                        )
+                    ).apply {
+                        statusCode shouldBe HttpStatus.SC_OK
+                        text shouldEqualJson """
+                            [
+                                {
+                                    "id": "testuser1",
+                                    "naam": "Test User1"
+                                },
+                                {
+                                    "id": "testuser2",
+                                    "naam": "Test User2"
+                                }
+                            ]
+                        """.trimIndent()
+                    }
+                }
+            }
+        }
+        given(
+            "'test user 1' is logged in to ZAC and is part of 'test group a'"
+        ) {
+            When("the 'get logged in user' endpoint is called") {
+                then(
+                    "'test user 1' is returned"
+                ) {
+                    khttp.get(
+                        url = "${ItestConfiguration.ZAC_API_URI}/identity/loggedInUser",
+                        headers = mapOf(
+                            "Content-Type" to "application/json",
+                            "Authorization" to "Bearer ${KeycloakClient.requestAccessToken()}"
+                        )
+                    ).apply {
+                        statusCode shouldBe HttpStatus.SC_OK
+                        text shouldEqualJson """
+                            {
+                                "id": "testuser1",
+                                "naam": "Test User1",
+                                "groupIds": [
+                                    "$TEST_GROUP_A_ID"
+                                ]
+                            }
+                        """.trimIndent()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/itest/kotlin/nl/lifely/zac/itest/IdentityServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/IdentityServiceTest.kt
@@ -82,7 +82,7 @@ class IdentityServiceTest : BehaviorSpec() {
         ) {
             When("the 'list users in group' endpoint is called for 'test group a'") {
                 then(
-                    "'testuser 1' and 'testuser 2'"
+                    "'testuser 1' and 'testuser 2' are returned"
                 ) {
                     khttp.get(
                         url = "${ItestConfiguration.ZAC_API_URI}/identity/groups/$TEST_GROUP_A_ID/users",
@@ -103,6 +103,31 @@ class IdentityServiceTest : BehaviorSpec() {
                                     "naam": "Test User2"
                                 }
                             ]
+                        """.trimIndent()
+                    }
+                }
+            }
+        }
+        given(
+            "Keycloak contains groups and users as group members"
+        ) {
+            When(
+                "the 'list users in group' endpoint is called with an illegal LDAP filter character using group name '*'"
+            ) {
+                then(
+                    "an empty list is returned"
+                ) {
+                    khttp.get(
+                        url = "${ItestConfiguration.ZAC_API_URI}/identity/groups/*/users",
+                        headers = mapOf(
+                            "Content-Type" to "application/json",
+                            "Authorization" to "Bearer ${KeycloakClient.requestAccessToken()}"
+                        )
+                    ).apply {
+                        statusCode shouldBe HttpStatus.SC_OK
+                        text shouldEqualJson """
+                            [
+                        ]
                         """.trimIndent()
                     }
                 }

--- a/src/main/java/net/atos/zac/identity/IdentityService.java
+++ b/src/main/java/net/atos/zac/identity/IdentityService.java
@@ -112,7 +112,7 @@ public class IdentityService {
                 usersDN,
                 Filter.createANDFilter(
                         Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, USER_OBJECT_CLASS),
-                        Filter.createEqualityFilter(USER_ID_ATTRIBUTE, Filter.encodeValue(userId))
+                        Filter.createEqualityFilter(USER_ID_ATTRIBUTE, userId)
                 ),
                 USER_ATTRIBUTES
         ).stream()
@@ -126,7 +126,7 @@ public class IdentityService {
                 groupsDN,
                 Filter.createANDFilter(
                         Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, GROUP_OBJECT_CLASS),
-                        Filter.createEqualityFilter(GROUP_ID_ATTRIBUTE, Filter.encodeValue(groupId))
+                        Filter.createEqualityFilter(GROUP_ID_ATTRIBUTE, groupId)
                 ),
                 GROUP_ATTRIBUTES
         ).stream()
@@ -141,7 +141,7 @@ public class IdentityService {
                 groupsDN,
                 Filter.createANDFilter(
                         Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, GROUP_OBJECT_CLASS),
-                        Filter.createEqualityFilter(GROUP_ID_ATTRIBUTE, Filter.encodeValue(groupId))
+                        Filter.createEqualityFilter(GROUP_ID_ATTRIBUTE, groupId)
                 ),
                 GROUP_MEMBERSHIP_ATTRIBUTES
         ).stream()
@@ -158,7 +158,7 @@ public class IdentityService {
                         Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, USER_OBJECT_CLASS),
                         Filter.createORFilter(
                                 userIds.stream()
-                                        .map(userId -> Filter.createEqualityFilter(USER_ID_ATTRIBUTE, Filter.encodeValue(userId)))
+                                        .map(userId -> Filter.createEqualityFilter(USER_ID_ATTRIBUTE, userId))
                                         .toList()
                         )
                 ),

--- a/src/main/java/net/atos/zac/identity/IdentityService.java
+++ b/src/main/java/net/atos/zac/identity/IdentityService.java
@@ -112,7 +112,7 @@ public class IdentityService {
                 usersDN,
                 Filter.createANDFilter(
                         Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, USER_OBJECT_CLASS),
-                        Filter.createEqualityFilter(USER_ID_ATTRIBUTE, userId)
+                        Filter.createEqualityFilter(USER_ID_ATTRIBUTE, Filter.encodeValue(userId))
                 ),
                 USER_ATTRIBUTES
         ).stream()
@@ -126,7 +126,7 @@ public class IdentityService {
                 groupsDN,
                 Filter.createANDFilter(
                         Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, GROUP_OBJECT_CLASS),
-                        Filter.createEqualityFilter(GROUP_ID_ATTRIBUTE, groupId)
+                        Filter.createEqualityFilter(GROUP_ID_ATTRIBUTE, Filter.encodeValue(groupId))
                 ),
                 GROUP_ATTRIBUTES
         ).stream()
@@ -141,7 +141,7 @@ public class IdentityService {
                 groupsDN,
                 Filter.createANDFilter(
                         Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, GROUP_OBJECT_CLASS),
-                        Filter.createEqualityFilter(GROUP_ID_ATTRIBUTE, groupId)
+                        Filter.createEqualityFilter(GROUP_ID_ATTRIBUTE, Filter.encodeValue(groupId))
                 ),
                 GROUP_MEMBERSHIP_ATTRIBUTES
         ).stream()
@@ -158,7 +158,7 @@ public class IdentityService {
                         Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, USER_OBJECT_CLASS),
                         Filter.createORFilter(
                                 userIds.stream()
-                                        .map(userId -> Filter.createEqualityFilter(USER_ID_ATTRIBUTE, userId))
+                                        .map(userId -> Filter.createEqualityFilter(USER_ID_ATTRIBUTE, Filter.encodeValue(userId)))
                                         .toList()
                         )
                 ),

--- a/src/main/java/net/atos/zac/identity/IdentityService.java
+++ b/src/main/java/net/atos/zac/identity/IdentityService.java
@@ -8,6 +8,7 @@ package net.atos.zac.identity;
 import static org.apache.commons.lang3.StringUtils.substringBetween;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Hashtable;
 import java.util.LinkedList;
@@ -15,8 +16,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -27,7 +26,12 @@ import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import com.unboundid.ldap.sdk.Filter;
 
 import net.atos.zac.identity.model.Group;
 import net.atos.zac.identity.model.User;
@@ -61,7 +65,9 @@ public class IdentityService {
 
     private static final String GROUP_OBJECT_CLASS = "groupOfUniqueNames";
 
-    private Hashtable<String, String> environment = new Hashtable<String, String>();
+    private static final String OBJECT_CLASS_ATTRIBUTE = "objectClass";
+
+    private final Hashtable<String, String> environment = new Hashtable<String, String>();
 
     @Inject
     @ConfigProperty(name = "LDAP_DN")
@@ -80,32 +86,50 @@ public class IdentityService {
     }
 
     public List<User> listUsers() {
-        final String filter = String.format("(&(objectClass=%s))", USER_OBJECT_CLASS);
-        return search(usersDN, filter, USER_ATTRIBUTES).stream()
+        return search(
+                usersDN,
+                Filter.createANDFilter(Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, USER_OBJECT_CLASS)),
+                USER_ATTRIBUTES
+        ).stream()
                 .map(this::convertToUser)
                 .sorted(Comparator.comparing(User::getFullName))
                 .toList();
     }
 
     public List<Group> listGroups() {
-        final String filter = String.format("(&(objectClass=%s))", GROUP_OBJECT_CLASS);
-        return search(groupsDN, filter, GROUP_ATTRIBUTES).stream()
+        return search(
+                groupsDN,
+                Filter.createANDFilter(Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, GROUP_OBJECT_CLASS)),
+                GROUP_ATTRIBUTES
+        ).stream()
                 .map(this::convertToGroup)
                 .sorted(Comparator.comparing(Group::getName))
                 .toList();
     }
 
     public User readUser(final String userId) {
-        final String filter = String.format("(&(objectClass=%s)(cn=%s))", USER_OBJECT_CLASS, userId);
-        return search(usersDN, filter, USER_ATTRIBUTES).stream()
+        return search(
+                usersDN,
+                Filter.createANDFilter(
+                        Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, USER_OBJECT_CLASS),
+                        Filter.createEqualityFilter(USER_ID_ATTRIBUTE, userId)
+                ),
+                USER_ATTRIBUTES
+        ).stream()
                 .findAny()
                 .map(this::convertToUser)
                 .orElseGet(() -> new User(userId));
     }
 
     public Group readGroup(final String groupId) {
-        final String filter = String.format("(&(objectClass=%s)(cn=%s))", GROUP_OBJECT_CLASS, groupId);
-        return search(groupsDN, filter, GROUP_ATTRIBUTES).stream()
+        return search(
+                groupsDN,
+                Filter.createANDFilter(
+                        Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, GROUP_OBJECT_CLASS),
+                        Filter.createEqualityFilter(GROUP_ID_ATTRIBUTE, groupId)
+                ),
+                GROUP_ATTRIBUTES
+        ).stream()
                 .findAny()
                 .map(this::convertToGroup)
                 .orElseGet(() -> new Group(groupId));
@@ -113,21 +137,33 @@ public class IdentityService {
     }
 
     public List<User> listUsersInGroup(final String groupId) {
-        final String filter = String.format("(&(objectClass=%s)(cn=%s))", GROUP_OBJECT_CLASS, groupId);
-        return search(groupsDN, filter, GROUP_MEMBERSHIP_ATTRIBUTES).stream()
+        return search(
+                groupsDN,
+                Filter.createANDFilter(
+                        Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, GROUP_OBJECT_CLASS),
+                        Filter.createEqualityFilter(GROUP_ID_ATTRIBUTE, groupId)
+                ),
+                GROUP_MEMBERSHIP_ATTRIBUTES
+        ).stream()
                 .map(this::convertToMembers)
                 .flatMap(this::readUsers)
                 .sorted(Comparator.comparing(User::getFullName))
                 .toList();
     }
 
-    private Stream<User> readUsers(final List<String> userIds) {
-        final StringBuilder filter = new StringBuilder();
-        filter.append(String.format("(&(objectClass=%s)(|", USER_OBJECT_CLASS));
-        userIds.forEach(userId -> filter.append(String.format("(cn=%s)", userId)));
-        filter.append("))");
-        return search(usersDN, filter.toString(), USER_ATTRIBUTES).stream()
-                .map(this::convertToUser);
+    private Stream<User> readUsers(final Collection<String> userIds) {
+        return search(
+                usersDN,
+                Filter.createANDFilter(
+                        Filter.createEqualityFilter(OBJECT_CLASS_ATTRIBUTE, USER_OBJECT_CLASS),
+                        Filter.createORFilter(
+                                userIds.stream()
+                                        .map(userId -> Filter.createEqualityFilter(USER_ID_ATTRIBUTE, userId))
+                                        .toList()
+                        )
+                ),
+                USER_ATTRIBUTES
+        ).stream().map(this::convertToUser);
     }
 
     private User convertToUser(final Attributes attributes) {
@@ -144,19 +180,24 @@ public class IdentityService {
     }
 
     private List<String> convertToMembers(final Attributes attributes) {
-        return readAttributeToListOfStrings(attributes, GROUP_MEMBER_ATTRIBUTE).stream()
+        return readAttributeToListOfStrings(attributes).stream()
                 .map(member -> substringBetween(member, "cn=", ","))
                 .filter(Objects::nonNull)
                 .toList();
     }
 
-    private List<Attributes> search(final String root, final String filter, final String[] attributesToReturn) {
+    private List<Attributes> search(final String root, final Filter filter,
+            final String[] attributesToReturn) {
         final SearchControls searchControls = new SearchControls();
         searchControls.setReturningAttributes(attributesToReturn);
         searchControls.setSearchScope(SearchControls.ONELEVEL_SCOPE);
         try {
             final DirContext dirContext = new InitialDirContext(environment);
-            final NamingEnumeration<SearchResult> namingEnumeration = dirContext.search(root, filter, searchControls);
+            final NamingEnumeration<SearchResult> namingEnumeration = dirContext.search(
+                    root,
+                    filter.toString(),
+                    searchControls
+            );
             final List<Attributes> attributesList = new LinkedList<>();
             while (namingEnumeration.hasMore()) {
                 attributesList.add(namingEnumeration.next().getAttributes());
@@ -177,10 +218,10 @@ public class IdentityService {
         }
     }
 
-    private List<String> readAttributeToListOfStrings(final Attributes attributes, final String attributeName) {
+    private List<String> readAttributeToListOfStrings(final Attributes attributes) {
         try {
             final List<String> strings = new LinkedList<>();
-            final Attribute attribute = attributes.get(attributeName);
+            final Attribute attribute = attributes.get(IdentityService.GROUP_MEMBER_ATTRIBUTE);
             if (attribute != null) {
                 final NamingEnumeration<?> enumeration = attribute.getAll();
                 while (enumeration.hasMore()) {


### PR DESCRIPTION
Fix CodeQL security finding: "LDAP query built from user-controlled sources" by using UnboundID LDAP library to build LDAP filters and escape user input.

Solves PZ-966