### PR TITLE
chore: reduce warning to fine for events we don't care about

### DIFF
--- a/src/main/java/net/atos/zac/signalering/event/SignaleringEventObserver.java
+++ b/src/main/java/net/atos/zac/signalering/event/SignaleringEventObserver.java
@@ -67,7 +67,7 @@ public class SignaleringEventObserver extends AbstractEventObserver<SignaleringE
 
             final Signalering signalering = buildSignalering(event);
             if (signalering == null) {
-                LOG.warning(() -> String.format("Cannot build signalering from event ontvangen: %s", event));
+                LOG.fine(() -> String.format("No signal generated for received event: %s", event));
                 return;
             }
             if (!signaleringenService.isNecessary(signalering, event.getActor())) {


### PR DESCRIPTION
Events that do not result in signals are now logged with warning. Change that to fine

Increased severity introduced with c45295d6b9d9ac78f54c70afc7321243d1aa47e0