### PR TITLE
chore: add support to our GitHub Workflows for GitHub Merge Queue

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -6,6 +6,7 @@ name: Build, test & deploy
 
 on:
   pull_request:
+  merge_group:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/check-for-conventional-commits.yml
+++ b/.github/workflows/check-for-conventional-commits.yml
@@ -7,6 +7,7 @@ name: Check for conventional commits
 on:
   pull_request:
     types: [opened, edited, synchronize]
+  merge_group:
 
 jobs:
   check-for-conventional-commits:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,9 +9,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    # ignore CodeQL analysis when only Markdown files have changed
+    # ignore code analysis when only Markdown files have changed
     paths-ignore:
       - '**/*.md'
+  merge_group:
   schedule:
     - cron: "21 11 * * 0"
 

--- a/.github/workflows/snyk-code-scanning.yml
+++ b/.github/workflows/snyk-code-scanning.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: "21 11 * * 0"
 

--- a/.github/workflows/trivy-code-scanning.yml
+++ b/.github/workflows/trivy-code-scanning.yml
@@ -9,9 +9,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    # ignore CodeQL analysis when only Markdown files have changed
+    # ignore code analysis when only Markdown files have changed
     paths-ignore:
       - '**/*.md'
+  merge_group:
   schedule:
     - cron: "21 11 * * 0"
 


### PR DESCRIPTION
Added support to our GitHub Workflows for a GitHub Merge Queue by adding `on: merge_group:` to those workflows that perform a check. See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

Solves PZ-2110