### PR TITLE
feat: filter wijzigingen in ZaakobjectProductaanvraag uit de historie

### DIFF
--- a/src/main/java/net/atos/zac/app/audit/converter/zaken/AuditZaakobjectWijzigingConverter.java
+++ b/src/main/java/net/atos/zac/app/audit/converter/zaken/AuditZaakobjectWijzigingConverter.java
@@ -25,22 +25,22 @@ public class AuditZaakobjectWijzigingConverter extends AbstractAuditWijzigingCon
 
     @Override
     protected Stream<RESTHistorieRegel> doConvert(final AuditWijziging<Zaakobject> wijziging) {
-        return Stream.of(new RESTHistorieRegel(toAttribuutLabel(wijziging), toWaarde(wijziging.getOud()), toWaarde(wijziging.getNieuw())));
+        var oud = wijziging.getOud();
+        var nieuw = wijziging.getNieuw();
+
+        if((oud != null && oud.getObjectType() == Objecttype.OVERIGE )
+           || nieuw.getObjectType() == Objecttype.OVERIGE
+        ) return Stream.empty();
+
+        return Stream.of(new RESTHistorieRegel(toAttribuutLabel(wijziging), toWaarde(oud), toWaarde(nieuw)));
     }
 
     private String toAttribuutLabel(final AuditWijziging<Zaakobject> wijziging) {
         final Objecttype objecttype;
-        final String objecttypeOverige;
         if (wijziging.getOud() != null) {
             objecttype = wijziging.getOud().getObjectType();
-            objecttypeOverige = wijziging.getOud().getObjectTypeOverige();
         } else {
             objecttype = wijziging.getNieuw().getObjectType();
-            objecttypeOverige = wijziging.getNieuw().getObjectTypeOverige();
-        }
-
-        if (Objecttype.OVERIGE == objecttype) {
-            return "objecttype." + StringUtils.upperCase(objecttypeOverige);
         }
         return "objecttype." + objecttype.name();
     }

--- a/src/main/java/net/atos/zac/app/audit/converter/zaken/AuditZaakobjectWijzigingConverter.java
+++ b/src/main/java/net/atos/zac/app/audit/converter/zaken/AuditZaakobjectWijzigingConverter.java
@@ -7,8 +7,6 @@ package net.atos.zac.app.audit.converter.zaken;
 
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
-
 import net.atos.client.zgw.shared.model.ObjectType;
 import net.atos.client.zgw.shared.model.audit.AuditWijziging;
 import net.atos.client.zgw.zrc.model.Objecttype;
@@ -28,9 +26,9 @@ public class AuditZaakobjectWijzigingConverter extends AbstractAuditWijzigingCon
         var oud = wijziging.getOud();
         var nieuw = wijziging.getNieuw();
 
-        if((oud != null && oud.getObjectType() == Objecttype.OVERIGE )
-           || nieuw.getObjectType() == Objecttype.OVERIGE
-        ) return Stream.empty();
+        if ((oud != null && oud.getObjectType() == Objecttype.OVERIGE) || nieuw.getObjectType() == Objecttype.OVERIGE
+        )
+            return Stream.empty();
 
         return Stream.of(new RESTHistorieRegel(toAttribuutLabel(wijziging), toWaarde(oud), toWaarde(nieuw)));
     }

--- a/src/main/java/net/atos/zac/app/audit/converter/zaken/AuditZaakobjectWijzigingConverter.java
+++ b/src/main/java/net/atos/zac/app/audit/converter/zaken/AuditZaakobjectWijzigingConverter.java
@@ -11,6 +11,7 @@ import net.atos.client.zgw.shared.model.ObjectType;
 import net.atos.client.zgw.shared.model.audit.AuditWijziging;
 import net.atos.client.zgw.zrc.model.Objecttype;
 import net.atos.client.zgw.zrc.model.zaakobjecten.Zaakobject;
+import net.atos.client.zgw.zrc.model.zaakobjecten.ZaakobjectProductaanvraag;
 import net.atos.zac.app.audit.converter.AbstractAuditWijzigingConverter;
 import net.atos.zac.app.audit.model.RESTHistorieRegel;
 
@@ -23,12 +24,12 @@ public class AuditZaakobjectWijzigingConverter extends AbstractAuditWijzigingCon
 
     @Override
     protected Stream<RESTHistorieRegel> doConvert(final AuditWijziging<Zaakobject> wijziging) {
-        var oud = wijziging.getOud();
         var nieuw = wijziging.getNieuw();
 
-        if ((oud != null && oud.getObjectType() == Objecttype.OVERIGE) || nieuw.getObjectType() == Objecttype.OVERIGE
-        )
+        if (nieuw instanceof ZaakobjectProductaanvraag)
             return Stream.empty();
+
+        var oud = wijziging.getOud();
 
         return Stream.of(new RESTHistorieRegel(toAttribuutLabel(wijziging), toWaarde(oud), toWaarde(nieuw)));
     }

--- a/src/test/kotlin/net/atos/zac/audit/model/AuditZaakobjectWijzigingConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/audit/model/AuditZaakobjectWijzigingConverterTest.kt
@@ -3,24 +3,64 @@ package net.atos.zac.audit.model
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import net.atos.client.zgw.shared.model.audit.zaken.objecten.ZaakobjectProductaanvraagWijziging
+import net.atos.client.zgw.shared.model.audit.zaken.objecten.ZaakobjectWoonplaatsWijziging
 import net.atos.client.zgw.zrc.model.Objecttype
+import net.atos.client.zgw.zrc.model.zaakobjecten.ObjectWoonplaats
 import net.atos.client.zgw.zrc.model.zaakobjecten.ZaakobjectProductaanvraag
+import net.atos.client.zgw.zrc.model.zaakobjecten.ZaakobjectWoonplaats
 import net.atos.zac.app.audit.converter.zaken.AuditZaakobjectWijzigingConverter
 import java.net.URI
 
 class AuditZaakobjectWijzigingConverterTest : BehaviorSpec({
     val converter = AuditZaakobjectWijzigingConverter()
-    Given("A object creation for type Overig") {
+
+    Given("A ZaakobjectProductaanvraagWijziging") {
         val wijzigingen = ZaakobjectProductaanvraagWijziging()
         val aanvraag = ZaakobjectProductaanvraag()
         wijzigingen.nieuw = aanvraag
         aanvraag.objectType = Objecttype.OVERIGE
         aanvraag.`object` = URI("www.google.nl/12345")
+
         When("The wijziging is converted") {
             val regels = converter.convert(wijzigingen).toList()
+
             Then("It should not show up in the list") {
                 with(regels) {
                     size shouldBe 0
+                }
+            }
+        }
+    }
+
+    Given("A ZaakobjectWoonplaatsWijziging") {
+        val wijzigingen = ZaakobjectWoonplaatsWijziging()
+        val zaakobjectWoonplaatsOud =
+            ZaakobjectWoonplaats(
+                URI("www.google.nl/12345"),
+                URI("www.google.nl/12345"),
+                ObjectWoonplaats("identificatie-oud", "woonplaats-oud")
+            )
+        val zaakobjectWoonplaatsNieuw =
+            ZaakobjectWoonplaats(
+                URI("www.google.nl/54321"),
+                URI("www.google.nl/54321"),
+                ObjectWoonplaats("identificatie-nieuw", "woonplaats-nieuw")
+            )
+        wijzigingen.oud = zaakobjectWoonplaatsOud
+        wijzigingen.nieuw = zaakobjectWoonplaatsNieuw
+
+        When("The wijziging is converted") {
+            val regels = converter.convert(wijzigingen).toList()
+            Then("It should show up in the list") {
+                with(regels) {
+                    size shouldBe 1
+                }
+            }
+            Then("The expected values are present") {
+                with(regels.first()) {
+                    oudeWaarde shouldBe "identificatie-oud"
+                    nieuweWaarde shouldBe "identificatie-nieuw"
+                    attribuutLabel shouldBe "objecttype.WOONPLAATS"
                 }
             }
         }

--- a/src/test/kotlin/net/atos/zac/audit/model/AuditZaakobjectWijzigingConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/audit/model/AuditZaakobjectWijzigingConverterTest.kt
@@ -32,7 +32,7 @@ class AuditZaakobjectWijzigingConverterTest : BehaviorSpec({
         }
     }
 
-    Given("A ZaakobjectWoonplaatsWijziging") {
+    Given("A ZaakobjectWoonplaatsWijziging with oud and nieuw") {
         val wijzigingen = ZaakobjectWoonplaatsWijziging()
         val zaakobjectWoonplaatsOud =
             ZaakobjectWoonplaats(
@@ -61,6 +61,46 @@ class AuditZaakobjectWijzigingConverterTest : BehaviorSpec({
                     oudeWaarde shouldBe "identificatie-oud"
                     nieuweWaarde shouldBe "identificatie-nieuw"
                     attribuutLabel shouldBe "objecttype.WOONPLAATS"
+                }
+            }
+        }
+    }
+
+    Given("A ZaakobjectWoonplaatsWijziging with only nieuw") {
+        val wijzigingen = ZaakobjectWoonplaatsWijziging()
+        val zaakobjectWoonplaatsNieuw =
+            ZaakobjectWoonplaats(
+                URI("www.google.nl/54321"),
+                URI("www.google.nl/54321"),
+                ObjectWoonplaats("identificatie-nieuw", "woonplaats-nieuw")
+            )
+        wijzigingen.nieuw = zaakobjectWoonplaatsNieuw
+
+        When("The wijziging is converted") {
+            val regels = converter.convert(wijzigingen).toList()
+            Then("It should show up in the list") {
+                with(regels) {
+                    size shouldBe 1
+                }
+            }
+            Then("The expected values are present") {
+                with(regels.first()) {
+                    oudeWaarde shouldBe null
+                    nieuweWaarde shouldBe "identificatie-nieuw"
+                    attribuutLabel shouldBe "objecttype.WOONPLAATS"
+                }
+            }
+        }
+    }
+
+    Given("A ZaakobjectWoonplaatsWijziging with neither oud nor new") {
+        val wijzigingen = ZaakobjectWoonplaatsWijziging()
+
+        When("The wijziging is converted") {
+            val regels = converter.convert(wijzigingen).toList()
+            Then("It should not show up in the list") {
+                with(regels) {
+                    size shouldBe 0
                 }
             }
         }

--- a/src/test/kotlin/net/atos/zac/audit/model/AuditZaakobjectWijzigingConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/audit/model/AuditZaakobjectWijzigingConverterTest.kt
@@ -19,7 +19,7 @@ class AuditZaakobjectWijzigingConverterTest : BehaviorSpec({
         val aanvraag = ZaakobjectProductaanvraag()
         wijzigingen.nieuw = aanvraag
         aanvraag.objectType = Objecttype.OVERIGE
-        aanvraag.`object` = URI("www.google.nl/12345")
+        aanvraag.`object` = URI("http://example.com/12345")
 
         When("The wijziging is converted") {
             val regels = converter.convert(wijzigingen).toList()
@@ -36,14 +36,14 @@ class AuditZaakobjectWijzigingConverterTest : BehaviorSpec({
         val wijzigingen = ZaakobjectWoonplaatsWijziging()
         val zaakobjectWoonplaatsOud =
             ZaakobjectWoonplaats(
-                URI("www.google.nl/12345"),
-                URI("www.google.nl/12345"),
+                URI("http://example.com/12345"),
+                URI("http://example.com/12345"),
                 ObjectWoonplaats("identificatie-oud", "woonplaats-oud")
             )
         val zaakobjectWoonplaatsNieuw =
             ZaakobjectWoonplaats(
-                URI("www.google.nl/54321"),
-                URI("www.google.nl/54321"),
+                URI("http://example.com/54321"),
+                URI("http://example.com/54321"),
                 ObjectWoonplaats("identificatie-nieuw", "woonplaats-nieuw")
             )
         wijzigingen.oud = zaakobjectWoonplaatsOud
@@ -70,8 +70,8 @@ class AuditZaakobjectWijzigingConverterTest : BehaviorSpec({
         val wijzigingen = ZaakobjectWoonplaatsWijziging()
         val zaakobjectWoonplaatsNieuw =
             ZaakobjectWoonplaats(
-                URI("www.google.nl/54321"),
-                URI("www.google.nl/54321"),
+                URI("http://example.com/54321"),
+                URI("http://example.com/54321"),
                 ObjectWoonplaats("identificatie-nieuw", "woonplaats-nieuw")
             )
         wijzigingen.nieuw = zaakobjectWoonplaatsNieuw

--- a/src/test/kotlin/net/atos/zac/audit/model/AuditZaakobjectWijzigingConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/audit/model/AuditZaakobjectWijzigingConverterTest.kt
@@ -1,0 +1,28 @@
+package net.atos.zac.audit.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import net.atos.client.zgw.shared.model.audit.zaken.objecten.ZaakobjectProductaanvraagWijziging
+import net.atos.client.zgw.zrc.model.Objecttype
+import net.atos.client.zgw.zrc.model.zaakobjecten.ZaakobjectProductaanvraag
+import net.atos.zac.app.audit.converter.zaken.AuditZaakobjectWijzigingConverter
+import java.net.URI
+
+class AuditZaakobjectWijzigingConverterTest : BehaviorSpec({
+    val converter = AuditZaakobjectWijzigingConverter()
+    Given("A object creation for type Overig") {
+        val wijzigingen = ZaakobjectProductaanvraagWijziging()
+        val aanvraag = ZaakobjectProductaanvraag()
+        wijzigingen.nieuw = aanvraag
+        aanvraag.objectType = Objecttype.OVERIGE
+        aanvraag.`object` = URI("www.google.nl/12345")
+        When("The wijziging is converted") {
+            val regels = converter.convert(wijzigingen).toList()
+            Then("It should not show up in the list") {
+                with(regels) {
+                    size shouldBe 0
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/net/atos/zac/audit/model/AuditZaakobjectWijzigingConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/audit/model/AuditZaakobjectWijzigingConverterTest.kt
@@ -92,17 +92,4 @@ class AuditZaakobjectWijzigingConverterTest : BehaviorSpec({
             }
         }
     }
-
-    Given("A ZaakobjectWoonplaatsWijziging with neither oud nor new") {
-        val wijzigingen = ZaakobjectWoonplaatsWijziging()
-
-        When("The wijziging is converted") {
-            val regels = converter.convert(wijzigingen).toList()
-            Then("It should not show up in the list") {
-                with(regels) {
-                    size shouldBe 0
-                }
-            }
-        }
-    }
 })


### PR DESCRIPTION
Audittrailrecords over ZaakobjectProductaanvraag bevatten geen nuttige informatie voor de eindgebruiker. Daarom gaan we deze uitfilteren.
Resolves PZ-1696