### PR TITLE
chore: generate Java model classes for new 'productaanvraag dimpact' object type

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -203,7 +203,7 @@ jsonSchema2Pojo {
     setSource(files("$rootDir/src/main/resources/json-schema"))
     targetDirectory = file("$rootDir/src/generated/java")
     setFileExtensions(".schema.json")
-    targetPackage = "net.atos.zac.aanvraag"
+    targetPackage = "net.atos.zac.aanvraag.model.generated"
     setAnnotationStyle("JSONB2")
     dateType = "java.time.LocalDate"
     dateTimeType = "java.time.ZonedDateTime"
@@ -358,7 +358,6 @@ tasks {
                         exclude("net/atos/client/contactmomenten/model/**")
                         exclude("net/atos/client/kvk/**/model/**")
                         exclude("net/atos/client/vrl/model/**")
-                        exclude("net/atos/zac/aanvraag/**")
                         exclude("**/generated/**")
                     }
                 }

--- a/src/main/java/net/atos/zac/aanvraag/ProductaanvraagService.java
+++ b/src/main/java/net/atos/zac/aanvraag/ProductaanvraagService.java
@@ -5,8 +5,27 @@
 
 package net.atos.zac.aanvraag;
 
+import static net.atos.zac.configuratie.ConfiguratieService.BRON_ORGANISATIE;
+import static net.atos.zac.configuratie.ConfiguratieService.COMMUNICATIEKANAAL_EFORMULIER;
+import static net.atos.zac.util.UriUtil.uuidFromURI;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import net.atos.client.or.object.ObjectsClientService;
 import net.atos.client.or.object.model.ORObject;
 import net.atos.client.vrl.VRLClientService;
@@ -40,23 +59,6 @@ import net.atos.zac.util.JsonbUtil;
 import net.atos.zac.zaaksturing.ZaakafhandelParameterBeheerService;
 import net.atos.zac.zaaksturing.ZaakafhandelParameterService;
 import net.atos.zac.zaaksturing.model.ZaakafhandelParameters;
-import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import java.net.URI;
-import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static net.atos.zac.configuratie.ConfiguratieService.BRON_ORGANISATIE;
-import static net.atos.zac.configuratie.ConfiguratieService.COMMUNICATIEKANAAL_EFORMULIER;
-import static net.atos.zac.util.UriUtil.uuidFromURI;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @ApplicationScoped
 public class ProductaanvraagService {

--- a/src/main/java/net/atos/zac/aanvraag/ProductaanvraagService.java
+++ b/src/main/java/net/atos/zac/aanvraag/ProductaanvraagService.java
@@ -5,27 +5,8 @@
 
 package net.atos.zac.aanvraag;
 
-import static net.atos.zac.configuratie.ConfiguratieService.BRON_ORGANISATIE;
-import static net.atos.zac.configuratie.ConfiguratieService.COMMUNICATIEKANAAL_EFORMULIER;
-import static net.atos.zac.util.UriUtil.uuidFromURI;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
-import java.net.URI;
-import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-
-import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.lang3.StringUtils;
-
 import net.atos.client.or.object.ObjectsClientService;
 import net.atos.client.or.object.model.ORObject;
 import net.atos.client.vrl.VRLClientService;
@@ -47,6 +28,7 @@ import net.atos.client.zgw.ztc.ZTCClientService;
 import net.atos.client.zgw.ztc.model.generated.RolType;
 import net.atos.client.zgw.ztc.model.generated.ZaakType;
 import net.atos.zac.aanvraag.model.InboxProductaanvraag;
+import net.atos.zac.aanvraag.model.generated.ProductaanvraagDenhaag;
 import net.atos.zac.configuratie.ConfiguratieService;
 import net.atos.zac.documenten.InboxDocumentenService;
 import net.atos.zac.flowable.BPMNService;
@@ -58,6 +40,23 @@ import net.atos.zac.util.JsonbUtil;
 import net.atos.zac.zaaksturing.ZaakafhandelParameterBeheerService;
 import net.atos.zac.zaaksturing.ZaakafhandelParameterService;
 import net.atos.zac.zaaksturing.model.ZaakafhandelParameters;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static net.atos.zac.configuratie.ConfiguratieService.BRON_ORGANISATIE;
+import static net.atos.zac.configuratie.ConfiguratieService.COMMUNICATIEKANAAL_EFORMULIER;
+import static net.atos.zac.util.UriUtil.uuidFromURI;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @ApplicationScoped
 public class ProductaanvraagService {
@@ -205,8 +204,10 @@ public class ProductaanvraagService {
     }
 
     public ProductaanvraagDenhaag getProductaanvraag(final ORObject productaanvraagObject) {
-        return JsonbUtil.JSONB.fromJson(JsonbUtil.JSONB.toJson(productaanvraagObject.getRecord().getData()),
-                ProductaanvraagDenhaag.class);
+        return JsonbUtil.JSONB.fromJson(
+                JsonbUtil.JSONB.toJson(productaanvraagObject.getRecord().getData()),
+                ProductaanvraagDenhaag.class
+        );
     }
 
     private void addInitiator(final String bsn, final URI zaak, final URI zaaktype) {

--- a/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
+++ b/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
@@ -5,6 +5,36 @@
 
 package net.atos.zac.app.zaken;
 
+import static net.atos.client.zgw.shared.util.URIUtil.parseUUIDFromResourceURI;
+import static net.atos.client.zgw.zrc.util.StatusTypeUtil.isHeropend;
+import static net.atos.client.zgw.zrc.util.StatusTypeUtil.isIntake;
+import static net.atos.zac.configuratie.ConfiguratieService.COMMUNICATIEKANAAL_EFORMULIER;
+import static net.atos.zac.configuratie.ConfiguratieService.STATUSTYPE_OMSCHRIJVING_HEROPEND;
+import static net.atos.zac.policy.PolicyService.assertPolicy;
+import static net.atos.zac.util.DateTimeConverterUtil.convertToDate;
+import static net.atos.zac.util.DateTimeConverterUtil.convertToLocalDate;
+import static net.atos.zac.util.UriUtil.uuidFromURI;
+import static net.atos.zac.websocket.event.ScreenEventType.TAAK;
+import static net.atos.zac.websocket.event.ScreenEventType.ZAAK;
+import static net.atos.zac.websocket.event.ScreenEventType.ZAAK_TAKEN;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -21,6 +51,10 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import net.atos.client.or.object.ObjectsClientService;
 import net.atos.client.or.object.model.ORObject;
 import net.atos.client.vrl.VRLClientService;
@@ -138,37 +172,6 @@ import net.atos.zac.zaaksturing.model.ZaakafhandelParameters;
 import net.atos.zac.zaaksturing.model.ZaakbeeindigParameter;
 import net.atos.zac.zoeken.IndexeerService;
 import net.atos.zac.zoeken.model.index.ZoekObjectType;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import javax.annotation.Nullable;
-import java.net.URI;
-import java.time.LocalDate;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static net.atos.client.zgw.shared.util.URIUtil.parseUUIDFromResourceURI;
-import static net.atos.client.zgw.zrc.util.StatusTypeUtil.isHeropend;
-import static net.atos.client.zgw.zrc.util.StatusTypeUtil.isIntake;
-import static net.atos.zac.configuratie.ConfiguratieService.COMMUNICATIEKANAAL_EFORMULIER;
-import static net.atos.zac.configuratie.ConfiguratieService.STATUSTYPE_OMSCHRIJVING_HEROPEND;
-import static net.atos.zac.policy.PolicyService.assertPolicy;
-import static net.atos.zac.util.DateTimeConverterUtil.convertToDate;
-import static net.atos.zac.util.DateTimeConverterUtil.convertToLocalDate;
-import static net.atos.zac.util.UriUtil.uuidFromURI;
-import static net.atos.zac.websocket.event.ScreenEventType.TAAK;
-import static net.atos.zac.websocket.event.ScreenEventType.ZAAK;
-import static net.atos.zac.websocket.event.ScreenEventType.ZAAK_TAKEN;
-import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 @Path("zaken")
 @Consumes(MediaType.APPLICATION_JSON)

--- a/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
+++ b/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
@@ -5,36 +5,6 @@
 
 package net.atos.zac.app.zaken;
 
-import static net.atos.client.zgw.shared.util.URIUtil.parseUUIDFromResourceURI;
-import static net.atos.client.zgw.zrc.util.StatusTypeUtil.isHeropend;
-import static net.atos.client.zgw.zrc.util.StatusTypeUtil.isIntake;
-import static net.atos.zac.configuratie.ConfiguratieService.COMMUNICATIEKANAAL_EFORMULIER;
-import static net.atos.zac.configuratie.ConfiguratieService.STATUSTYPE_OMSCHRIJVING_HEROPEND;
-import static net.atos.zac.policy.PolicyService.assertPolicy;
-import static net.atos.zac.util.DateTimeConverterUtil.convertToDate;
-import static net.atos.zac.util.DateTimeConverterUtil.convertToLocalDate;
-import static net.atos.zac.util.UriUtil.uuidFromURI;
-import static net.atos.zac.websocket.event.ScreenEventType.TAAK;
-import static net.atos.zac.websocket.event.ScreenEventType.ZAAK;
-import static net.atos.zac.websocket.event.ScreenEventType.ZAAK_TAKEN;
-import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-
-import java.net.URI;
-import java.time.LocalDate;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import javax.annotation.Nullable;
-
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -51,10 +21,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-
 import net.atos.client.or.object.ObjectsClientService;
 import net.atos.client.or.object.model.ORObject;
 import net.atos.client.vrl.VRLClientService;
@@ -99,8 +65,8 @@ import net.atos.client.zgw.ztc.model.generated.StatusType;
 import net.atos.client.zgw.ztc.model.generated.ZaakType;
 import net.atos.client.zgw.ztc.util.ZaakTypeUtil;
 import net.atos.zac.aanvraag.InboxProductaanvraagService;
-import net.atos.zac.aanvraag.ProductaanvraagDenhaag;
 import net.atos.zac.aanvraag.ProductaanvraagService;
+import net.atos.zac.aanvraag.model.generated.ProductaanvraagDenhaag;
 import net.atos.zac.app.admin.converter.RESTZaakAfzenderConverter;
 import net.atos.zac.app.admin.model.RESTZaakAfzender;
 import net.atos.zac.app.audit.converter.RESTHistorieRegelConverter;
@@ -172,6 +138,37 @@ import net.atos.zac.zaaksturing.model.ZaakafhandelParameters;
 import net.atos.zac.zaaksturing.model.ZaakbeeindigParameter;
 import net.atos.zac.zoeken.IndexeerService;
 import net.atos.zac.zoeken.model.index.ZoekObjectType;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static net.atos.client.zgw.shared.util.URIUtil.parseUUIDFromResourceURI;
+import static net.atos.client.zgw.zrc.util.StatusTypeUtil.isHeropend;
+import static net.atos.client.zgw.zrc.util.StatusTypeUtil.isIntake;
+import static net.atos.zac.configuratie.ConfiguratieService.COMMUNICATIEKANAAL_EFORMULIER;
+import static net.atos.zac.configuratie.ConfiguratieService.STATUSTYPE_OMSCHRIJVING_HEROPEND;
+import static net.atos.zac.policy.PolicyService.assertPolicy;
+import static net.atos.zac.util.DateTimeConverterUtil.convertToDate;
+import static net.atos.zac.util.DateTimeConverterUtil.convertToLocalDate;
+import static net.atos.zac.util.UriUtil.uuidFromURI;
+import static net.atos.zac.websocket.event.ScreenEventType.TAAK;
+import static net.atos.zac.websocket.event.ScreenEventType.ZAAK;
+import static net.atos.zac.websocket.event.ScreenEventType.ZAAK_TAKEN;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 @Path("zaken")
 @Consumes(MediaType.APPLICATION_JSON)

--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -5,34 +5,6 @@
 
 package net.atos.zac.notificaties;
 
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.servlet.http.HttpSession;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import net.atos.client.or.objecttype.ObjecttypesClientService;
-import net.atos.client.or.objecttype.model.Objecttype;
-import net.atos.zac.aanvraag.ProductaanvraagService;
-import net.atos.zac.authentication.ActiveSession;
-import net.atos.zac.authentication.SecurityUtil;
-import net.atos.zac.configuratie.ConfiguratieService;
-import net.atos.zac.documenten.InboxDocumentenService;
-import net.atos.zac.event.EventingService;
-import net.atos.zac.signalering.event.SignaleringEventUtil;
-import net.atos.zac.websocket.event.ScreenEventType;
-import net.atos.zac.zaaksturing.ZaakafhandelParameterBeheerService;
-import net.atos.zac.zoeken.IndexeerService;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import static jakarta.ws.rs.core.Response.noContent;
 import static net.atos.zac.notificaties.Action.CREATE;
 import static net.atos.zac.notificaties.Action.DELETE;
@@ -49,6 +21,36 @@ import static net.atos.zac.notificaties.Resource.ZAAKTYPE;
 import static net.atos.zac.util.UriUtil.uuidFromURI;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpSession;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import net.atos.client.or.objecttype.ObjecttypesClientService;
+import net.atos.client.or.objecttype.model.Objecttype;
+import net.atos.zac.aanvraag.ProductaanvraagService;
+import net.atos.zac.authentication.ActiveSession;
+import net.atos.zac.authentication.SecurityUtil;
+import net.atos.zac.configuratie.ConfiguratieService;
+import net.atos.zac.documenten.InboxDocumentenService;
+import net.atos.zac.event.EventingService;
+import net.atos.zac.signalering.event.SignaleringEventUtil;
+import net.atos.zac.websocket.event.ScreenEventType;
+import net.atos.zac.zaaksturing.ZaakafhandelParameterBeheerService;
+import net.atos.zac.zoeken.IndexeerService;
+
 /**
  *
  */
@@ -56,41 +58,48 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class NotificatieReceiver {
-
     private static final Logger LOG = Logger.getLogger(NotificatieReceiver.class.getName());
-
     private static final String OBJECTTYPE_KENMERK = "objectType";
-
     private static final String PRODUCTAANVRAAGTYPE_NAAM_DENHAAG = "Productaanvraag-Denhaag";
 
-    @Inject
     private EventingService eventingService;
-
-    @Inject
     private ProductaanvraagService productaanvraagService;
-
-    @Inject
     private ConfiguratieService configuratieService;
-
-    @Inject
     private IndexeerService indexeerService;
-
-    @Inject
     private InboxDocumentenService inboxDocumentenService;
-
-    @Inject
     private ZaakafhandelParameterBeheerService zaakafhandelParameterBeheerService;
-
-    @Inject
     private ObjecttypesClientService objecttypesClientService;
-
-    @Inject
-    @ConfigProperty(name = "OPEN_NOTIFICATIONS_API_SECRET_KEY")
     private String secret;
+    private Instance<HttpSession> httpSession;
+
+    /**
+     * Empty no-op constructor as required by JAX-RS.
+     */
+    public NotificatieReceiver() {
+    }
 
     @Inject
-    @ActiveSession
-    private Instance<HttpSession> httpSession;
+    public NotificatieReceiver(
+            EventingService eventingService,
+            ProductaanvraagService productaanvraagService,
+            ConfiguratieService configuratieService,
+            IndexeerService indexeerService,
+            InboxDocumentenService inboxDocumentenService,
+            ZaakafhandelParameterBeheerService zaakafhandelParameterBeheerService,
+            ObjecttypesClientService objecttypesClientService,
+            @ConfigProperty(name = "OPEN_NOTIFICATIONS_API_SECRET_KEY") String secret,
+            @ActiveSession Instance<HttpSession> httpSession
+    ) {
+        this.eventingService = eventingService;
+        this.productaanvraagService = productaanvraagService;
+        this.configuratieService = configuratieService;
+        this.indexeerService = indexeerService;
+        this.inboxDocumentenService = inboxDocumentenService;
+        this.zaakafhandelParameterBeheerService = zaakafhandelParameterBeheerService;
+        this.objecttypesClientService = objecttypesClientService;
+        this.secret = secret;
+        this.httpSession = httpSession;
+    }
 
     @POST
     public Response notificatieReceive(@Context HttpHeaders headers, final Notificatie notificatie) {

--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -5,6 +5,34 @@
 
 package net.atos.zac.notificaties;
 
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpSession;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import net.atos.client.or.objecttype.ObjecttypesClientService;
+import net.atos.client.or.objecttype.model.Objecttype;
+import net.atos.zac.aanvraag.ProductaanvraagService;
+import net.atos.zac.authentication.ActiveSession;
+import net.atos.zac.authentication.SecurityUtil;
+import net.atos.zac.configuratie.ConfiguratieService;
+import net.atos.zac.documenten.InboxDocumentenService;
+import net.atos.zac.event.EventingService;
+import net.atos.zac.signalering.event.SignaleringEventUtil;
+import net.atos.zac.websocket.event.ScreenEventType;
+import net.atos.zac.zaaksturing.ZaakafhandelParameterBeheerService;
+import net.atos.zac.zoeken.IndexeerService;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import static jakarta.ws.rs.core.Response.noContent;
 import static net.atos.zac.notificaties.Action.CREATE;
 import static net.atos.zac.notificaties.Action.DELETE;
@@ -20,36 +48,6 @@ import static net.atos.zac.notificaties.Resource.ZAAKOBJECT;
 import static net.atos.zac.notificaties.Resource.ZAAKTYPE;
 import static net.atos.zac.util.UriUtil.uuidFromURI;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-import jakarta.servlet.http.HttpSession;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import net.atos.client.or.objecttype.ObjecttypesClientService;
-import net.atos.client.or.objecttype.model.Objecttype;
-import net.atos.zac.aanvraag.ProductaanvraagService;
-import net.atos.zac.authentication.ActiveSession;
-import net.atos.zac.authentication.SecurityUtil;
-import net.atos.zac.configuratie.ConfiguratieService;
-import net.atos.zac.documenten.InboxDocumentenService;
-import net.atos.zac.event.EventingService;
-import net.atos.zac.signalering.event.SignaleringEventUtil;
-import net.atos.zac.websocket.event.ScreenEventType;
-import net.atos.zac.zaaksturing.ZaakafhandelParameterBeheerService;
-import net.atos.zac.zoeken.IndexeerService;
 
 /**
  *

--- a/src/main/resources/json-schema/productaanvraag-dimpact.json
+++ b/src/main/resources/json-schema/productaanvraag-dimpact.json
@@ -1,0 +1,440 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "$id" : "https://open-objecten.org/schemas/productaanvraag",
+  "title" : "Productaanvraag",
+  "type" : "object",
+  "properties" : {
+    "bron" : {
+      "title" : "Bron",
+      "description" : "Bron waaruit de productaanvraag voortkomt",
+      "type" : "object",
+      "properties" : {
+        "naam" : {
+          "title" : "Naam",
+          "description" : "Naam van de bron",
+          "type" : "string",
+          "examples" : [
+            "Open Formulieren"
+          ]
+        },
+        "kenmerk" : {
+          "title" : "Kenmerk",
+          "description" : "Kenmerk van de productaanvraag zoals bekend bij de bron. Bijvoorbeeld ID van de submission in Open Forms",
+          "type" : "string",
+          "examples" : [
+            "a43e84ac-e08b-4d5f-8d5c-5874c6dddf56"
+          ]
+        }
+      },
+      "required" : [
+        "naam",
+        "kenmerk"
+      ]
+    },
+    "type" : {
+      "title" : "Type",
+      "description" : "Type productaanvraag",
+      "type" : "string",
+      "examples" : [
+        "verhuizing",
+        "terugbelnotitie"
+      ]
+    },
+    "aanvraaggegevens" : {
+      "title" : "Aanvraaggegevens",
+      "description" : "Gegevens uit de aanvraag van het product",
+      "type" : "object",
+      "examples" : [
+        {
+          "uw-gegevens" : {
+            "voornaam" : "Voorbeeld",
+            "achternaam" : "Vries",
+            "tussenvoegsel" : "de",
+            "geboortedatum" : "1980-12-31"
+          },
+          "uw-verhuizing" : {
+            "beschrijving" : "Lorem ipsum..."
+          }
+        }
+      ]
+    },
+    "taal" : {
+      "title" : "Taal",
+      "description" : "ISO 639-2/B taalcode waarin de productaanvraag is vastgelegd. Zie: https://www.iso.org/standard/4767.html",
+      "type" : "string",
+      "minLength" : 3,
+      "maxLength" : 3,
+      "default" : "nld"
+    },
+    "zaakgegevens" : {
+      "title" : "Zaakgegevens",
+      "description" : "Gegevens voor de zaak welke kan voortvloeien uit de productaanvraag",
+      "type" : "object",
+      "properties" : {
+        "identificatie" : {
+          "title" : "Identificatie",
+          "description" : "Unieke identificatie van de zaak binnen de organisatie die verantwoordelijk is voor de behandeling van de zaak",
+          "type" : "string",
+          "maxLength" : 40,
+          "examples" : [
+            "123123",
+            "ZAAK-2023-0000000121"
+          ]
+        },
+        "communicatiekanaal" : {
+          "title" : "Communicatiekanaal",
+          "description" : "Medium waarlangs de aanleiding om een zaak te starten is ontvangen. URL naar een communicatiekanaal in de VNG-Referentielijst van communicatiekanalen.",
+          "type" : "string",
+          "formaat" : "uri",
+          "examples" : [
+            "https://referentielijsten-api.vng.cloud/api/v1/communicatiekanalen/f56552a8-a082-4306-9111-eb1664fcb05d"
+          ]
+        },
+        "omschrijving" : {
+          "title" : "Omschrijving",
+          "description" : "Korte omschrijving van de zaak",
+          "type" : "string",
+          "maxLength" : 80,
+          "examples" : [
+            "Verhuizing Blaak 27"
+          ]
+        },
+        "toelichting" : {
+          "title" : "Toelichting",
+          "description" : "Toelichting op de zaak",
+          "type" : "string",
+          "maxLength" : 1000,
+          "examples" : [
+            "Nieuw huis gekocht"
+          ]
+        },
+        "geometry": {
+          "title": "Geometry",
+          "description": "Zaaklocatie",
+          "type": "object",
+          "properties": {
+            "type": {
+              "title": "Type",
+              "description": "Geometry type",
+              "type": "string",
+              "enum": [
+                "Point"
+              ]
+            },
+            "coordinates": {
+              "title": "Coordinates",
+              "description": "Latitude en longitude in WGS 84 coordinatenstelsel",
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2,
+              "examples": [
+                "[52.36673378967122, 4.893164274470299]"
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "coordinates"
+          ]
+        }
+      }
+    },
+    "betrokkenen" : {
+      "title" : "Betrokkenen",
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/$defs/betrokkene"
+      }
+    },
+    "betaling" : {
+      "title" : "Betaling",
+      "description" : "Gegevens aangaande de betaling van de productaanvraag",
+      "type" : "object",
+      "properties" : {
+        "kenmerk" : {
+          "title" : "Kenmerk",
+          "description" : "Betalingskenmerk; Uniek kenmerk waarmee de betaling geidentificeerd kan worden",
+          "type" : "string",
+          "examples" : [
+            "2022ESUITE0320"
+          ]
+        },
+        "bedrag" : {
+          "title" : "Bedrag",
+          "type" : "number",
+          "examples" : [
+            19.20
+          ]
+        },
+        "status" : {
+          "title" : "Status",
+          "description" : "Status van de betaling",
+          "type" : "string",
+          "enum" : [
+            "in_behandeling",
+            "geslaagd",
+            "niet_geslaagd",
+            "geannuleerd"
+          ]
+        },
+        "transactieId" : {
+          "title" : "Transactie ID",
+          "description" : "Identificatie van de transactie uit het betaalsysteem",
+          "type" : "string",
+          "examples" : [
+            "123456784"
+          ]
+        },
+        "transactiedatumtijd" : {
+          "title" : "Transactie datum/tijd",
+          "description" : "Tijdstip waarop de transactie met het betaalsysteem heeft plaatsgevonden",
+          "type" : "string",
+          "format": "date-time",
+          "examples": [
+            "2022-03-15T22:15:30.123+01:00"
+          ]
+        },
+        "statusCode" : {
+          "title" : "Status code",
+          "description" : "Originele code van de betalingsstatus uit het betaalsysteem",
+          "type" : "string",
+          "examples" : [
+            "5"
+          ]
+        },
+        "melding" : {
+          "title" : "Melding",
+          "description" : "Toelichtende melding uit het betaalsysteem",
+          "type" : "string"
+        }
+      },
+      "required" : [
+        "kenmerk",
+        "bedrag",
+        "status"
+      ]
+    },
+    "pdf" : {
+      "title" : "PDF",
+      "description" : "URL naar het informatieobject (in de Documenten API) dat de bevestigings PDF van de productaanvraag bevat",
+      "type" : "string",
+      "format" : "uri",
+      "examples" : [
+        "https://example.com/documenten/api/v1/enkelvoudiginformatieobjecten/230bab4a-4b51-40c6-91b2-f2022008a7f8"
+      ]
+    },
+    "csv" : {
+      "title" : "CSV",
+      "description" : "URL naar het informatieobject (in de Documenten API) dat de CSV met ingezonden productaanvraag gegevens bevat",
+      "type" : "string",
+      "format" : "uri",
+      "examples" : [
+        "https://example.com/documenten/api/v1/enkelvoudiginformatieobjecten/aeaba696-4968-46a6-8b1e-016f503ed88d"
+      ]
+    },
+    "bijlagen" : {
+      "title" : "Bijlagen",
+      "description" : "Lijst met URLs naar informatieobjecten (in de Documenten API) zijnde de bijlagen van de productaanvraag",
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "format" : "uri"
+      },
+      "examples" : [
+        [
+          "https://example.com/documenten/api/v1/enkelvoudiginformatieobjecten/94ff43d6-0ee5-4b5c-8ed7-b86eaa908718",
+          "https://example.com/documenten/api/v1/enkelvoudiginformatieobjecten/a43e84ac-e08b-4d5f-8d5c-5874c6dddf56"
+        ]
+      ]
+    },
+    "additionalProperties" : true
+  },
+  "required" : [
+    "bron",
+    "type",
+    "aanvraaggegevens"
+  ],
+  "examples" : [
+    {
+      "bron" : {
+        "naam" : "Open Formulieren"
+      },
+      "type" : "verhuizing",
+      "aanvraaggegevens" : {
+        "uw-gegevens" : {
+          "voornaam" : "Voorbeeld",
+          "achternaam" : "Vries",
+          "tussenvoegsel" : "de",
+          "geboortedatum" : "1980-12-31"
+        },
+        "uw-verhuizing" : {
+          "beschrijving" : "Lorem ipsum..."
+        }
+      }
+    },
+    {
+      "bron" : {
+        "naam" : "Open Formulieren",
+        "kenmerk" : "f56552a8-a082-4306-9111-eb1664fcb05d"
+      },
+      "type" : "verhuizing",
+      "aanvraaggegevens" : {
+        "uw-gegevens" : {
+          "voornaam" : "Voorbeeld",
+          "achternaam" : "Vries",
+          "tussenvoegsel" : "de",
+          "geboortedatum" : "1980-12-31"
+        },
+        "uw-verhuizing" : {
+          "beschrijving" : "Lorem ipsum..."
+        }
+      },
+      "taal" : "nld",
+      "zaakgegevens" : {
+        "identificatie" : "ZAAK-2023-0000000121",
+        "communicatiekanaal" : "https://referentielijsten-api.vng.cloud/api/v1/communicatiekanalen/f56552a8-a082-4306-9111-eb1664fcb05d",
+        "omschrijving" : "Verhuizing Blaak 27",
+        "toelichting" : "Nieuw huis gekocht"
+      },
+      "betrokkenen" : [
+        {
+          "inpBsn" : "111222333",
+          "rolOmschrijvingGeneriek" : "initiator",
+          "indicatieMachtiging" : "gemachtigde",
+          "indicatieCorrespondentie" : true
+        },
+        {
+          "inpBsn" : "222333444",
+          "rolOmschrijvingGeneriek" : "mede_initiator",
+          "indicatieMachtiging" : "machtiginggever",
+          "indicatieCorrespondentie" : false
+        },
+        {
+          "medewerkerIdentificatie" : "MDW123",
+          "rolOmschrijvingGeneriek" : "klantcontacter"
+        }
+      ],
+      "betaling" : {
+        "kenmerk" : "2022ESUITE0320",
+        "bedrag" : 19.20,
+        "status" : "niet_geslaagd",
+        "transactieId" : "123456784",
+        "transactiedatumtijd" : "2021-04-25T21:30:05+00",
+        "statusCode" : "5",
+        "melding" : "Saldo tekort"
+      },
+      "pdf" : "https://example.com/documenten/api/v1/enkelvoudiginformatieobjecten/230bab4a-4b51-40c6-91b2-f2022008a7f8",
+      "csv" : "https://example.com/documenten/api/v1/enkelvoudiginformatieobjecten/aeaba696-4968-46a6-8b1e-016f503ed88d",
+      "bijlagen" : [
+        "https://example.com/documenten/api/v1/enkelvoudiginformatieobjecten/94ff43d6-0ee5-4b5c-8ed7-b86eaa908718",
+        "https://example.com/documenten/api/v1/enkelvoudiginformatieobjecten/a43e84ac-e08b-4d5f-8d5c-5874c6dddf56"
+      ]
+    }
+  ],
+  "$defs" : {
+    "betrokkene" : {
+      "title" : "Betrokkene",
+      "type" : "object",
+      "properties" : {
+        "inpBsn" : {
+          "title" : "Inp bsn",
+          "description" : "Burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer",
+          "type" : "string",
+          "minLength" : 9,
+          "maxLength" : 9,
+          "examples" : [
+            "111222333"
+          ]
+        },
+        "innNnpId" : {
+          "title" : "Inn nnp id",
+          "description" : "Door een kamer toegekend uniek nummer voor de ingeschreven niet-natuurlijke-persoon",
+          "type" : "string",
+          "maxLength" : 9
+        },
+        "vestigingsNummer" : {
+          "title" : "Vestigings nummer",
+          "description" : "Korte unieke aanduiding van de Vestiging",
+          "type" : "string",
+          "maxLength" : 24
+        },
+        "organisatorischeEenheidIdentificatie" : {
+          "title" : "Organisatorische eenheid identificatie",
+          "description" : "Korte identificatie van de organisatorische eenheid",
+          "type" : "string",
+          "maxLength" : 24
+        },
+        "medewerkerIdentificatie" : {
+          "title" : "Medewerker identificatie",
+          "description" : "Korte unieke aanduiding van de medewerker",
+          "type" : "string",
+          "maxLength" : 24
+        },
+        "rolOmschrijvingGeneriek" : {
+          "title" : "Rol omschrijving generiek",
+          "description" : "Algemeen gehanteerde benaming van de aard van de rol van de betrokkene",
+          "type" : "string",
+          "enum" : [
+            "adviseur",
+            "behandelaar",
+            "belanghebbende",
+            "beslisser",
+            "initiator",
+            "klantcontacter",
+            "zaakcoordinator",
+            "mede_initiator"
+          ]
+        },
+        "indicatieMachtiging" : {
+          "title" : "Indicatie machtiging",
+          "description" : "Uitleg bij mogelijke waarden: `gemachtigde` - Betrokkene is door een andere betrokkene gemachtigd om namens hem of haar te handelen. * `machtiginggever` - Betrokkene heeft een andere betrokkene gemachtigd om namens hem of haar te handelen",
+          "type" : "string",
+          "enum" : [
+            "gemachtigde",
+            "machtiginggever"
+          ]
+        },
+        "indicatieCorrespondentie" : {
+          "title" : "Indicatie correspondentie",
+          "description" : "Indicatie of met de betrokkene gecorrespondeerd moet/mag worden inzake de productaanvraag",
+          "type" : "boolean"
+        }
+      },
+      "oneOf" : [
+        {
+          "required" : [
+            "inpBsn",
+            "rolOmschrijvingGeneriek"
+          ]
+        },
+        {
+          "required" : [
+            "innNnpId",
+            "rolOmschrijvingGeneriek"
+          ]
+        },
+        {
+          "required" : [
+            "vestigingsNummer",
+            "rolOmschrijvingGeneriek"
+          ]
+        },
+        {
+          "required" : [
+            "organisatorischeEenheidIdentificatie",
+            "rolOmschrijvingGeneriek"
+          ]
+        },
+        {
+          "required" : [
+            "medewerkerIdentificatie",
+            "rolOmschrijvingGeneriek"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/test/kotlin/net/atos/client/or/object/model/ObjectRegistratieFixtures.kt
+++ b/src/test/kotlin/net/atos/client/or/object/model/ObjectRegistratieFixtures.kt
@@ -2,6 +2,7 @@
 
 package net.atos.client.or.`object`.model
 
+import net.atos.client.or.objecttype.model.Objecttype
 import java.net.URI
 import java.util.UUID
 
@@ -9,4 +10,15 @@ fun createObjectRegistratieObject() =
     ORObject().apply {
         url = URI("https://example.com/objects/1")
         uuid = UUID.randomUUID()
+    }
+
+fun createObjecttype(
+    url: URI = URI("https://example.com/objecttypes/1"),
+    uuid: UUID = UUID.randomUUID(),
+    name: String = "dummyName"
+) =
+    Objecttype().apply {
+        this.url = url
+        this.uuid = uuid
+        this.name = name
     }

--- a/src/test/kotlin/net/atos/zac/aanvraag/AanvraagFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/aanvraag/AanvraagFixtures.kt
@@ -5,6 +5,8 @@
 
 package net.atos.zac.aanvraag
 
+import net.atos.zac.aanvraag.model.generated.Data
+import net.atos.zac.aanvraag.model.generated.ProductaanvraagDenhaag
 import java.net.URI
 
 @Suppress("LongParameterList")

--- a/src/test/kotlin/net/atos/zac/notificaties/NotificatieFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/notificaties/NotificatieFixtures.kt
@@ -1,0 +1,26 @@
+package net.atos.zac.notificaties
+
+import java.net.URI
+import java.time.ZonedDateTime
+import java.util.*
+
+@Suppress("LongParameterList")
+fun createNotificatie(
+    channel: Channel = Channel.OBJECTEN,
+    creationDateTime: ZonedDateTime = ZonedDateTime.now(),
+    properties: Map<String, String> = mapOf(
+        "objectType" to "http://example.com/dummyproducttype/${UUID.randomUUID()}"
+    ),
+    resource: Resource = Resource.OBJECT,
+    action: Action = Action.CREATE,
+    resourceUrl: URI = URI("http://example.com/dummyresourceurl"),
+    mainResourceUrl: URI = resourceUrl
+) = Notificatie().apply {
+    this.channel = channel
+    this.creationDateTime = creationDateTime
+    this.properties = properties
+    this.resource = resource
+    this.action = action
+    this.resourceUrl = resourceUrl
+    this.mainResourceUrl = mainResourceUrl
+}

--- a/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
+++ b/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package net.atos.zac.notificaties
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import jakarta.enterprise.inject.Instance
+import jakarta.servlet.http.HttpSession
+import jakarta.ws.rs.core.HttpHeaders
+import net.atos.client.or.`object`.model.createObjecttype
+import net.atos.client.or.objecttype.ObjecttypesClientService
+import net.atos.zac.aanvraag.ProductaanvraagService
+import net.atos.zac.configuratie.ConfiguratieService
+import net.atos.zac.documenten.InboxDocumentenService
+import net.atos.zac.event.EventingService
+import net.atos.zac.zaaksturing.ZaakafhandelParameterBeheerService
+import net.atos.zac.zoeken.IndexeerService
+import java.net.URI
+import java.util.UUID
+
+const val SECRET = "dummySecret"
+
+@MockKExtension.CheckUnnecessaryStub
+class NotificatieReceiverTest : BehaviorSpec({
+    val eventingService = mockk<EventingService>()
+    val productaanvraagService = mockk<ProductaanvraagService>()
+    val configuratieService = mockk<ConfiguratieService>()
+    val indexeerService = mockk<IndexeerService>()
+    val inboxDocumentenService = mockk<InboxDocumentenService>()
+    val zaakafhandelParameterBeheerService = mockk<ZaakafhandelParameterBeheerService>()
+    val objecttypesClientService = mockk<ObjecttypesClientService>()
+    val httpSessionInstance = mockk<Instance<HttpSession>>()
+
+    val notificatieReceiver = NotificatieReceiver(
+        eventingService,
+        productaanvraagService,
+        configuratieService,
+        indexeerService,
+        inboxDocumentenService,
+        zaakafhandelParameterBeheerService,
+        objecttypesClientService,
+        SECRET,
+        httpSessionInstance
+    )
+
+    given(
+        "a request containing a authorization header, a productaanvraag notificatie with a object type UUID " +
+            "for the 'productaanvraag DenHaag' object type"
+    ) {
+        `when`("notificatieReceive is called") {
+            then(
+                "the 'functional user' is added to the HTTP sessionm the productaanvraag service is invoked " +
+                    "and a 'no content' response is returned"
+            ) {
+                val secret = "dummySecret"
+                val objectTypeUUID = UUID.randomUUID()
+                val productTypeUUID = UUID.randomUUID()
+                val httpHeaders = mockk<HttpHeaders>()
+                val httpSession = mockk<HttpSession>()
+                val notifcatie = createNotificatie(
+                    resourceUrl = URI("http://example.com/dummyproductaanvraag/$objectTypeUUID"),
+                    properties = mapOf("objectType" to "http://example.com/dummyproducttype/$productTypeUUID")
+                )
+                val objectType = createObjecttype(name = "Productaanvraag-Denhaag")
+                every { httpHeaders.getHeaderString("Authorization") } returns secret
+                every { httpSessionInstance.get() } returns httpSession
+                every { httpSession.setAttribute("logged-in-user", any()) } just runs
+                every { configuratieService.isLocalDevelopment } returns false
+                every { objecttypesClientService.readObjecttype(productTypeUUID) } returns objectType
+                every { productaanvraagService.verwerkProductaanvraag(notifcatie.resourceUrl) } just runs
+
+                val response = notificatieReceiver.notificatieReceive(httpHeaders, notifcatie)
+
+                response.status shouldBe 204
+                verify(exactly = 1) {
+                    productaanvraagService.verwerkProductaanvraag(notifcatie.resourceUrl)
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Added OpenAPI spec for new 'productaanvraag dimpact' object type so that Java model classes for this object type are generated. Added unit test for the NotifcatieReceiver class. And also moved these generated Java classes to a 'generated' subpackage. Note that in this PR this new productaanvraag type is not actually used yet. It is just preparing for that.

Solves PZ-1477