### PR TITLE
fix: BRP Proxy and GBA Mock Docker containers fail to start on M3 Pro Mac

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -300,15 +300,25 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Release
       - ASPNETCORE_URLS=http://+:5010
+      # Disable FileSystemWatcher because it causes this Docker container to
+      # fail when running on an M3 Pro Mac with: "Unhandled exception.
+      # System.IO.IOException: Function not implemented
+      #   at System.IO.FileSystemWatcher.StartRaisingEvents()"
+      - ASPNETCORE_hostBuilder__reloadConfigOnChange=false
     ports:
       - "5010:5010"
 
   brpproxy:
-    image: ghcr.io/brp-api/haal-centraal-brp-bevragen-proxy:2.1.0
+    image: ghcr.io/brp-api/haal-centraal-brp-bevragen-proxy:2.1.1
     platform: linux/amd64
     environment:
       - ASPNETCORE_ENVIRONMENT=Release
       - ASPNETCORE_URLS=http://+:5000
+      # Disable FileSystemWatcher because it causes this Docker container to
+      # fail when running on an M3 Pro Mac with: "Unhandled exception.
+      # System.IO.IOException: Function not implemented
+      #   at System.IO.FileSystemWatcher.StartRaisingEvents()"
+      - ASPNETCORE_hostBuilder__reloadConfigOnChange=false
     ports:
       - "5001:5000"
     depends_on:


### PR DESCRIPTION
Added workaround for the issue where both the BRP Proxy and GBA Mock Docker containers fail to start on an M3 Pro Mac. Also upgraded the BRP Proxy Docker image to the latest version.

Solves PZ-1147