### PR TITLE
fix: persist Toelichting when finishing a Taak

### DIFF
--- a/src/main/app/src/app/taken/taak-view/taak-view.component.ts
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.ts
@@ -341,15 +341,6 @@ export class TaakViewComponent
     }
   }
 
-  partialEditTaak(value: string, field: string): void {
-    this.taak[field] = value[field];
-    this.websocketService.suspendListener(this.taakListener);
-    this.takenService.update(this.taak).subscribe((taak) => {
-      this.utilService.openSnackbar("msg.taak.opgeslagen");
-      this.initTaakGegevens(taak);
-    });
-  }
-
   private reloadTaak() {
     this.takenService.readTaak(this.taak.id).subscribe((taak) => {
       this.init(taak, true);

--- a/src/main/java/net/atos/zac/app/taken/TakenRESTService.java
+++ b/src/main/java/net/atos/zac/app/taken/TakenRESTService.java
@@ -169,7 +169,9 @@ public class TakenRESTService {
         assertPolicy(getTaakStatus(task) != AFGEROND && policyService.readTaakRechten(task).wijzigen());
         taakVariabelenService.setTaakdata(task, restTaak.taakdata);
         taakVariabelenService.setTaakinformatie(task, restTaak.taakinformatie);
-        task = updateTaak(restTaak);
+        task.setDescription(restTaak.toelichting);
+        task.setDueDate(convertToDate(restTaak.fataledatum));
+        task = takenService.updateTask(task);
         eventingService.send(TAAK.updated(task));
         eventingService.send(ZAAK_TAKEN.updated(restTaak.zaakUuid));
         return restTaak;
@@ -262,13 +264,6 @@ public class TakenRESTService {
         return restTaakConverter.convert(task);
     }
 
-    private Task updateTaak(RESTTaak restTaak) {
-        Task task = takenService.readOpenTask(restTaak.id);
-        task.setDescription(restTaak.toelichting);
-        task.setDueDate(convertToDate(restTaak.fataledatum));
-        task = takenService.updateTask(task);
-        return task;
-    }
 
     @PATCH
     @Path("complete")
@@ -295,7 +290,9 @@ public class TakenRESTService {
         ondertekenEnkelvoudigInformatieObjecten(restTaak.taakdata, zaak);
         taakVariabelenService.setTaakdata(task, restTaak.taakdata);
         taakVariabelenService.setTaakinformatie(task, restTaak.taakinformatie);
-        task = updateTaak(restTaak);
+        task.setDescription(restTaak.toelichting);
+        task.setDueDate(convertToDate(restTaak.fataledatum));
+        task = takenService.updateTask(task);
         final HistoricTaskInstance completedTask = takenService.completeTask(task);
         indexeerService.addOrUpdateZaak(restTaak.zaakUuid, false);
         eventingService.send(TAAK.updated(completedTask));

--- a/src/main/java/net/atos/zac/app/taken/TakenRESTService.java
+++ b/src/main/java/net/atos/zac/app/taken/TakenRESTService.java
@@ -295,6 +295,7 @@ public class TakenRESTService {
         ondertekenEnkelvoudigInformatieObjecten(restTaak.taakdata, zaak);
         taakVariabelenService.setTaakdata(task, restTaak.taakdata);
         taakVariabelenService.setTaakinformatie(task, restTaak.taakinformatie);
+        task = updateTaak(restTaak);
         final HistoricTaskInstance completedTask = takenService.completeTask(task);
         indexeerService.addOrUpdateZaak(restTaak.zaakUuid, false);
         eventingService.send(TAAK.updated(completedTask));

--- a/src/test/kotlin/net/atos/zac/app/taken/TakenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/taken/TakenRESTServiceTest.kt
@@ -195,7 +195,10 @@ class TakenRESTServiceTest : BehaviorSpec() {
                     )
 
                     every { task.assignee } returns "dummyAssignee"
+                    every { task.setDescription(restTaak.toelichting) } just runs
+                    every { task.setDueDate(any()) } just runs
                     every { takenService.readOpenTask(restTaak.id) } returns task
+                    every { takenService.updateTask(task) } returns task
                     every { zrcClientService.readZaak(restTaak.zaakUuid) } returns zaak
                     every { policyService.readTaakRechten(task) } returns createTaakRechten()
                     every { httpSessionInstance.get() } returns httpSession
@@ -244,7 +247,10 @@ class TakenRESTServiceTest : BehaviorSpec() {
                     val documentenRechten = createDocumentRechten()
 
                     every { task.assignee } returns "dummyAssignee"
+                    every { task.setDescription(restTaak.toelichting) } just runs
+                    every { task.setDueDate(any()) } just runs
                     every { takenService.readOpenTask(restTaak.id) } returns task
+                    every { takenService.updateTask(task) } returns task
                     every { zrcClientService.readZaak(restTaak.zaakUuid) } returns zaak
                     every { policyService.readTaakRechten(task) } returns createTaakRechten()
                     every { httpSessionInstance.get() } returns httpSession

--- a/src/test/kotlin/net/atos/zac/app/taken/TakenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/taken/TakenRESTServiceTest.kt
@@ -82,52 +82,52 @@ class TakenRESTServiceTest : BehaviorSpec() {
     }
 
     init {
-        given("a task is not yet assigned") {
+        Given("a task is not yet assigned") {
+            val restTaakToekennenGegevens = createRESTTaakToekennenGegevens()
+            val task = mockk<Task>()
+            val identityLinkInfo = mockk<IdentityLinkInfo>()
+            val identityLinks = listOf(identityLinkInfo)
+            val signaleringEventSlot = slot<SignaleringEvent<*>>()
+            val screenEventSlots = mutableListOf<ScreenEvent>()
+
+            every { takenService.readOpenTask(restTaakToekennenGegevens.taakId) } returns task
+            every { getTaakStatus(task) } returns TaakStatus.NIET_TOEGEKEND
+            every {
+                takenService.assignTaskToUser(
+                        restTaakToekennenGegevens.taakId,
+                        restTaakToekennenGegevens.behandelaarId,
+                        restTaakToekennenGegevens.reden
+                )
+            } returns task
+            every {
+                takenService.assignTaskToGroup(
+                        task,
+                        restTaakToekennenGegevens.groepId,
+                        restTaakToekennenGegevens.reden
+                )
+            } returns task
+            every { policyService.readTaakRechten(task) } returns createTaakRechten()
+            every { task.assignee } returns ""
+            every { task.identityLinks } returns identityLinks
+            every { task.id } returns restTaakToekennenGegevens.taakId
+            every { restTaakConverter.extractGroupId(identityLinks) } returns "dummyGroupId"
+            every { eventingService.send(capture(signaleringEventSlot)) } just runs
+            every { eventingService.send(capture(screenEventSlots)) } just runs
+            every {
+                indexeerService.indexeerDirect(
+                        restTaakToekennenGegevens.taakId,
+                        ZoekObjectType.TAAK
+                )
+            } just runs
+
             When("'toekennen' is called") {
-                then(
+                takenRESTService.toekennen(restTaakToekennenGegevens)
+
+                Then(
                     "the task is assigned to the provided user and group, " +
-                        "an signalering event and two screen events are sent,  " +
+                        "a signalling event and two screen events are sent,  " +
                         "and the indexed task data is updated"
                 ) {
-                    val restTaakToekennenGegevens = createRESTTaakToekennenGegevens()
-                    val task = mockk<Task>()
-                    val identityLinkInfo = mockk<IdentityLinkInfo>()
-                    val identityLinks = listOf(identityLinkInfo)
-                    val signaleringEventSlot = slot<SignaleringEvent<*>>()
-                    val screenEventSlots = mutableListOf<ScreenEvent>()
-
-                    every { takenService.readOpenTask(restTaakToekennenGegevens.taakId) } returns task
-                    every { getTaakStatus(task) } returns TaakStatus.NIET_TOEGEKEND
-                    every {
-                        takenService.assignTaskToUser(
-                            restTaakToekennenGegevens.taakId,
-                            restTaakToekennenGegevens.behandelaarId,
-                            restTaakToekennenGegevens.reden
-                        )
-                    } returns task
-                    every {
-                        takenService.assignTaskToGroup(
-                            task,
-                            restTaakToekennenGegevens.groepId,
-                            restTaakToekennenGegevens.reden
-                        )
-                    } returns task
-                    every { policyService.readTaakRechten(task) } returns createTaakRechten()
-                    every { task.assignee } returns ""
-                    every { task.identityLinks } returns identityLinks
-                    every { task.id } returns restTaakToekennenGegevens.taakId
-                    every { restTaakConverter.extractGroupId(identityLinks) } returns "dummyGroupId"
-                    every { eventingService.send(capture(signaleringEventSlot)) } just runs
-                    every { eventingService.send(capture(screenEventSlots)) } just runs
-                    every {
-                        indexeerService.indexeerDirect(
-                            restTaakToekennenGegevens.taakId,
-                            ZoekObjectType.TAAK
-                        )
-                    } just runs
-
-                    takenRESTService.toekennen(restTaakToekennenGegevens)
-
                     verify(exactly = 1) {
                         takenService.assignTaskToUser(
                             restTaakToekennenGegevens.taakId,
@@ -174,45 +174,46 @@ class TakenRESTServiceTest : BehaviorSpec() {
                 }
             }
         }
-        given("a task is assigned to the current user") {
+
+        Given("a task is assigned to the current user") {
+            val task = mockk<Task>()
+            val zaak = mockk<Zaak>()
+            val httpSession = mockk<HttpSession>()
+            val historicTaskInstance = mockk<HistoricTaskInstance>()
+            val restUser = createRESTUser(
+                    id = loggedInUser.id,
+                    name = loggedInUser.fullName
+            )
+            val restTaak = createRESTTaak(
+                    behandelaar = restUser
+            )
+            val restTaakConverted = createRESTTaak(
+                    behandelaar = restUser
+            )
+
+            every { task.assignee } returns "dummyAssignee"
+            every { task.description = restTaak.toelichting } just runs
+            every { task.dueDate = any() } just runs
+            every { takenService.readOpenTask(restTaak.id) } returns task
+            every { takenService.updateTask(task) } returns task
+            every { zrcClientService.readZaak(restTaak.zaakUuid) } returns zaak
+            every { policyService.readTaakRechten(task) } returns createTaakRechten()
+            every { httpSessionInstance.get() } returns httpSession
+            every { taakVariabelenService.isZaakHervatten(restTaak.taakdata) } returns false
+            every { taakVariabelenService.readOndertekeningen(restTaak.taakdata) } returns Optional.empty()
+            every { taakVariabelenService.setTaakdata(task, restTaak.taakdata) } just runs
+            every { taakVariabelenService.setTaakinformatie(task, null) } just runs
+            every { takenService.completeTask(task) } returns historicTaskInstance
+            every { indexeerService.addOrUpdateZaak(restTaak.zaakUuid, false) } just runs
+            every { historicTaskInstance.id } returns restTaak.id
+            every { restTaakConverter.convert(historicTaskInstance) } returns restTaakConverted
+
             When("'complete' is called") {
-                then(
+                val restTaakReturned = takenRESTService.completeTaak(restTaak)
+
+                Then(
                     "the task is completed and the search index service is invoked"
                 ) {
-                    val task = mockk<Task>()
-                    val zaak = mockk<Zaak>()
-                    val httpSession = mockk<HttpSession>()
-                    val historicTaskInstance = mockk<HistoricTaskInstance>()
-                    val restUser = createRESTUser(
-                        id = loggedInUser.id,
-                        name = loggedInUser.fullName
-                    )
-                    val restTaak = createRESTTaak(
-                        behandelaar = restUser
-                    )
-                    val restTaakConverted = createRESTTaak(
-                        behandelaar = restUser
-                    )
-
-                    every { task.assignee } returns "dummyAssignee"
-                    every { task.setDescription(restTaak.toelichting) } just runs
-                    every { task.setDueDate(any()) } just runs
-                    every { takenService.readOpenTask(restTaak.id) } returns task
-                    every { takenService.updateTask(task) } returns task
-                    every { zrcClientService.readZaak(restTaak.zaakUuid) } returns zaak
-                    every { policyService.readTaakRechten(task) } returns createTaakRechten()
-                    every { httpSessionInstance.get() } returns httpSession
-                    every { taakVariabelenService.isZaakHervatten(restTaak.taakdata) } returns false
-                    every { taakVariabelenService.readOndertekeningen(restTaak.taakdata) } returns Optional.empty()
-                    every { taakVariabelenService.setTaakdata(task, restTaak.taakdata) } just runs
-                    every { taakVariabelenService.setTaakinformatie(task, null) } just runs
-                    every { takenService.completeTask(task) } returns historicTaskInstance
-                    every { indexeerService.addOrUpdateZaak(restTaak.zaakUuid, false) } just runs
-                    every { historicTaskInstance.id } returns restTaak.id
-                    every { restTaakConverter.convert(historicTaskInstance) } returns restTaakConverted
-
-                    val restTaakReturned = takenRESTService.completeTaak(restTaak)
-
                     restTaakReturned shouldBe restTaakConverted
                     verify(exactly = 1) {
                         takenService.completeTask(task)
@@ -220,68 +221,69 @@ class TakenRESTServiceTest : BehaviorSpec() {
                 }
             }
         }
-        given("a task is assigned to the current user with a document that is signed") {
+
+        Given("a task is assigned to the current user with a document that is signed") {
+            val task = mockk<Task>()
+            val zaak = mockk<Zaak>()
+            val httpSession = mockk<HttpSession>()
+            val historicTaskInstance = mockk<HistoricTaskInstance>()
+
+            val restUser = createRESTUser(
+                    id = loggedInUser.id,
+                    name = loggedInUser.fullName
+            )
+            val restTaak = createRESTTaak(
+                    behandelaar = restUser
+            )
+            val restTaakConverted = createRESTTaak(
+                    behandelaar = restUser
+            )
+            val enkelvoudigInformatieObjectUUID = UUID.randomUUID()
+            val enkelvoudigInformatieObject = createEnkelvoudigInformatieObject(
+                    url = URI("http://example.com/$enkelvoudigInformatieObjectUUID")
+            )
+            val documentenRechten = createDocumentRechten()
+
+            every { task.assignee } returns "dummyAssignee"
+            every { task.description = restTaak.toelichting } just runs
+            every { task.dueDate = any() } just runs
+            every { takenService.readOpenTask(restTaak.id) } returns task
+            every { takenService.updateTask(task) } returns task
+            every { zrcClientService.readZaak(restTaak.zaakUuid) } returns zaak
+            every { policyService.readTaakRechten(task) } returns createTaakRechten()
+            every { httpSessionInstance.get() } returns httpSession
+            every { taakVariabelenService.isZaakHervatten(restTaak.taakdata) } returns false
+            every { taakVariabelenService.readOndertekeningen(restTaak.taakdata) } returns Optional.of(
+                    enkelvoudigInformatieObjectUUID.toString()
+            )
+            every { taakVariabelenService.setTaakdata(task, restTaak.taakdata) } just runs
+            every { taakVariabelenService.setTaakinformatie(task, null) } just runs
+            every { takenService.completeTask(task) } returns historicTaskInstance
+            every { indexeerService.addOrUpdateZaak(restTaak.zaakUuid, false) } just runs
+            every { historicTaskInstance.id } returns restTaak.id
+            every { restTaakConverter.convert(historicTaskInstance) } returns restTaakConverted
+            every {
+                drcClientService.readEnkelvoudigInformatieobject(enkelvoudigInformatieObjectUUID)
+            } returns enkelvoudigInformatieObject
+            every {
+                policyService.readDocumentRechten(
+                        enkelvoudigInformatieObject,
+                        zaak
+                )
+            } returns documentenRechten
+            every {
+                enkelvoudigInformatieObjectUpdateService.ondertekenEnkelvoudigInformatieObject(
+                        enkelvoudigInformatieObjectUUID
+                )
+            } just runs
+            every { eventingService.send(any<ScreenEvent>()) } just runs
+
             When("'complete' is called") {
-                then(
+                val restTaakReturned = takenRESTService.completeTaak(restTaak)
+
+                Then(
                     "the document is signed, the task is completed and the search index service is invoked"
                 ) {
-                    val task = mockk<Task>()
-                    val zaak = mockk<Zaak>()
-                    val httpSession = mockk<HttpSession>()
-                    val historicTaskInstance = mockk<HistoricTaskInstance>()
-
-                    val restUser = createRESTUser(
-                        id = loggedInUser.id,
-                        name = loggedInUser.fullName
-                    )
-                    val restTaak = createRESTTaak(
-                        behandelaar = restUser
-                    )
-                    val restTaakConverted = createRESTTaak(
-                        behandelaar = restUser
-                    )
-                    val enkelvoudigInformatieObjectUUID = UUID.randomUUID()
-                    val enkelvoudigInformatieObject = createEnkelvoudigInformatieObject(
-                        url = URI("http://example.com/$enkelvoudigInformatieObjectUUID")
-                    )
-                    val documentenRechten = createDocumentRechten()
-
-                    every { task.assignee } returns "dummyAssignee"
-                    every { task.setDescription(restTaak.toelichting) } just runs
-                    every { task.setDueDate(any()) } just runs
-                    every { takenService.readOpenTask(restTaak.id) } returns task
-                    every { takenService.updateTask(task) } returns task
-                    every { zrcClientService.readZaak(restTaak.zaakUuid) } returns zaak
-                    every { policyService.readTaakRechten(task) } returns createTaakRechten()
-                    every { httpSessionInstance.get() } returns httpSession
-                    every { taakVariabelenService.isZaakHervatten(restTaak.taakdata) } returns false
-                    every { taakVariabelenService.readOndertekeningen(restTaak.taakdata) } returns Optional.of(
-                        enkelvoudigInformatieObjectUUID.toString()
-                    )
-                    every { taakVariabelenService.setTaakdata(task, restTaak.taakdata) } just runs
-                    every { taakVariabelenService.setTaakinformatie(task, null) } just runs
-                    every { takenService.completeTask(task) } returns historicTaskInstance
-                    every { indexeerService.addOrUpdateZaak(restTaak.zaakUuid, false) } just runs
-                    every { historicTaskInstance.id } returns restTaak.id
-                    every { restTaakConverter.convert(historicTaskInstance) } returns restTaakConverted
-                    every {
-                        drcClientService.readEnkelvoudigInformatieobject(enkelvoudigInformatieObjectUUID)
-                    } returns enkelvoudigInformatieObject
-                    every {
-                        policyService.readDocumentRechten(
-                            enkelvoudigInformatieObject,
-                            zaak
-                        )
-                    } returns documentenRechten
-                    every {
-                        enkelvoudigInformatieObjectUpdateService.ondertekenEnkelvoudigInformatieObject(
-                            enkelvoudigInformatieObjectUUID
-                        )
-                    } just runs
-                    every { eventingService.send(any<ScreenEvent>()) } just runs
-
-                    val restTaakReturned = takenRESTService.completeTaak(restTaak)
-
                     restTaakReturned shouldBe restTaakConverted
                     verify(exactly = 1) {
                         enkelvoudigInformatieObjectUpdateService.ondertekenEnkelvoudigInformatieObject(


### PR DESCRIPTION
When clicking "Opslaan & afronden" for a Taak, the Toelichting is now correctly persisted.

Solves PZ-1570