### PR TITLE
fix: Verdelen van taken werkt niet als je alleen een groep opgeeft en geen behandelaar

### DIFF
--- a/src/e2e/features/6-zaken-verdelen.feature
+++ b/src/e2e/features/6-zaken-verdelen.feature
@@ -2,7 +2,7 @@ Feature: Zaken verdelen
 
   Scenario: Bob wants to verdeel a number of zaken
     Given "Bob" navigates to "zac" with path "/zaken/werkvoorraad" with delay after of 5000 ms
-    And There at least 3 zaken
+    And there are at least 3 zaken
     When "Bob" selects that number of zaken
     And "Bob" verdeels the zaken to group "Test group A"
     Then "Bob" gets a message confirming that the verdelen of zaken is complete

--- a/src/e2e/features/6-zaken-verdelen.feature
+++ b/src/e2e/features/6-zaken-verdelen.feature
@@ -1,0 +1,8 @@
+Feature: Zaken verdelen
+
+  Scenario: Bob wants to verdeel a number of zaken
+    Given "Bob" navigates to "zac" with path "/zaken/werkvoorraad" with delay after of 5000 ms
+    And There at least 3 zaken
+    When "Bob" selects that number of zaken
+    And "Bob" verdeels the zaken to group "Test group A"
+    Then "Bob" gets a message confirming that the verdelen of zaken is complete

--- a/src/e2e/features/6-zaken-verdelen.feature
+++ b/src/e2e/features/6-zaken-verdelen.feature
@@ -1,8 +1,8 @@
 Feature: Zaken verdelen
 
-  Scenario: Bob wants to verdeel a number of zaken
+  Scenario: Bob distributes zaken to a group
     Given "Bob" navigates to "zac" with path "/zaken/werkvoorraad" with delay after of 5000 ms
     And there are at least 3 zaken
     When "Bob" selects that number of zaken
-    And "Bob" verdeels the zaken to group "Test group A"
-    Then "Bob" gets a message confirming that the verdelen of zaken is complete
+    And "Bob" distributes the zaken to group "Test group A"
+    Then "Bob" gets a message confirming that the distribution of zaken is complete

--- a/src/e2e/features/7-taken-verdelen.feature
+++ b/src/e2e/features/7-taken-verdelen.feature
@@ -2,7 +2,7 @@ Feature: Zaken verdelen
 
   Scenario: Bob wants to verdeel a number of taken
     Given "Bob" navigates to "zac" with path "/taken/werkvoorraad" with delay after of 5000 ms
-    And There at least 3 taken
+    And there are at least 3 taken
     When "Bob" selects that number of taken
     And "Bob" verdeels the taken to group "Test group A"
     Then "Bob" gets a message confirming that the verdelen of taken is complete

--- a/src/e2e/features/7-taken-verdelen.feature
+++ b/src/e2e/features/7-taken-verdelen.feature
@@ -1,0 +1,8 @@
+Feature: Zaken verdelen
+
+  Scenario: Bob wants to verdeel a number of taken
+    Given "Bob" navigates to "zac" with path "/taken/werkvoorraad" with delay after of 5000 ms
+    And There at least 3 taken
+    When "Bob" selects that number of taken
+    And "Bob" verdeels the taken to group "Test group A"
+    Then "Bob" gets a message confirming that the verdelen of taken is complete

--- a/src/e2e/features/7-taken-verdelen.feature
+++ b/src/e2e/features/7-taken-verdelen.feature
@@ -1,8 +1,8 @@
-Feature: Zaken verdelen
+Feature: Taken verdelen
 
-  Scenario: Bob wants to verdeel a number of taken
+  Scenario: Bob distributes taken to a group
     Given "Bob" navigates to "zac" with path "/taken/werkvoorraad" with delay after of 5000 ms
     And there are at least 3 taken
     When "Bob" selects that number of taken
-    And "Bob" verdeels the taken to group "Test group A"
-    Then "Bob" gets a message confirming that the verdelen of taken is complete
+    And "Bob" distributes the taken to group "Test group A"
+    Then "Bob" gets a message confirming that the distribution of taken is complete

--- a/src/e2e/step-definitions/taken-verdelen.ts
+++ b/src/e2e/step-definitions/taken-verdelen.ts
@@ -29,7 +29,7 @@ When(
 );
 
 When(
-  "{string} verdeels the taken to group {string}",
+  "{string} distributes the taken to group {string}",
   async function (this: CustomWorld, s: string, groep: string) {
     await this.page.getByTitle("Verdelen").click();
     const expectedLabel = "Taak toekennen aan groep";
@@ -41,7 +41,7 @@ When(
 );
 
 Then(
-  "{string} gets a message confirming that the verdelen of taken is complete",
+  "{string} gets a message confirming that the distribution of taken is complete",
   { timeout: ONE_MINUTE_IN_MS },
   async function (this: CustomWorld, s: string) {
     await this.page

--- a/src/e2e/step-definitions/taken-verdelen.ts
+++ b/src/e2e/step-definitions/taken-verdelen.ts
@@ -6,7 +6,7 @@ const ONE_MINUTE_IN_MS = 60_000;
 let _noOfTaken = 0;
 
 Given(
-  "There at least {int} taken",
+  "There are at least {int} taken",
   async function (this: CustomWorld, noOfTaken: number) {
     _noOfTaken = noOfTaken;
     const zaakCount = await this.page

--- a/src/e2e/step-definitions/taken-verdelen.ts
+++ b/src/e2e/step-definitions/taken-verdelen.ts
@@ -6,7 +6,7 @@ const ONE_MINUTE_IN_MS = 60_000;
 let _noOfTaken = 0;
 
 Given(
-  "There are at least {int} taken",
+  "there are ate at least {int} taken",
   async function (this: CustomWorld, noOfTaken: number) {
     _noOfTaken = noOfTaken;
     const zaakCount = await this.page

--- a/src/e2e/step-definitions/taken-verdelen.ts
+++ b/src/e2e/step-definitions/taken-verdelen.ts
@@ -6,7 +6,7 @@ const ONE_MINUTE_IN_MS = 60_000;
 let _noOfTaken = 0;
 
 Given(
-  "there are ate at least {int} taken",
+  "there are at at least {int} taken",
   async function (this: CustomWorld, noOfTaken: number) {
     _noOfTaken = noOfTaken;
     const zaakCount = await this.page

--- a/src/e2e/step-definitions/taken-verdelen.ts
+++ b/src/e2e/step-definitions/taken-verdelen.ts
@@ -3,43 +3,49 @@ import { CustomWorld } from "support/worlds/world";
 
 const ONE_MINUTE_IN_MS = 60_000;
 
-let _noOfTaken = 0
+let _noOfTaken = 0;
 
 Given(
   "There at least {int} taken",
   async function (this: CustomWorld, noOfTaken: number) {
-    _noOfTaken = noOfTaken
-    const zaakCount = await this.page.getByLabel("Selecteren", { exact: true })
-      .count()
-    this.expect(
-      zaakCount,
-    ).toBeGreaterThanOrEqual(noOfTaken);
-  }
+    _noOfTaken = noOfTaken;
+    const zaakCount = await this.page
+      .getByLabel("Selecteren", { exact: true })
+      .count();
+    this.expect(zaakCount).toBeGreaterThanOrEqual(noOfTaken);
+  },
 );
 
-When('{string} selects that number of taken', async function (this: CustomWorld, s: string) {
-  for (let i = 0; i < _noOfTaken; i++) {
-    await this.page.getByLabel("Selecteren", { exact: true })
-      .first()
-      .setChecked(true)
-  }
-})
+When(
+  "{string} selects that number of taken",
+  async function (this: CustomWorld, s: string) {
+    for (let i = 0; i < _noOfTaken; i++) {
+      await this.page
+        .getByLabel("Selecteren", { exact: true })
+        .first()
+        .setChecked(true);
+    }
+  },
+);
 
-When('{string} verdeels the taken to group {string}', async function (this: CustomWorld, s: string, groep: string) {
-  await this.page.getByTitle("Verdelen").click()
-  const expectedLabel = "Taak toekennen aan groep"
-  await this.page.getByLabel(expectedLabel).click()
-  await this.page
-    .getByRole("option", { name: groep })
-    .click();
-  await this.page.getByLabel("Reden")
-    .fill("Dummy reason")
-  await this.page.locator("#takenVerdelen_button")
-    .click()
-})
+When(
+  "{string} verdeels the taken to group {string}",
+  async function (this: CustomWorld, s: string, groep: string) {
+    await this.page.getByTitle("Verdelen").click();
+    const expectedLabel = "Taak toekennen aan groep";
+    await this.page.getByLabel(expectedLabel).click();
+    await this.page.getByRole("option", { name: groep }).click();
+    await this.page.getByLabel("Reden").fill("Dummy reason");
+    await this.page.locator("#takenVerdelen_button").click();
+  },
+);
 
-Then('{string} gets a message confirming that the verdelen of taken is complete', { timeout: ONE_MINUTE_IN_MS }, async function (this: CustomWorld, s: string) {
-  await this.page.getByText(`${_noOfTaken} zaken zijn verdeeld`).waitFor({ timeout: ONE_MINUTE_IN_MS })
-})
-
-
+Then(
+  "{string} gets a message confirming that the verdelen of taken is complete",
+  { timeout: ONE_MINUTE_IN_MS },
+  async function (this: CustomWorld, s: string) {
+    await this.page
+      .getByText(`${_noOfTaken} zaken zijn verdeeld`)
+      .waitFor({ timeout: ONE_MINUTE_IN_MS });
+  },
+);

--- a/src/e2e/step-definitions/taken-verdelen.ts
+++ b/src/e2e/step-definitions/taken-verdelen.ts
@@ -1,0 +1,45 @@
+import { Given, Then, When } from "@cucumber/cucumber";
+import { CustomWorld } from "support/worlds/world";
+
+const ONE_MINUTE_IN_MS = 60_000;
+
+let _noOfTaken = 0
+
+Given(
+  "There at least {int} taken",
+  async function (this: CustomWorld, noOfTaken: number) {
+    _noOfTaken = noOfTaken
+    const zaakCount = await this.page.getByLabel("Selecteren", { exact: true })
+      .count()
+    this.expect(
+      zaakCount,
+    ).toBeGreaterThanOrEqual(noOfTaken);
+  }
+);
+
+When('{string} selects that number of taken', async function (this: CustomWorld, s: string) {
+  for (let i = 0; i < _noOfTaken; i++) {
+    await this.page.getByLabel("Selecteren", { exact: true })
+      .first()
+      .setChecked(true)
+  }
+})
+
+When('{string} verdeels the taken to group {string}', async function (this: CustomWorld, s: string, groep: string) {
+  await this.page.getByTitle("Verdelen").click()
+  const expectedLabel = "Taak toekennen aan groep"
+  await this.page.getByLabel(expectedLabel).click()
+  await this.page
+    .getByRole("option", { name: groep })
+    .click();
+  await this.page.getByLabel("Reden")
+    .fill("Dummy reason")
+  await this.page.locator("#takenVerdelen_button")
+    .click()
+})
+
+Then('{string} gets a message confirming that the verdelen of taken is complete', { timeout: ONE_MINUTE_IN_MS }, async function (this: CustomWorld, s: string) {
+  await this.page.getByText(`${_noOfTaken} zaken zijn verdeeld`).waitFor({ timeout: ONE_MINUTE_IN_MS })
+})
+
+

--- a/src/e2e/step-definitions/zaken-verdelen.ts
+++ b/src/e2e/step-definitions/zaken-verdelen.ts
@@ -30,7 +30,7 @@ When(
 );
 
 When(
-  "{string} verdeels the zaken to group {string}",
+  "{string} distributes the zaken to group {string}",
   async function (this: CustomWorld, s: string, groep: string) {
     await this.page.getByTitle("Verdelen").click();
     const expectedLabel = "Zaak toekennen aan groep";
@@ -42,7 +42,7 @@ When(
 );
 
 Then(
-  "{string} gets a message confirming that the verdelen of zaken is complete",
+  "{string} gets a message confirming that the distribution of zaken is complete",
   { timeout: ONE_MINUTE_IN_MS },
   async function (this: CustomWorld, s: string) {
     await this.page

--- a/src/e2e/step-definitions/zaken-verdelen.ts
+++ b/src/e2e/step-definitions/zaken-verdelen.ts
@@ -1,0 +1,46 @@
+import { Given, Then, When } from "@cucumber/cucumber";
+import { CustomWorld } from "support/worlds/world";
+
+const ONE_MINUTE_IN_MS = 60_000;
+
+const zaakCheckmarkTitle = "Selecteren"
+let _noOfZaken = 0
+
+Given(
+  "There at least {int} zaken",
+  async function (this: CustomWorld, noOfZaken: number) {
+    _noOfZaken = noOfZaken
+    const zaakCount = await this.page.getByLabel(zaakCheckmarkTitle, { exact: true })
+      .count()
+    this.expect(
+      zaakCount,
+    ).toBeGreaterThanOrEqual(noOfZaken);
+  }
+);
+
+When('{string} selects that number of zaken', async function (this: CustomWorld, s: string) {
+  for (let i = 0; i < _noOfZaken; i++) {
+    await this.page.getByLabel(zaakCheckmarkTitle, { exact: true })
+      .first()
+      .setChecked(true)
+  }
+})
+
+When('{string} verdeels the zaken to group {string}', async function (this: CustomWorld, s: string, groep: string) {
+  await this.page.getByTitle("Verdelen").click()
+  const expectedLabel = "Zaak toekennen aan groep"
+  await this.page.getByLabel(expectedLabel).click()
+  await this.page
+    .getByRole("option", { name: groep })
+    .click();
+  await this.page.getByLabel("Reden")
+    .fill("Dummy reason")
+  await this.page.locator("#zakenVerdelen_button")
+    .click()
+})
+
+Then('{string} gets a message confirming that the verdelen of zaken is complete', { timeout: ONE_MINUTE_IN_MS }, async function (this: CustomWorld, s: string) {
+  await this.page.getByText(`${_noOfZaken} zaken zijn verdeeld`).waitFor({ timeout: ONE_MINUTE_IN_MS })
+})
+
+

--- a/src/e2e/step-definitions/zaken-verdelen.ts
+++ b/src/e2e/step-definitions/zaken-verdelen.ts
@@ -7,7 +7,7 @@ const zaakCheckmarkTitle = "Selecteren";
 let _noOfZaken = 0;
 
 Given(
-  "There at least {int} zaken",
+  "there are at least {int} zaken",
   async function (this: CustomWorld, noOfZaken: number) {
     _noOfZaken = noOfZaken;
     const zaakCount = await this.page

--- a/src/e2e/step-definitions/zaken-verdelen.ts
+++ b/src/e2e/step-definitions/zaken-verdelen.ts
@@ -3,44 +3,50 @@ import { CustomWorld } from "support/worlds/world";
 
 const ONE_MINUTE_IN_MS = 60_000;
 
-const zaakCheckmarkTitle = "Selecteren"
-let _noOfZaken = 0
+const zaakCheckmarkTitle = "Selecteren";
+let _noOfZaken = 0;
 
 Given(
   "There at least {int} zaken",
   async function (this: CustomWorld, noOfZaken: number) {
-    _noOfZaken = noOfZaken
-    const zaakCount = await this.page.getByLabel(zaakCheckmarkTitle, { exact: true })
-      .count()
-    this.expect(
-      zaakCount,
-    ).toBeGreaterThanOrEqual(noOfZaken);
-  }
+    _noOfZaken = noOfZaken;
+    const zaakCount = await this.page
+      .getByLabel(zaakCheckmarkTitle, { exact: true })
+      .count();
+    this.expect(zaakCount).toBeGreaterThanOrEqual(noOfZaken);
+  },
 );
 
-When('{string} selects that number of zaken', async function (this: CustomWorld, s: string) {
-  for (let i = 0; i < _noOfZaken; i++) {
-    await this.page.getByLabel(zaakCheckmarkTitle, { exact: true })
-      .first()
-      .setChecked(true)
-  }
-})
+When(
+  "{string} selects that number of zaken",
+  async function (this: CustomWorld, s: string) {
+    for (let i = 0; i < _noOfZaken; i++) {
+      await this.page
+        .getByLabel(zaakCheckmarkTitle, { exact: true })
+        .first()
+        .setChecked(true);
+    }
+  },
+);
 
-When('{string} verdeels the zaken to group {string}', async function (this: CustomWorld, s: string, groep: string) {
-  await this.page.getByTitle("Verdelen").click()
-  const expectedLabel = "Zaak toekennen aan groep"
-  await this.page.getByLabel(expectedLabel).click()
-  await this.page
-    .getByRole("option", { name: groep })
-    .click();
-  await this.page.getByLabel("Reden")
-    .fill("Dummy reason")
-  await this.page.locator("#zakenVerdelen_button")
-    .click()
-})
+When(
+  "{string} verdeels the zaken to group {string}",
+  async function (this: CustomWorld, s: string, groep: string) {
+    await this.page.getByTitle("Verdelen").click();
+    const expectedLabel = "Zaak toekennen aan groep";
+    await this.page.getByLabel(expectedLabel).click();
+    await this.page.getByRole("option", { name: groep }).click();
+    await this.page.getByLabel("Reden").fill("Dummy reason");
+    await this.page.locator("#zakenVerdelen_button").click();
+  },
+);
 
-Then('{string} gets a message confirming that the verdelen of zaken is complete', { timeout: ONE_MINUTE_IN_MS }, async function (this: CustomWorld, s: string) {
-  await this.page.getByText(`${_noOfZaken} zaken zijn verdeeld`).waitFor({ timeout: ONE_MINUTE_IN_MS })
-})
-
-
+Then(
+  "{string} gets a message confirming that the verdelen of zaken is complete",
+  { timeout: ONE_MINUTE_IN_MS },
+  async function (this: CustomWorld, s: string) {
+    await this.page
+      .getByText(`${_noOfZaken} zaken zijn verdeeld`)
+      .waitFor({ timeout: ONE_MINUTE_IN_MS });
+  },
+);

--- a/src/main/app/src/app/taken/taken.service.ts
+++ b/src/main/app/src/app/taken/taken.service.ts
@@ -136,7 +136,7 @@ export class TakenService {
       taakId: taak.id,
       zaakUuid: taak.zaakUuid,
     }));
-    taakBody.behandelaarGebruikersnaam = medewerker.id;
+    taakBody.behandelaarGebruikersnaam = medewerker?.id;
     taakBody.groepId = groep?.id;
     taakBody.reden = reden;
     return this.http


### PR DESCRIPTION
Het verdelen van taken naar een groep, zonder een gebruiker te selecteren, was stuk
Solves PZ-1963