### PR TITLE
fix: increased max upload file size in Wildfly / RESTEasy 

### DIFF
--- a/src/main/java/net/atos/zac/configuratie/ConfiguratieService.java
+++ b/src/main/java/net/atos/zac/configuratie/ConfiguratieService.java
@@ -5,12 +5,6 @@
 
 package net.atos.zac.configuratie;
 
-import java.net.URI;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -21,12 +15,16 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.core.UriBuilder;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 import net.atos.client.zgw.ztc.ZTCClientService;
 import net.atos.client.zgw.ztc.model.CatalogusListParameters;
 import net.atos.zac.configuratie.model.Taal;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @ApplicationScoped
 @Transactional
@@ -61,12 +59,11 @@ public class ConfiguratieService {
 
     public static final String ENV_VAR_ZGW_API_CLIENT_MP_REST_URL = "ZGW_API_CLIENT_MP_REST_URL";
 
-    // This value should also be set in the widlfly configuration.
-    // The value used in wildfly should be slightly higher to account for overhead. (e.g. 80MB -> 100MB)
+    // Note that WildFly / RESTEasy also defines a max file upload size.
+    // The value used in our WildFly configuration should be set higher to account for overhead. (e.g. 80MB -> 120MB).
     public static final Integer MAX_FILE_SIZE_MB = 80;
+
     private static final String NONE = "<NONE>";
-
-
 
     @PersistenceContext(unitName = "ZaakafhandelcomponentPU")
     private EntityManager entityManager;

--- a/src/main/resources/wildfly/configure-wildfly.cli
+++ b/src/main/resources/wildfly/configure-wildfly.cli
@@ -31,6 +31,6 @@ data-source add \
 #/subsystem=logging/root-logger=ROOT:write-attribute(name=level,value=DEBUG)
 #/subsystem=logging/console-handler=CONSOLE:write-attribute(name=level,value=DEBUG)
 
-# This sets the max post size accepted by the server/RESTEasy.
-# NOTE: This is higher than our limit of 80MB because there seems to be some overhead.
-/subsystem=microprofile-config-smallrye/config-source=props:add(properties={"dev.resteasy.entity.file.threshold" = "100MB"})
+# This sets the max post size accepted by the RESTEasy framework in WildFly
+# NOTE: This needs to set higher than our max file size setting in ZAC because of the way RESTEasy handles file uploads.
+/subsystem=microprofile-config-smallrye/config-source=props:add(properties={"dev.resteasy.entity.file.threshold" = "120MB"})


### PR DESCRIPTION
To allow for max 80MB file uploads.

Solves PZ-1566