### PR TITLE
feat: add OpenTelemetry to WildFly

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -547,7 +547,6 @@ services:
     ports:
       - "8080:8080"
       - "9990:9990"
-      - "14250:14250" # Open Telemetry endpoint
     volumes:
       # mount volumes for (optional) JaCoCo test coverage for our integration tests
       # see: https://blog.akquinet.de/2018/09/06/test-coverage-for-containerized-java-apps/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -540,6 +540,7 @@ services:
       - SD_FIXED_USER_NAME=${SD_FIXED_USER_NAME:-}
       - SOLR_URL=http://solr:8983
       - SUBSYSTEM_OPENTELEMETRY__SAMPLER_TYPE=on
+      - SUBSYSTEM_OPENTELEMETRY__ENDPOINT=http://otel-collector:4317
       - VRL_API_CLIENT_MP_REST_URL=http://zgw-referentielijsten.local:8000/
       # Enable the ability to override WildFly settings using environment variables
       - WILDFLY_OVERRIDING_ENV_VARS=1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -481,6 +481,18 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
+  otel-collector:
+    image: otel/opentelemetry-collector:0.98.0
+    command: [ --config=/etc/otel-collector-config.yaml ]
+    volumes:
+      - ./scripts/docker-compose/imports/otel-collector/otel-collector-config.yaml:/etc/otel-collector-config.yaml:Z
+    ports:
+      - "1888:1888" # pprof extension
+      - "13133:13133" # health_check extension
+      - "4317:4317" # OTLP gRPC receiver
+      - "4318:4318" # OTLP http receiver
+      - "55679:55679" # zpages extension
+
   zac:
     # By default, we use the latest ZAC Docker Image. Change this if you wish to use a specific version.
     image: ${ZAC_DOCKER_IMAGE:-ghcr.io/infonl/zaakafhandelcomponent:latest}
@@ -535,6 +547,7 @@ services:
     ports:
       - "8080:8080"
       - "9990:9990"
+      - "14250:14250" # Open Telemetry endpoint
     volumes:
       # mount volumes for (optional) JaCoCo test coverage for our integration tests
       # see: https://blog.akquinet.de/2018/09/06/test-coverage-for-containerized-java-apps/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -539,7 +539,10 @@ services:
       - SD_CLIENT_MP_REST_URL=${SD_CLIENT_MP_REST_URL:-http://smartdocuments-wiremock:8080}
       - SD_FIXED_USER_NAME=${SD_FIXED_USER_NAME:-}
       - SOLR_URL=http://solr:8983
+      - SUBSYSTEM_OPENTELEMETRY__SAMPLER_TYPE=on
       - VRL_API_CLIENT_MP_REST_URL=http://zgw-referentielijsten.local:8000/
+      # Enable the ability to override WildFly settings using environment variables
+      - WILDFLY_OVERRIDING_ENV_VARS=1
       - ZGW_API_CLIENT_MP_REST_URL=http://openzaak.local:8000/
       - ZGW_API_CLIENTID=zac_client
       - ZGW_API_SECRET=openzaakZaakafhandelcomponentClientSecret

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ nodejs = "20.11.1"
 jsonschema2pojo = "1.2.1"
 openapi = "3.10.0"
 openapi-generator = "7.4.0"
+opentelemetry = "1.37.0"
 node-gradle = "7.0.2"
 taskinfo = "2.2.0"
 swagger-generator = "2.19.2"
@@ -120,6 +121,8 @@ jackson-core = { group = "com.fasterxml.jackson.core", name = "jackson-core", ve
 jackson-annotations = { group = "com.fasterxml.jackson.core", name = "jackson-annotations", version.ref = "jackson" }
 jackson-jsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jackson" }
 jackson-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
+
+opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api", version.ref = "opentelemetry"}
 
 # dependencies provided by Wildfly
 # update these versions when upgrading WildFly

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
                             <version>${wildfly-datasources-galleon-pack.version}</version>
                         </featurePack>
                     </featurePacks>
+                    <!-- please keep these layers in sync with those in our `install-wildfly.sh` script -->
                     <layers>
                         <layer>jaxrs-server</layer>
                         <layer>microprofile-health</layer>
@@ -48,6 +49,7 @@
                         <layer>microprofile-fault-tolerance</layer>
                         <layer>elytron-oidc-client</layer>
                         <layer>postgresql-driver</layer>
+                        <layer>opentelemetry</layer>
                     </layers>
                     <excludedLayers>
                         <layer>deployment-scanner</layer>

--- a/scripts/docker-compose/imports/otel-collector/otel-collector-config.yaml
+++ b/scripts/docker-compose/imports/otel-collector/otel-collector-config.yaml
@@ -1,0 +1,28 @@
+extensions:
+  health_check:
+  pprof:
+    endpoint: 0.0.0.0:1777
+  zpages:
+    endpoint: 0.0.0.0:55679
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+
+exporters:
+  logging:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [logging]
+
+  extensions: [health_check, pprof, zpages]

--- a/scripts/wildfly/install-wildfly.sh
+++ b/scripts/wildfly/install-wildfly.sh
@@ -21,7 +21,7 @@ export PATH=$PATH:$(pwd)/galleon/bin
 
 echo ">>> Installing WildFly ..."
 rm -fr $WILDFLY_SERVER_DIR
-galleon.sh install wildfly#$WILDFLY_VERSION --dir=$WILDFLY_SERVER_DIR --layers=jaxrs-server,microprofile-health,microprofile-fault-tolerance,elytron-oidc-client,metrics
+galleon.sh install wildfly#$WILDFLY_VERSION --dir=$WILDFLY_SERVER_DIR --layers=jaxrs-server,microprofile-health,microprofile-fault-tolerance,elytron-oidc-client,metrics,opentelemetry
 galleon.sh install org.wildfly:wildfly-datasources-galleon-pack:$WILDFLY_DATASOURCES_GALLEON_PACK_VERSION --dir=$WILDFLY_SERVER_DIR --layers=postgresql-driver
 $WILDFLY_SERVER_DIR/bin/jboss-cli.sh --file=install-wildfly.cli
 

--- a/src/main/resources/wildfly/configure-wildfly.cli
+++ b/src/main/resources/wildfly/configure-wildfly.cli
@@ -34,9 +34,12 @@ data-source add \
 # NOTE: This needs to set higher than our max file size setting in ZAC because of the way RESTEasy handles file uploads.
 /subsystem=microprofile-config-smallrye/config-source=props:add(properties={"dev.resteasy.entity.file.threshold" = "120MB"})
 
-# To change the default settings for the Open Telemetry subsystem use something like this
+# To change the default settings for the Open Telemetry subsystem you can use statements similar to:
 # (for details see: https://docs.wildfly.org/31/Admin_Guide.html#Observability_Tracing)
 #/subsystem=opentelemetry:exporter(name=endpoint):write-attribute(name=endpoint,value="http://localhost:4317")
+# By default we turn off the Open Telemetry sampler so that by deftault no traces are sent to an Open Telemetry Collector.
+# Using the correponding environment variable we turn this back on when required.
+/subsystem=opentelemetry/:write-attribute(name=sampler-type,value=off)
 
 # To set the log level to DEBUG (default is INFO) uncomment the following lines.
 # Note that this will result in _a lot_ of logging including SessionRegistry sessionRegistry security sensitive data

--- a/src/main/resources/wildfly/configure-wildfly.cli
+++ b/src/main/resources/wildfly/configure-wildfly.cli
@@ -34,6 +34,10 @@ data-source add \
 # NOTE: This needs to set higher than our max file size setting in ZAC because of the way RESTEasy handles file uploads.
 /subsystem=microprofile-config-smallrye/config-source=props:add(properties={"dev.resteasy.entity.file.threshold" = "120MB"})
 
+# To change the default settings for the Open Telemetry subsystem use something like this
+# (for details see: https://docs.wildfly.org/31/Admin_Guide.html#Observability_Tracing)
+#/subsystem=opentelemetry:exporter(name=endpoint):write-attribute(name=endpoint,value="http://localhost:4317")
+
 # To set the log level to DEBUG (default is INFO) uncomment the following lines.
 # Note that this will result in _a lot_ of logging including SessionRegistry sessionRegistry security sensitive data
 # so use with care and only enable this for debugging purposes.

--- a/src/main/resources/wildfly/configure-wildfly.cli
+++ b/src/main/resources/wildfly/configure-wildfly.cli
@@ -34,11 +34,9 @@ data-source add \
 # NOTE: This needs to set higher than our max file size setting in ZAC because of the way RESTEasy handles file uploads.
 /subsystem=microprofile-config-smallrye/config-source=props:add(properties={"dev.resteasy.entity.file.threshold" = "120MB"})
 
-# To change the default settings for the Open Telemetry subsystem you can use statements similar to:
-# (for details see: https://docs.wildfly.org/31/Admin_Guide.html#Observability_Tracing)
-#/subsystem=opentelemetry:exporter(name=endpoint):write-attribute(name=endpoint,value="http://localhost:4317")
-# By default we turn off the Open Telemetry sampler so that by deftault no traces are sent to an Open Telemetry Collector.
-# Using the correponding environment variable we turn this back on when required.
+# We turn off the Open Telemetry sampler here so that by default no traces are sent to an Open Telemetry Collector
+# since there might be a collector available in the ZAC deployment environment.
+# Using a corresponding environment variable `SUBSYSTEM_OPENTELEMETRY__SAMPLER_TYPE` we can then turn this back on when needed.
 /subsystem=opentelemetry/:write-attribute(name=sampler-type,value=off)
 
 # To set the log level to DEBUG (default is INFO) uncomment the following lines.


### PR DESCRIPTION
Add standard Open Telemetry metrics to WildFly. Also added a Open Telemetry Collector in the Docker Compose setup. When deployed to an environment this does mean that an Open Telemetry Collector is required there as well or else WildFly will log many error messages about not being able to connect to Open Telemetry collector.

Solves PZ-604