### PR TITLE
PZ-1206: fix(wildfly): change limit to 500MB

### DIFF
--- a/src/main/resources/wildfly/configure-wildfly.cli
+++ b/src/main/resources/wildfly/configure-wildfly.cli
@@ -33,4 +33,4 @@ data-source add \
 
 # This sets the max post size accepted by the server/RESTEasy.
 # NOTE: This is higher than our limit of 80MB because there seems to be some overhead.
-/subsystem=microprofile-config-smallrye/config-source=props:add(properties={"dev.resteasy.entity.file.threshold" = "100MB"})
+/subsystem=microprofile-config-smallrye/config-source=props:add(properties={"dev.resteasy.entity.file.threshold" = "500MB"})


### PR DESCRIPTION
I am changing the filesize limit to 500MB in wildfly so the 500 error should not occur anymore.

I was unable to reproduce the error Camiel found