### PR TITLE
chore: added flags to Codecov reports 

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -139,9 +139,10 @@ jobs:
 
       - name: Upload unit test coverage report to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          flags: unittests
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests
 
   build-docker-image-and-run-itests:
     needs: [build]
@@ -226,9 +227,10 @@ jobs:
 
       - name: Upload integration test coverage report to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          flags: integrationtests
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          flags: integrationtests
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -141,6 +141,7 @@ jobs:
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests
 
   build-docker-image-and-run-itests:
     needs: [build]
@@ -227,6 +228,7 @@ jobs:
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          flags: integrationtests
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
So that we can distinguish between unit- and integration test coverage in Codecov when we want to.

Solves PZ-1636