### PR TITLE
chore: removed obsolete version number from Docker Compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   keycloak:
     image: quay.io/keycloak/keycloak:23.0.4


### PR DESCRIPTION
Removed obsolete version number from Docker Compose file.

Solves PZ-2133