### PR TITLE
fix: set max heap size in ZAC Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY target/zaakafhandelcomponent.jar /
 RUN date -Iseconds > /build_timestamp.txt
 
 # Start zaakafhandelcomponent
-ENTRYPOINT ["java", "-jar", "zaakafhandelcomponent.jar"]
+ENTRYPOINT ["java", "-Xms1024m", "-Xmx1024m", "-jar", "zaakafhandelcomponent.jar"]
 EXPOSE 8080 9990
 
 ARG branchName


### PR DESCRIPTION
Set JVM max heap size in ZAC Docker container to 1GB.

Solves PZ-1562