### PR TITLE
chore: removed obsolete usage of Apache Commons hashcodebuilder

### DIFF
--- a/src/main/java/net/atos/client/zgw/zrc/model/GeometryCollection.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/GeometryCollection.java
@@ -6,9 +6,9 @@
 package net.atos.client.zgw.zrc.model;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  *
@@ -49,6 +49,6 @@ public class GeometryCollection extends Geometry {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37).append(geometries).toHashCode();
+        return Objects.hash(geometries);
     }
 }

--- a/src/main/java/net/atos/client/zgw/zrc/model/Point.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Point.java
@@ -5,8 +5,9 @@
 
 package net.atos.client.zgw.zrc.model;
 
+import java.util.Objects;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  *
@@ -50,6 +51,6 @@ public class Point extends Geometry {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37).append(coordinates).toHashCode();
+        return Objects.hash(coordinates);
     }
 }

--- a/src/main/java/net/atos/client/zgw/zrc/model/Point2D.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Point2D.java
@@ -8,12 +8,12 @@ package net.atos.client.zgw.zrc.model;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import jakarta.json.bind.adapter.JsonbAdapter;
 import jakarta.json.bind.annotation.JsonbTypeAdapter;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  *
@@ -76,6 +76,6 @@ public class Point2D {
 
     @Override
     public final int hashCode() {
-        return new HashCodeBuilder(17, 37).append(x).append(y).toHashCode();
+        return Objects.hash(x, y);
     }
 }

--- a/src/main/java/net/atos/client/zgw/zrc/model/Polygon.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Polygon.java
@@ -6,13 +6,11 @@
 package net.atos.client.zgw.zrc.model;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-/**
- *
- */
+
 public class Polygon extends Geometry {
 
     private final List<List<Point2D>> coordinates;
@@ -28,8 +26,7 @@ public class Polygon extends Geometry {
 
     @Override
     public String toString() {
-        //TODO yet to be implemented
-        return "POLYGON()";
+        return "Polygon{coordinates=" + coordinates + "}";
     }
 
     @Override
@@ -48,6 +45,6 @@ public class Polygon extends Geometry {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37).append(coordinates).toHashCode();
+        return Objects.hash(coordinates);
     }
 }


### PR DESCRIPTION
Removed obsolete usage of Apache Commons hashcodebuilder and use the more standard Objects.hash() instead.

Solves PZ-973