### PR TITLE
feat: upgraded Solr in Docker Compose to 9.5.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -210,7 +210,8 @@ services:
       - objecttypen-api
 
   solr:
-    image: solr:9.4.1
+    image: solr:9.5.0-slim
+    platform: linux/amd64
     ports:
       - "8983:8983"
     volumes:


### PR DESCRIPTION
Upgraded Solr in Docker Compose to 9.5.0. Also switched to slim version to reduce size and vulnerabilities. #minor

Solves PZ-1442