### PR TITLE
chore: add typescript codeql analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["java-kotlin", "javascript"]
+        language: ["java-kotlin", "javascript-typescript"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,12 +37,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup JDK
+        if: matrix.language == 'java-kotlin'
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: "temurin"
 
       - name: Setup Gradle
+        if: matrix.language == 'java-kotlin'
         uses: gradle/gradle-build-action@v2
 
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # ignore CodeQL analysis when only Markdown files have changed
+    paths-ignore:
+      - '**/*.md'
   schedule:
     - cron: "21 11 * * 0"
 


### PR DESCRIPTION
Added CodeQL analysis for 'javascript-typescript' (see: https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) and only setup Java & Gradle for 'java-kotlin' analysis.

Solves PZ-968