### PR TITLE
chore: upgraded Node in the Gradle Node plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -202,7 +202,8 @@ jsonSchema2Pojo {
 
 node {
     download.set(true)
-    version.set("18.13.0")
+    // try to keep this (LTS) Node version as much in sync with the version used in our package.json as possible
+    version.set("20.11.1")
     distBaseUrl.set("https://nodejs.org/dist")
     nodeProjectDir.set(file("$rootDir/src/main/app"))
     if (System.getenv("CI") != null) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -202,7 +202,6 @@ jsonSchema2Pojo {
 
 node {
     download.set(true)
-    // try to keep this (LTS) Node version as much in sync with the version used in our package.json as possible
     version.set("20.11.1")
     distBaseUrl.set("https://nodejs.org/dist")
     nodeProjectDir.set(file("$rootDir/src/main/app"))


### PR DESCRIPTION
Because it was out of date and not in sync with the Node version we use in our package.json.

Solves PZ-1569