### PR TITLE
chore: add e2e folder to Dependabot to updates e2e NPM dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,15 @@ updates:
     reviewers:
       - "infonl/dimpact"
 
+  - package-ecosystem: "npm"
+    directory: "/src/e2e/"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+      timezone: "Europe/Amsterdam"
+    reviewers:
+      - "infonl/dimpact"
+
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:


### PR DESCRIPTION
Added e2e folder to Dependabot to updates e2e NPM dependencies.

Solves PZ-1028