### PR TITLE
chore: use construction injection for ZakenRESTService 

### DIFF
--- a/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
@@ -132,6 +132,7 @@ import net.atos.zac.zaaksturing.model.ZaakbeeindigParameter
 import net.atos.zac.zaken.ZakenService
 import net.atos.zac.zoeken.IndexeerService
 import net.atos.zac.zoeken.model.index.ZoekObjectType
+import nl.lifely.zac.util.NoArgConstructor
 import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
 import java.net.URI
@@ -147,8 +148,45 @@ import java.util.stream.Stream
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 @Singleton
-@Suppress("TooManyFunctions", "LargeClass")
-class ZakenRESTService {
+@Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
+@NoArgConstructor
+class ZakenRESTService @Inject constructor(
+    private val zgwApiService: ZGWApiService,
+    private val productaanvraagService: ProductaanvraagService,
+    private val brcClientService: BRCClientService,
+    private val drcClientService: DRCClientService,
+    private val ztcClientService: ZTCClientService,
+    private val zrcClientService: ZRCClientService,
+    private val vrlClientService: VRLClientService,
+    private val eventingService: EventingService,
+    private val identityService: IdentityService,
+    private val signaleringenService: SignaleringenService,
+    private val ontkoppeldeDocumentenService: OntkoppeldeDocumentenService,
+    private val indexeerService: IndexeerService,
+    private val policyService: PolicyService,
+    private val cmmnService: CMMNService,
+    private val bpmnService: BPMNService,
+    private val takenService: TakenService,
+    private val objectsClientService: ObjectsClientService,
+    private val inboxProductaanvraagService: InboxProductaanvraagService,
+    private val zaakVariabelenService: ZaakVariabelenService,
+    private val configuratieService: ConfiguratieService,
+    private val loggedInUserInstance: Instance<LoggedInUser>,
+    private val restZaakConverter: RESTZaakConverter,
+    private val restZaaktypeConverter: RESTZaaktypeConverter,
+    private val restBesluitConverter: RESTBesluitConverter,
+    private val restBesluittypeConverter: RESTBesluittypeConverter,
+    private val restResultaattypeConverter: RESTResultaattypeConverter,
+    private val restZaakOverzichtConverter: RESTZaakOverzichtConverter,
+    private val restBAGConverter: RESTBAGConverter,
+    private val restHistorieRegelConverter: RESTHistorieRegelConverter,
+    private val zaakafhandelParameterService: ZaakafhandelParameterService,
+    private val restGeometryConverter: RESTGeometryConverter,
+    private val healthCheckService: HealthCheckService,
+    private val opschortenZaakHelper: OpschortenZaakHelper,
+    private val restZaakAfzenderConverter: RESTZaakAfzenderConverter,
+    private val zakenService: ZakenService
+) {
     companion object {
         private val LOG = Logger.getLogger(ZakenRESTService::class.java.name)
 
@@ -160,116 +198,11 @@ class ZakenRESTService {
         private const val WIJZIGEN_BESLUIT_TOELICHTING = "Wijzigen besluit"
     }
 
-    @Inject
-    private lateinit var zgwApiService: ZGWApiService
-
-    @Inject
-    private lateinit var productaanvraagService: ProductaanvraagService
-
-    @Inject
-    private lateinit var brcClientService: BRCClientService
-
-    @Inject
-    private lateinit var drcClientService: DRCClientService
-
-    @Inject
-    private lateinit var ztcClientService: ZTCClientService
-
-    @Inject
-    private lateinit var zrcClientService: ZRCClientService
-
-    @Inject
-    private lateinit var vrlClientService: VRLClientService
-
-    @Inject
-    private lateinit var eventingService: EventingService
-
-    @Inject
-    private lateinit var identityService: IdentityService
-
-    @Inject
-    private lateinit var signaleringenService: SignaleringenService
-
-    @Inject
-    private lateinit var ontkoppeldeDocumentenService: OntkoppeldeDocumentenService
-
-    @Inject
-    private lateinit var indexeerService: IndexeerService
-
-    @Inject
-    private lateinit var policyService: PolicyService
-
-    @Inject
-    private lateinit var cmmnService: CMMNService
-
-    @Inject
-    private lateinit var bpmnService: BPMNService
-
-    @Inject
-    private lateinit var takenService: TakenService
-
-    @Inject
-    private lateinit var objectsClientService: ObjectsClientService
-
-    @Inject
-    private lateinit var inboxProductaanvraagService: InboxProductaanvraagService
-
-    @Inject
-    private lateinit var zaakVariabelenService: ZaakVariabelenService
-
-    @Inject
-    private lateinit var configuratieService: ConfiguratieService
-
-    @Inject
-    private lateinit var loggedInUserInstance: Instance<LoggedInUser>
-
-    @Inject
-    private lateinit var zaakConverter: RESTZaakConverter
-
-    @Inject
-    private lateinit var zaaktypeConverter: RESTZaaktypeConverter
-
-    @Inject
-    private lateinit var besluitConverter: RESTBesluitConverter
-
-    @Inject
-    private lateinit var besluittypeConverter: RESTBesluittypeConverter
-
-    @Inject
-    private lateinit var resultaattypeConverter: RESTResultaattypeConverter
-
-    @Inject
-    private lateinit var zaakOverzichtConverter: RESTZaakOverzichtConverter
-
-    @Inject
-    private lateinit var bagConverter: RESTBAGConverter
-
-    @Inject
-    private lateinit var auditTrailConverter: RESTHistorieRegelConverter
-
-    @Inject
-    private lateinit var zaakafhandelParameterService: ZaakafhandelParameterService
-
-    @Inject
-    private lateinit var restGeometryConverter: RESTGeometryConverter
-
-    @Inject
-    private lateinit var healthCheckService: HealthCheckService
-
-    @Inject
-    private lateinit var opschortenZaakHelper: OpschortenZaakHelper
-
-    @Inject
-    private lateinit var zaakAfzenderConverter: RESTZaakAfzenderConverter
-
-    @Inject
-    private lateinit var zakenService: ZakenService
-
     @GET
     @Path("zaak/{uuid}")
     fun readZaak(@PathParam("uuid") zaakUUID: UUID): RESTZaak {
         val zaak = zrcClientService.readZaak(zaakUUID)
-        val restZaak = zaakConverter.convert(zaak)
+        val restZaak = restZaakConverter.convert(zaak)
         assertPolicy(restZaak.rechten.lezen)
         deleteSignaleringen(zaak)
         return restZaak
@@ -279,7 +212,7 @@ class ZakenRESTService {
     @Path("zaak/id/{identificatie}")
     fun readZaakById(@PathParam("identificatie") identificatie: String): RESTZaak {
         val zaak = zrcClientService.readZaakByID(identificatie)
-        val restZaak: RESTZaak = zaakConverter.convert(zaak)
+        val restZaak: RESTZaak = restZaakConverter.convert(zaak)
         assertPolicy(restZaak.rechten.lezen)
         deleteSignaleringen(zaak)
         return restZaak
@@ -292,7 +225,7 @@ class ZakenRESTService {
         zgwApiService.findInitiatorForZaak(zaak)
             .ifPresent { initiator: Rol<*> -> removeInitiator(zaak, initiator, ROL_VERWIJDER_REDEN) }
         addInitiator(gegevens.betrokkeneIdentificatieType, gegevens.betrokkeneIdentificatie, zaak)
-        return zaakConverter.convert(zaak)
+        return restZaakConverter.convert(zaak)
     }
 
     @DELETE
@@ -301,7 +234,7 @@ class ZakenRESTService {
         val zaak = zrcClientService.readZaak(zaakUUID)
         zgwApiService.findInitiatorForZaak(zaak)
             .ifPresent { initiator: Rol<*> -> removeInitiator(zaak, initiator, reden.reden) }
-        return zaakConverter.convert(zaak)
+        return restZaakConverter.convert(zaak)
     }
 
     @POST
@@ -315,7 +248,7 @@ class ZakenRESTService {
             gegevens.roltoelichting,
             zaak
         )
-        return zaakConverter.convert(zaak)
+        return restZaakConverter.convert(zaak)
     }
 
     @DELETE
@@ -327,7 +260,7 @@ class ZakenRESTService {
         val betrokkene = zrcClientService.readRol(betrokkeneUUID)
         val zaak = zrcClientService.readZaak(betrokkene.zaak)
         removeBetrokkene(zaak, betrokkene, reden.reden)
-        return zaakConverter.convert(zaak)
+        return restZaakConverter.convert(zaak)
     }
 
     @POST
@@ -343,7 +276,7 @@ class ZakenRESTService {
                 loggedInUserInstance.get().isGeautoriseerdZaaktype(zaaktype.omschrijving)
         )
 
-        val zaak = zgwApiService.createZaak(zaakConverter.convert(restZaak, zaaktype))
+        val zaak = zgwApiService.createZaak(restZaakConverter.convert(restZaak, zaaktype))
         if (StringUtils.isNotEmpty(restZaak.initiatorIdentificatie)) {
             addInitiator(
                 restZaak.initiatorIdentificatieType!!,
@@ -374,12 +307,12 @@ class ZakenRESTService {
 
         restZaakAanmaakGegevens.bagObjecten?.let { restbagObjecten ->
             for (restbagObject in restbagObjecten) {
-                val zaakobject: Zaakobject = bagConverter.convertToZaakobject(restbagObject, zaak)
+                val zaakobject: Zaakobject = restBAGConverter.convertToZaakobject(restbagObject, zaak)
                 zrcClientService.createZaakobject(zaakobject)
             }
         }
 
-        return zaakConverter.convert(zaak)
+        return restZaakConverter.convert(zaak)
     }
 
     @PATCH
@@ -391,10 +324,10 @@ class ZakenRESTService {
         assertPolicy(policyService.readZaakRechten(zrcClientService.readZaak(zaakUUID)).wijzigen)
         val updatedZaak = zrcClientService.patchZaak(
             zaakUUID,
-            zaakConverter.convertToPatch(restZaakEditMetRedenGegevens.zaak),
+            restZaakConverter.convertToPatch(restZaakEditMetRedenGegevens.zaak),
             restZaakEditMetRedenGegevens.reden
         )
-        return zaakConverter.convert(updatedZaak)
+        return restZaakConverter.convert(updatedZaak)
     }
 
     @PATCH
@@ -412,7 +345,7 @@ class ZakenRESTService {
             locatieZaakPatch,
             locatieGegevens.reden
         )
-        return zaakConverter.convert(updatedZaak)
+        return restZaakConverter.convert(updatedZaak)
     }
 
     @PATCH
@@ -423,7 +356,7 @@ class ZakenRESTService {
     ): RESTZaak {
         val zaak = zrcClientService.readZaak(zaakUUID)
         return if (opschortGegevens.indicatieOpschorting) {
-            zaakConverter.convert(
+            restZaakConverter.convert(
                 opschortenZaakHelper.opschortenZaak(
                     zaak,
                     opschortGegevens.duurDagen,
@@ -431,7 +364,7 @@ class ZakenRESTService {
                 )
             )
         } else {
-            zaakConverter.convert(
+            restZaakConverter.convert(
                 opschortenZaakHelper.hervattenZaak(zaak, opschortGegevens.redenOpschorting)
             )
         }
@@ -475,7 +408,7 @@ class ZakenRESTService {
         val toelichting = "$VERLENGING: ${restZaakVerlengGegevens.redenVerlenging}"
         val updatedZaak = zrcClientService.patchZaak(
             zaakUUID,
-            zaakConverter.convertToPatch(
+            restZaakConverter.convertToPatch(
                 zaakUUID,
                 restZaakVerlengGegevens
             ),
@@ -490,7 +423,7 @@ class ZakenRESTService {
                 eventingService.send(ScreenEventType.ZAAK_TAKEN.updated(updatedZaak))
             }
         }
-        return zaakConverter.convert(updatedZaak, status, statustype)
+        return restZaakConverter.convert(updatedZaak, status, statustype)
     }
 
     @PUT
@@ -562,7 +495,7 @@ class ZakenRESTService {
                     uiterlijkeEinddatumAfdoeningWaarschuwing
                 )
             }
-            .map { zaak -> zaakOverzichtConverter.convert(zaak) }
+            .map { zaak -> restZaakOverzichtConverter.convert(zaak) }
             .toList()
     }
 
@@ -575,7 +508,7 @@ class ZakenRESTService {
             .filter { zaaktype -> !zaaktype.concept }
             .filter { zaakType -> isNuGeldig(zaakType) }
             .filter { zaaktype -> healthCheckService.controleerZaaktype(zaaktype.url).isValide }
-            .map { zaaktype: ZaakType -> zaaktypeConverter.convert(zaaktype) }
+            .map { zaaktype: ZaakType -> restZaaktypeConverter.convert(zaaktype) }
             .toList()
 
     @PUT
@@ -642,7 +575,7 @@ class ZakenRESTService {
             indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK)
         }
 
-        return zaakConverter.convert(zaak)
+        return restZaakConverter.convert(zaak)
     }
 
     @PUT
@@ -653,7 +586,7 @@ class ZakenRESTService {
         assertPolicy(policyService.readWerklijstRechten().zakenTaken)
         val zaak = ingelogdeMedewerkerToekennenAanZaak(toekennenGegevens)
         indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK)
-        return zaakOverzichtConverter.convert(zaak)
+        return restZaakOverzichtConverter.convert(zaak)
     }
 
     @PUT
@@ -827,7 +760,7 @@ class ZakenRESTService {
         toekennenGegevens: @Valid RESTZaakToekennenGegevens
     ): RESTZaak {
         val zaak = ingelogdeMedewerkerToekennenAanZaak(toekennenGegevens)
-        return zaakConverter.convert(zaak)
+        return restZaakConverter.convert(zaak)
     }
 
     @GET
@@ -835,7 +768,7 @@ class ZakenRESTService {
     fun listHistorie(@PathParam("uuid") zaakUUID: UUID?): List<RESTHistorieRegel> {
         assertPolicy(policyService.readZaakRechten(zrcClientService.readZaak(zaakUUID)).lezen)
         val auditTrail: List<AuditTrailRegel> = zrcClientService.listAuditTrail(zaakUUID)
-        return auditTrailConverter.convert(auditTrail)
+        return restHistorieRegelConverter.convert(auditTrail)
     }
 
     @GET
@@ -869,7 +802,7 @@ class ZakenRESTService {
         val zaak = zrcClientService.readZaak(zaakUUID)
         return sortAndRemoveDuplicates(
             resolveZaakAfzenderMail(
-                zaakAfzenderConverter.convertZaakAfzenders(
+                restZaakAfzenderConverter.convertZaakAfzenders(
                     zaakafhandelParameterService.readZaakafhandelParameters(
                         UriUtil.uuidFromURI(zaak.zaaktype)
                     ).zaakAfzenders
@@ -894,7 +827,7 @@ class ZakenRESTService {
             )
                 .zaakAfzenders.stream()
                 .filter { obj -> obj.isDefault }
-                .map { zaakAfzender -> zaakAfzenderConverter.convertZaakAfzender(zaakAfzender) }
+                .map { zaakAfzender -> restZaakAfzenderConverter.convertZaakAfzender(zaakAfzender) }
         )
             .findAny()
             .orElse(null)
@@ -918,7 +851,7 @@ class ZakenRESTService {
     @Path("besluit/zaakUuid/{zaakUuid}")
     fun listBesluitenForZaakUUID(@PathParam("zaakUuid") zaakUuid: UUID): List<RESTBesluit> {
         return brcClientService.listBesluiten(zrcClientService.readZaak(zaakUuid))
-            .map { besluiten -> besluitConverter.convertToRESTBesluit(besluiten) }
+            .map { besluiten -> restBesluitConverter.convertToRESTBesluit(besluiten) }
             .orElse(null)
     }
 
@@ -941,13 +874,13 @@ class ZakenRESTService {
                 policyService.readZaakRechten(zaak, zaaktype).behandelen &&
                 !StatusTypeUtil.isIntake(zaakStatustype)
         )
-        val besluit = besluitConverter.convertToBesluit(zaak, besluitToevoegenGegevens)
+        val besluit = restBesluitConverter.convertToBesluit(zaak, besluitToevoegenGegevens)
         if (zaak.resultaat != null) {
             zgwApiService.updateResultaatForZaak(zaak, besluitToevoegenGegevens.resultaattypeUuid, null)
         } else {
             zgwApiService.createResultaatForZaak(zaak, besluitToevoegenGegevens.resultaattypeUuid, null)
         }
-        val restBesluit = besluitConverter.convertToRESTBesluit(brcClientService.createBesluit(besluit))
+        val restBesluit = restBesluitConverter.convertToRESTBesluit(brcClientService.createBesluit(besluit))
         besluitToevoegenGegevens.informatieobjecten!!.forEach(
             Consumer { documentUri: UUID? ->
                 val informatieobject = drcClientService.readEnkelvoudigInformatieobject(documentUri)
@@ -971,7 +904,7 @@ class ZakenRESTService {
         var besluit = brcClientService.readBesluit(restBesluitWijzigenGegevens.besluitUuid)
         val zaak = zrcClientService.readZaak(besluit!!.zaak)
         assertPolicy(zaak.isOpen && policyService.readZaakRechten(zaak).behandelen)
-        besluit = besluitConverter.convertToBesluit(besluit, restBesluitWijzigenGegevens)
+        besluit = restBesluitConverter.convertToBesluit(besluit, restBesluitWijzigenGegevens)
         besluit = brcClientService.updateBesluit(besluit, restBesluitWijzigenGegevens.reden)
         if (zaak.resultaat != null) {
             val zaakResultaat = zrcClientService.readResultaat(zaak.resultaat)
@@ -991,7 +924,7 @@ class ZakenRESTService {
         // This event should result from a ZAAKBESLUIT CREATED notification on the ZAKEN channel
         // but open_zaak does not send that one, so emulate it here.
         eventingService.send(ScreenEventType.ZAAK_BESLUITEN.updated(zaak))
-        return besluitConverter.convertToRESTBesluit(besluit)
+        return restBesluitConverter.convertToRESTBesluit(besluit)
     }
 
     private fun updateBesluitInformatieobjecten(
@@ -1041,7 +974,7 @@ class ZakenRESTService {
         var besluit = brcClientService.readBesluit(restBesluitIntrekkenGegevens.besluitUuid)
         val zaak = zrcClientService.readZaak(besluit!!.zaak)
         assertPolicy(zaak.isOpen && policyService.readZaakRechten(zaak).behandelen)
-        besluit = besluitConverter.convertToBesluit(besluit, restBesluitIntrekkenGegevens)
+        besluit = restBesluitConverter.convertToBesluit(besluit, restBesluitIntrekkenGegevens)
         val intrekToelichting = getIntrekToelichting(besluit.vervalreden)
         besluit = brcClientService.updateBesluit(
             besluit,
@@ -1050,14 +983,14 @@ class ZakenRESTService {
         // This event should result from a ZAAKBESLUIT UPDATED notification on the ZAKEN channel
         // but open_zaak does not send that one, so emulate it here.
         eventingService.send(ScreenEventType.ZAAK_BESLUITEN.updated(zaak))
-        return besluitConverter.convertToRESTBesluit(besluit)
+        return restBesluitConverter.convertToRESTBesluit(besluit)
     }
 
     @GET
     @Path("besluit/{uuid}/historie")
     fun listBesluitHistorie(@PathParam("uuid") uuid: UUID?): List<RESTHistorieRegel> {
         val auditTrail: List<AuditTrailRegel> = brcClientService.listAuditTrail(uuid)
-        return auditTrailConverter.convert(auditTrail)
+        return restHistorieRegelConverter.convert(auditTrail)
     }
 
     @GET
@@ -1071,7 +1004,7 @@ class ZakenRESTService {
         ).stream()
             .filter { besluittype: BesluitType? -> LocalDateUtil.dateNowIsBetween(besluittype) }
             .toList()
-        return besluittypeConverter.convertToRESTBesluittypes(besluittypen)
+        return restBesluittypeConverter.convertToRESTBesluittypes(besluittypen)
     }
 
     @GET
@@ -1080,7 +1013,7 @@ class ZakenRESTService {
         @PathParam("zaaktypeUUID") zaaktypeUUID: UUID?
     ): List<RESTResultaattype> {
         assertPolicy(policyService.readWerklijstRechten().zakenTaken)
-        return resultaattypeConverter.convertResultaattypes(
+        return restResultaattypeConverter.convertResultaattypes(
             ztcClientService.readResultaattypen(ztcClientService.readZaaktype(zaaktypeUUID!!).url)
         )
     }

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluit.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluit.kt
@@ -32,7 +32,7 @@ data class RESTBesluit(
 
     var vervalreden: Besluit.VervalredenEnum? = null,
 
-    @get:JsonbProperty("isIngetrokken")
+    @field:JsonbProperty("isIngetrokken")
     var isIngetrokken: Boolean = false,
 
     var toelichting: String? = null,

--- a/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
+++ b/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
@@ -19,9 +19,9 @@ import net.atos.zac.zoeken.model.index.ZoekObjectType
 import java.util.UUID
 
 class ZakenService @Inject constructor(
-    val zrcClientService: ZRCClientService,
-    val ztcClientService: ZTCClientService,
-    val indexeerService: IndexeerService
+    private val zrcClientService: ZRCClientService,
+    private val ztcClientService: ZTCClientService,
+    private val indexeerService: IndexeerService
 ) {
     companion object {
         private val defaultCoroutineScope = CoroutineScope(Dispatchers.Default)

--- a/src/test/kotlin/net/atos/zac/app/zaken/ZakenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaken/ZakenRESTServiceTest.kt
@@ -6,10 +6,7 @@
 package net.atos.zac.app.zaken
 
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.core.test.TestCase
-import io.mockk.MockKAnnotations
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.junit5.MockKExtension
 import io.mockk.just
 import io.mockk.mockk
@@ -19,6 +16,9 @@ import io.mockk.verify
 import jakarta.enterprise.inject.Instance
 import net.atos.client.or.`object`.ObjectsClientService
 import net.atos.client.or.`object`.model.createORObject
+import net.atos.client.vrl.VRLClientService
+import net.atos.client.zgw.brc.BRCClientService
+import net.atos.client.zgw.drc.DRCClientService
 import net.atos.client.zgw.shared.ZGWApiService
 import net.atos.client.zgw.shared.util.URIUtil
 import net.atos.client.zgw.zrc.ZRCClientService
@@ -42,21 +42,37 @@ import net.atos.client.zgw.ztc.model.generated.RolType
 import net.atos.zac.aanvraag.InboxProductaanvraagService
 import net.atos.zac.aanvraag.ProductaanvraagService
 import net.atos.zac.aanvraag.createProductaanvraagDimpact
+import net.atos.zac.app.admin.converter.RESTZaakAfzenderConverter
+import net.atos.zac.app.audit.converter.RESTHistorieRegelConverter
 import net.atos.zac.app.bag.converter.RESTBAGConverter
+import net.atos.zac.app.zaken.converter.RESTBesluitConverter
+import net.atos.zac.app.zaken.converter.RESTBesluittypeConverter
+import net.atos.zac.app.zaken.converter.RESTGeometryConverter
+import net.atos.zac.app.zaken.converter.RESTResultaattypeConverter
 import net.atos.zac.app.zaken.converter.RESTZaakConverter
+import net.atos.zac.app.zaken.converter.RESTZaakOverzichtConverter
+import net.atos.zac.app.zaken.converter.RESTZaaktypeConverter
 import net.atos.zac.app.zaken.model.ZAAK_TYPE_1_OMSCHRIJVING
 import net.atos.zac.app.zaken.model.createRESTZaak
 import net.atos.zac.app.zaken.model.createRESTZaakAanmaakGegevens
 import net.atos.zac.app.zaken.model.createRESTZaakToekennenGegevens
 import net.atos.zac.authentication.LoggedInUser
 import net.atos.zac.authentication.createLoggedInUser
+import net.atos.zac.configuratie.ConfiguratieService
+import net.atos.zac.documenten.OntkoppeldeDocumentenService
+import net.atos.zac.event.EventingService
+import net.atos.zac.flowable.BPMNService
 import net.atos.zac.flowable.CMMNService
+import net.atos.zac.flowable.TakenService
 import net.atos.zac.flowable.ZaakVariabelenService
+import net.atos.zac.healthcheck.HealthCheckService
 import net.atos.zac.identity.IdentityService
 import net.atos.zac.identity.model.createGroup
 import net.atos.zac.policy.PolicyService
 import net.atos.zac.policy.output.OverigeRechten
 import net.atos.zac.policy.output.createZaakRechten
+import net.atos.zac.shared.helper.OpschortenZaakHelper
+import net.atos.zac.signalering.SignaleringenService
 import net.atos.zac.zaaksturing.ZaakafhandelParameterService
 import net.atos.zac.zaaksturing.model.createZaakafhandelParameters
 import net.atos.zac.zaken.ZakenService
@@ -66,32 +82,81 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import java.util.Optional
 
 @MockKExtension.CheckUnnecessaryStub
+@Suppress("LongParameterList")
 class ZakenRESTServiceTest : BehaviorSpec() {
-    private val cmmnService = mockk<CMMNService>()
-    private val identityService = mockk<IdentityService>()
-    private val inboxProductaanvraagService = mockk<InboxProductaanvraagService>()
-    private val indexeerService = mockk<IndexeerService>()
-    private val loggedInUserInstance = mockk<Instance<LoggedInUser>>()
-    private val objectsClientService = mockk<ObjectsClientService>()
-    private val policyService = mockk<PolicyService>()
-    private val productaanvraagService = mockk<ProductaanvraagService>()
-    private val restBagConverter = mockk<RESTBAGConverter>()
-    private val restZaakConverter = mockk<RESTZaakConverter>()
-    private val zaakafhandelParameterService = mockk<ZaakafhandelParameterService>()
-    private val zaakVariabelenService = mockk<ZaakVariabelenService>()
-    private val zgwApiService = mockk<ZGWApiService>()
-    private val zrcClientService = mockk<ZRCClientService>()
-    private val ztcClientService = mockk<ZTCClientService>()
-    private val zakenService = mockk<ZakenService>()
+    private val bpmnService: BPMNService = mockk<BPMNService>()
+    private val brcClientService: BRCClientService = mockk<BRCClientService>()
+    private val configuratieService: ConfiguratieService = mockk<ConfiguratieService>()
+    private val cmmnService: CMMNService = mockk<CMMNService>()
+    private val drcClientService: DRCClientService = mockk<DRCClientService>()
+    private val eventingService: EventingService = mockk<EventingService>()
+    private val healthCheckService: HealthCheckService = mockk<HealthCheckService>()
+    private val identityService: IdentityService = mockk<IdentityService>()
+    private val inboxProductaanvraagService: InboxProductaanvraagService = mockk<InboxProductaanvraagService>()
+    private val indexeerService: IndexeerService = mockk<IndexeerService>()
+    private val loggedInUserInstance: Instance<LoggedInUser> = mockk<Instance<LoggedInUser>>()
+    private val objectsClientService: ObjectsClientService = mockk<ObjectsClientService>()
+    private val ontkoppeldeDocumentenService: OntkoppeldeDocumentenService = mockk<OntkoppeldeDocumentenService>()
+    private val opschortenZaakHelper: OpschortenZaakHelper = mockk<OpschortenZaakHelper>()
+    private val policyService: PolicyService = mockk<PolicyService>()
+    private val productaanvraagService: ProductaanvraagService = mockk<ProductaanvraagService>()
+    private val restBAGConverter: RESTBAGConverter = mockk<RESTBAGConverter>()
+    private val restBesluitConverter: RESTBesluitConverter = mockk<RESTBesluitConverter>()
+    private val restBesluittypeConverter: RESTBesluittypeConverter = mockk<RESTBesluittypeConverter>()
+    private val restGeometryConverter: RESTGeometryConverter = mockk<RESTGeometryConverter>()
+    private val restResultaattypeConverter: RESTResultaattypeConverter = mockk<RESTResultaattypeConverter>()
+    private val restZaakConverter: RESTZaakConverter = mockk<RESTZaakConverter>()
+    private val restZaakAfzenderConverter: RESTZaakAfzenderConverter = mockk<RESTZaakAfzenderConverter>()
+    private val restZaakOverzichtConverter: RESTZaakOverzichtConverter = mockk<RESTZaakOverzichtConverter>()
+    private val restZaaktypeConverter: RESTZaaktypeConverter = mockk<RESTZaaktypeConverter>()
+    private val restHistorieRegelConverter: RESTHistorieRegelConverter = mockk<RESTHistorieRegelConverter>()
+    private val signaleringenService: SignaleringenService = mockk<SignaleringenService>()
+    private val takenService: TakenService = mockk<TakenService>()
+    private val vrlClientService: VRLClientService = mockk<VRLClientService>()
+    private val zaakafhandelParameterService: ZaakafhandelParameterService = mockk<ZaakafhandelParameterService>()
+    private val zaakVariabelenService: ZaakVariabelenService = mockk<ZaakVariabelenService>()
+    private val zakenService: ZakenService = mockk<ZakenService>()
+    private val zgwApiService: ZGWApiService = mockk<ZGWApiService>()
+    private val zrcClientService: ZRCClientService = mockk<ZRCClientService>()
+    private val ztcClientService: ZTCClientService = mockk<ZTCClientService>()
 
-    // We have to use @InjectMockKs since the class under test uses field injection instead of constructor injection.
-    // This is because WildFly does not properly support constructor injection for JAX-RS REST services.
-    @InjectMockKs
-    lateinit var zakenRESTService: ZakenRESTService
-
-    override suspend fun beforeTest(testCase: TestCase) {
-        MockKAnnotations.init(this)
-    }
+    private val zakenRESTService = ZakenRESTService(
+        zgwApiService = zgwApiService,
+        cmmnService = cmmnService,
+        identityService = identityService,
+        inboxProductaanvraagService = inboxProductaanvraagService,
+        loggedInUserInstance = loggedInUserInstance,
+        objectsClientService = objectsClientService,
+        policyService = policyService,
+        productaanvraagService = productaanvraagService,
+        restBAGConverter = restBAGConverter,
+        restZaakConverter = restZaakConverter,
+        zaakafhandelParameterService = zaakafhandelParameterService,
+        zaakVariabelenService = zaakVariabelenService,
+        zrcClientService = zrcClientService,
+        ztcClientService = ztcClientService,
+        zakenService = zakenService,
+        indexeerService = indexeerService,
+        restHistorieRegelConverter = restHistorieRegelConverter,
+        restBesluitConverter = restBesluitConverter,
+        bpmnService = bpmnService,
+        brcClientService = brcClientService,
+        configuratieService = configuratieService,
+        drcClientService = drcClientService,
+        eventingService = eventingService,
+        healthCheckService = healthCheckService,
+        ontkoppeldeDocumentenService = ontkoppeldeDocumentenService,
+        opschortenZaakHelper = opschortenZaakHelper,
+        restBesluittypeConverter = restBesluittypeConverter,
+        restGeometryConverter = restGeometryConverter,
+        restResultaattypeConverter = restResultaattypeConverter,
+        restZaakOverzichtConverter = restZaakOverzichtConverter,
+        signaleringenService = signaleringenService,
+        takenService = takenService,
+        vrlClientService = vrlClientService,
+        restZaakAfzenderConverter = restZaakAfzenderConverter,
+        restZaaktypeConverter = restZaaktypeConverter
+    )
 
     init {
         given("zaak input data is provided") {
@@ -143,10 +208,10 @@ class ZakenRESTServiceTest : BehaviorSpec() {
                         )
                     } just runs
                     every {
-                        restBagConverter.convertToZaakobject(restZaakAanmaakGegevens.bagObjecten?.get(0), zaak)
+                        restBAGConverter.convertToZaakobject(restZaakAanmaakGegevens.bagObjecten?.get(0), zaak)
                     } returns zaakObjectPand
                     every {
-                        restBagConverter.convertToZaakobject(
+                        restBAGConverter.convertToZaakobject(
                             restZaakAanmaakGegevens.bagObjecten?.get(1),
                             zaak
                         )


### PR DESCRIPTION
Use construction injection for ZakenRESTService and no longer field injection as constructor injection is preferred, mainly for better testability. See e.g. https://www.baeldung.com/java-spring-field-injection-cons

Solves PZ-1942