### PR TITLE
chore: use jlumbroso/free-disk-space GitHub action

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -159,6 +159,7 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true
+          docker-images: false
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -156,7 +156,7 @@ jobs:
     steps:
       # workaround to avoid 'No space left on device' error
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -155,9 +155,10 @@ jobs:
       BAG_API_KEY: ${{ secrets.BAG_API_KEY }}
     steps:
       # workaround to avoid 'No space left on device' error
-      # see: https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
-      - name: Delete unnecessary tools folder to make space on disk
-        run: rm -rf /opt/hostedtoolcache
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1
+        with:
+          tool-cache: true
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
To hopefully free up more disk space and fix the 'no space left on device' issue when saving the Docker images we use.

Solves PZ-1454