### PR TITLE
chore: only report high & severity level vulnerabilities in Trivy Docker image scans on GitHub

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -217,6 +217,9 @@ jobs:
           image-ref: '${{ env.ZAC_DOCKER_IMAGE }}'
           format: 'sarif'
           output: 'trivy-results.sarif'
+          # limit the severities even when using Sarif
+          # or else all vulnerabilities will be reported
+          limitSeveritiesForSARIF: true
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -219,7 +219,7 @@ jobs:
           output: 'trivy-results.sarif'
           # limit the severities even when using Sarif
           # or else all vulnerabilities will be reported
-          limitSeveritiesForSARIF: true
+          limit-severities-for-sarif: true
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/scheduled-container-scanning.yml
+++ b/.github/workflows/scheduled-container-scanning.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Pull Docker Image
         run: docker pull ${{ env.ZAC_IMAGE_URL }}
-  
+
       - name: Run Trivy Vulnerability Scanner
         uses: aquasecurity/trivy-action@master
         with:
@@ -27,7 +27,7 @@ jobs:
           output: 'trivy-results.sarif'
           # limit the severities even when using Sarif
           # or else all vulnerabilities will be reported
-          limitSeveritiesForSARIF: true
+          limit-severities-for-sarif: true
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy Scan Results to GitHub Security Tab
@@ -50,4 +50,4 @@ jobs:
         with:
           sarif_file: 'snyk.sarif'
 
-          
+

--- a/.github/workflows/scheduled-container-scanning.yml
+++ b/.github/workflows/scheduled-container-scanning.yml
@@ -25,6 +25,9 @@ jobs:
           image-ref: ${{ env.ZAC_IMAGE_URL }}
           format: 'sarif'
           output: 'trivy-results.sarif'
+          # limit the severities even when using Sarif
+          # or else all vulnerabilities will be reported
+          limitSeveritiesForSARIF: true
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy Scan Results to GitHub Security Tab

--- a/.github/workflows/trivy-code-scanning.yml
+++ b/.github/workflows/trivy-code-scanning.yml
@@ -38,6 +38,9 @@ jobs:
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'
+          # limit the severities even when using Sarif
+          # or else all vulnerabilities will be reported
+          limit-severities-for-sarif: true
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
Only report high & severity level vulnerabilities in Trivy Docker image scans on GitHub.

Solves PZ-1614