### PR TITLE
chore: switched to UBI9 Minimal base Docker image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Create runtime image fase
-FROM docker.io/eclipse-temurin:21-jre-alpine as runtime
+FROM docker.io/eclipse-temurin:21-ubi9-minimal as runtime
 
 # Import certificates into Java truststore
 ADD certificates /certificates


### PR DESCRIPTION
Switched to UBI9 Minimal base Docker image as it seems a more secure and better maintained image.

Solves PZ-1553