### PR TITLE
chore: show GitHub CI status badge on our GitHub homepage for the main branch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dimpact Zaakafhandelcomponent (ZAC)
 
-[![GitHub CI](https://github.com/infonl/dimpact-zaakafhandelcomponent/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/infonl/dimpact-zaakafhandelcomponent/actions/workflows/build-test-deploy.yml)
+[![GitHub CI](https://github.com/infonl/dimpact-zaakafhandelcomponent/actions/workflows/build-test-deploy.yml/badge.svg?branch=main)](https://github.com/infonl/dimpact-zaakafhandelcomponent/actions/workflows/build-test-deploy.yml)
 [![Codecov](https://codecov.io/gh/infonl/dimpact-zaakafhandelcomponent/branch/main/graph/badge.svg)](https://app.codecov.io/gh/infonl/dimpact-zaakafhandelcomponent/)
 [![License](https://img.shields.io/badge/License-EUPL_1.2-blue.svg)](https://opensource.org/licenses/https://opensource.org/license/eupl-1-2/)
 


### PR DESCRIPTION
Because now it shows failing if there is just one PR branch that is failing. We just want to show the status of the main branch in our badges.

Solves PZ-1631