### PR TITLE
chore: use latest version of WebDAV servlet lib

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -31,9 +31,6 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    env:
-      READ_PACKAGES_USERNAME: $${{ vars.READ_PACKAGES_USERNAME }}
-      READ_PACKAGES_TOKEN: ${{ secrets.READ_PACKAGES_TOKEN }}
     outputs:
       branch_name: ${{ steps.gen_branch_name.outputs.BRANCH_NAME }}
       build_number: ${{ steps.gen_build_number.outputs.BUILD_NUMBER }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,6 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    env:
-      READ_PACKAGES_USERNAME: $${{ vars.READ_PACKAGES_USERNAME }}
-      READ_PACKAGES_TOKEN: ${{ secrets.READ_PACKAGES_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,7 +110,7 @@ dependencies {
     implementation("org.flywaydb:flyway-core:10.4.1")
     implementation("org.flywaydb:flyway-database-postgresql:10.4.1")
     implementation("org.apache.solr:solr-solrj:9.4.0")
-    implementation("nl.lifely.webdav-servlet:webdav-servlet:1.0.0")
+    implementation("nl.info.webdav:webdav-servlet:1.2.7")
     implementation("com.itextpdf:itextpdf:5.5.13.3")
     implementation("com.itextpdf.tool:xmlworker:5.5.13.3")
     implementation("net.sourceforge.htmlcleaner:htmlcleaner:2.29")

--- a/docs/development/INSTALL.md
+++ b/docs/development/INSTALL.md
@@ -14,18 +14,6 @@ General ZAC usage instructions may be found in the [README.md](../../README.md) 
 The software is built using Gradle and for the final step using Maven.
 Both a Gradle and a Maven wrapper are included in the source code, so you do not need to install either Gradle or Maven yourself.
 
-Unfortunately we use a customized 3rd Java party library (https://github.com/infonl/webdav-servlet) which currently is only published to our own GitHub Packages Maven repository.
-Since GitHub Packages Maven repositories are not public you require a GitHub Personal Access Token (PAT) with read permissions on GitHub Packages to be able to download this library.
-Lifely developers can find these credentials in our 1Password vault.
-
-To build the software use the following command:
-
-```shell
-READ_PACKAGES_USERNAME=XXX READ_PACKAGES_TOKEN=XXX ./gradlew build
-```
-
-Replace the `XXX` placeholders with the credentials from the 1Password vault.
-
 This builds all the software, including the Java backend as well as the TypeScript frontend (using `npm`), runs all unit tests
 and packages the built software first into a WAR archive and then finally by invoking a Maven command from Gradle into a
 [WildFly application server](https://www.wildfly.org/) bootable fat-JAR. This last step uses [Galleon](https://docs.wildfly.org/galleon/).

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -32,7 +32,7 @@ To do this you will first need to do the following:
     ./gradlew buildZacDockerImage
     ```
 3. If BAG integration is part of the test suite: create a 'run configuration' in your IDE where the following two environment variables are set: `BAG_API_CLIENT_MP_REST_URL` and `BAG_API_KEY`.
-4. Add the following environemt variable to this 'run configuration': `JAVA_TOOL_OPTIONS=--add-opens=java.base/java.net=ALL-UNNAMED` (see: https://github.com/lojewalo/khttp/issues/88 for details).
+4. Add the following environment variable to this 'run configuration': `JAVA_TOOL_OPTIONS=--add-opens=java.base/java.net=ALL-UNNAMED` (see: https://github.com/lojewalo/khttp/issues/88 for details).
 5. Run the integration tests from your IDE using this run configuration.
 
 Running the integration tests will first start up all required services (Keycloak, Open Zaak, etc) as Docker containers using our [Docker Compose file](installDockerCompose.md),

--- a/scripts/github/.actrc
+++ b/scripts/github/.actrc
@@ -1,2 +1,1 @@
 -s GITHUB_TOKEN=github-token
--s READ_PACKAGES_TOKEN=read-packages-token

--- a/scripts/github/.secrets-sample
+++ b/scripts/github/.secrets-sample
@@ -1,3 +1,2 @@
 # Create you're own .secrets file and set all secrets that will be loaded by ACT
 GITHUB_TOKEN=github-token
-READ_PACKAGES_TOKEN=read-packages-token

--- a/src/main/java/net/atos/zac/webdav/WebdavStore.java
+++ b/src/main/java/net/atos/zac/webdav/WebdavStore.java
@@ -10,21 +10,23 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.servlet.http.HttpSession;
+
 import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import jakarta.enterprise.inject.spi.CDI;
-import jakarta.servlet.http.HttpSession;
 import net.atos.client.zgw.drc.DRCClientService;
 import net.atos.client.zgw.drc.model.EnkelvoudigInformatieobject;
 import net.atos.client.zgw.drc.model.EnkelvoudigInformatieobjectWithInhoudAndLock;
 import net.atos.zac.app.informatieobjecten.EnkelvoudigInformatieObjectUpdateService;
 import net.atos.zac.authentication.SecurityUtil;
-import net.sf.webdav.ITransaction;
-import net.sf.webdav.IWebdavStore;
-import net.sf.webdav.StoredObject;
+import nl.info.webdav.ITransaction;
+import nl.info.webdav.IWebdavStore;
+import nl.info.webdav.StoredObject;
+
 
 public class WebdavStore implements IWebdavStore {
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -113,7 +113,7 @@
 
     <servlet>
         <servlet-name>webdav</servlet-name>
-        <servlet-class>net.sf.webdav.WebdavServlet</servlet-class>
+        <servlet-class>nl.info.webdav.WebdavServlet</servlet-class>
         <init-param>
             <param-name>ResourceHandlerImplementation</param-name>
             <param-value>net.atos.zac.webdav.WebdavStore</param-value>


### PR DESCRIPTION
Updated to latest nl.info version of WebDAV servlet lib, which is now published to Maven Central. Removed now obsolete references to GitHub 'read packages' tokens since the webdav-servlet JAR is now publicly available.

Solves PZ-1040