### PR TITLE
fix: do not use mounted volume for generated import file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -233,19 +233,19 @@ services:
       - "8181:8181"
 
   openldap:
-    image: bitnami/openldap:2.6.6
+    image: bitnami/openldap:2.6.7
     ports:
       - "1389:1389"
       - "1636:1636"
     volumes:
       - ./scripts/docker-compose/imports/openldap/schemas:/schemas
-      - ./scripts/docker-compose/imports/openldap/ldifs:/ldifs
       - ./scripts/docker-compose/imports/openldap/zac-scripts:/zac-scripts
     environment:
       - LDAP_ADMIN_USERNAME=admin
       - LDAP_ADMIN_PASSWORD=admin
       - LDAP_ROOT=dc=example,dc=org
       - LDAP_SKIP_DEFAULT_TREE=yes
+      - LDAP_CUSTOM_LDIF_DIR=/tmp
       - ZAC_TESTUSER1_EMAIL_ADDRESS=${DOCKER_COMPOSE_LDAP_TEST_USER_1_EMAIL_ADDRESS:-testuser1@example.com}
       - ZAC_TESTUSER2_EMAIL_ADDRESS=${DOCKER_COMPOSE_LDAP_TEST_USER_2_EMAIL_ADDRESS:-testuser2@example.com}
       - ZAC_RECORD_MANAGER_1_EMAIL_ADDRESS=${DOCKER_COMPOSE_LDAP_RECORD_MANAGER_1_EMAIL_ADDRESS:-recordmanager1@example.com}

--- a/scripts/docker-compose/imports/openldap/ldifs/README.md
+++ b/scripts/docker-compose/imports/openldap/ldifs/README.md
@@ -1,4 +1,0 @@
-# ZAC OpenLDAP LDIF folder
-
-This folder is intentionally left empty.
-When starting up OpenLDAP using our Docker Compose file the generated ZAC LDIF import file will be placed here.

--- a/scripts/docker-compose/imports/openldap/zac-scripts/generate-zac-import-ldif-and-start-openldap.sh
+++ b/scripts/docker-compose/imports/openldap/zac-scripts/generate-zac-import-ldif-and-start-openldap.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+set -e
+
 echo -e "Generating ZAC LDIF import file.."
 
 # generate ZAC import LDIF by substituting variables in template with environment variables
 # note that we cannot do this in an /docker-entrypoint-initdb.d/ script because OpenLDAP may already have started then
-sed "s/\${TESTUSER1_EMAIL_ADDRESS}/${ZAC_TESTUSER1_EMAIL_ADDRESS}/g; s/\${TESTUSER2_EMAIL_ADDRESS}/${ZAC_TESTUSER2_EMAIL_ADDRESS}/g; s/\${RECORDMANAGER1_EMAIL_ADDRESS}/${ZAC_RECORD_MANAGER_1_EMAIL_ADDRESS}/g; s/\${FUNCTIONAL_ADMIN1_EMAIL_ADDRESS}/${ZAC_FUNCTIONAL_ADMIN_1_EMAIL_ADDRESS}/g; s/\${GROUP_A_EMAIL_ADDRESS}/${ZAC_GROUP_A_EMAIL_ADDRESS}/g; s/\${GROUP_FUNCTIONEEL_BEHEERDERS_EMAIL_ADDRESS}/${ZAC_GROUP_FUNCTIONEEL_BEHEERDERS_EMAIL_ADDRESS}/g; s/\${GROUP_RECORD_MANAGERS_EMAIL_ADDRESS}/${ZAC_GROUP_RECORD_MANAGERS_EMAIL_ADDRESS}/g;" /zac-scripts/zac-ldap-setup-template.ldif > /ldifs/zac-ldap-setup.ldif
+sed "s/\${TESTUSER1_EMAIL_ADDRESS}/${ZAC_TESTUSER1_EMAIL_ADDRESS}/g; s/\${TESTUSER2_EMAIL_ADDRESS}/${ZAC_TESTUSER2_EMAIL_ADDRESS}/g; s/\${RECORDMANAGER1_EMAIL_ADDRESS}/${ZAC_RECORD_MANAGER_1_EMAIL_ADDRESS}/g; s/\${FUNCTIONAL_ADMIN1_EMAIL_ADDRESS}/${ZAC_FUNCTIONAL_ADMIN_1_EMAIL_ADDRESS}/g; s/\${GROUP_A_EMAIL_ADDRESS}/${ZAC_GROUP_A_EMAIL_ADDRESS}/g; s/\${GROUP_FUNCTIONEEL_BEHEERDERS_EMAIL_ADDRESS}/${ZAC_GROUP_FUNCTIONEEL_BEHEERDERS_EMAIL_ADDRESS}/g; s/\${GROUP_RECORD_MANAGERS_EMAIL_ADDRESS}/${ZAC_GROUP_RECORD_MANAGERS_EMAIL_ADDRESS}/g;" /zac-scripts/zac-ldap-setup-template.ldif > /tmp/zac-ldap-setup.ldif
 
-echo -e "ZAC LDIF import file '/ldifs/zac-ldap-setup.ldif' generated"
+echo -e "ZAC LDIF import file '/tmp/zac-ldap-setup.ldif' generated"
 
 echo -e "Starting OpenLDAP.."
 


### PR DESCRIPTION
Linux seems to be stricter around permissions and `/lidfs` cannot be used due to insufficient permissions.

To solve this we can use the current user from `./start-docker-compose`. This however needs to be supported also from the integration tests and couples the docker-compose file with user/group environment variables.

Alternatively, since the ldif file is generated on every start we can safely assume it is ephemeral and move it to `/tmp`. This also solves the permissions issue.