### PR TITLE
fix: make new e2e tests work on the build server

### DIFF
--- a/src/e2e/features/6-zaken-verdelen.feature
+++ b/src/e2e/features/6-zaken-verdelen.feature
@@ -1,14 +1,18 @@
 Feature: Zaken verdelen / vrijgeven
 
   Scenario: Bob distributes zaken to a group
-    Given "Bob" navigates to "zac" with path "/zaken/werkvoorraad" with delay after of 5000 ms
+    Given "Bob" is logged in to zac
+    And "Bob" navigates to "zac" with path "/zaken/werkvoorraad"
+    And the page is done searching
     And there are at least 3 zaken
     When "Bob" selects that number of zaken
     And "Bob" distributes the zaken to the first group available
     Then "Bob" gets a message confirming that the distribution of zaken is complete
 
   Scenario: Bob releases zaken
-    Given "Bob" navigates to "zac" with path "/zaken/werkvoorraad" with delay after of 5000 ms
+    Given "Bob" is logged in to zac
+    And "Bob" navigates to "zac" with path "/zaken/werkvoorraad"
+    And the page is done searching
     And there are at least 3 zaken
     When "Bob" selects that number of zaken
     And "Bob" releases the zaken

--- a/src/e2e/features/7-taken-verdelen.feature
+++ b/src/e2e/features/7-taken-verdelen.feature
@@ -1,14 +1,18 @@
 Feature: Taken verdelen / vrijgeven
 
   Scenario: Bob distributes taken to a group
-    Given "Bob" navigates to "zac" with path "/taken/werkvoorraad" with delay after of 5000 ms
+    Given "Bob" is logged in to zac
+    And "Bob" navigates to "zac" with path "/taken/werkvoorraad"
+    And the page is done searching
     And there are at least 3 taken
     When "Bob" selects that number of taken
     And "Bob" distributes the taken to the first group available
     Then "Bob" gets a message confirming that the distribution of taken is complete
 
   Scenario: Bob releases taken
-    Given "Bob" navigates to "zac" with path "/taken/werkvoorraad" with delay after of 5000 ms
+    Given "Bob" is logged in to zac
+    And "Bob" navigates to "zac" with path "/taken/werkvoorraad"
+    And the page is done searching
     And there are at least 3 taken
     When "Bob" selects that number of taken
     And "Bob" releases the taken

--- a/src/e2e/step-definitions/common.ts
+++ b/src/e2e/step-definitions/common.ts
@@ -63,6 +63,15 @@ Given(
   },
 );
 
+Given(
+  "the page is done searching",
+  { timeout: ONE_MINUTE_IN_MS },
+  async function (this: CustomWorld) {
+    await this.page.waitForResponse(/zoeken\/list/);
+    await this.page.waitForTimeout(100);
+  },
+);
+
 Then(
   "{string} sees the text: {string}",
   { timeout: ONE_MINUTE_IN_MS },


### PR DESCRIPTION
The end-to-end tests behave differently on the build server to when they are run locally. This change deals with this by making sure the user is logged in (as a Given) before running the test
Solves PZ-2094