### PR TITLE
fix: set WildFly socket read and write timeouts to infinity 

### DIFF
--- a/src/main/java/net/atos/zac/websocket/event/ScreenEventObserver.java
+++ b/src/main/java/net/atos/zac/websocket/event/ScreenEventObserver.java
@@ -5,19 +5,21 @@
 
 package net.atos.zac.websocket.event;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.ObservesAsync;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.websocket.Session;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import net.atos.zac.event.AbstractEventObserver;
 import net.atos.zac.websocket.SessionRegistry;
-
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * This bean listens for {@link ScreenEvent}, converts them to a Websockets event and then forwards it to the browsers that have subscribed

--- a/src/main/java/net/atos/zac/websocket/event/ScreenEventObserver.java
+++ b/src/main/java/net/atos/zac/websocket/event/ScreenEventObserver.java
@@ -5,34 +5,35 @@
 
 package net.atos.zac.websocket.event;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.websocket.Session;
+import net.atos.zac.event.AbstractEventObserver;
+import net.atos.zac.websocket.SessionRegistry;
+
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import jakarta.annotation.ManagedBean;
-import jakarta.enterprise.event.ObservesAsync;
-import jakarta.inject.Inject;
-import jakarta.websocket.Session;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import net.atos.zac.event.AbstractEventObserver;
-import net.atos.zac.websocket.SessionRegistry;
 
 /**
  * This bean listens for {@link ScreenEvent}, converts them to a Websockets event and then forwards it to the browsers that have subscribed
  * to it.
  */
-@ManagedBean
+@Named
+@ApplicationScoped
 public class ScreenEventObserver extends AbstractEventObserver<ScreenEvent> {
-
     private static final Logger LOG = Logger.getLogger(ScreenEventObserver.class.getName());
-
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private final SessionRegistry sessionRegistry;
 
     @Inject
-    private SessionRegistry sessionRegistry;
+    public ScreenEventObserver(SessionRegistry sessionRegistry) {
+        this.sessionRegistry = sessionRegistry;
+    }
 
     public void onFire(final @ObservesAsync ScreenEvent event) {
         try {

--- a/src/main/resources/wildfly/configure-wildfly.cli
+++ b/src/main/resources/wildfly/configure-wildfly.cli
@@ -25,12 +25,23 @@ data-source add \
 # Enlarge Undertow max POST size
 /subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=max-post-size,value=1000000000)
 
-# To set the log level to DEBUG (default is INFO) uncomment the following lines.
-# Note that this will result in _a lot_ of logging including security sensitive data
-# so use with care and only enable this for debugging purposes.
-#/subsystem=logging/root-logger=ROOT:write-attribute(name=level,value=DEBUG)
-#/subsystem=logging/console-handler=CONSOLE:write-attribute(name=level,value=DEBUG)
+# Set read and write socket timeouts to infinite (=0) to avoid websocket timeouts
+# Also see: https://stackoverflow.com/questions/77127050/websocket-server-is-being-timeout-after-90-seconds
+/subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=read-timeout,value=0)
+/subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=write-timeout,value=0)
 
 # This sets the max post size accepted by the RESTEasy framework in WildFly
 # NOTE: This needs to set higher than our max file size setting in ZAC because of the way RESTEasy handles file uploads.
 /subsystem=microprofile-config-smallrye/config-source=props:add(properties={"dev.resteasy.entity.file.threshold" = "120MB"})
+
+# To set the log level to DEBUG (default is INFO) uncomment the following lines.
+# Note that this will result in _a lot_ of logging including SessionRegistry sessionRegistry security sensitive data
+# so use with care and only enable this for debugging purposes.
+#/subsystem=logging/console-handler=CONSOLE:write-attribute(name=level,value=DEBUG)
+#/subsystem=logging/root-logger=ROOT:write-attribute(name=level,value=DEBUG)
+
+# To set the log level to TRACE for the ZAC packages uncomment the following lines.
+# Note that this will result in _a lot_ of logging including potentially security sensitive data
+# so use with care and only enable this for debugging purposes.
+#/subsystem=logging/console-handler=CONSOLE:write-attribute(name=level,value=TRACE)
+#/subsystem=logging/logger=net.atos:add(level=TRACE)


### PR DESCRIPTION
To hopefully solve websocket timeout issues and hopefully solve the issue of newly created tasks sometimes not appearing automatically in the zaak detail screen.

Solves PZ-1465