### PR TITLE
chore: PZ-1868: add unit test

### DIFF
--- a/src/main/java/net/atos/zac/signalering/model/SignaleringType.java
+++ b/src/main/java/net/atos/zac/signalering/model/SignaleringType.java
@@ -24,7 +24,6 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
 
-
 @Entity
 @Table(schema = SCHEMA, name = "signaleringtype")
 public class SignaleringType implements Comparable<SignaleringType> {

--- a/src/main/java/net/atos/zac/signalering/model/SignaleringType.java
+++ b/src/main/java/net/atos/zac/signalering/model/SignaleringType.java
@@ -24,6 +24,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
 
+
 @Entity
 @Table(schema = SCHEMA, name = "signaleringtype")
 public class SignaleringType implements Comparable<SignaleringType> {
@@ -49,8 +50,16 @@ public class SignaleringType implements Comparable<SignaleringType> {
         return type;
     }
 
+    public void setType(Type type) {
+        this.type = type;
+    }
+
     public SignaleringSubject getSubjecttype() {
         return subjecttype;
+    }
+
+    public void setSubjecttype(SignaleringSubject subjecttype) {
+        this.subjecttype = subjecttype;
     }
 
     /**

--- a/src/main/java/net/atos/zac/signalering/model/SignaleringType.java
+++ b/src/main/java/net/atos/zac/signalering/model/SignaleringType.java
@@ -50,7 +50,7 @@ public class SignaleringType implements Comparable<SignaleringType> {
         return type;
     }
 
-    public void setType(Type type) {
+    void setType(Type type) {
         this.type = type;
     }
 
@@ -58,7 +58,7 @@ public class SignaleringType implements Comparable<SignaleringType> {
         return subjecttype;
     }
 
-    public void setSubjecttype(SignaleringSubject subjecttype) {
+    void setSubjecttype(SignaleringSubject subjecttype) {
         this.subjecttype = subjecttype;
     }
 

--- a/src/test/kotlin/net/atos/zac/app/signaleringen/SignaleringenRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/signaleringen/SignaleringenRestServiceTest.kt
@@ -49,7 +49,7 @@ class SignaleringenRestServiceTest : BehaviorSpec() {
     init {
         Given("there are multiple ZAAK_OP_NAAM signals ") {
             val numberOfSignals = 100
-            val maxDelay = 10L
+            val maxDelay = 15L
 
             val zaakList = MutableList(numberOfSignals) { createZaak() }
             val signals: List<Signalering> =

--- a/src/test/kotlin/net/atos/zac/app/signaleringen/SignaleringenRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/signaleringen/SignaleringenRestServiceTest.kt
@@ -1,0 +1,81 @@
+package net.atos.zac.app.signaleringen
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.test.TestCase
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.enterprise.inject.Instance
+import net.atos.client.zgw.zrc.ZRCClientService
+import net.atos.client.zgw.zrc.model.createZaak
+import net.atos.zac.app.zaken.converter.RESTZaakOverzichtConverter
+import net.atos.zac.app.zaken.model.createRESTZaakOverzicht
+import net.atos.zac.authentication.LoggedInUser
+import net.atos.zac.authentication.createLoggedInUser
+import net.atos.zac.signalering.SignaleringenService
+import net.atos.zac.signalering.model.Signalering
+import net.atos.zac.signalering.model.SignaleringType
+import net.atos.zac.signalering.model.createSignalering
+import java.util.UUID
+import kotlin.random.Random
+
+class SignaleringenRestServiceTest : BehaviorSpec() {
+    private val loggedInUserInstance = mockk<Instance<LoggedInUser>>()
+    private val signaleringenService = mockk<SignaleringenService>()
+    private val restZaakOverzichtConverter = mockk<RESTZaakOverzichtConverter>()
+    private val zrcClientService = mockk<ZRCClientService>()
+    private val loggedInUser = createLoggedInUser()
+
+    @InjectMockKs
+    lateinit var signaleringenRestService: SignaleringenRestService
+
+    override suspend fun beforeContainer(testCase: TestCase) {
+        super.beforeContainer(testCase)
+
+        // Only run before Given
+        if (testCase.parent != null) return
+
+        MockKAnnotations.init(this)
+        clearAllMocks()
+
+        every { loggedInUserInstance.get() } returns loggedInUser
+    }
+
+    init {
+        Given("there are multiple ZAAK_OP_NAAM signals ") {
+            val numberOfSignals = 100
+            val maxDelay = 10L
+
+            val zaakList = MutableList(numberOfSignals) { createZaak() }
+            val signals: List<Signalering> =
+                MutableList(numberOfSignals) { index -> createSignalering(zaakList[index]) }
+            every { signaleringenService.listSignaleringen(any()) } returns signals
+            zaakList.forEach { zaak ->
+                every { zrcClientService.readZaak(zaak.uuid) } answers {
+                    Thread.sleep(Random.nextLong(10, maxDelay))
+                    zaak
+                }
+                every { restZaakOverzichtConverter.convert(zaak) } returns createRESTZaakOverzicht(uuid = zaak.uuid)
+            }
+
+            When("zaak signals with type ZAAK_OP_NAAM are requested") {
+                val list = signaleringenRestService.listZakenSignaleringen(SignaleringType.Type.ZAAK_OP_NAAM)
+
+                Then("an overview for all signals is generated") {
+                    list shouldHaveSize numberOfSignals
+                    list.forEachIndexed { index, restZaakOverzicht ->
+                        restZaakOverzicht.uuid shouldBe zaakList[index].uuid
+                    }
+                    verify(exactly = numberOfSignals) {
+                        zrcClientService.readZaak(any<UUID>())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/net/atos/zac/app/zaken/model/RESTZakenFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaken/model/RESTZakenFixtures.kt
@@ -187,3 +187,9 @@ private fun createZaakData(): Map<String, Any> {
     zaakdata["key3"] = LocalDate.of(2023, 9, 14)
     return zaakdata
 }
+
+fun createRESTZaakOverzicht(
+    uuid: UUID = UUID.randomUUID()
+) = RESTZaakOverzicht().apply {
+    this.uuid = uuid
+}

--- a/src/test/kotlin/net/atos/zac/signalering/model/SignaleringFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/signalering/model/SignaleringFixtures.kt
@@ -12,8 +12,8 @@ fun createSignalering(
     zaak: Zaak = createZaak()
 ) = Signalering().apply {
     this.type = SignaleringType().apply {
-        this.type = SignaleringType.Type.ZAAK_OP_NAAM
-        this.subjecttype = SignaleringSubject.ZAAK
+        type = SignaleringType.Type.ZAAK_OP_NAAM
+        subjecttype = SignaleringSubject.ZAAK
     }
     this.setSubject(zaak)
 }

--- a/src/test/kotlin/net/atos/zac/signalering/model/SignaleringFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/signalering/model/SignaleringFixtures.kt
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+package net.atos.zac.signalering.model
+
+import net.atos.client.zgw.zrc.model.Zaak
+import net.atos.client.zgw.zrc.model.createZaak
+
+fun createSignalering(
+    zaak: Zaak = createZaak()
+) = Signalering().apply {
+    this.type = SignaleringType().apply {
+        this.type = SignaleringType.Type.ZAAK_OP_NAAM
+        this.subjecttype = SignaleringSubject.ZAAK
+    }
+    this.setSubject(zaak)
+}


### PR DESCRIPTION
Unit test to allow us test order of elements and partially execution time

Increasing maxDelay to 1000 ms shows that by using parallelStream:
* we do not lose order or elements
* execution time is reduced from 50-60 seconds to 1-2 seconds

Note that in real-life the difference would not be that big since common thread pool is busier and REST requests might take longer