### PR TITLE
fix: you cannot postpone and resume a zaak if the zaak has no streefdatum

### DIFF
--- a/scripts/docker-compose/imports/openzaak-database/database/3-setup-indienen-aansprakelijkstelling-zaaktype.sql
+++ b/scripts/docker-compose/imports/openzaak-database/database/3-setup-indienen-aansprakelijkstelling-zaaktype.sql
@@ -63,7 +63,7 @@ VALUES
     'Behandelen', -- handeling_behandelaar
     'P30D', -- doorlooptijd_behandeling
     NULL, -- servicenorm_behandeling
-    false, -- opschorting_en_aanhouding_mogelijk
+    true, -- opschorting_en_aanhouding_mogelijk
     true, -- verlenging_mogelijk
     'P1M', -- verlengingstermijn
     '{}', -- trefwoorden (empty array)

--- a/src/main/java/net/atos/zac/shared/helper/OpschortenZaakHelper.java
+++ b/src/main/java/net/atos/zac/shared/helper/OpschortenZaakHelper.java
@@ -73,14 +73,18 @@ public class OpschortenZaakHelper {
                 .orElse(0);
         final long dagenVerschil = ChronoUnit.DAYS.between(datumOpgeschort, ZonedDateTime.now());
         final long offset = dagenVerschil - verwachteDagenOpgeschort;
-        final LocalDate einddatumGepland = zaak.getEinddatumGepland().plusDays(offset);
+        LocalDate einddatumGepland = null;
+        if (zaak.getEinddatumGepland() != null) {
+            einddatumGepland = zaak.getEinddatumGepland().plusDays(offset);
+        }
         final LocalDate uiterlijkeEinddatumAfdoening = zaak.getUiterlijkeEinddatumAfdoening().plusDays(offset);
 
         final String toelichting = String.format("%s: %s", HERVATTING, redenHervatting);
-        final Zaak updatedZaak = zrcClientService.patchZaak(zaakUUID,
-                                                            toPatch(einddatumGepland, uiterlijkeEinddatumAfdoening,
-                                                                    redenHervatting, false),
-                                                            toelichting);
+        final Zaak updatedZaak = zrcClientService.patchZaak(
+                zaakUUID,
+                toPatch(einddatumGepland, uiterlijkeEinddatumAfdoening, redenHervatting, false),
+                toelichting
+        );
         zaakVariabelenService.removeDatumtijdOpgeschort(zaakUUID);
         zaakVariabelenService.removeVerwachteDagenOpgeschort(zaakUUID);
         return updatedZaak;

--- a/src/main/java/net/atos/zac/shared/helper/OpschortenZaakHelper.java
+++ b/src/main/java/net/atos/zac/shared/helper/OpschortenZaakHelper.java
@@ -48,11 +48,16 @@ public class OpschortenZaakHelper {
                 ztcClientService.readStatustype(status.getStatustype()) : null;
         assertPolicy(zaak.isOpen() && !isHeropend(statustype) && !zaak.isOpgeschort() && StringUtils.isEmpty(zaak.getOpschorting().getReden()));
         final String toelichting = String.format("%s: %s", OPSCHORTING, redenOpschorting);
-        final LocalDate einddatumGepland = zaak.getEinddatumGepland().plusDays(aantalDagen);
+        LocalDate einddatumGepland = null;
+        if (zaak.getEinddatumGepland() != null) {
+            einddatumGepland = zaak.getEinddatumGepland().plusDays(aantalDagen);
+        }
         final LocalDate uiterlijkeEinddatumAfdoening = zaak.getUiterlijkeEinddatumAfdoening().plusDays(aantalDagen);
-        final Zaak updatedZaak = zrcClientService.patchZaak(zaakUUID,
-                                                            toPatch(einddatumGepland, uiterlijkeEinddatumAfdoening, redenOpschorting, true),
-                                                            toelichting);
+        final Zaak updatedZaak = zrcClientService.patchZaak(
+                zaakUUID,
+                toPatch(einddatumGepland, uiterlijkeEinddatumAfdoening, redenOpschorting, true),
+                toelichting
+        );
         zaakVariabelenService.setDatumtijdOpgeschort(zaakUUID, ZonedDateTime.now());
         zaakVariabelenService.setVerwachteDagenOpgeschort(zaakUUID, Math.toIntExact(aantalDagen));
         return updatedZaak;
@@ -81,9 +86,9 @@ public class OpschortenZaakHelper {
         return updatedZaak;
     }
 
-
     /**
-     * @param einddatumGepland             streefdatum van de zaak
+     * @param einddatumGepland             streefdatum van de zaak; may be null in which case the
+     *                                     streefdatum is not patched
      * @param uiterlijkeEinddatumAfdoening fataledatum van de zaak
      * @param reden                        reden voor de opschorting
      * @param isOpschorting                  true indien opschorten, false indien hervatten
@@ -96,7 +101,9 @@ public class OpschortenZaakHelper {
             final boolean isOpschorting
     ) {
         final Zaak zaak = new Zaak();
-        zaak.setEinddatumGepland(einddatumGepland);
+        if (einddatumGepland != null) {
+            zaak.setEinddatumGepland(einddatumGepland);
+        }
         zaak.setUiterlijkeEinddatumAfdoening(uiterlijkeEinddatumAfdoening);
         final Opschorting opschorting = new Opschorting();
         opschorting.setReden(reden);
@@ -104,5 +111,4 @@ public class OpschortenZaakHelper {
         zaak.setOpschorting(opschorting);
         return zaak;
     }
-
 }

--- a/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
@@ -46,6 +46,7 @@ fun createRolNatuurlijkPersoon(
     natuurlijkPersoon
 )
 
+@Suppress("LongParameterList")
 fun createZaak(
     zaaktypeURI: URI = URI("http://example.com/${UUID.randomUUID()}"),
     startDate: LocalDate = LocalDate.now(),

--- a/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
@@ -1,6 +1,7 @@
 package net.atos.client.zgw.zrc.model
 
 import net.atos.client.zgw.shared.model.Archiefnominatie
+import net.atos.client.zgw.zrc.model.generated.Opschorting
 import net.atos.client.zgw.zrc.model.zaakobjecten.ObjectOpenbareRuimte
 import net.atos.client.zgw.zrc.model.zaakobjecten.ObjectPand
 import net.atos.client.zgw.zrc.model.zaakobjecten.ZaakobjectOpenbareRuimte
@@ -25,6 +26,14 @@ fun createObjectOpenbareRuimte(
 
 fun createObjectPand(identificatie: String = "dummyIdentificatie") = ObjectPand(identificatie)
 
+fun createOpschorting(
+    reden: String? = null,
+    indicatie: Boolean = false
+) = Opschorting().apply {
+    this.reden = reden
+    this.indicatie = indicatie
+}
+
 fun createRolNatuurlijkPersoon(
     zaaktypeURI: URI = URI("http://example.com/${UUID.randomUUID()}"),
     rolType: RolType = createRolType(zaaktypeURI),
@@ -43,7 +52,10 @@ fun createZaak(
     bronOrganisatie: String = "dummyBronOrganisatie",
     verantwoordelijkeOrganisatie: String = "dummyVerantwoordelijkeOrganisatie",
     // an archiefnominatie which is not null means that the zaak is closed
-    archiefnominatie: Archiefnominatie? = null
+    archiefnominatie: Archiefnominatie? = null,
+    opschorting: Opschorting? = null,
+    einddatumGepland: LocalDate? = null,
+    uiterlijkeEinddatumAfdoening: LocalDate = LocalDate.now().plusDays(1)
 ) = Zaak(
     zaaktypeURI,
     startDate,
@@ -53,6 +65,9 @@ fun createZaak(
     this.url = URI("https://example.com/zaak/${UUID.randomUUID()}")
     this.uuid = UUID.randomUUID()
     this.archiefnominatie = archiefnominatie
+    this.opschorting = opschorting
+    this.einddatumGepland = einddatumGepland
+    this.uiterlijkeEinddatumAfdoening = uiterlijkeEinddatumAfdoening
 }
 
 fun createZaakobjectOpenbareRuimte(

--- a/src/test/kotlin/net/atos/zac/shared/helper/OpschortenZaakHelperTest.kt
+++ b/src/test/kotlin/net/atos/zac/shared/helper/OpschortenZaakHelperTest.kt
@@ -1,0 +1,94 @@
+package net.atos.zac.shared.helper
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.test.TestCase
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import net.atos.client.zgw.zrc.ZRCClientService
+import net.atos.client.zgw.zrc.model.Zaak
+import net.atos.client.zgw.zrc.model.createOpschorting
+import net.atos.client.zgw.zrc.model.createZaak
+import net.atos.client.zgw.ztc.ZTCClientService
+import net.atos.zac.flowable.ZaakVariabelenService
+import net.atos.zac.policy.PolicyService
+import net.atos.zac.policy.output.createZaakRechten
+import java.time.LocalDate
+
+class OpschortenZaakHelperTest : BehaviorSpec() {
+    val policyService = mockk<PolicyService>()
+    val zrcClientService = mockk<ZRCClientService>()
+    val ztcClientService = mockk<ZTCClientService>()
+    val zaakVariabelenService = mockk<ZaakVariabelenService>()
+
+    // We have to use @InjectMockKs since the class under test uses field injection instead of constructor injection.
+    // This is because WildFly does not properly support constructor injection.
+    @InjectMockKs
+    lateinit var opschortenZaakHelper: OpschortenZaakHelper
+
+    override suspend fun beforeTest(testCase: TestCase) {
+        MockKAnnotations.init(this)
+    }
+
+    init {
+        given("a zaak that is open and not yet postponed and does not have an planned end date") {
+            When("the zaak is postponed for x days") {
+                then("the zaak should be postponed and the final date should be extended with x days") {
+                    val numberOfDaysPostponed = 123L
+                    val postPonementReason = "dummyReason"
+                    val zaak = createZaak(
+                        opschorting = createOpschorting(reden = null),
+                        einddatumGepland = null,
+                        uiterlijkeEinddatumAfdoening = LocalDate.now().plusDays(1)
+                    )
+                    val postponedZaak = createZaak(
+                        opschorting = createOpschorting(reden = "dummyReason"),
+                        einddatumGepland = null,
+                        uiterlijkeEinddatumAfdoening = LocalDate.now()
+                            .plusDays(1 + numberOfDaysPostponed)
+                    )
+
+                    val patchedZaak = slot<Zaak>()
+                    every { policyService.readZaakRechten(zaak) } returns createZaakRechten()
+                    every {
+                        zrcClientService.patchZaak(
+                            zaak.uuid,
+                            capture(patchedZaak),
+                            "Opschorting: $postPonementReason"
+                        )
+                    } returns postponedZaak
+                    every {
+                        zaakVariabelenService.setDatumtijdOpgeschort(
+                            zaak.uuid,
+                            any()
+                        )
+                    } just runs
+                    every {
+                        zaakVariabelenService.setVerwachteDagenOpgeschort(
+                            zaak.uuid,
+                            numberOfDaysPostponed.toInt()
+                        )
+                    } just runs
+
+                    val returnedZaak = opschortenZaakHelper.opschortenZaak(
+                        zaak,
+                        numberOfDaysPostponed,
+                        postPonementReason
+                    )
+
+                    returnedZaak shouldBe postponedZaak
+                    with(patchedZaak.captured) {
+                        opschorting.reden shouldBe postPonementReason
+                        einddatumGepland shouldBe null
+                        uiterlijkeEinddatumAfdoening shouldBe postponedZaak.uiterlijkeEinddatumAfdoening
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/net/atos/zac/shared/helper/OpschortenZaakHelperTest.kt
+++ b/src/test/kotlin/net/atos/zac/shared/helper/OpschortenZaakHelperTest.kt
@@ -2,6 +2,7 @@ package net.atos.zac.shared.helper
 
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.core.test.TestCase
+import io.kotest.matchers.ints.exactly
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -10,6 +11,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.verify
 import net.atos.client.zgw.zrc.ZRCClientService
 import net.atos.client.zgw.zrc.model.Zaak
 import net.atos.client.zgw.zrc.model.createOpschorting
@@ -19,6 +21,7 @@ import net.atos.zac.flowable.ZaakVariabelenService
 import net.atos.zac.policy.PolicyService
 import net.atos.zac.policy.output.createZaakRechten
 import java.time.LocalDate
+import java.util.Optional
 
 class OpschortenZaakHelperTest : BehaviorSpec() {
     val policyService = mockk<PolicyService>()
@@ -52,16 +55,9 @@ class OpschortenZaakHelperTest : BehaviorSpec() {
                         uiterlijkeEinddatumAfdoening = LocalDate.now()
                             .plusDays(1 + numberOfDaysPostponed)
                     )
-
                     val patchedZaak = slot<Zaak>()
+
                     every { policyService.readZaakRechten(zaak) } returns createZaakRechten()
-                    every {
-                        zrcClientService.patchZaak(
-                            zaak.uuid,
-                            capture(patchedZaak),
-                            "Opschorting: $postPonementReason"
-                        )
-                    } returns postponedZaak
                     every {
                         zaakVariabelenService.setDatumtijdOpgeschort(
                             zaak.uuid,
@@ -74,6 +70,13 @@ class OpschortenZaakHelperTest : BehaviorSpec() {
                             numberOfDaysPostponed.toInt()
                         )
                     } just runs
+                    every {
+                        zrcClientService.patchZaak(
+                            zaak.uuid,
+                            capture(patchedZaak),
+                            "Opschorting: $postPonementReason"
+                        )
+                    } returns postponedZaak
 
                     val returnedZaak = opschortenZaakHelper.opschortenZaak(
                         zaak,
@@ -82,10 +85,73 @@ class OpschortenZaakHelperTest : BehaviorSpec() {
                     )
 
                     returnedZaak shouldBe postponedZaak
+                    verify(exactly = 1) {
+                        zaakVariabelenService.setDatumtijdOpgeschort(zaak.uuid, any())
+                        zaakVariabelenService.setVerwachteDagenOpgeschort(
+                            zaak.uuid,
+                            numberOfDaysPostponed.toInt()
+                        )
+                        zrcClientService.patchZaak(
+                            zaak.uuid,
+                            any(),
+                            "Opschorting: $postPonementReason"
+                        )
+                    }
                     with(patchedZaak.captured) {
                         opschorting.reden shouldBe postPonementReason
                         einddatumGepland shouldBe null
                         uiterlijkeEinddatumAfdoening shouldBe postponedZaak.uiterlijkeEinddatumAfdoening
+                    }
+                }
+            }
+        }
+        given("a zaak that is postponed and does not have an planned end date") {
+            When("the zaak is resumed") {
+                then("the zaak should be resumed") {
+                    val reasonResumed = "dummyResumeReason"
+                    val zaak = createZaak(
+                        opschorting = createOpschorting(
+                            reden = "dummyPostponementReason",
+                            indicatie = true
+                        ),
+                        einddatumGepland = null,
+                        uiterlijkeEinddatumAfdoening = LocalDate.now().plusDays(1)
+                    )
+                    val resumedZaak = createZaak(
+                        opschorting = createOpschorting(reden = null),
+                        einddatumGepland = null,
+                        uiterlijkeEinddatumAfdoening = LocalDate.now().plusDays(1)
+                    )
+                    val patchedZaak = slot<Zaak>()
+
+                    every { policyService.readZaakRechten(zaak) } returns createZaakRechten()
+                    every { zaakVariabelenService.findDatumtijdOpgeschort(zaak.uuid) } returns Optional.empty()
+                    every { zaakVariabelenService.findVerwachteDagenOpgeschort(zaak.uuid) } returns Optional.empty()
+                    every {
+                        zrcClientService.patchZaak(
+                            zaak.uuid,
+                            capture(patchedZaak),
+                            "Hervatting: $reasonResumed"
+                        )
+                    } returns resumedZaak
+                    every { zaakVariabelenService.removeDatumtijdOpgeschort(zaak.uuid) } just runs
+                    every { zaakVariabelenService.removeVerwachteDagenOpgeschort(zaak.uuid) } just runs
+
+                    opschortenZaakHelper.hervattenZaak(zaak, reasonResumed)
+
+                    verify(exactly = 1) {
+                        zrcClientService.patchZaak(
+                            zaak.uuid,
+                            any(),
+                            "Hervatting: $reasonResumed"
+                        )
+                        zaakVariabelenService.removeDatumtijdOpgeschort(zaak.uuid)
+                        zaakVariabelenService.removeVerwachteDagenOpgeschort(zaak.uuid)
+                    }
+                    with(patchedZaak.captured) {
+                        opschorting.reden shouldBe reasonResumed
+                        einddatumGepland shouldBe null
+                        uiterlijkeEinddatumAfdoening shouldBe resumedZaak.uiterlijkeEinddatumAfdoening
                     }
                 }
             }


### PR DESCRIPTION
Fixed code so that you can now postpone and resume a zaak when the zaak/zaaktype does not have a 'streefdatum', which may be the case depending on how the zaaktype is configured.

Solves PZ-1407