### PR TITLE
fix: pin version of OpenKlant in Docker Compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -343,7 +343,7 @@ services:
       - ./scripts/docker-compose/volume-data/openklant-database-data:/var/lib/postgresql/data
 
   openklant:
-    image: docker.io/maykinmedia/open-klant:latest
+    image: docker.io/maykinmedia/open-klant:0.5-pre
     platform: linux/amd64
     environment:
       - ALLOWED_HOSTS=localhost,host.docker.internal,openklant


### PR DESCRIPTION
Pin version of OpenKlant in Docker Compose file. This also solves the issue that the latest version of OpenZaak does not work on a Mac M3.

Solves PZ-1154