### PR TITLE
chore: set memory limit for ZAC Docker container in Docker Compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -441,6 +441,12 @@ services:
     ports:
       - "8080:8080"
       - "9990:9990"
+    deploy:
+      resources:
+        limits:
+          # Set a maximum memory limit for the ZAC container for a more realistic
+          # scenario when testing ZAC locally or when running our integration tests.
+          memory: 4G
     depends_on:
       zac-database:
         condition: service_healthy


### PR DESCRIPTION
For a more realistic scenario when using our Docker Compose file. E.g. in our integration tests. This can help in finding memory related issues.

Solves PZ-1568