### PR TITLE
fix: set the runners for github action jobs dynamically

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -307,7 +307,7 @@ jobs:
     needs: [set-runner, push-docker-image]
     runs-on: ${{ needs.set-runner.outputs.runner }}
     timeout-minutes: 30
-    if: github.ref == 'refs/heads/main' && ${{ env.ACT != 'true' }}
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set runner
         id: set-runner
         run: |
-          echo "::set-output name=runner::ubuntu-22.04"
+          echo "runner=ubuntu-22.04" >> $GITHUB_OUTPUT
   build:
     needs: [set-runner]
     runs-on: ${{ needs.set-runner.outputs.runner }}

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -17,7 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  UBUNTU_RUNNNER: 'ubuntu-22.04' # Explicit ubuntu runner version
   JAVA_VERSION: '17'
   CONTAINER_REGISTRY_URL: 'ghcr.io/infonl'
   APPLICATION_NAME: 'zaakafhandelcomponent'
@@ -29,8 +28,19 @@ permissions:
   pull-requests: write
 
 jobs:
+  set-runner:
+    # This is the (current) way to set a runner that can be used in other tasks
+    runs-on: ubuntu-22.04
+    outputs:
+      runner: ${{ steps.set-runner.outputs.runner }}
+    steps:
+      - name: Set runner
+        id: set-runner
+        run: |
+          echo "::set-output name=runner::ubuntu-22.04"
   build:
-    runs-on: ${{ env.UBUNTU_RUNNNER }}
+    needs: [set-runner]
+    runs-on: ${{ needs.set-runner.outputs.runner }}
     timeout-minutes: 30
     env:
       READ_PACKAGES_USERNAME: $${{ vars.READ_PACKAGES_USERNAME }}
@@ -92,8 +102,8 @@ jobs:
           key: maven-build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   run-unit-tests:
-    needs: [build]
-    runs-on: ${{ env.UBUNTU_RUNNNER }}
+    needs: [set-runner, build]
+    runs-on: ${{ needs.set-runner.outputs.runner }}
     timeout-minutes: 30
     env:
       READ_PACKAGES_USERNAME: $${{ vars.READ_PACKAGES_USERNAME }}
@@ -137,8 +147,8 @@ jobs:
             src/main/app/reports/*.xml
 
   build-docker-image-and-run-itests:
-    needs: [build]
-    runs-on: ${{ env.UBUNTU_RUNNNER }}
+    needs: [set-runner, build]
+    runs-on: ${{ needs.set-runner.outputs.runner }}
     timeout-minutes: 30
     env:
       BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
@@ -212,8 +222,9 @@ jobs:
           key: docker-image-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   next-version:
+    needs: [set-runner]
     if: github.ref == 'refs/heads/main'
-    runs-on: ${{ env.UBUNTU_RUNNNER }}
+    runs-on: ${{ needs.set-runner.outputs.runner }}
     outputs:
       next_version: ${{ steps.next-version.outputs.new_tag }}
     steps:
@@ -234,8 +245,8 @@ jobs:
           RELEASE_BRANCHES: main
 
   push-docker-image:
-    needs: [build, run-unit-tests, build-docker-image-and-run-itests, next-version]
-    runs-on: ${{ env.UBUNTU_RUNNNER }}
+    needs: [set-runner, build, run-unit-tests, build-docker-image-and-run-itests, next-version]
+    runs-on: ${{ needs.set-runner.outputs.runner }}
     timeout-minutes: 30
     if: github.ref == 'refs/heads/main'
     env:
@@ -269,9 +280,9 @@ jobs:
         run: docker push --all-tags ${CONTAINER_REGISTRY_URL}/${APPLICATION_NAME}
 
   create-release:
-    needs: [next-version, push-docker-image]
+    needs: [set-runner, next-version, push-docker-image]
     if: github.ref == 'refs/heads/main'
-    runs-on: ${{ env.UBUNTU_RUNNNER }}
+    runs-on: ${{ needs.set-runner.outputs.runner }}
     env:
       NEXT_VERSION: ${{ needs.build.outputs.next-version }}
     steps:
@@ -293,8 +304,8 @@ jobs:
           generateReleaseNotes: true
 
   trigger-provision:
-    needs: [push-docker-image]
-    runs-on: ${{ env.UBUNTU_RUNNNER }}
+    needs: [set-runner, push-docker-image]
+    runs-on: ${{ needs.set-runner.outputs.runner }}
     timeout-minutes: 30
     if: github.ref == 'refs/heads/main' && ${{ env.ACT != 'true' }}
     steps:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -28,19 +28,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  set-runner:
-    # This is the (current) way to set a runner that can be used in other tasks
-    runs-on: ubuntu-22.04
-    outputs:
-      runner: ${{ steps.set-runner.outputs.runner }}
-    steps:
-      - name: Set runner
-        id: set-runner
-        run: |
-          echo "runner=ubuntu-22.04" >> $GITHUB_OUTPUT
   build:
-    needs: [set-runner]
-    runs-on: ${{ needs.set-runner.outputs.runner }}
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:
       READ_PACKAGES_USERNAME: $${{ vars.READ_PACKAGES_USERNAME }}
@@ -102,8 +91,8 @@ jobs:
           key: maven-build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   run-unit-tests:
-    needs: [set-runner, build]
-    runs-on: ${{ needs.set-runner.outputs.runner }}
+    needs: [build]
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:
       READ_PACKAGES_USERNAME: $${{ vars.READ_PACKAGES_USERNAME }}
@@ -147,8 +136,8 @@ jobs:
             src/main/app/reports/*.xml
 
   build-docker-image-and-run-itests:
-    needs: [set-runner, build]
-    runs-on: ${{ needs.set-runner.outputs.runner }}
+    needs: [build]
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:
       BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
@@ -222,9 +211,8 @@ jobs:
           key: docker-image-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   next-version:
-    needs: [set-runner]
     if: github.ref == 'refs/heads/main'
-    runs-on: ${{ needs.set-runner.outputs.runner }}
+    runs-on: ubuntu-22.04
     outputs:
       next_version: ${{ steps.next-version.outputs.new_tag }}
     steps:
@@ -245,8 +233,8 @@ jobs:
           RELEASE_BRANCHES: main
 
   push-docker-image:
-    needs: [set-runner, build, run-unit-tests, build-docker-image-and-run-itests, next-version]
-    runs-on: ${{ needs.set-runner.outputs.runner }}
+    needs: [build, run-unit-tests, build-docker-image-and-run-itests, next-version]
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     if: github.ref == 'refs/heads/main'
     env:
@@ -280,9 +268,9 @@ jobs:
         run: docker push --all-tags ${CONTAINER_REGISTRY_URL}/${APPLICATION_NAME}
 
   create-release:
-    needs: [set-runner, next-version, push-docker-image]
+    needs: [next-version, push-docker-image]
     if: github.ref == 'refs/heads/main'
-    runs-on: ${{ needs.set-runner.outputs.runner }}
+    runs-on: ubuntu-22.04
     env:
       NEXT_VERSION: ${{ needs.build.outputs.next-version }}
     steps:
@@ -304,8 +292,8 @@ jobs:
           generateReleaseNotes: true
 
   trigger-provision:
-    needs: [set-runner, push-docker-image]
-    runs-on: ${{ needs.set-runner.outputs.runner }}
+    needs: [push-docker-image]
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     if: github.ref == 'refs/heads/main'
     steps:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Tag Docker Image with next version tag
         if: env.NEXT_VERSION != ''
-        run: docker tag ${ZAC_DOCKER_IMAGE} ${CONTAINER_REGISTRY_URL}/${APPLICATION_NAME}:${NEXT_VERSION}
+        run: docker tag ${ZAC_DOCKER_IMAGE} ${CONTAINER_REGISTRY_URL}/${APPLICATION_NAME}:${env.NEXT_VERSION}
 
       - name: Push Docker Image with all tags
         run: docker push --all-tags ${CONTAINER_REGISTRY_URL}/${APPLICATION_NAME}
@@ -294,11 +294,11 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: v${{ NEXT_VERSION }}
-          name: Release ${{ NEXT_VERSION }}
+          tag: v${{ env.NEXT_VERSION }}
+          name: Release ${{ env.NEXT_VERSION }}
           draft: false
           prerelease: false
-          artifacts: "${env.CONTAINER_REGISTRY_URL}/${env.APPLICATION_NAME}:${NEXT_VERSION}"
+          artifacts: "${env.CONTAINER_REGISTRY_URL}/${env.APPLICATION_NAME}:${env.NEXT_VERSION}"
           allowUpdates: true
           makeLatest: true
           generateReleaseNotes: true

--- a/scripts/github/test-workflows.sh
+++ b/scripts/github/test-workflows.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd ../..
-act --job create-release --verbose --dryrun
+act --verbose --dryrun


### PR DESCRIPTION
Runners can't be set through environment variables, but can be set via a job output.

new line for build