### PR TITLE
chore: use okhttpclient in integration tests in favor of khttp

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,11 +157,12 @@ dependencies {
     "itestImplementation"("org.testcontainers:testcontainers:1.19.6")
     "itestImplementation"("org.testcontainers:mockserver:1.19.6")
     "itestImplementation"("org.testcontainers:postgresql:1.19.6")
+    "itestImplementation"("org.json:json:20240303")
     "itestImplementation"("io.kotest:kotest-runner-junit5:5.8.0")
     "itestImplementation"("io.kotest:kotest-assertions-json:5.8.0")
     "itestImplementation"("org.slf4j:slf4j-simple:2.0.12")
     "itestImplementation"("io.github.oshai:kotlin-logging-jvm:6.0.3")
-    "itestImplementation"("org.danilopianini:khttp:1.6.0")
+    "itestImplementation"("org.danilopianini:khttp:1.6.0")         // TODO
     "itestImplementation"("com.squareup.okhttp3:okhttp:4.12.0")
     "itestImplementation"("com.squareup.okhttp3:okhttp-urlconnection:4.12.0")
     "itestImplementation"("org.awaitility:awaitility-kotlin:4.2.0")
@@ -547,10 +548,6 @@ tasks {
         classpath = sourceSets["itest"].runtimeClasspath
 
         systemProperty("zacDockerImage", zacDockerImage)
-        // note that the PATCH (and PUT?) HTTP requests in the integration tests currently
-        // require the following environment variable to be set
-        // see: https://github.com/lojewalo/khttp/issues/88
-        environment("JAVA_TOOL_OPTIONS", "--add-opens=java.base/java.net=ALL-UNNAMED")
     }
 
     register<JacocoReport>("jacocoIntegrationTestReport") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,7 +162,6 @@ dependencies {
     "itestImplementation"("io.kotest:kotest-assertions-json:5.8.0")
     "itestImplementation"("org.slf4j:slf4j-simple:2.0.12")
     "itestImplementation"("io.github.oshai:kotlin-logging-jvm:6.0.3")
-    "itestImplementation"("org.danilopianini:khttp:1.6.0")         // TODO
     "itestImplementation"("com.squareup.okhttp3:okhttp:4.12.0")
     "itestImplementation"("com.squareup.okhttp3:okhttp-urlconnection:4.12.0")
     "itestImplementation"("org.awaitility:awaitility-kotlin:4.2.0")

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -32,8 +32,7 @@ To do this you will first need to do the following:
     ./gradlew buildZacDockerImage
     ```
 3. If BAG integration is part of the test suite: create a 'run configuration' in your IDE where the following two environment variables are set: `BAG_API_CLIENT_MP_REST_URL` and `BAG_API_KEY`.
-4. Add the following environment variable to this 'run configuration': `JAVA_TOOL_OPTIONS=--add-opens=java.base/java.net=ALL-UNNAMED` (see: https://github.com/lojewalo/khttp/issues/88 for details).
-5. Run the integration tests from your IDE using this run configuration.
+4. Run the integration tests from your IDE using this run configuration.
 
 Running the integration tests will first start up all required services (Keycloak, Open Zaak, etc) as Docker containers using our [Docker Compose file](installDockerCompose.md),
 then start up ZAC as Docker container and finally run the integration tests.

--- a/src/itest/kotlin/nl/lifely/zac/itest/IdentityServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/IdentityServiceTest.kt
@@ -5,12 +5,10 @@
 
 package nl.lifely.zac.itest
 
-import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.json.shouldEqualSpecifiedJsonIgnoringOrder
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import nl.lifely.zac.itest.client.KeycloakClient
 import nl.lifely.zac.itest.client.ZacClient
 import nl.lifely.zac.itest.config.ItestConfiguration
 
@@ -137,17 +135,12 @@ class IdentityServiceTest : BehaviorSpec() {
                 then(
                     "an empty list is returned"
                 ) {
-                    khttp.get(
-                        url = "${ItestConfiguration.ZAC_API_URI}/identity/groups/*/users",
-                        headers = mapOf(
-                            "Content-Type" to "application/json",
-                            "Authorization" to "Bearer ${KeycloakClient.requestAccessToken()}"
-                        )
-                    ).apply {
-                        statusCode shouldBe HttpStatus.SC_OK
-                        text shouldEqualJson """
-                            [
-                        ]
+                    zacClient.performGetRequest(
+                        url = "${ItestConfiguration.ZAC_API_URI}/identity/groups/*/users"
+                    ).use { response ->
+                        response.isSuccessful shouldBe true
+                        response.body!!.string() shouldEqualJson """
+                            []
                         """.trimIndent()
                     }
                 }

--- a/src/itest/kotlin/nl/lifely/zac/itest/InformatieObjectenTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/InformatieObjectenTest.kt
@@ -11,7 +11,6 @@ import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import nl.lifely.zac.itest.client.KeycloakClient
 import nl.lifely.zac.itest.client.ZacClient
 import nl.lifely.zac.itest.config.ItestConfiguration
 import nl.lifely.zac.itest.config.ItestConfiguration.INFORMATIE_OBJECT_TYPE_BIJLAGE_OMSCHRIJVING
@@ -21,7 +20,6 @@ import nl.lifely.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_TASK_
 import nl.lifely.zac.itest.config.ItestConfiguration.USER_FULL_NAME
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
-import okhttp3.Request
 import okhttp3.RequestBody.Companion.asRequestBody
 import org.json.JSONObject
 import java.io.File
@@ -61,7 +59,7 @@ class InformatieObjectenTest : BehaviorSpec() {
 
                     zacClient.performPostRequest(
                         url = endpointUrl,
-                        postBody = JSONObject(
+                        requestBodyAsString = JSONObject(
                             mapOf(
                                 "zaakUUID" to zaak1UUID
                             )
@@ -91,31 +89,24 @@ class InformatieObjectenTest : BehaviorSpec() {
                     val file = Thread.currentThread().getContextClassLoader().getResource("dummyTestDocument.pdf").let {
                         File(it!!.path)
                     }
-                    val endpointUrl = "${ItestConfiguration.ZAC_API_URI}/informatieobjecten/informatieobject/upload/$zaak1UUID"
-                    logger.info { "Calling $endpointUrl endpoint" }
-
-                    val request = Request.Builder()
-                        .header("Authorization", "Bearer ${KeycloakClient.requestAccessToken()}")
-                        .url(endpointUrl)
-                        .post(
-                            MultipartBody.Builder()
-                                .setType(MultipartBody.FORM)
-                                .addFormDataPart("filename", FILE_NAME)
-                                .addFormDataPart("filesize", file.length().toString())
-                                .addFormDataPart("type", FILE_FORMAAT)
-                                .addFormDataPart(
-                                    "file",
-                                    FILE_NAME,
-                                    file.asRequestBody("application/pdf".toMediaType())
-                                )
-                                .build()
-                        )
-                        .build()
-
-                    zacClient.okHttpClient.newCall(request).execute().use { response ->
+                    val requestBody =
+                        MultipartBody.Builder()
+                            .setType(MultipartBody.FORM)
+                            .addFormDataPart("filename", FILE_NAME)
+                            .addFormDataPart("filesize", file.length().toString())
+                            .addFormDataPart("type", FILE_FORMAAT)
+                            .addFormDataPart(
+                                "file",
+                                FILE_NAME,
+                                file.asRequestBody("application/pdf".toMediaType())
+                            )
+                            .build()
+                    zacClient.performPostRequest(
+                        url = "${ItestConfiguration.ZAC_API_URI}/informatieobjecten/informatieobject/upload/$zaak1UUID",
+                        requestBody = requestBody
+                    ).use { response ->
                         val responseBody = response.body!!.string()
-                        logger.info { "$endpointUrl response: $responseBody" }
-
+                        logger.info { "Response: $responseBody" }
                         response.isSuccessful shouldBe true
                     }
                 }
@@ -142,7 +133,7 @@ class InformatieObjectenTest : BehaviorSpec() {
                         "}"
                     zacClient.performPostRequest(
                         url = endpointUrl,
-                        postBody = postBody
+                        requestBodyAsString = postBody
 
                     ).use { response ->
                         val responseBody = response.body!!.string()
@@ -180,31 +171,26 @@ class InformatieObjectenTest : BehaviorSpec() {
                     val file = Thread.currentThread().getContextClassLoader().getResource("dummyTestDocument.pdf").let {
                         File(it!!.path)
                     }
-                    val endpointUrl = "${ItestConfiguration.ZAC_API_URI}/informatieobjecten/informatieobject/upload/$task1ID"
-                    logger.info { "Calling $endpointUrl endpoint" }
 
-                    val request = Request.Builder()
-                        .header("Authorization", "Bearer ${KeycloakClient.requestAccessToken()}")
-                        .url(endpointUrl)
-                        .post(
-                            MultipartBody.Builder()
-                                .setType(MultipartBody.FORM)
-                                .addFormDataPart("filename", FILE_NAME)
-                                .addFormDataPart("filesize", file.length().toString())
-                                .addFormDataPart("type", FILE_FORMAAT)
-                                .addFormDataPart(
-                                    "file",
-                                    FILE_NAME,
-                                    file.asRequestBody("application/pdf".toMediaType())
-                                )
-                                .build()
-                        )
-                        .build()
+                    val requestBody =
+                        MultipartBody.Builder()
+                            .setType(MultipartBody.FORM)
+                            .addFormDataPart("filename", FILE_NAME)
+                            .addFormDataPart("filesize", file.length().toString())
+                            .addFormDataPart("type", FILE_FORMAAT)
+                            .addFormDataPart(
+                                "file",
+                                FILE_NAME,
+                                file.asRequestBody("application/pdf".toMediaType())
+                            )
+                            .build()
 
-                    zacClient.okHttpClient.newCall(request).execute().use { response ->
+                    zacClient.performPostRequest(
+                        url = "${ItestConfiguration.ZAC_API_URI}/informatieobjecten/informatieobject/upload/$task1ID",
+                        requestBody = requestBody
+                    ).use { response ->
                         val responseBody = response.body!!.string()
-                        logger.info { "$endpointUrl response: $responseBody" }
-
+                        logger.info { "Response: $responseBody" }
                         response.isSuccessful shouldBe true
                     }
                 }
@@ -227,7 +213,7 @@ class InformatieObjectenTest : BehaviorSpec() {
                         "}"
                     zacClient.performPostRequest(
                         url = endpointUrl,
-                        postBody = postBody
+                        requestBodyAsString = postBody
 
                     ).use { response ->
                         val responseBody = response.body!!.string()

--- a/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
@@ -11,7 +11,7 @@ import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.provided.ProjectConfig
-import nl.lifely.zac.itest.client.KeycloakClient
+import nl.lifely.zac.itest.client.ZacClient
 import nl.lifely.zac.itest.config.ItestConfiguration.OBJECTS_API_HOSTNAME_URL
 import nl.lifely.zac.itest.config.ItestConfiguration.OBJECTTYPE_UUID_PRODUCTAANVRAAG_DENHAAG
 import nl.lifely.zac.itest.config.ItestConfiguration.OBJECT_PRODUCTAANVRAAG_UUID
@@ -20,6 +20,7 @@ import nl.lifely.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_INITIAL
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAK_1_IDENTIFICATION
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
+import okhttp3.Headers
 import org.json.JSONObject
 import org.testcontainers.containers.wait.strategy.Wait
 import java.time.ZoneId
@@ -27,7 +28,7 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 private val logger = KotlinLogging.logger {}
-
+private val zacClient = ZacClient()
 lateinit var zaak1UUID: UUID
 
 /**
@@ -38,16 +39,16 @@ class NotificationsTest : BehaviorSpec({
     given("ZAC and all related Docker containers are running") {
         When("the notificaties endpoint is called with dummy payload without authentication header") {
             then("the response should be forbidden") {
-                khttp.post(
+                zacClient.performPostRequest(
                     url = "${ZAC_API_URI}/notificaties",
-                    headers = mapOf("Content-Type" to "application/json"),
-                    data = JSONObject(
+                    headers = Headers.headersOf("Content-Type", "application/json"),
+                    requestBodyAsString = JSONObject(
                         mapOf(
                             "dummy" to "dummy"
                         )
-                    )
-                ).apply {
-                    statusCode shouldBe HttpStatus.SC_FORBIDDEN
+                    ).toString()
+                ).use { response ->
+                    response.code shouldBe HttpStatus.SC_FORBIDDEN
                 }
             }
         }
@@ -61,15 +62,17 @@ class NotificationsTest : BehaviorSpec({
                 "the response should be 'no content', a zaak should be created in OpenZaak " +
                     "and a zaak productaanvraag proces of type 'Productaanvraag-Denhaag' should be started in ZAC"
             ) {
-                khttp.post(
+                zacClient.performPostRequest(
                     url = "${ZAC_API_URI}/notificaties",
-                    headers = mapOf(
-                        "Content-Type" to "application/json",
+                    headers = Headers.headersOf(
+                        "Content-Type",
+                        "application/json",
                         // this test simulates that Open Notificaties sends the request to ZAC
                         // using the secret API key that is configured in ZAC
-                        "Authorization" to OPEN_NOTIFICATIONS_API_SECRET_KEY
+                        "Authorization",
+                        OPEN_NOTIFICATIONS_API_SECRET_KEY
                     ),
-                    data = JSONObject(
+                    requestBodyAsString = JSONObject(
                         mapOf(
                             "resource" to "object",
                             "resourceUrl" to "$OBJECTS_API_HOSTNAME_URL/$OBJECT_PRODUCTAANVRAAG_UUID",
@@ -79,24 +82,17 @@ class NotificationsTest : BehaviorSpec({
                             ),
                             "aanmaakdatum" to ZonedDateTime.now(ZoneId.of("UTC")).toString()
                         )
-                    )
-                ).apply {
-                    // Note that the 'notificaties' endpoint always returns 'no content' even if things go wrong
-                    // since it is a fire-and-forget kind of endpoint.
-                    statusCode shouldBe HttpStatus.SC_NO_CONTENT
+                    ).toString()
+                ).use { response ->
+                    response.isSuccessful shouldBe true
 
                     // retrieve the newly created zaak and check the contents
-                    khttp.get(
-                        url = "${ZAC_API_URI}/zaken/zaak/id/$ZAAK_1_IDENTIFICATION",
-                        headers = mapOf(
-                            "Content-Type" to "application/json",
-                            "Authorization" to "Bearer ${KeycloakClient.requestAccessToken()}"
-                        ),
-                    ).apply {
-                        logger.info { "Response: $text" }
-
-                        statusCode shouldBe HttpStatus.SC_OK
-                        val zaak = JSONObject(text)
+                    zacClient.performGetRequest(
+                        "${ZAC_API_URI}/zaken/zaak/id/$ZAAK_1_IDENTIFICATION"
+                    ).use { getZaakResponse ->
+                        val responseBody = getZaakResponse.body!!.string()
+                        logger.info { "Response: $responseBody" }
+                        val zaak = JSONObject(responseBody)
                         zaak.getString("identificatie") shouldBe ZAAK_1_IDENTIFICATION
                         zaak.getJSONObject("zaaktype")
                             .getString("uuid") shouldBe ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID.toString()

--- a/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
@@ -119,26 +119,26 @@ class NotificationsTest : BehaviorSpec({
             then(
                 "a corresponding error message should be logged in ZAC"
             ) {
-                khttp.post(
+                zacClient.performPostRequest(
                     url = "${ZAC_API_URI}/notificaties",
-                    headers = mapOf(
-                        "Content-Type" to "application/json",
+                    headers = Headers.headersOf(
+                        "Content-Type",
+                        "application/json",
                         // this test simulates that Open Notificaties sends the request to ZAC
                         // using the secret API key that is configured in ZAC
-                        "Authorization" to OPEN_NOTIFICATIONS_API_SECRET_KEY
+                        "Authorization",
+                        OPEN_NOTIFICATIONS_API_SECRET_KEY
                     ),
-                    data = JSONObject(
+                    requestBodyAsString = JSONObject(
                         mapOf(
                             "resource" to "zaaktype",
                             "resourceUrl" to "http://example.com/dummyResourceUrl",
                             "actie" to "create",
                             "aanmaakdatum" to ZonedDateTime.now(ZoneId.of("UTC")).toString()
                         )
-                    )
-                ).apply {
-                    // Note that the 'notificaties' endpoint always returns 'no content' even if things go wrong
-                    // since it is a fire-and-forget kind of endpoint.
-                    statusCode shouldBe HttpStatus.SC_NO_CONTENT
+                    ).toString()
+                ).use { response ->
+                    response.isSuccessful shouldBe true
 
                     // we expect ZAC to log an error message indicating that the resourceURL is invalid
                     ProjectConfig.dockerComposeContainer.waitingFor(

--- a/src/itest/kotlin/nl/lifely/zac/itest/PlanItemsRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/PlanItemsRESTServiceTest.kt
@@ -91,7 +91,7 @@ class PlanItemsRESTServiceTest : BehaviorSpec() {
                     val fataleDatum = LocalDate.now().plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
                     zacClient.performPostRequest(
                         url = "${ItestConfiguration.ZAC_API_URI}/planitems/doHumanTaskPlanItem",
-                        postBody = "{\n" +
+                        requestBodyAsString = "{\n" +
                             "\"planItemInstanceId\":\"$humanTaskItemAanvullendeInformatieId\",\n" +
                             "\"fataledatum\":\"$fataleDatum\",\n" +
                             "\"taakStuurGegevens\":{\"sendMail\":false},\n" +

--- a/src/itest/kotlin/nl/lifely/zac/itest/ZakenRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZakenRESTServiceTest.kt
@@ -5,6 +5,9 @@
 
 package nl.lifely.zac.itest
 
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.assertions.json.shouldContainJsonKey
+import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -16,10 +19,11 @@ import nl.lifely.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_ZAAK_
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAK_2_IDENTIFICATION
-import org.apache.http.HttpStatus
+import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import org.json.JSONObject
 
 private val zacClient = ZacClient()
+private val logger = KotlinLogging.logger {}
 
 /**
  * This test assumes a zaak has been created in a previously run test.
@@ -29,14 +33,48 @@ class ZakenRESTServiceTest : BehaviorSpec({
     given("ZAC Docker container is running and zaakafhandelparameters have been created") {
         When("the create zaak endpoint is called and the user has permissions for the zaaktype used") {
             then("the response should be a 200 HTTP response with the created zaak") {
-                val response = zacClient.createZaak(ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID, GROUP_A_ID, GROUP_A_NAME)
-                response.statusCode shouldBe HttpStatus.SC_OK
-                JSONObject(response.text).apply {
-                    getJSONObject("zaaktype").getString("identificatie") shouldBe ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE
+                zacClient.createZaak(
+                    ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID,
+                    GROUP_A_ID,
+                    GROUP_A_NAME
+                ).use { response ->
+                    response.isSuccessful shouldBe true
+                    JSONObject(response.body!!.string()).apply {
+                        getJSONObject("zaaktype").getString("identificatie") shouldBe ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE
+                        getJSONObject("zaakdata").apply {
+                            getString("zaakUUID") shouldNotBe null
+                            getString("zaakIdentificatie") shouldBe ZAAK_2_IDENTIFICATION
+                        }
+                    }
+                }
+            }
+        }
+    }
+    given("A zaak has been created") {
+        When("the assign group to zaak endpoint is called") {
+            then("the group should be assigned to the zaak") {
+                // note that this HTTP request currently requires the following environment variable
+                // to be set when running this test: JAVA_TOOL_OPTIONS=--add-opens=java.base/java.net=ALL-UNNAMED
+                // see: https://github.com/lojewalo/khttp/issues/88
+                zacClient.performPatchRequest(
+                    url = "${ZAC_API_URI}/zaken/toekennen",
+                    requestBodyAsString = "{\n" +
+                        "  \"zaakUUID\": \"$zaak1UUID\",\n" +
+                        "  \"groepId\": \"$GROUP_A_ID\",\n" +
+                        "  \"reden\": \"dummyReason\"\n" +
+                        "}"
+                ).use { response ->
+                    val responseBody = response.body!!.string()
+                    logger.info { "Response: $responseBody" }
+                    response.isSuccessful shouldBe true
 
-                    getJSONObject("zaakdata").apply {
-                        getString("zaakUUID") shouldNotBe null
-                        getString("zaakIdentificatie") shouldBe ZAAK_2_IDENTIFICATION
+                    with(responseBody) {
+                        shouldContainJsonKeyValue("uuid", zaak1UUID.toString())
+                        shouldContainJsonKey("groep")
+                        JSONObject(this).getJSONObject("groep").apply {
+                            getString("id") shouldBe GROUP_A_ID
+                            getString("naam") shouldBe GROUP_A_NAME
+                        }
                     }
                 }
             }

--- a/src/itest/kotlin/nl/lifely/zac/itest/client/KeycloakClient.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/client/KeycloakClient.kt
@@ -5,29 +5,34 @@
 
 package nl.lifely.zac.itest.client
 
-import khttp.requests.GenericRequest
 import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_CLIENT
 import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_CLIENT_SECRET
 import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_HOSTNAME_URL
 import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_REALM
+import okhttp3.FormBody
+import okhttp3.Headers
+import org.json.JSONObject
 
 object KeycloakClient {
+    private const val ACCESS_TOKEN_ATTRIBUTE = "access_token"
+    private const val REFRESH_TOKEN_ATTRIBUTE = "refresh_token"
+
+    private val zacClient = ZacClient()
     private lateinit var refreshToken: String
 
-    fun authenticate() =
-        khttp.post(
-            url = "$KEYCLOAK_HOSTNAME_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token",
-            headers = GenericRequest.DEFAULT_FORM_HEADERS,
-            data = mapOf(
-                "client_id" to KEYCLOAK_CLIENT,
-                "grant_type" to "password",
-                "username" to "testuser1",
-                "password" to "testuser1",
-                "client_secret" to KEYCLOAK_CLIENT_SECRET
-            )
-        ).apply {
-            refreshToken = jsonObject.getString("refresh_token")
-        }
+    fun authenticate() = zacClient.performPostRequest(
+        url = "$KEYCLOAK_HOSTNAME_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token",
+        headers = Headers.headersOf("Content-Type", "application/x-www-form-urlencoded"),
+        requestBody = FormBody.Builder()
+            .add("client_id", KEYCLOAK_CLIENT)
+            .add("grant_type", "password")
+            .add("username", "testuser1")
+            .add("password", "testuser1")
+            .add("client_secret", KEYCLOAK_CLIENT_SECRET)
+            .build()
+    ).apply {
+        refreshToken = JSONObject(this.body!!.string()).getString(REFRESH_TOKEN_ATTRIBUTE)
+    }
 
     /**
      * Always request a new access token using the current refresh token to make sure we remain
@@ -36,21 +41,22 @@ object KeycloakClient {
      * refresh token does not expire in the meantime.
      */
     fun requestAccessToken(): String {
-        khttp.post(
+        zacClient.performPostRequest(
             url = "$KEYCLOAK_HOSTNAME_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token",
-            headers = GenericRequest.DEFAULT_FORM_HEADERS,
-            data = mapOf(
-                "client_id" to KEYCLOAK_CLIENT,
-                "grant_type" to "refresh_token",
-                "refresh_token" to refreshToken,
-                "client_secret" to KEYCLOAK_CLIENT_SECRET
-            )
+            headers = Headers.headersOf("Content-Type", "application/x-www-form-urlencoded"),
+            requestBody = FormBody.Builder()
+                .add("client_id", KEYCLOAK_CLIENT)
+                .add("grant_type", REFRESH_TOKEN_ATTRIBUTE)
+                .add(REFRESH_TOKEN_ATTRIBUTE, refreshToken)
+                .add("client_secret", KEYCLOAK_CLIENT_SECRET)
+                .build()
         ).apply {
-            // a new refresh token is optional, so only update it if it is present
-            if (jsonObject.has("refresh_token")) {
-                refreshToken = jsonObject.getString("refresh_token")
+            with(JSONObject(this.body!!.string())) {
+                if (has(REFRESH_TOKEN_ATTRIBUTE)) {
+                    refreshToken = getString(REFRESH_TOKEN_ATTRIBUTE)
+                }
+                return getString(ACCESS_TOKEN_ATTRIBUTE)
             }
-            return jsonObject.getString("access_token")
         }
     }
 }

--- a/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
@@ -18,15 +18,15 @@ import okhttp3.JavaNetCookieJar
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.net.CookieManager
 import java.net.CookiePolicy
 import java.util.UUID
 
-private val logger = KotlinLogging.logger {}
-
 class ZacClient {
-    var okHttpClient: OkHttpClient
+    private var okHttpClient: OkHttpClient
+    private val logger = KotlinLogging.logger {}
 
     init {
         // use a non-persistent cookie manager to we can reuse HTTP sessions across requests in ZAC
@@ -37,40 +37,58 @@ class ZacClient {
             .build()
     }
 
-    fun performGetRequest(url: String): okhttp3.Response {
+    fun performGetRequest(
+        url: String,
+        headers: Headers = Headers.headersOf(
+            "Authorization",
+            "Bearer ${KeycloakClient.requestAccessToken()}",
+            "Accept",
+            "application/json"
+        )
+    ): okhttp3.Response {
         logger.info { "Performing GET request on: '$url'" }
-
         val request = Request.Builder()
-            .headers(
-                Headers.headersOf(
-                    "Authorization",
-                    "Bearer ${KeycloakClient.requestAccessToken()}",
-                    "Accept",
-                    "application/json"
-                )
-            )
+            .headers(headers)
             .url(url)
             .get()
             .build()
         return okHttpClient.newCall(request).execute()
     }
 
-    fun performPostRequest(url: String, postBody: String): okhttp3.Response {
+    fun performPostRequest(
+        url: String,
+        headers: Headers = Headers.headersOf(
+            "Authorization",
+            "Bearer ${KeycloakClient.requestAccessToken()}",
+            "Accept",
+            "application/json"
+        ),
+        requestBody: RequestBody
+    ): okhttp3.Response {
         logger.info { "Performing POST request on: '$url'" }
-
         val request = Request.Builder()
-            .headers(
-                Headers.headersOf(
-                    "Authorization",
-                    "Bearer ${KeycloakClient.requestAccessToken()}",
-                    "Accept",
-                    "application/json"
-                )
-            )
+            .headers(headers)
             .url(url)
-            .post(postBody.toRequestBody("application/json".toMediaType()))
+            .post(requestBody)
             .build()
         return okHttpClient.newCall(request).execute()
+    }
+
+    fun performPostRequest(
+        url: String,
+        headers: Headers = Headers.headersOf(
+            "Authorization",
+            "Bearer ${KeycloakClient.requestAccessToken()}",
+            "Accept",
+            "application/json"
+        ),
+        requestBodyAsString: String
+    ): okhttp3.Response {
+        return performPostRequest(
+            url = url,
+            headers = headers,
+            requestBody = requestBodyAsString.toRequestBody("application/json".toMediaType())
+        )
     }
 
     @Suppress("LongMethod")


### PR DESCRIPTION
Use the OkHttpClient lib everywhere in our integration tests in favour of the old no longer supported KHttp library.

Solves PZ-1644