### PR TITLE
fix: retry listing signaleringen on empty list

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/SignaleringenRestServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/SignaleringenRestServiceTest.kt
@@ -46,8 +46,8 @@ class SignaleringenRestServiceTest : BehaviorSpec({
     val logger = KotlinLogging.logger {}
     val itestHttpClient = ItestHttpClient()
 
-    val afterFifteenSeconds = eventuallyConfig {
-        duration = 15.seconds
+    val afterThirtySeconds = eventuallyConfig {
+        duration = 30.seconds
         interval = 500.milliseconds
     }
 
@@ -212,7 +212,7 @@ class SignaleringenRestServiceTest : BehaviorSpec({
 
             Then("it returns a date between the start of the tests and current moment") {
                 // The backend event processing is asynchronous. Wait a bit until the events are processed
-                eventually(afterFifteenSeconds) {
+                eventually(afterThirtySeconds) {
                     val response = itestHttpClient.performGetRequest(latestSignaleringenDateUrl)
                     val responseBody = response.body!!.string()
                     logger.info { "Response: $responseBody" }
@@ -241,7 +241,7 @@ class SignaleringenRestServiceTest : BehaviorSpec({
 
             Then("it returns the correct signaleringen for ZAAK_OP_NAAM via websocket") {
                 // the backend process is asynchronous, so we need to wait a bit until the DB is populated
-                eventually(afterFifteenSeconds) {
+                eventually(afterThirtySeconds) {
                     with(JSONObject(websocketListener.messagesReceived.last())) {
                         getString("opcode") shouldBe "UPDATED"
                         getString("objectType") shouldBe "ZAKEN_SIGNALERINGEN"
@@ -276,7 +276,7 @@ class SignaleringenRestServiceTest : BehaviorSpec({
 
             Then("it returns the correct signaleringen for ZAAK_DOCUMENT_TOEGEVOEGD via websocket") {
                 // the backend process is asynchronous, so we need to wait a bit until DB is populated
-                eventually(afterFifteenSeconds) {
+                eventually(afterThirtySeconds) {
                     with(JSONObject(websocketListener.messagesReceived.last())) {
                         getString("opcode") shouldBe "UPDATED"
                         getString("objectType") shouldBe "ZAKEN_SIGNALERINGEN"

--- a/src/itest/kotlin/nl/lifely/zac/itest/SignaleringenRestServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/SignaleringenRestServiceTest.kt
@@ -12,7 +12,6 @@ import io.kotest.assertions.nondeterministic.eventuallyConfig
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.date.shouldBeBetween
-import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import nl.lifely.zac.itest.client.ItestHttpClient
 import nl.lifely.zac.itest.config.ItestConfiguration
@@ -251,7 +250,7 @@ class SignaleringenRestServiceTest : BehaviorSpec({
                             val detail = JSONArray(getString("detail"))
                             if (detail.isEmpty) {
                                 // we got an empty list - DB not populated. Request a new list
-                                requestZaakSignaleringen("ZAAK_OP_NAAM");
+                                requestZaakSignaleringen("ZAAK_OP_NAAM")
                             }
                             with(detail.getJSONObject(0).toString()) {
                                 shouldContainJsonKey("behandelaar")
@@ -286,7 +285,7 @@ class SignaleringenRestServiceTest : BehaviorSpec({
                             val detail = JSONArray(getString("detail"))
                             if (detail.isEmpty) {
                                 // we got an empty list - DB not populated. Request a new list
-                                requestZaakSignaleringen("ZAAK_DOCUMENT_TOEGEVOEGD");
+                                requestZaakSignaleringen("ZAAK_DOCUMENT_TOEGEVOEGD")
                             }
                             with(detail.getJSONObject(0).toString()) {
                                 shouldContainJsonKeyValue("identificatie", ZAAK_1_IDENTIFICATION)


### PR DESCRIPTION
On empty DB we return empty list
In this case the test should retry listing 