### PR TITLE
fix: first retrieve zaaktype and only then check authorisation on zaaktype when creating zaak

### DIFF
--- a/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
+++ b/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
@@ -360,9 +360,11 @@ public class ZakenRESTService {
         final RESTZaak restZaak = restZaakAanmaakGegevens.zaak;
         final Zaaktype zaaktype = ztcClientService.readZaaktype(restZaak.zaaktype.uuid);
 
+        // make sure to use the omschrijving of the zaaktype that was retrieved to perform
+        // authorisation on zaaktype
         assertPolicy(policyService.readOverigeRechten().getStartenZaak() &&
                              loggedInUserInstance.get()
-                                     .isGeautoriseerdZaaktype(restZaak.zaaktype.omschrijving));
+                                     .isGeautoriseerdZaaktype(zaaktype.getOmschrijving()));
 
         final Zaak zaak = zgwApiService.createZaak(zaakConverter.convert(restZaak, zaaktype));
         if (StringUtils.isNotEmpty(restZaak.initiatorIdentificatie)) {


### PR DESCRIPTION
First retrieve zaaktype and only then check authorisation on zaaktype when creating zaak. Added integration test to create a zaak.

Solves PZ-1318