### PR TITLE
fix: exclude frontend coverage JSON report from Spotless

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -300,7 +300,8 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
                 "src/main/app/node_modules/**",
                 "src/main/app/dist/**",
                 "src/main/app/.angular/**",
-                "src/**/package-lock.json"
+                "src/**/package-lock.json",
+                "src/main/app/coverage/**.json"
         )
 
         prettier(mapOf("prettier" to "3.2.5")).config(mapOf("parser" to "json"))


### PR DESCRIPTION
Excluded generated coverage JSON reports from Spotless JSON check.

Solves PZ-1791