### PR TITLE
feat: no longer perform direct Solr indexing when assigning and releasing zaken

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -250,11 +250,11 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Save Docker Image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
         run: docker save --output docker-image.tar ${ZAC_DOCKER_IMAGE}
 
       - name: Cache ZAC Docker Image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
         uses: actions/cache/save@v4
         with:
           path: docker-image.tar
@@ -277,7 +277,7 @@ jobs:
           target: minor
 
   next-version:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.get-version.outputs.replaced }}
@@ -314,7 +314,7 @@ jobs:
     needs: [build, run-unit-tests, build-docker-image-and-run-itests, next-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
     env:
       ZAC_DOCKER_IMAGE: ${{ needs.build.outputs.zac_docker_image }}
       NEXT_VERSION: ${{ needs.next-version.outputs.version }}
@@ -347,7 +347,7 @@ jobs:
 
   create-release:
     needs: [next-version, push-docker-image]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
     runs-on: ubuntu-22.04
     env:
       NEXT_VERSION: ${{ needs.next-version.outputs.version }}
@@ -375,7 +375,7 @@ jobs:
     needs: [push-docker-image]
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -250,11 +250,11 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Save Docker Image
-        if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
+        if: github.ref == 'refs/heads/main'
         run: docker save --output docker-image.tar ${ZAC_DOCKER_IMAGE}
 
       - name: Cache ZAC Docker Image
-        if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
+        if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
           path: docker-image.tar
@@ -277,7 +277,7 @@ jobs:
           target: minor
 
   next-version:
-    if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.get-version.outputs.replaced }}
@@ -314,7 +314,7 @@ jobs:
     needs: [build, run-unit-tests, build-docker-image-and-run-itests, next-version]
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
+    if: github.ref == 'refs/heads/main'
     env:
       ZAC_DOCKER_IMAGE: ${{ needs.build.outputs.zac_docker_image }}
       NEXT_VERSION: ${{ needs.next-version.outputs.version }}
@@ -347,7 +347,7 @@ jobs:
 
   create-release:
     needs: [next-version, push-docker-image]
-    if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     env:
       NEXT_VERSION: ${{ needs.next-version.outputs.version }}
@@ -375,7 +375,7 @@ jobs:
     needs: [push-docker-image]
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    if: github.ref == 'refs/heads/main' || github.ref_name == 'feature/PZ-2117-no-longer-perform-direct-solr-indexing-when-assigning-and-releasing-zaken'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/github-script@v7
         with:

--- a/src/itest/kotlin/nl/lifely/zac/itest/IndexerenRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/IndexerenRESTServiceTest.kt
@@ -6,18 +6,14 @@ package nl.lifely.zac.itest
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.assertions.json.shouldContainJsonKeyValue
-import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContainOnlyOnce
 import nl.lifely.zac.itest.client.ItestHttpClient
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_TASK_CREATED
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import okhttp3.Headers
-import org.json.JSONObject
-import kotlin.time.Duration.Companion.seconds
 
 const val INDEXING_COUNT = 10
 
@@ -33,37 +29,6 @@ class IndexerenRESTServiceTest : BehaviorSpec({
 
     Given("""Two zaken, a task and a document have been created""") {
         When("""the reindexing endpoint is called for type 'zaak'""") {
-            // In previous tests the zaken were added to the search index already but the indexing may still be in process.
-            // So we need to wait a bit until the zaken are really added to the index or else the zaken may be marked
-            // to be _added_ to the index instead of being marked to be _reindexed_ when performing the 'reindexing' request.
-            // We do this by performing a search on all zaken using the ZAC search endpoint.
-            eventually(5.seconds) {
-                with(
-                    itestHttpClient.performPutRequest(
-                        url = "$ZAC_API_URI/zoeken/list",
-                        requestBodyAsString = """
-                    {
-                    "filtersType":"ZoekParameters",
-                    "alleenMijnZaken":false,
-                    "alleenOpenstaandeZaken":true,
-                    "alleenAfgeslotenZaken":false,
-                    "alleenMijnTaken":false,
-                    "zoeken":{"ZAAK_OMSCHRIJVING":"","ZAAK_IDENTIFICATIE":""},
-                    "filters":{},
-                    "datums":{},
-                    "rows":$INDEXING_COUNT,
-                    "page":0,
-                    "type":"ZAAK"
-                    }
-                        """.trimIndent()
-                    )
-                ) {
-                    isSuccessful shouldBe true
-                    val responseBody = body!!.string()
-                    logger.info { "Response: $responseBody" }
-                    JSONObject(responseBody).getJSONArray("resultaten") shouldHaveSize 2
-                }
-            }
             val response = itestHttpClient.performGetRequest(
                 url = "$ZAC_API_URI/indexeren/herindexeren/ZAAK",
                 addAuthorizationHeader = false
@@ -75,8 +40,8 @@ class IndexerenRESTServiceTest : BehaviorSpec({
                 logger.info { "Response: $responseBody" }
                 response.isSuccessful shouldBe true
                 with(responseBody) {
-                    shouldContainJsonKeyValue("herindexeren", 2)
-                    shouldContainJsonKeyValue("toevoegen", 0)
+                    shouldContainJsonKeyValue("herindexeren", 0)
+                    shouldContainJsonKeyValue("toevoegen", 2)
                     shouldContainJsonKeyValue("verwijderen", 0)
                 }
             }

--- a/src/main/java/net/atos/zac/zoeken/IndexeerService.java
+++ b/src/main/java/net/atos/zac/zoeken/IndexeerService.java
@@ -31,7 +31,6 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.transaction.Transactional;
 
-import net.atos.zac.zoeken.model.index.IndexResult;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;

--- a/src/main/java/net/atos/zac/zoeken/model/index/IndexResult.java
+++ b/src/main/java/net/atos/zac/zoeken/model/index/IndexResult.java
@@ -5,4 +5,3 @@ public record IndexResult(long indexed, long removed, long remaining) {
         this(0, 0, 0);
     }
 }
-

--- a/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
+++ b/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
@@ -23,15 +23,12 @@ import net.atos.zac.event.EventingService
 import net.atos.zac.identity.model.Group
 import net.atos.zac.identity.model.User
 import net.atos.zac.websocket.event.ScreenEventType
-import net.atos.zac.zoeken.IndexeerService
-import net.atos.zac.zoeken.model.index.ZoekObjectType
 import java.util.UUID
 import java.util.logging.Logger
 
 class ZakenService @Inject constructor(
     private val zrcClientService: ZRCClientService,
     private val ztcClientService: ZTCClientService,
-    private val indexeerService: IndexeerService,
     private var eventingService: EventingService
 ) {
     companion object {
@@ -40,7 +37,7 @@ class ZakenService @Inject constructor(
     }
 
     /**
-     * Asynchronously assigns a list of zaken to a group and/or user and updates the search index on the fly.
+     * Asynchronously assigns a list of zaken to a group and/or user.
      */
     @Suppress("LongParameterList")
     fun assignZakenAsync(
@@ -73,10 +70,6 @@ class ZakenService @Inject constructor(
                             explanation
                         )
                     }
-                    indexeerService.indexeerDirect(
-                        zaak.uuid.toString(),
-                        ZoekObjectType.ZAAK
-                    )
                     zakenAssignedList.add(zaak.uuid)
                 }
         }
@@ -122,7 +115,7 @@ class ZakenService @Inject constructor(
         )
 
     /**
-     * Asynchronously releases a list of zaken from a user and updates the search index on the fly.
+     * Asynchronously releases a list of zaken from a user.
      */
     fun releaseZakenAsync(
         zaakUUIDs: List<UUID>,
@@ -137,10 +130,6 @@ class ZakenService @Inject constructor(
                 .map { zrcClientService.readZaak(it) }
                 .forEach {
                     zrcClientService.deleteRol(it, BetrokkeneType.MEDEWERKER, explanation)
-                    indexeerService.indexeerDirect(
-                        it.uuid.toString(),
-                        ZoekObjectType.ZAAK
-                    )
                 }
         }
         LOG.fine(


### PR DESCRIPTION
No longer perform direct Solr indexing when assigning and releasing zaken from the list because the updated zaken are already updated from the related notifications received from Open Notificaties. DRAFT for now.

Solves PZ-2117