### PR TITLE
feat: made the 'assign zaken from list' REST endpoint asynchronous

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,7 @@ sourceSets {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
+    implementation(libs.kotlinx.coroutines.core)
     implementation(libs.apache.commons.lang)
     implementation(libs.apache.commons.text)
     implementation(libs.apache.commons.collections)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 kotlin = "1.9.23"
+kotlinx-coroutines = "1.8.0"
 nodejs = "20.11.1"
 jsonschema2pojo = "1.2.1"
 openapi = "3.10.0"
@@ -96,6 +97,7 @@ apache-solr = { group = "org.apache.solr", name = "solr-solrj", version.ref = "a
 webdav-servlet = { group = "nl.info.webdav", name = "webdav-servlet", version.ref = "webdav-servlet" }
 htmlcleaner = { group = "net.sourceforge.htmlcleaner", name = "htmlcleaner", version.ref = "htmlcleaner" }
 unboundid-ldapsdk = { group = "com.unboundid", name = "unboundid-ldapsdk", version.ref = "unboundid" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 
 swagger-ui = { group = "org.webjars", name = "swagger-ui", version.ref = "swagger" }
 

--- a/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/src/itest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -13,6 +13,8 @@ import io.kotest.matchers.shouldBe
 import nl.lifely.zac.itest.client.ItestHttpClient
 import nl.lifely.zac.itest.client.KeycloakClient
 import nl.lifely.zac.itest.client.ZacClient
+import nl.lifely.zac.itest.config.ItestConfiguration.DURATION_THIRTY_SECONDS
+import nl.lifely.zac.itest.config.ItestConfiguration.DURATION_THREE_MINUTES
 import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_HEALTH_READY_URL
 import nl.lifely.zac.itest.config.ItestConfiguration.SMARTDOCUMENTS_MOCK_BASE_URI
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_CONTAINER_SERVICE_NAME
@@ -28,17 +30,10 @@ import org.testcontainers.containers.output.Slf4jLogConsumer
 import org.testcontainers.containers.wait.strategy.Wait
 import java.io.File
 import java.net.SocketException
-import java.time.Duration
 
 private val logger = KotlinLogging.logger {}
 
 object ProjectConfig : AbstractProjectConfig() {
-    @Suppress("MagicNumber")
-    val THREE_MINUTES = Duration.ofMinutes(3)
-
-    @Suppress("MagicNumber")
-    val THIRTY_SECONDS = Duration.ofSeconds(30)
-
     lateinit var dockerComposeContainer: ComposeContainer
     private val itestHttpClient = ItestHttpClient()
 
@@ -50,7 +45,7 @@ object ProjectConfig : AbstractProjectConfig() {
             dockerComposeContainer.start()
             logger.info { "Started ZAC Docker Compose containers" }
             logger.info { "Waiting until Keycloak is healthy by calling the health endpoint and checking the response" }
-            await.atMost(THIRTY_SECONDS)
+            await.atMost(DURATION_THIRTY_SECONDS)
                 .until {
                     try {
                         itestHttpClient.performGetRequest(
@@ -67,7 +62,7 @@ object ProjectConfig : AbstractProjectConfig() {
                 }
             logger.info { "Keycloak is healthy" }
             logger.info { "Waiting until ZAC is healthy by calling the health endpoint and checking the response" }
-            await.atMost(THIRTY_SECONDS)
+            await.atMost(DURATION_THIRTY_SECONDS)
                 .until {
                     itestHttpClient.performGetRequest(
                         headers = Headers.headersOf("Content-Type", "application/json"),
@@ -96,7 +91,7 @@ object ProjectConfig : AbstractProjectConfig() {
             logger.info { "Stopping ZAC Docker container" }
             dockerClient
                 .stopContainerCmd(containerId)
-                .withTimeout(THIRTY_SECONDS.toSecondsPart())
+                .withTimeout(DURATION_THIRTY_SECONDS.toSecondsPart())
                 .exec()
             logger.info { "Stopped ZAC Docker container" }
         }
@@ -158,12 +153,12 @@ object ProjectConfig : AbstractProjectConfig() {
             .waitingFor(
                 "openzaak.local",
                 Wait.forLogMessage(".*spawned uWSGI worker 2.*", 1)
-                    .withStartupTimeout(THREE_MINUTES)
+                    .withStartupTimeout(DURATION_THREE_MINUTES)
             )
             .waitingFor(
                 "zac",
                 Wait.forLogMessage(".* WildFly Full .* started .*", 1)
-                    .withStartupTimeout(THREE_MINUTES)
+                    .withStartupTimeout(DURATION_THREE_MINUTES)
             )
     }
 

--- a/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
@@ -12,6 +12,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.provided.ProjectConfig
 import nl.lifely.zac.itest.client.ItestHttpClient
+import nl.lifely.zac.itest.config.ItestConfiguration.DURATION_THIRTY_SECONDS
 import nl.lifely.zac.itest.config.ItestConfiguration.OBJECTS_API_HOSTNAME_URL
 import nl.lifely.zac.itest.config.ItestConfiguration.OBJECTTYPE_UUID_PRODUCTAANVRAAG_DIMPACT
 import nl.lifely.zac.itest.config.ItestConfiguration.OBJECT_PRODUCTAANVRAAG_UUID
@@ -151,7 +152,7 @@ class NotificationsTest : BehaviorSpec({
                             "null ZAAKTYPE CREATE .*: java.lang.RuntimeException: URI 'http://example.com/dummyResourceUrl' does not " +
                             "start with value for environment variable 'ZGW_API_CLIENT_MP_REST_URL': 'http://openzaak.local:8000/' .*",
                         1
-                    ).withStartupTimeout(ProjectConfig.THIRTY_SECONDS)
+                    ).withStartupTimeout(DURATION_THIRTY_SECONDS)
                 )
             }
         }

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
@@ -5,6 +5,7 @@
 
 package nl.lifely.zac.itest.config
 
+import java.time.Duration
 import java.util.UUID
 
 /**
@@ -75,4 +76,13 @@ object ItestConfiguration {
     const val SMARTDOCUMENTS_MOCK_BASE_URI = "http://smartdocuments-wiremock:8080"
 
     val ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID: UUID = UUID.fromString("448356ff-dcfb-4504-9501-7fe929077c4f")
+
+    @Suppress("MagicNumber")
+    val DURATION_THREE_MINUTES: Duration = Duration.ofMinutes(3)
+
+    @Suppress("MagicNumber")
+    val DURATION_TEN_SECONDS: Duration = Duration.ofSeconds(10)
+
+    @Suppress("MagicNumber")
+    val DURATION_THIRTY_SECONDS: Duration = Duration.ofSeconds(30)
 }

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZakenVerdeelGegevens.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZakenVerdeelGegevens.kt
@@ -4,6 +4,7 @@
  */
 package net.atos.zac.app.zaken.model
 
+import jakarta.validation.constraints.NotBlank
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import java.util.UUID
@@ -13,9 +14,11 @@ import java.util.UUID
 data class RESTZakenVerdeelGegevens(
     var uuids: List<UUID>,
 
+    var reden: String,
+
+    @field:NotBlank
     var groepId: String? = null,
 
-    var behandelaarGebruikersnaam: String? = null,
-
-    var reden: String? = null
+    @field:NotBlank
+    var behandelaarGebruikersnaam: String? = null
 )

--- a/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
+++ b/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
@@ -1,0 +1,86 @@
+package net.atos.zac.zaken
+
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import net.atos.client.zgw.zrc.ZRCClientService
+import net.atos.client.zgw.zrc.model.Medewerker
+import net.atos.client.zgw.zrc.model.OrganisatorischeEenheid
+import net.atos.client.zgw.zrc.model.RolMedewerker
+import net.atos.client.zgw.zrc.model.RolOrganisatorischeEenheid
+import net.atos.client.zgw.zrc.model.Zaak
+import net.atos.client.zgw.ztc.ZTCClientService
+import net.atos.client.zgw.ztc.model.generated.RolType
+import net.atos.zac.identity.model.Group
+import net.atos.zac.identity.model.User
+import net.atos.zac.zoeken.IndexeerService
+import net.atos.zac.zoeken.model.index.ZoekObjectType
+import java.util.UUID
+
+class ZakenService @Inject constructor(
+    val zrcClientService: ZRCClientService,
+    val ztcClientService: ZTCClientService,
+    val indexeerService: IndexeerService
+) {
+    companion object {
+        private val defaultCoroutineScope = CoroutineScope(Dispatchers.Default)
+    }
+
+    /**
+     * Asynchronously assigns a list of zaken to a group and/or user and updates the search index on the fly.
+     */
+    fun assignZakenAsync(zaakUUIDs: List<UUID>, explanation: String, group: Group? = null, user: User? = null) =
+        defaultCoroutineScope.launch {
+            zaakUUIDs.forEach { zaakUUID ->
+                val zaak = zrcClientService.readZaak(zaakUUID)
+                group?.let {
+                    zrcClientService.updateRol(
+                        zaak,
+                        bepaalRolGroep(it, zaak),
+                        explanation
+                    )
+                }
+                user?.let {
+                    zrcClientService.updateRol(
+                        zaak,
+                        bepaalRolMedewerker(it, zaak),
+                        explanation
+                    )
+                }
+                indexeerService.indexeerDirect(
+                    zaakUUID.toString(),
+                    ZoekObjectType.ZAAK
+                )
+            }
+        }
+
+    fun bepaalRolGroep(group: Group, zaak: Zaak) =
+        RolOrganisatorischeEenheid(
+            zaak.url,
+            ztcClientService.readRoltype(
+                RolType.OmschrijvingGeneriekEnum.BEHANDELAAR,
+                zaak.zaaktype
+            ),
+            "Behandelend groep van de zaak",
+            OrganisatorischeEenheid().apply {
+                identificatie = group.id
+                naam = group.name
+            }
+        )
+
+    fun bepaalRolMedewerker(user: User, zaak: Zaak) =
+        RolMedewerker(
+            zaak.url,
+            ztcClientService.readRoltype(
+                RolType.OmschrijvingGeneriekEnum.BEHANDELAAR,
+                zaak.zaaktype
+            ),
+            "Behandelaar van de zaak",
+            Medewerker().apply {
+                identificatie = user.id
+                voorletters = user.firstName
+                achternaam = user.lastName
+            }
+        )
+}

--- a/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
@@ -48,6 +48,14 @@ fun createOpschorting(
     this.indicatie = indicatie
 }
 
+fun createOrganisatorischeEenheid(
+    identificatie: String = "dummyIdentificatie",
+    naam: String = "dummyNaam"
+) = OrganisatorischeEenheid().apply {
+    this.identificatie = identificatie
+    this.naam = naam
+}
+
 fun createRolMedewerker(
     zaak: URI = URI("http://example.com/${UUID.randomUUID()}"),
     roltype: RolType = createRolType(),
@@ -70,6 +78,18 @@ fun createRolNatuurlijkPersoon(
     rolType,
     toelichting,
     natuurlijkPersoon
+)
+
+fun createRolOrganisatorischeEenheid(
+    zaaktypeURI: URI = URI("http://example.com/${UUID.randomUUID()}"),
+    rolType: RolType = createRolType(zaaktypeURI),
+    toelichting: String = "dummyToelichting",
+    organisatorischeEenheid: OrganisatorischeEenheid = createOrganisatorischeEenheid()
+) = RolOrganisatorischeEenheid(
+    zaaktypeURI,
+    rolType,
+    toelichting,
+    organisatorischeEenheid
 )
 
 @Suppress("LongParameterList")


### PR DESCRIPTION
The 'assign zaken from list' REST endpoint now returns immediately while the process is started in the background using Kotlin coroutines. There is no feedback of this process to the client yet. This will come in a follow-up PR.

Solves PZ-1750