### PR TITLE
fix: add delay before clicking create document

### DIFF
--- a/src/e2e/features/5-external-systems.feature
+++ b/src/e2e/features/5-external-systems.feature
@@ -2,6 +2,6 @@ Feature: External Systems
 
   Scenario: Bob wants to create a new document for a zaak
     Given Employee "Bob" is on the newly created zaak with status "Intake"
-    When "Bob" clicks on Create Document for zaak
+    When "Bob" clicks on Create Document for zaak with a delay
     And "Bob" closes the SmartDocuments tab
     Then "Bob" should not get an error

--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -158,12 +158,14 @@ Then("{string} sees the created zaak with a delay", { timeout: ONE_MINUTE_IN_MS 
     await this.page.getByText(caseNumber);
 });
 
-When('{string} clicks on Create Document for zaak', { timeout: ONE_MINUTE_IN_MS + 15000 }, async function (this: CustomWorld, user) {
+When('{string} clicks on Create Document for zaak with a delay', { timeout: ONE_MINUTE_IN_MS + 30000 }, async function (this: CustomWorld, user) {
+    await this.page.waitForTimeout(ONE_MINUTE_IN_MS)
+
     await this.page.getByText('note_addDocument maken').click();
 
     const smartDocumentsPage = await this.page.waitForEvent('popup');
     await this.expect(smartDocumentsPage.getByRole('link', { name: 'SmartDocuments' })).toBeVisible();
-});
+})
 
 Then('{string} closes the SmartDocuments tab', { timeout: ONE_MINUTE_IN_MS }, async function (this: CustomWorld, user) {
     const allPages = this.page.context().pages();


### PR DESCRIPTION
Add delay before clicking on create document to allow page to load

