### PR TITLE
fix: skip searching for address in BAG in e2e tests for now

### DIFF
--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -142,6 +142,7 @@ When(
       .getByRole("button", { name: "Zoeken" })
       .click();
     await this.page.getByRole("button", { name: "Select" }).click();
+    // TEMPORARY: disable searching in BAG until we find a solution for the fact that there is no longer an acceptance environment for BAG
     // await this.page
     //   .locator("div")
     //   .filter({ hasText: /^gps_fixed$/ })

--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -142,26 +142,26 @@ When(
       .getByRole("button", { name: "Zoeken" })
       .click();
     await this.page.getByRole("button", { name: "Select" }).click();
-    await this.page
-      .locator("div")
-      .filter({ hasText: /^gps_fixed$/ })
-      .click();
-    await this.page
-      .getByPlaceholder("Zoeken op adres, postcode of woonplaats")
-      .click();
-    await this.page
-      .getByPlaceholder("Zoeken op adres, postcode of woonplaats")
-      .fill("1112gv");
-    await this.page
-      .getByPlaceholder("Zoeken op adres, postcode of woonplaats")
-      .press("Enter");
-    await this.page
-      .getByRole("row", {
-        name: "Gerelateerde gegevens tonen 0384200000005901 Adres Meelbeskamp 49, 1112GV Diemen Selecteren",
-      })
-      .getByTitle("Selecteren")
-      .click();
-    await this.page.getByText("close").click();
+    // await this.page
+    //   .locator("div")
+    //   .filter({ hasText: /^gps_fixed$/ })
+    //   .click();
+    // await this.page
+    //   .getByPlaceholder("Zoeken op adres, postcode of woonplaats")
+    //   .click();
+    // await this.page
+    //   .getByPlaceholder("Zoeken op adres, postcode of woonplaats")
+    //   .fill("1112gv");
+    // await this.page
+    //   .getByPlaceholder("Zoeken op adres, postcode of woonplaats")
+    //   .press("Enter");
+    // await this.page
+    //   .getByRole("row", {
+    //     name: "Gerelateerde gegevens tonen 0384200000005901 Adres Meelbeskamp 49, 1112GV Diemen Selecteren",
+    //   })
+    //   .getByTitle("Selecteren")
+    //   .click();
+    // await this.page.getByText("close").click();
     await this.page.getByLabel("Communicatiekanaal").click();
     await this.page.getByRole("option", { name: " E-mail " }).click();
     await this.page.waitForTimeout(1000);


### PR DESCRIPTION
The BAG acceptance environment has been taken down. Until we find a solution, we need to skip searching for an address in the e2e tests.
Solves PZ-1973