### PR TITLE
chore: do not allow java.util.* wildcard imports for Kotlin files

### DIFF
--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -1,6 +1,8 @@
 style:
   MaxLineLength:
     maxLineLength: 140
+  WildcardImport:
+    excludeImports: []
 
 formatting:
   MaximumLineLength:

--- a/src/itest/kotlin/nl/lifely/zac/itest/ZakenRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZakenRESTServiceTest.kt
@@ -36,7 +36,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.mockserver.model.HttpStatusCode
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
 
 private val itestHttpClient = ItestHttpClient()

--- a/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
@@ -12,7 +12,7 @@ import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVEN
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import okhttp3.Response
-import java.util.*
+import java.util.UUID
 
 class ZacClient {
     private val logger = KotlinLogging.logger {}

--- a/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
@@ -137,7 +137,8 @@ import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
 import java.net.URI
 import java.time.LocalDate
-import java.util.*
+import java.util.Locale
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Consumer
 import java.util.logging.Logger

--- a/src/main/kotlin/net/atos/zac/app/zaken/converter/RESTOpenstaandeTakenConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/converter/RESTOpenstaandeTakenConverter.kt
@@ -7,7 +7,7 @@ package net.atos.zac.app.zaken.converter
 import jakarta.inject.Inject
 import net.atos.zac.app.zaken.model.RESTOpenstaandeTaken
 import net.atos.zac.flowable.TakenService
-import java.util.*
+import java.util.UUID
 
 class RESTOpenstaandeTakenConverter {
     @Inject

--- a/src/main/kotlin/net/atos/zac/app/zaken/converter/RESTZaakConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/converter/RESTZaakConverter.kt
@@ -39,7 +39,8 @@ import org.apache.commons.collections4.CollectionUtils
 import org.apache.commons.lang3.StringUtils
 import java.time.LocalDate
 import java.time.Period
-import java.util.*
+import java.util.EnumSet
+import java.util.UUID
 import java.util.stream.Collectors
 import kotlin.jvm.optionals.getOrNull
 

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluit.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluit.kt
@@ -11,7 +11,7 @@ import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import java.net.URI
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 @AllOpen
 @NoArgConstructor

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluitIntrekkenGegevens.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluitIntrekkenGegevens.kt
@@ -7,7 +7,7 @@ package net.atos.zac.app.zaken.model
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 @AllOpen
 @NoArgConstructor

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluitVastleggenGegevens.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluitVastleggenGegevens.kt
@@ -7,7 +7,7 @@ package net.atos.zac.app.zaken.model
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 @AllOpen
 @NoArgConstructor

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluitWijzigenGegevens.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluitWijzigenGegevens.kt
@@ -7,7 +7,7 @@ package net.atos.zac.app.zaken.model
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 @AllOpen
 @NoArgConstructor

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluittype.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTBesluittype.kt
@@ -7,7 +7,7 @@ package net.atos.zac.app.zaken.model
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import java.net.URI
-import java.util.*
+import java.util.UUID
 
 @AllOpen
 @NoArgConstructor

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTCommunicatiekanaal.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTCommunicatiekanaal.kt
@@ -6,7 +6,7 @@ package net.atos.zac.app.zaken.model
 
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
-import java.util.*
+import java.util.UUID
 
 @NoArgConstructor
 @AllOpen

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTDocumentOntkoppelGegevens.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTDocumentOntkoppelGegevens.kt
@@ -6,7 +6,7 @@ package net.atos.zac.app.zaken.model
 
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
-import java.util.*
+import java.util.UUID
 
 @NoArgConstructor
 @AllOpen

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaak.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaak.kt
@@ -14,7 +14,8 @@ import net.atos.zac.zoeken.model.ZaakIndicatie
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import java.time.LocalDate
-import java.util.*
+import java.util.EnumSet
+import java.util.UUID
 
 @NoArgConstructor
 @AllOpen

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaakBetrokkeneGegevens.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaakBetrokkeneGegevens.kt
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotBlank
 import net.atos.zac.app.klanten.model.klant.IdentificatieType
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
-import java.util.*
+import java.util.UUID
 
 @AllOpen
 @NoArgConstructor

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaakKoppelGegevens.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaakKoppelGegevens.kt
@@ -6,7 +6,7 @@ package net.atos.zac.app.zaken.model
 
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
-import java.util.*
+import java.util.UUID
 
 @NoArgConstructor
 @AllOpen

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaakOntkoppelGegevens.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaakOntkoppelGegevens.kt
@@ -6,7 +6,7 @@ package net.atos.zac.app.zaken.model
 
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
-import java.util.*
+import java.util.UUID
 
 @AllOpen
 @NoArgConstructor

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaakOverzicht.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaakOverzicht.kt
@@ -10,7 +10,7 @@ import net.atos.zac.app.policy.model.RESTZaakRechten
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 @NoArgConstructor
 @AllOpen

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaakToekennenGegevens.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZaakToekennenGegevens.kt
@@ -7,7 +7,7 @@ package net.atos.zac.app.zaken.model
 import jakarta.validation.constraints.Size
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
-import java.util.*
+import java.util.UUID
 
 @AllOpen
 @NoArgConstructor

--- a/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
+++ b/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
@@ -20,7 +20,7 @@ import net.atos.zac.identity.model.User
 import net.atos.zac.websocket.event.ScreenEventType
 import net.atos.zac.zoeken.IndexeerService
 import net.atos.zac.zoeken.model.index.ZoekObjectType
-import java.util.*
+import java.util.UUID
 import java.util.logging.Logger
 
 class ZakenService @Inject constructor(

--- a/src/test/kotlin/net/atos/zac/aanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/aanvraag/ProductaanvraagServiceTest.kt
@@ -29,7 +29,8 @@ import net.atos.zac.zaaksturing.ZaakafhandelParameterBeheerService
 import net.atos.zac.zaaksturing.ZaakafhandelParameterService
 import net.atos.zac.zaaksturing.model.createZaakafhandelParameters
 import java.net.URI
-import java.util.*
+import java.util.Optional
+import java.util.UUID
 
 class ProductaanvraagServiceTest : BehaviorSpec({
     val objectsClientService = mockk<ObjectsClientService>()

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverterTest.kt
@@ -27,7 +27,9 @@ import net.atos.zac.policy.PolicyService
 import net.atos.zac.policy.output.createDocumentRechten
 import java.net.URI
 import java.time.LocalDate
-import java.util.*
+import java.util.Base64
+import java.util.Optional
+import java.util.UUID
 
 class RESTInformatieobjectConverterTest : BehaviorSpec() {
     private val loggedInUserInstance = mockk<Instance<LoggedInUser>>()

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/model/InformatieObjectenRESTFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/model/InformatieObjectenRESTFixtures.kt
@@ -3,7 +3,7 @@ package net.atos.zac.app.informatieobjecten.model
 import net.atos.client.zgw.drc.model.generated.EnkelvoudigInformatieObject.StatusEnum
 import net.atos.client.zgw.ztc.model.generated.ZaakType.VertrouwelijkheidaanduidingEnum
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 @Suppress("LongParameterList")
 fun createRESTEnkelvoudigInformatieobject(

--- a/src/test/kotlin/net/atos/zac/app/taken/model/TakenRESTFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/taken/model/TakenRESTFixtures.kt
@@ -9,7 +9,7 @@ import net.atos.zac.app.identity.model.RESTUser
 import net.atos.zac.app.informatieobjecten.model.RESTInformatieobjecttype
 import net.atos.zac.app.informatieobjecten.model.createRESTInformatieobjecttype
 import net.atos.zac.app.zaken.model.createRESTUser
-import java.util.*
+import java.util.UUID
 
 fun createRESTTaak(
     id: String = "dummyId",

--- a/src/test/kotlin/net/atos/zac/app/util/UUIDReaderTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/UUIDReaderTest.kt
@@ -3,7 +3,7 @@ package net.atos.zac.app.util
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import java.util.*
+import java.util.UUID
 
 class UUIDReaderTest : DescribeSpec({
 

--- a/src/test/kotlin/net/atos/zac/app/zaken/model/RESTZakenFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaken/model/RESTZakenFixtures.kt
@@ -17,7 +17,8 @@ import net.atos.zac.app.productaanvragen.model.RESTInboxProductaanvraag
 import net.atos.zac.zoeken.model.ZaakIndicatie
 import java.net.URI
 import java.time.LocalDate
-import java.util.*
+import java.util.EnumSet
+import java.util.UUID
 import kotlin.collections.HashMap
 
 // note: the value of the zaak type 'omschrijving' field is used to determine whether users

--- a/src/test/kotlin/net/atos/zac/notificaties/NotificatieFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/notificaties/NotificatieFixtures.kt
@@ -2,7 +2,7 @@ package net.atos.zac.notificaties
 
 import java.net.URI
 import java.time.ZonedDateTime
-import java.util.*
+import java.util.UUID
 
 @Suppress("LongParameterList")
 fun createNotificatie(

--- a/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
@@ -23,7 +23,8 @@ import net.atos.zac.identity.IdentityService
 import net.atos.zac.identity.model.createUser
 import net.atos.zac.zoeken.model.index.ZoekObjectType
 import java.time.ZoneId
-import java.util.*
+import java.util.Date
+import java.util.Optional
 
 @MockKExtension.CheckUnnecessaryStub
 class ZaakZoekObjectConverterTest : BehaviorSpec({


### PR DESCRIPTION
Default setting in Detekt is to allow this. See: https://ncorti.com/detekt/docs/rules/style#wildcardimport.

Solves PZ-1950