### PR TITLE
chore: rename CodeQL GitHub workflow file 

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,3 +60,5 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
To comply with GitHub default naming. Also added category to CodeQL analysis action.

Solves PZ-971