### PR TITLE
feast: add snyk gradle dependencies scanner

### DIFF
--- a/.github/workflows/snyk-code-scanning.yml
+++ b/.github/workflows/snyk-code-scanning.yml
@@ -1,0 +1,37 @@
+#
+# SPDX-FileCopyrightText: 2024 INFO.nl
+# SPDX-License-Identifier: EUPL-1.2+
+#
+name: Snyk Security code scanner
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "21 11 * * 0"
+
+permissions:
+  # Required for uploading SARIF reports
+  security-events: write
+
+jobs:
+  snyk:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Snyk to check for Gradle vulnerabilities
+        uses: snyk/actions/gradle@master
+        continue-on-error: true # To make sure that SARIF upload gets called
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high --sarif-file-output=snyk-gradle.sarif
+
+      - name: Upload Snyk Gradle result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk-gradle.sarif

--- a/.github/workflows/trivy-code-scanning.yml
+++ b/.github/workflows/trivy-code-scanning.yml
@@ -28,6 +28,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner in repo mode
+        # Note that Trivy for Java requires a Gradle lock file.
+        # We do not use Gradle dependency locking yet because we use Dependabot
+        # to update our Gradle dependencies and Dependabot does not support Gradle lock
+        # files yet. See: https://github.com/dependabot/dependabot-core/issues/2222
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'fs'


### PR DESCRIPTION
Added Snyk Gradle dependencies scanner GitHub workflow. Also because we cannot use Trivy for this since Trivy requires Gradle dependency locking and Dependabot does not support this yet..

Solves PZ-1289