### PR TITLE
chore: re-enable e2e tests

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -4,9 +4,9 @@
 #
 name: Playwright Tests
 on:
-  #schedule:
+  schedule:
     # Runs at 9:00 PM UTC from Monday to Friday
-    #- cron: "0 21 * * 1-5"
+    - cron: "0 21 * * 1-5"
   workflow_dispatch:
 jobs:
   playwright:


### PR DESCRIPTION
Re-enabled the nightly e2e tests that were temporarily disabled since we switched off our Azure environment over xmas.

Solves PZ-1048