### PR TITLE
chore: added Dependabot Maven checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,15 @@ updates:
       - dependency-name: "org.jboss.resteasy:resteasy-multipart-provider"
       - dependency-name: "org.wildfly.security:wildfly-elytron-http-oidc"
 
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+      timezone: "Europe/Amsterdam"
+    reviewers:
+      - "infonl/dimpact"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,10 @@
         <revision>latest-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
         <wildfly.version>30.0.1.Final</wildfly.version>
+        <wildfly-jar-maven-plaugin.version>10.0.0.Final</wildfly-jar-maven-plaugin.version>
+        <wildfly-datasources-galleon-pack.version>6.0.0.Final</wildfly-datasources-galleon-pack.version>
     </properties>
 
     <build>
@@ -26,7 +29,7 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>10.0.0.Final</version>
+                <version>${wildfly-jar-maven-plaugin.version}</version>
                 <configuration>
                     <featurePacks>
                         <featurePack>
@@ -35,7 +38,7 @@
                         <featurePack>
                             <groupId>org.wildfly</groupId>
                             <artifactId>wildfly-datasources-galleon-pack</artifactId>
-                            <version>6.0.0.Final</version>
+                            <version>${wildfly-datasources-galleon-pack.version}</version>
                         </featurePack>
                     </featurePacks>
                     <layers>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <wildfly.version>30.0.1.Final</wildfly.version>
-        <wildfly-jar-maven-plaugin.version>10.0.0.Final</wildfly-jar-maven-plaugin.version>
+        <wildfly-jar-maven-plugin.version>10.0.0.Final</wildfly-jar-maven-plugin.version>
         <wildfly-datasources-galleon-pack.version>6.0.0.Final</wildfly-datasources-galleon-pack.version>
     </properties>
 
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>${wildfly-jar-maven-plaugin.version}</version>
+                <version>${wildfly-jar-maven-plugin.version}</version>
                 <configuration>
                     <featurePacks>
                         <featurePack>


### PR DESCRIPTION
Added Dependabot checks for the dependencies in our Maven pom.xml file to at least get notified of new WildFly releases (extra manual steps are also required for WildFly upgrades).

Solves PZ-1451