### PR TITLE
fix: fixed Solr search indexing of zaak stakeholders(betrokkenen)

### DIFF
--- a/src/main/java/net/atos/zac/event/AbstractEvent.java
+++ b/src/main/java/net/atos/zac/event/AbstractEvent.java
@@ -52,7 +52,7 @@ public abstract class AbstractEvent<TYPE, ID> implements Serializable {
         return objectId;
     }
 
-    public boolean delay() {
+    public void delay() {
         if (0 < delay) {
             try {
                 TimeUnit.SECONDS.sleep(delay);
@@ -60,9 +60,7 @@ public abstract class AbstractEvent<TYPE, ID> implements Serializable {
                 LOG.log(Level.WARNING, "Thread interrupted", e);
                 Thread.currentThread().interrupt();
             }
-            return true;
         }
-        return false;
     }
 
     public void setDelay(final int seconds) {

--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -52,7 +52,8 @@ import net.atos.zac.zaaksturing.ZaakafhandelParameterBeheerService;
 import net.atos.zac.zoeken.IndexeerService;
 
 /**
- *
+ * Provides REST endpoints for receiving notifications about events that ZAC needs to know about
+ * so that it can take appropriate action.
  */
 @Path("notificaties")
 @Consumes(MediaType.APPLICATION_JSON)

--- a/src/main/java/net/atos/zac/zoeken/IndexeerServiceHelper.java
+++ b/src/main/java/net/atos/zac/zoeken/IndexeerServiceHelper.java
@@ -5,6 +5,13 @@
 
 package net.atos.zac.zoeken;
 
+import static net.atos.zac.zoeken.model.index.IndexStatus.ADD;
+import static net.atos.zac.zoeken.model.index.IndexStatus.REMOVE;
+import static net.atos.zac.zoeken.model.index.IndexStatus.UPDATE;
+
+import java.util.List;
+import java.util.stream.Stream;
+
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
@@ -14,16 +21,10 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.transaction.Transactional;
+
 import net.atos.zac.zoeken.model.index.IndexStatus;
 import net.atos.zac.zoeken.model.index.ZoekIndexEntity;
 import net.atos.zac.zoeken.model.index.ZoekObjectType;
-
-import java.util.List;
-import java.util.stream.Stream;
-
-import static net.atos.zac.zoeken.model.index.IndexStatus.ADD;
-import static net.atos.zac.zoeken.model.index.IndexStatus.REMOVE;
-import static net.atos.zac.zoeken.model.index.IndexStatus.UPDATE;
 
 public class IndexeerServiceHelper {
 

--- a/src/main/java/net/atos/zac/zoeken/IndexeerServiceHelper.java
+++ b/src/main/java/net/atos/zac/zoeken/IndexeerServiceHelper.java
@@ -5,13 +5,6 @@
 
 package net.atos.zac.zoeken;
 
-import static net.atos.zac.zoeken.model.index.IndexStatus.ADD;
-import static net.atos.zac.zoeken.model.index.IndexStatus.REMOVE;
-import static net.atos.zac.zoeken.model.index.IndexStatus.UPDATE;
-
-import java.util.List;
-import java.util.stream.Stream;
-
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
@@ -21,10 +14,16 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.transaction.Transactional;
-
 import net.atos.zac.zoeken.model.index.IndexStatus;
 import net.atos.zac.zoeken.model.index.ZoekIndexEntity;
 import net.atos.zac.zoeken.model.index.ZoekObjectType;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static net.atos.zac.zoeken.model.index.IndexStatus.ADD;
+import static net.atos.zac.zoeken.model.index.IndexStatus.REMOVE;
+import static net.atos.zac.zoeken.model.index.IndexStatus.UPDATE;
 
 public class IndexeerServiceHelper {
 

--- a/src/main/java/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.java
+++ b/src/main/java/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.java
@@ -37,24 +37,29 @@ import net.atos.zac.zoeken.model.index.ZoekObjectType;
 import net.atos.zac.zoeken.model.zoekobject.ZaakZoekObject;
 
 public class ZaakZoekObjectConverter extends AbstractZoekObjectConverter<ZaakZoekObject> {
+    private final ZRCClientService zrcClientService;
+    private final ZTCClientService ztcClientService;
+    private final VRLClientService vrlClientService;
+    private final ZGWApiService zgwApiService;
+    private final IdentityService identityService;
+    private final TakenService takenService;
 
     @Inject
-    private ZRCClientService zrcClientService;
-
-    @Inject
-    private ZTCClientService ztcClientService;
-
-    @Inject
-    private VRLClientService vrlClientService;
-
-    @Inject
-    private ZGWApiService zgwApiService;
-
-    @Inject
-    private IdentityService identityService;
-
-    @Inject
-    private TakenService takenService;
+    public ZaakZoekObjectConverter(
+            ZRCClientService zrcClientService,
+            ZTCClientService ztcClientService,
+            VRLClientService vrlClientService,
+            ZGWApiService zgwApiService,
+            IdentityService identityService,
+            TakenService takenService
+    ) {
+        this.zrcClientService = zrcClientService;
+        this.ztcClientService = ztcClientService;
+        this.vrlClientService = vrlClientService;
+        this.zgwApiService = zgwApiService;
+        this.identityService = identityService;
+        this.takenService = takenService;
+    }
 
     public ZaakZoekObject convert(final String zaakUUID) {
         final Zaak zaak = zrcClientService.readZaak(UUID.fromString(zaakUUID));

--- a/src/main/java/net/atos/zac/zoeken/model/zoekobject/ZaakZoekObject.java
+++ b/src/main/java/net/atos/zac/zoeken/model/zoekobject/ZaakZoekObject.java
@@ -508,8 +508,9 @@ public class ZaakZoekObject implements ZoekObject {
         }
         if (betrokkenen.containsKey(key)) {
             betrokkenen.get(key).add(identificatie);
+        } else {
+            betrokkenen.put(key, Lists.newArrayList(identificatie));
         }
-        betrokkenen.put(key, Lists.newArrayList(identificatie));
     }
 
     public Map<String, List<String>> getBetrokkenen() {

--- a/src/test/kotlin/net/atos/client/zgw/shared/model/SharedFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/shared/model/SharedFixtures.kt
@@ -1,0 +1,11 @@
+package net.atos.client.zgw.shared.model
+
+import net.atos.client.zgw.zrc.model.zaakobjecten.Zaakobject
+
+fun createResultsOfZaakObjecten(
+    list: List<Zaakobject> = emptyList(),
+    count: Int = 0
+): Results<Zaakobject> = Results(
+    list,
+    count
+)

--- a/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
@@ -1,5 +1,6 @@
 package net.atos.client.zgw.zrc.model
 
+import net.atos.client.zgw.drc.model.generated.EnkelvoudigInformatieObject.VertrouwelijkheidaanduidingEnum
 import net.atos.client.zgw.shared.model.Archiefnominatie
 import net.atos.client.zgw.zrc.model.generated.Opschorting
 import net.atos.client.zgw.zrc.model.zaakobjecten.ObjectOpenbareRuimte
@@ -12,6 +13,18 @@ import net.atos.client.zgw.ztc.model.generated.RolType
 import java.net.URI
 import java.time.LocalDate
 import java.util.UUID
+
+fun createMedewerker(
+    identificatie: String = "dummyIdentificatie",
+    achternaam: String = "dummyAchternaam",
+    voorletters: String = "dummyVoorletters",
+    voorvoegselAchternaam: String? = null
+) = Medewerker().apply {
+    this.identificatie = identificatie
+    this.achternaam = achternaam
+    this.voorletters = voorletters
+    this.voorvoegselAchternaam = voorvoegselAchternaam
+}
 
 fun createNatuurlijkPersoon(bsn: String = "dummyBsn") = NatuurlijkPersoon(bsn)
 
@@ -35,6 +48,18 @@ fun createOpschorting(
     this.indicatie = indicatie
 }
 
+fun createRolMedewerker(
+    zaak: URI = URI("http://example.com/${UUID.randomUUID()}"),
+    roltype: RolType = createRolType(),
+    roltoelichting: String = "dummyToelichting",
+    betrokkeneIdentificatie: Medewerker = createMedewerker()
+) = RolMedewerker(
+    zaak,
+    roltype,
+    roltoelichting,
+    betrokkeneIdentificatie
+)
+
 fun createRolNatuurlijkPersoon(
     zaaktypeURI: URI = URI("http://example.com/${UUID.randomUUID()}"),
     rolType: RolType = createRolType(zaaktypeURI),
@@ -57,7 +82,9 @@ fun createZaak(
     archiefnominatie: Archiefnominatie? = null,
     opschorting: Opschorting? = null,
     einddatumGepland: LocalDate? = null,
-    uiterlijkeEinddatumAfdoening: LocalDate = LocalDate.now().plusDays(1)
+    registratiedatum: LocalDate = LocalDate.now(),
+    uiterlijkeEinddatumAfdoening: LocalDate = LocalDate.now().plusDays(1),
+    vertrouwelijkheidaanduiding: VertrouwelijkheidaanduidingEnum = VertrouwelijkheidaanduidingEnum.OPENBAAR
 ) = Zaak(
     zaaktypeURI,
     startDate,
@@ -69,7 +96,9 @@ fun createZaak(
     this.archiefnominatie = archiefnominatie
     this.opschorting = opschorting
     this.einddatumGepland = einddatumGepland
+    this.registratiedatum = registratiedatum
     this.uiterlijkeEinddatumAfdoening = uiterlijkeEinddatumAfdoening
+    this.vertrouwelijkheidaanduiding = vertrouwelijkheidaanduiding
 }
 
 fun createZaakobjectOpenbareRuimte(

--- a/src/test/kotlin/net/atos/zac/identity/model/IdentityFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/identity/model/IdentityFixtures.kt
@@ -14,3 +14,17 @@ fun createGroup(
     name,
     email
 )
+
+fun createUser(
+    id: String = "dummyId",
+    firstName: String = "dummyFirstName",
+    lastName: String = "dummyLastName",
+    fullName: String = "dummyFullName",
+    email: String = "dummy@example.com"
+) = User(
+    id,
+    firstName,
+    lastName,
+    fullName,
+    email
+)

--- a/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
+++ b/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
@@ -51,12 +51,12 @@ class NotificatieReceiverTest : BehaviorSpec({
         httpSessionInstance
     )
 
-    given(
+    Given(
         "a request containing a authorization header, a productaanvraag notificatie with a object type UUID " +
             "for the productaanvraag object type"
     ) {
-        `when`("notificatieReceive is called") {
-            then(
+        When("notificatieReceive is called") {
+            Then(
                 "the 'functional user' is added to the HTTP sessionm the productaanvraag service is invoked " +
                     "and a 'no content' response is returned"
             ) {

--- a/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
@@ -1,0 +1,113 @@
+package net.atos.zac.zoeken.converter
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.maps.shouldContain
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import net.atos.client.vrl.VRLClientService
+import net.atos.client.zgw.shared.ZGWApiService
+import net.atos.client.zgw.shared.model.createResultsOfZaakObjecten
+import net.atos.client.zgw.zrc.ZRCClientService
+import net.atos.client.zgw.zrc.model.createNatuurlijkPersoon
+import net.atos.client.zgw.zrc.model.createRolMedewerker
+import net.atos.client.zgw.zrc.model.createRolNatuurlijkPersoon
+import net.atos.client.zgw.zrc.model.createZaak
+import net.atos.client.zgw.zrc.model.zaakobjecten.Zaakobject
+import net.atos.client.zgw.ztc.ZTCClientService
+import net.atos.client.zgw.ztc.model.createRolType
+import net.atos.client.zgw.ztc.model.createZaakType
+import net.atos.client.zgw.ztc.model.generated.RolType
+import net.atos.zac.flowable.TakenService
+import net.atos.zac.identity.IdentityService
+import net.atos.zac.identity.model.createUser
+import net.atos.zac.zoeken.model.index.ZoekObjectType
+import java.time.ZoneId
+import java.util.*
+
+@MockKExtension.CheckUnnecessaryStub
+class ZaakZoekObjectConverterTest : BehaviorSpec({
+    val zrcClientService = mockk<ZRCClientService>()
+    val ztcClientService = mockk<ZTCClientService>()
+    val vrlClientService = mockk<VRLClientService>()
+    val zgwApiService = mockk<ZGWApiService>()
+    val identityService = mockk<IdentityService>()
+    val takenService = mockk<TakenService>()
+
+    val zaakZoekenObjectConverter = ZaakZoekObjectConverter(
+        zrcClientService,
+        ztcClientService,
+        vrlClientService,
+        zgwApiService,
+        identityService,
+        takenService
+    )
+
+    Given("a zaak with betrokkenen, without open tasks, zaak objecten and communication channels") {
+        val zaakType = createZaakType()
+        val zaak = createZaak(
+            zaaktypeURI = zaakType.url
+        )
+        val rolInitiator = createRolNatuurlijkPersoon(
+            rolType = createRolType(omschrijvingGeneriek = RolType.OmschrijvingGeneriekEnum.INITIATOR)
+        )
+        val rolAdviseur = createRolNatuurlijkPersoon(
+            rolType = createRolType(omschrijvingGeneriek = RolType.OmschrijvingGeneriekEnum.ADVISEUR),
+            natuurlijkPersoon = createNatuurlijkPersoon(bsn = "dummyBsnAdviseur")
+        )
+        val rolBelanghebbende = createRolNatuurlijkPersoon(
+            rolType = createRolType(omschrijvingGeneriek = RolType.OmschrijvingGeneriekEnum.BELANGHEBBENDE),
+            natuurlijkPersoon = createNatuurlijkPersoon(bsn = "dummyBsnBelanghebbende")
+
+        )
+        val rollenZaak = listOf(rolAdviseur, rolBelanghebbende)
+        val rolMedewerkerBehandelaar = createRolMedewerker()
+        val userBehandelaar = createUser()
+        val zaakObjectenList = emptyList<Zaakobject>()
+        every { zrcClientService.readZaak(zaak.uuid) } returns zaak
+        every { zgwApiService.findInitiatorForZaak(zaak) } returns Optional.of(rolInitiator)
+        every { zrcClientService.listRollen(zaak) } returns rollenZaak
+        every { zgwApiService.findGroepForZaak(zaak) } returns Optional.empty()
+        every { zgwApiService.findBehandelaarForZaak(zaak) } returns Optional.of(rolMedewerkerBehandelaar)
+        every {
+            identityService.readUser(rolMedewerkerBehandelaar.betrokkeneIdentificatie.identificatie)
+        } returns userBehandelaar
+        every { ztcClientService.readZaaktype(zaak.zaaktype) } returns zaakType
+        every { takenService.countOpenTasksForZaak(zaak.uuid) } returns 0
+        every { zrcClientService.listZaakobjecten(any()) } returns createResultsOfZaakObjecten(
+            list = zaakObjectenList,
+            count = zaakObjectenList.size
+        )
+
+        When("the zaak is converted to a zaak zoek object") {
+            val zaakZoekObject = zaakZoekenObjectConverter.convert(zaak.uuid.toString())
+
+            Then("the zaak zoek object should contain expected data that is converted from the zaak") {
+                with(zaakZoekObject) {
+                    uuid shouldBe zaak.uuid.toString()
+                    type shouldBe ZoekObjectType.ZAAK
+                    identificatie shouldBe zaak.identificatie
+                    omschrijving shouldBe zaak.omschrijving
+                    toelichting shouldBe zaak.toelichting
+                    registratiedatum shouldBe Date.from(zaak.registratiedatum.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant())
+                    vertrouwelijkheidaanduiding shouldBe zaak.vertrouwelijkheidaanduiding.toString()
+                    isAfgehandeld shouldBe !zaak.isOpen
+                    initiatorIdentificatie shouldBe rolInitiator.identificatienummer
+                    // locatie conversion is not implemented (yet?)
+                    locatie shouldBe null
+
+                    betrokkenen.size shouldBe rollenZaak.size
+                    betrokkenen shouldContain Pair(
+                        "zaak_betrokkene_${rolAdviseur.omschrijvingGeneriek}",
+                        listOf(rolAdviseur.identificatienummer)
+                    )
+                    betrokkenen shouldContain Pair(
+                        "zaak_betrokkene_${rolBelanghebbende.omschrijvingGeneriek}",
+                        listOf(rolBelanghebbende.identificatienummer)
+                    )
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Fixed the indexing of zaak stakeholders (betrokkenen, zaak-roles in the ZGW APIs) by ZAC where multiple roles of the same type were not added to the Solr index of a zaak.

Solves PZ-1603