### PR TITLE
chore: make groupId mandatory in the backend when assigning zaken from a list

### DIFF
--- a/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
@@ -600,7 +600,7 @@ class ZakenRESTService @Inject constructor(
         zakenService.assignZakenAsync(
             zaakUUIDs = verdeelGegevens.uuids,
             explanation = verdeelGegevens.reden,
-            group = verdeelGegevens.groepId?.let { identityService.readGroup(verdeelGegevens.groepId) },
+            group = verdeelGegevens.groepId.let { identityService.readGroup(verdeelGegevens.groepId) },
             user = verdeelGegevens.behandelaarGebruikersnaam?.let {
                 identityService.readUser(verdeelGegevens.behandelaarGebruikersnaam)
             },

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZakenVerdeelGegevens.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZakenVerdeelGegevens.kt
@@ -4,6 +4,7 @@
  */
 package net.atos.zac.app.zaken.model
 
+import jakarta.validation.constraints.NotBlank
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import java.util.UUID
@@ -13,6 +14,7 @@ import java.util.UUID
 data class RESTZakenVerdeelGegevens(
     var uuids: List<UUID>,
 
+    @field:NotBlank
     var groepId: String,
 
     var behandelaarGebruikersnaam: String? = null,

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZakenVerdeelGegevens.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTZakenVerdeelGegevens.kt
@@ -4,7 +4,6 @@
  */
 package net.atos.zac.app.zaken.model
 
-import jakarta.validation.constraints.NotBlank
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import java.util.UUID
@@ -14,13 +13,11 @@ import java.util.UUID
 data class RESTZakenVerdeelGegevens(
     var uuids: List<UUID>,
 
-    var reden: String?,
+    var groepId: String,
 
-    @field:NotBlank
-    var groepId: String? = null,
-
-    @field:NotBlank
     var behandelaarGebruikersnaam: String? = null,
+
+    var reden: String? = null,
 
     /**
      * Unique screen event resource ID which can be used

--- a/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
+++ b/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
@@ -40,9 +40,9 @@ class ZakenService @Inject constructor(
     @Suppress("LongParameterList")
     fun assignZakenAsync(
         zaakUUIDs: List<UUID>,
-        explanation: String? = null,
-        group: Group? = null,
+        group: Group,
         user: User? = null,
+        explanation: String? = null,
         screenEventResourceId: String? = null,
     ) = defaultCoroutineScope.launch(CoroutineName("AssignZakenCoroutine")) {
         LOG.fine {
@@ -54,7 +54,7 @@ class ZakenService @Inject constructor(
             zaakUUIDs
                 .map { zrcClientService.readZaak(it) }
                 .map { zaak ->
-                    group?.let {
+                    group.let {
                         zrcClientService.updateRol(
                             zaak,
                             bepaalRolGroep(it, zaak),


### PR DESCRIPTION
Because this should be mandatory according to the frontend and the user manual.

Solves PZ-1952