### PR TITLE
fix update gebruikersnaam_medewerker on notitie patch

### DIFF
--- a/src/main/app/src/app/notities/notities.component.ts
+++ b/src/main/app/src/app/notities/notities.component.ts
@@ -82,7 +82,9 @@ export class NotitiesComponent implements OnInit {
   updateNotitie(notitie: Notitie, notitieTekst: string) {
     if (notitieTekst.length <= this.maxLengteTextArea) {
       notitie.tekst = notitieTekst;
-      this.notitieService.updateNotitie(notitie).subscribe(() => {
+      notitie.gebruikersnaamMedewerker = this.ingelogdeMedewerker.id;
+      this.notitieService.updateNotitie(notitie).subscribe((updatedNotitie) => {
+        Object.assign(notitie, updatedNotitie)
         this.geselecteerdeNotitieId = null;
       });
     }

--- a/src/main/java/net/atos/zac/notities/model/Notitie.java
+++ b/src/main/java/net/atos/zac/notities/model/Notitie.java
@@ -50,7 +50,7 @@ public class Notitie {
     private ZonedDateTime tijdstipLaatsteWijziging;
 
     @NotBlank
-    @Column(name = "gebruikersnaam_medewerker", nullable = false, updatable = false)
+    @Column(name = "gebruikersnaam_medewerker", nullable = false, updatable = true)
     private String gebruikersnaamMedewerker;
 
     public Long getId() {


### PR DESCRIPTION
When updating a Notitie by another user, the username assigned to it is now correctly updated.

Solves PZ-1472