### PR TITLE
PZ-604: expose metrics

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -7,3 +7,11 @@ The following ZAC developer documentation is available:
 - [installDockerCompose.md](installDockerCompose.md) - Instructions on how to run the software using Docker Compose.
 - [endToEndTypeSafety.md](endToEndTypeSafety.md) - Instructions on how to develop ZAC using end-to-end type safety.
 - [testing.md](testing.md) - Instructions on how to run and develop tests for ZAC.
+
+## Monitoring
+ZAC exposes two monitoring endpoints through WildFly by default:
+
+- `/health`
+- `/metrics`
+
+Note: These are not secured. To disable, remove the metrics layers from the install-wildfly.sh script.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -11,7 +11,7 @@ The following ZAC developer documentation is available:
 ## Monitoring
 ZAC exposes two monitoring endpoints through WildFly by default:
 
-- `/health`
-- `/metrics`
+- http://localhost:9990/health
+- http://localhost:9990/metrics
 
-Note: These are not secured. To disable, remove the metrics layers from the install-wildfly.sh script.
+Note: These are not secured. To disable, remove the metrics layer from the install-wildfly.sh script.

--- a/scripts/wildfly/install-wildfly.sh
+++ b/scripts/wildfly/install-wildfly.sh
@@ -20,7 +20,7 @@ export PATH=$PATH:$(pwd)/galleon/bin
 
 echo ">>> Installing WildFly ..."
 rm -fr $WILDFLY_SERVER_DIR
-galleon.sh install wildfly#$WILDFLY_VERSION --dir=$WILDFLY_SERVER_DIR --layers=jaxrs-server,microprofile-health,microprofile-fault-tolerance,elytron-oidc-client
+galleon.sh install wildfly#$WILDFLY_VERSION --dir=$WILDFLY_SERVER_DIR --layers=jaxrs-server,microprofile-health,microprofile-fault-tolerance,elytron-oidc-client,metrics
 galleon.sh install org.wildfly:wildfly-datasources-galleon-pack:$WILDFLY_DATASOURCES_GALLEON_PACK_VERSION --dir=$WILDFLY_SERVER_DIR --layers=postgresql-driver
 $WILDFLY_SERVER_DIR/bin/jboss-cli.sh --file=install-wildfly.cli
 


### PR DESCRIPTION
This will expose /metrics and /health on the wildlfy admin port (9990)

Note: You might need to run `./scripts/widlfly/install-wildfly.sh` to enable this