### PR TITLE
fix: typings for FoutAfhandelingService were broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ wildfly-*
 .env*
 src/e2e/ExportData/*
 src/main/app/.nvmrc
+/bin
 
 ### INTELLIJ ###
 *.iml

--- a/src/main/app/src/app/admin/formulier-defintie.service.ts
+++ b/src/main/app/src/app/admin/formulier-defintie.service.ts
@@ -31,7 +31,7 @@ export class FormulierDefinitieService {
 
   read(id: number | string): Observable<FormulierDefinitie> {
     return this.http
-      .get<FormulierDefinitie[]>(`${this.basepath}/${id}`)
+      .get<FormulierDefinitie>(`${this.basepath}/${id}`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );
@@ -39,7 +39,7 @@ export class FormulierDefinitieService {
 
   run(systeemnaam: string): Observable<FormulierDefinitie> {
     return this.http
-      .get<FormulierDefinitie[]>(`${this.basepath}/runtime/${systeemnaam}`)
+      .get<FormulierDefinitie>(`${this.basepath}/runtime/${systeemnaam}`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/admin/health-check.service.ts
+++ b/src/main/app/src/app/admin/health-check.service.ts
@@ -32,9 +32,7 @@ export class HealthCheckService {
 
   readBestaatCommunicatiekanaalEformulier(): Observable<boolean> {
     return this.http
-      .get<
-        boolean
-      >(`${this.basepath}/bestaat-communicatiekanaal-eformulier`)
+      .get<boolean>(`${this.basepath}/bestaat-communicatiekanaal-eformulier`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/admin/health-check.service.ts
+++ b/src/main/app/src/app/admin/health-check.service.ts
@@ -33,7 +33,7 @@ export class HealthCheckService {
   readBestaatCommunicatiekanaalEformulier(): Observable<boolean> {
     return this.http
       .get<
-        ZaaktypeInrichtingscheck[]
+        boolean
       >(`${this.basepath}/bestaat-communicatiekanaal-eformulier`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
@@ -58,7 +58,7 @@ export class HealthCheckService {
 
   readBuildInformatie(): Observable<BuildInformatie> {
     return this.http
-      .get<string>(`${this.basepath}/build-informatie`)
+      .get<BuildInformatie>(`${this.basepath}/build-informatie`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/admin/mailtemplate-beheer.service.ts
+++ b/src/main/app/src/app/admin/mailtemplate-beheer.service.ts
@@ -25,7 +25,7 @@ export class MailtemplateBeheerService {
 
   readMailtemplate(id: string): Observable<Mailtemplate> {
     return this.http
-      .get<Mailtemplate[]>(`${this.basepath}/${id}`)
+      .get<Mailtemplate>(`${this.basepath}/${id}`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/admin/mailtemplate-koppeling.service.ts
+++ b/src/main/app/src/app/admin/mailtemplate-koppeling.service.ts
@@ -23,7 +23,7 @@ export class MailtemplateKoppelingService {
 
   readMailtemplateKoppeling(id: string): Observable<MailtemplateKoppeling> {
     return this.http
-      .get<MailtemplateKoppeling[]>(`${this.basepath}/${id}`)
+      .get<MailtemplateKoppeling>(`${this.basepath}/${id}`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/admin/referentie-tabel.service.ts
+++ b/src/main/app/src/app/admin/referentie-tabel.service.ts
@@ -39,7 +39,7 @@ export class ReferentieTabelService {
 
   readReferentieTabel(id: string): Observable<ReferentieTabel> {
     return this.http
-      .get<ReferentieTabel[]>(`${this.basepath}/${id}`)
+      .get<ReferentieTabel>(`${this.basepath}/${id}`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/admin/zaakafhandel-parameters.service.ts
+++ b/src/main/app/src/app/admin/zaakafhandel-parameters.service.ts
@@ -92,7 +92,7 @@ export class ZaakafhandelParametersService {
     zaakafhandelparameters: ZaakafhandelParameters,
   ): Observable<ZaakafhandelParameters> {
     return this.http
-      .put<void>(`${this.basepath}`, zaakafhandelparameters)
+      .put<ZaakafhandelParameters>(`${this.basepath}`, zaakafhandelparameters)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );
@@ -100,7 +100,7 @@ export class ZaakafhandelParametersService {
 
   listFormulierDefinities(): Observable<FormulierDefinitie[]> {
     return this.http
-      .get<string[]>(`${this.basepath}/formulierDefinities`)
+      .get<FormulierDefinitie[]>(`${this.basepath}/formulierDefinities`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/bag/bag.service.ts
+++ b/src/main/app/src/app/bag/bag.service.ts
@@ -44,7 +44,7 @@ export class BAGService {
 
   list(zaakUuid: string): Observable<BAGObjectGegevens[]> {
     return this.http
-      .get<Adres[]>(`${this.basepath}/zaak/${zaakUuid}`)
+      .get<BAGObjectGegevens[]>(`${this.basepath}/zaak/${zaakUuid}`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.spec.ts
+++ b/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.spec.ts
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import { HttpClientModule } from "@angular/common/http";
 import { TestBed } from "@angular/core/testing";
+import { MatDialog } from "@angular/material/dialog";
+import { firstValueFrom } from "rxjs";
+import { UtilService } from "../core/service/util.service";
 import { FoutAfhandelingService } from "./fout-afhandeling.service";
 
 describe("FoutAfhandelingService", () => {
@@ -12,8 +14,11 @@ describe("FoutAfhandelingService", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [{ provide: FoutAfhandelingService, useValue: {} }],
-      imports: [HttpClientModule],
+      providers: [
+        { provide: UtilService, useValue: {} },
+        { provide: MatDialog, useValue: { open() {} } },
+      ],
+      imports: [],
     });
 
     service = TestBed.inject(FoutAfhandelingService);
@@ -21,5 +26,11 @@ describe("FoutAfhandelingService", () => {
 
   it("should be created", () => {
     expect(service).toBeTruthy();
+  });
+
+  it("should return an observable error message when openFoutDialog is called", async () => {
+    const error$ = service.openFoutDialog("some error");
+    const errorMessage = await firstValueFrom(error$).catch((r) => r);
+    expect(errorMessage).toEqual("Fout!");
   });
 });

--- a/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
+++ b/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
@@ -49,7 +49,7 @@ export class FoutAfhandelingService {
 
   public foutAfhandelen(
     err: HttpErrorResponse | JakartaBeanValidationError,
-  ): Observable<any> {
+  ): Observable<never> {
     return match(err)
       .with(ValidationErrorPattern, (e: JakartaBeanValidationError) =>
         this.validatieErrorAfhandelen(e),
@@ -81,7 +81,7 @@ export class FoutAfhandelingService {
     }
   }
 
-  public openFoutDialog(error: string): Observable<any> {
+  public openFoutDialog(error: string): Observable<never> {
     this.dialog.open(FoutDialogComponent, {
       data: error,
     });
@@ -92,7 +92,7 @@ export class FoutAfhandelingService {
   public openFoutDetailedDialog(
     error: string,
     details: string,
-  ): Observable<any> {
+  ): Observable<never> {
     this.dialog.open(FoutDetailedDialogComponent, {
       data: {
         error,

--- a/src/main/app/src/app/identity/model/logged-in-user.ts
+++ b/src/main/app/src/app/identity/model/logged-in-user.ts
@@ -6,5 +6,5 @@
 import { User } from "./user";
 
 export class LoggedInUser extends User {
-  groupIds: string[];
+  groupIds?: string[];
 }

--- a/src/main/app/src/app/identity/model/user.ts
+++ b/src/main/app/src/app/identity/model/user.ts
@@ -5,5 +5,5 @@
 
 export class User {
   id: string;
-  naam: string;
+  naam?: string;
 }

--- a/src/main/app/src/app/informatie-objecten/informatie-objecten.service.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-objecten.service.ts
@@ -244,7 +244,7 @@ export class InformatieObjectenService {
     uuid: string,
   ): Observable<EnkelvoudigInformatieobject> {
     return this.http
-      .get<ZaakInformatieobject>(
+      .get<EnkelvoudigInformatieobject>(
         `${this.basepath}/zaakinformatieobject/${uuid}/informatieobject`,
       )
       .pipe(
@@ -282,7 +282,7 @@ export class InformatieObjectenService {
       )
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
-      );
+      ) as Observable<void>;
   }
 
   listHistorie(uuid: string): Observable<HistorieRegel[]> {

--- a/src/main/app/src/app/klanten/klanten.service.ts
+++ b/src/main/app/src/app/klanten/klanten.service.ts
@@ -56,7 +56,9 @@ export class KlantenService {
     vestigingsnummer: string,
   ): Observable<Vestigingsprofiel> {
     return this.http
-      .get<Vestigingsprofiel>(`${this.basepath}/vestigingsprofiel/${vestigingsnummer}`)
+      .get<Vestigingsprofiel>(
+        `${this.basepath}/vestigingsprofiel/${vestigingsnummer}`,
+      )
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/klanten/klanten.service.ts
+++ b/src/main/app/src/app/klanten/klanten.service.ts
@@ -56,7 +56,7 @@ export class KlantenService {
     vestigingsnummer: string,
   ): Observable<Vestigingsprofiel> {
     return this.http
-      .get<Bedrijf>(`${this.basepath}/vestigingsprofiel/${vestigingsnummer}`)
+      .get<Vestigingsprofiel>(`${this.basepath}/vestigingsprofiel/${vestigingsnummer}`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/mailtemplate/mailtemplate.service.ts
+++ b/src/main/app/src/app/mailtemplate/mailtemplate.service.ts
@@ -21,7 +21,7 @@ export class MailtemplateService {
     zaakUUID: string,
   ): Observable<Mailtemplate> {
     return this.http
-      .get<Mailtemplate[]>(`${this.basepath}/${mailtemplateEnum}/${zaakUUID}`)
+      .get<Mailtemplate>(`${this.basepath}/${mailtemplateEnum}/${zaakUUID}`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/zaken/zaken.service.ts
+++ b/src/main/app/src/app/zaken/zaken.service.ts
@@ -45,6 +45,11 @@ import { ZaakVerlengGegevens } from "./model/zaak-verleng-gegevens";
 import { Zaaktype } from "./model/zaaktype";
 import { ZakenVerdeelGegevens } from "./model/zaken-verdeel-gegevens";
 
+type CommunicatieKanaal = {
+  naam: string;
+  uuid: string;
+};
+
 @Injectable({
   providedIn: "root",
 })
@@ -392,7 +397,7 @@ export class ZakenService {
     besluitVestleggenGegevens: BesluitVastleggenGegevens,
   ): Observable<Besluit> {
     return this.http
-      .post<BesluitVastleggenGegevens>(
+      .post<Besluit>(
         `${this.basepath}/besluit`,
         besluitVestleggenGegevens,
       )
@@ -405,7 +410,7 @@ export class ZakenService {
     besluitWijzigenGegevens: BesluitWijzigenGegevens,
   ): Observable<Besluit> {
     return this.http
-      .put<BesluitWijzigenGegevens>(
+      .put<Besluit>(
         `${this.basepath}/besluit`,
         besluitWijzigenGegevens,
       )
@@ -418,7 +423,7 @@ export class ZakenService {
     besluitIntrekkenGegevens: BesluitIntrekkenGegevens,
   ): Observable<Besluit> {
     return this.http
-      .put<BesluitIntrekkenGegevens>(
+      .put<Besluit>(
         `${this.basepath}/besluit/intrekken`,
         besluitIntrekkenGegevens,
       )
@@ -445,11 +450,9 @@ export class ZakenService {
 
   listCommunicatiekanalen(
     inclusiefEFormulier?: boolean,
-  ): Observable<{ naam: string; uuid: string }[]> {
+  ): Observable<CommunicatieKanaal[]> {
     return this.http
-      .get<
-        string[]
-      >(`${this.basepath}/communicatiekanalen/${inclusiefEFormulier}`)
+      .get<CommunicatieKanaal[]>(`${this.basepath}/communicatiekanalen/${inclusiefEFormulier}`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/zaken/zaken.service.ts
+++ b/src/main/app/src/app/zaken/zaken.service.ts
@@ -397,10 +397,7 @@ export class ZakenService {
     besluitVestleggenGegevens: BesluitVastleggenGegevens,
   ): Observable<Besluit> {
     return this.http
-      .post<Besluit>(
-        `${this.basepath}/besluit`,
-        besluitVestleggenGegevens,
-      )
+      .post<Besluit>(`${this.basepath}/besluit`, besluitVestleggenGegevens)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );
@@ -410,10 +407,7 @@ export class ZakenService {
     besluitWijzigenGegevens: BesluitWijzigenGegevens,
   ): Observable<Besluit> {
     return this.http
-      .put<Besluit>(
-        `${this.basepath}/besluit`,
-        besluitWijzigenGegevens,
-      )
+      .put<Besluit>(`${this.basepath}/besluit`, besluitWijzigenGegevens)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );
@@ -452,7 +446,9 @@ export class ZakenService {
     inclusiefEFormulier?: boolean,
   ): Observable<CommunicatieKanaal[]> {
     return this.http
-      .get<CommunicatieKanaal[]>(`${this.basepath}/communicatiekanalen/${inclusiefEFormulier}`)
+      .get<
+        CommunicatieKanaal[]
+      >(`${this.basepath}/communicatiekanalen/${inclusiefEFormulier}`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );


### PR DESCRIPTION
The FoutAfhandelingService was returning `Observable<any>`, which effectively removed the type checking on any observable that got passed to it. All mistyping that came to light have been fixed as well.

Resolves PZ-1882