### PR TITLE
fix: remove uploaded file document from the HTTP session when done with it

### DIFF
--- a/src/main/java/net/atos/zac/app/informatieobjecten/InformatieObjectenRESTService.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/InformatieObjectenRESTService.java
@@ -5,23 +5,6 @@
 
 package net.atos.zac.app.informatieobjecten;
 
-import static net.atos.client.zgw.shared.util.InformatieobjectenUtil.convertByteArrayToBase64String;
-import static net.atos.client.zgw.shared.util.URIUtil.parseUUIDFromResourceURI;
-import static net.atos.zac.app.informatieobjecten.converter.RESTInformatieobjectConverter.convertToEnkelvoudigInformatieObject;
-import static net.atos.zac.configuratie.ConfiguratieService.INFORMATIEOBJECTTYPE_OMSCHRIJVING_BIJLAGE;
-import static net.atos.zac.configuratie.ConfiguratieService.OMSCHRIJVING_VOORWAARDEN_GEBRUIKSRECHTEN;
-import static net.atos.zac.policy.PolicyService.assertPolicy;
-import static net.atos.zac.websocket.event.ScreenEventType.ENKELVOUDIG_INFORMATIEOBJECT;
-import static org.apache.commons.lang3.BooleanUtils.isFalse;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -42,11 +25,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.core.UriInfo;
-
-import org.apache.commons.lang3.StringUtils;
-import org.flowable.task.api.Task;
-import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
-
 import net.atos.client.officeconverter.OfficeConverterClientService;
 import net.atos.client.zgw.drc.DRCClientService;
 import net.atos.client.zgw.drc.model.generated.EnkelvoudigInformatieObject;
@@ -97,6 +75,26 @@ import net.atos.zac.flowable.TakenService;
 import net.atos.zac.policy.PolicyService;
 import net.atos.zac.util.UriUtil;
 import net.atos.zac.webdav.WebdavHelper;
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.task.api.Task;
+import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static net.atos.client.zgw.shared.util.InformatieobjectenUtil.convertByteArrayToBase64String;
+import static net.atos.client.zgw.shared.util.URIUtil.parseUUIDFromResourceURI;
+import static net.atos.zac.app.informatieobjecten.converter.RESTInformatieobjectConverter.convertToEnkelvoudigInformatieObject;
+import static net.atos.zac.configuratie.ConfiguratieService.INFORMATIEOBJECTTYPE_OMSCHRIJVING_BIJLAGE;
+import static net.atos.zac.configuratie.ConfiguratieService.OMSCHRIJVING_VOORWAARDEN_GEBRUIKSRECHTEN;
+import static net.atos.zac.policy.PolicyService.assertPolicy;
+import static net.atos.zac.websocket.event.ScreenEventType.ENKELVOUDIG_INFORMATIEOBJECT;
+import static org.apache.commons.lang3.BooleanUtils.isFalse;
 
 @Singleton
 @Path("informatieobjecten")
@@ -287,33 +285,37 @@ public class InformatieObjectenRESTService {
         assertPolicy(policyService.readZaakRechten(zaak).wijzigen());
 
         final RESTFileUpload file = (RESTFileUpload) httpSession.get().getAttribute("FILE_" + documentReferentieId);
-        final EnkelvoudigInformatieObjectData enkelvoudigInformatieObjectData = taakObject ?
-                informatieobjectConverter.convertTaakObject(restEnkelvoudigInformatieobject, file) :
-                informatieobjectConverter.convertZaakObject(restEnkelvoudigInformatieobject, file);
+        try {
+            final EnkelvoudigInformatieObjectData enkelvoudigInformatieObjectData = taakObject ?
+                    informatieobjectConverter.convertTaakObject(restEnkelvoudigInformatieobject, file) :
+                    informatieobjectConverter.convertZaakObject(restEnkelvoudigInformatieobject, file);
+            final ZaakInformatieobject zaakInformatieobject =
+                    zgwApiService.createZaakInformatieobjectForZaak(
+                            zaak,
+                            enkelvoudigInformatieObjectData,
+                            enkelvoudigInformatieObjectData.getTitel(),
+                            enkelvoudigInformatieObjectData.getBeschrijving(),
+                            OMSCHRIJVING_VOORWAARDEN_GEBRUIKSRECHTEN
+                    );
+            if (taakObject) {
+                final Task task = takenService.findOpenTask(documentReferentieId);
+                if (task == null) {
+                    throw new WebApplicationException((
+                            String.format("No open task found with task id: '%s'", documentReferentieId)),
+                            Response.Status.CONFLICT
+                    );
+                }
+                assertPolicy(policyService.readTaakRechten(task, zaak).toevoegenDocument());
 
-        final ZaakInformatieobject zaakInformatieobject =
-                zgwApiService.createZaakInformatieobjectForZaak(
-                        zaak,
-                        enkelvoudigInformatieObjectData,
-                        enkelvoudigInformatieObjectData.getTitel(),
-                        enkelvoudigInformatieObjectData.getBeschrijving(),
-                        OMSCHRIJVING_VOORWAARDEN_GEBRUIKSRECHTEN
-                );
-        if (taakObject) {
-            final Task task = takenService.findOpenTask(documentReferentieId);
-            if (task == null) {
-                throw new WebApplicationException((
-                        String.format("No open task found with task id: '%s'", documentReferentieId)),
-                        Response.Status.CONFLICT
-                );
+                final List<UUID> taakdocumenten = new ArrayList<>(taakVariabelenService.readTaakdocumenten(task));
+                taakdocumenten.add(UriUtil.uuidFromURI(zaakInformatieobject.getInformatieobject()));
+                taakVariabelenService.setTaakdocumenten(task, taakdocumenten);
             }
-            assertPolicy(policyService.readTaakRechten(task, zaak).toevoegenDocument());
-
-            final List<UUID> taakdocumenten = new ArrayList<>(taakVariabelenService.readTaakdocumenten(task));
-            taakdocumenten.add(UriUtil.uuidFromURI(zaakInformatieobject.getInformatieobject()));
-            taakVariabelenService.setTaakdocumenten(task, taakdocumenten);
+            return informatieobjectConverter.convertToREST(zaakInformatieobject);
+        } finally {
+            // always remove the uploaded file from the HTTP session even if exceptions are thrown
+            httpSession.get().removeAttribute("FILE_" + documentReferentieId);
         }
-        return informatieobjectConverter.convertToREST(zaakInformatieobject);
     }
 
     @POST
@@ -374,6 +376,9 @@ public class InformatieObjectenRESTService {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public Response uploadFile(@PathParam("documentReferentieId") final String documentReferentieId,
             @MultipartForm final RESTFileUpload data) {
+        // note that there is no guarantee that the file will be removed from the session afterwards
+        // since the user may abandon the upload process
+        // this should to be improved at some point
         httpSession.get().setAttribute("FILE_" + documentReferentieId, data);
         return Response.ok("\"Success\"").build();
     }


### PR DESCRIPTION
Remove uploaded file document from the HTTP session after the document has been added to the zaak; also if this should fail.

Solves PZ-1560