### PR TITLE
fix: retry listing signals with unique websocket id

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/SignaleringenRestServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/SignaleringenRestServiceTest.kt
@@ -275,7 +275,7 @@ class SignaleringenRestServiceTest : BehaviorSpec({
         }
         When("the list of zaken signaleringen for ZAAK_DOCUMENT_TOEGEVOEGD is requested") {
             var uniqueResourceId = UUID.randomUUID()
-            var websocketListener = requestZaakSignaleringen(uniqueResourceId,"ZAAK_DOCUMENT_TOEGEVOEGD")
+            var websocketListener = requestZaakSignaleringen(uniqueResourceId, "ZAAK_DOCUMENT_TOEGEVOEGD")
 
             Then("it returns the correct signaleringen for ZAAK_DOCUMENT_TOEGEVOEGD via websocket") {
                 // the backend process is asynchronous, so we need to wait a bit until DB is populated
@@ -289,7 +289,10 @@ class SignaleringenRestServiceTest : BehaviorSpec({
                             if (detail.isEmpty) {
                                 // we got an empty list - DB not populated. Request a new list
                                 uniqueResourceId = UUID.randomUUID()
-                                websocketListener = requestZaakSignaleringen(uniqueResourceId,"ZAAK_DOCUMENT_TOEGEVOEGD")
+                                websocketListener = requestZaakSignaleringen(
+                                    uniqueResourceId,
+                                    "ZAAK_DOCUMENT_TOEGEVOEGD"
+                                )
                             }
                             with(detail.getJSONObject(0).toString()) {
                                 shouldContainJsonKeyValue("identificatie", ZAAK_1_IDENTIFICATION)


### PR DESCRIPTION
Current test retries with the same ID. However this fails if the session gets invalidated: 
/websocket: java.lang.IllegalStateException: UT000021: Session already invalidated