### PR TITLE
chore: no longer automatically update year in SPDX copyright header

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Please reach out to us if you have questions or wish to contribute.
 
 ## License
 
+The license information for this project can be found in [LICENSE.md](LICENSE.md).
 We use [SPDX](https://spdx.dev/) license identifiers in source code files.
 
 When adding a new source code file or modifying an existing one as a Lifely/INFO developer, please update the `SPDX` license identifier accordingly:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,11 @@
 # Licence
 
-Original work Copyright @ Atos, 2021 - 2021
+Original work Copyright @ Atos, 2021 - 2022
 Modified and new work Copyright 2024 Lifely
 
 Licensed under the EUPL-1.2-or-later
+
+For instructions on how to use the license please see: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 **Table of Contents**
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -281,9 +281,6 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
         // Latest supported version:
         // https://github.com/diffplug/spotless/tree/main/lib-extra/src/main/resources/com/diffplug/spotless/extra/eclipse_wtp_formatter
         eclipse(libs.versions.spotless.eclipse.formatter.get()).configFile("config/zac.xml")
-
-        licenseHeaderFile("config/licenseHeader.txt")
-            .onlyIfContentMatches("FileCopyrightText: 2[0-9-]+ Lifely").updateYearWithLatest(true)
     }
     format("e2e") {
         target("src/e2e/**/*.js", "src/e2e/**/*.ts")

--- a/config/licenseHeader.txt
+++ b/config/licenseHeader.txt
@@ -1,4 +1,0 @@
-/*
- * SPDX-FileCopyrightText: $YEAR Lifely
- * SPDX-License-Identifier: EUPL-1.2+
- */


### PR DESCRIPTION
Because our new convention is that the the year in our SPDX headers indicates the initial year of contribution (i.e. it is not updated thereafter).

Solves PZ-2109