### PR TITLE
fix: handle the initial empty signature when signing documents

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/InformatieObjectenTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/InformatieObjectenTest.kt
@@ -22,6 +22,7 @@ import okhttp3.Headers
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 import org.mockserver.model.HttpStatusCode
 import java.io.File
@@ -302,6 +303,23 @@ class InformatieObjectenTest : BehaviorSpec() {
                         shouldContainJsonKeyValue("bestandsomvang", TXT_FILE_SIZE)
                         shouldContainJsonKeyValue("formaat", TXT_FILE_FORMAAT)
                     }
+                }
+            }
+            When("ondertekenInformatieObject endpoint is called") {
+                val endpointUrl =
+                    "${ItestConfiguration.ZAC_API_URI}/informatieobjecten/informatieobject" +
+                        "/$enkelvoudigInformatieObjectUUID/onderteken?zaak=$zaak1UUID"
+                logger.info { "Calling $endpointUrl endpoint" }
+
+                val response = itestHttpClient.performPostRequest(
+                    url = endpointUrl,
+                    requestBody = "".toRequestBody()
+                )
+                Then(
+                    "the response should be OK"
+                ) {
+                    logger.info { "$endpointUrl status code: ${response.code}" }
+                    response.code shouldBe HttpStatusCode.OK_200.code()
                 }
             }
         }

--- a/src/main/java/net/atos/zac/app/informatieobjecten/InformatieObjectenRESTService.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/InformatieObjectenRESTService.java
@@ -694,10 +694,10 @@ public class InformatieObjectenRESTService {
         Ondertekening ondertekening = enkelvoudigInformatieobject.getOndertekening();
         boolean hasOndertekening = ondertekening != null && ondertekening.getDatum() != null;
         assertPolicy(
-           !hasOndertekening && policyService.readDocumentRechten(
-                enkelvoudigInformatieobject,
-                zaak
-            ).ondertekenen()
+                !hasOndertekening && policyService.readDocumentRechten(
+                        enkelvoudigInformatieobject,
+                        zaak
+                ).ondertekenen()
         );
         enkelvoudigInformatieObjectUpdateService.ondertekenEnkelvoudigInformatieObject(uuid);
 

--- a/src/main/java/net/atos/zac/app/informatieobjecten/InformatieObjectenRESTService.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/InformatieObjectenRESTService.java
@@ -693,7 +693,12 @@ public class InformatieObjectenRESTService {
         );
         Ondertekening ondertekening = enkelvoudigInformatieobject.getOndertekening();
         boolean hasOndertekening = ondertekening != null && ondertekening.getDatum() != null;
-        assertPolicy(!hasOndertekening && documentRechten.ondertekenen());
+        assertPolicy(
+           !hasOndertekening && policyService.readDocumentRechten(
+                enkelvoudigInformatieobject,
+                zaak
+            ).ondertekenen()
+        );
         enkelvoudigInformatieObjectUpdateService.ondertekenEnkelvoudigInformatieObject(uuid);
 
         // Hiervoor wordt door open zaak geen notificatie verstuurd. Dus zelf het ScreenEvent versturen!


### PR DESCRIPTION
When first uploading a document, OpenZaak initializes it with an empty signature (not null). This is now supported by ZAC when signing documents.

Solves PZ-1584