### PR TITLE
chore: added support for Open Telemetry instrumentation annotations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,6 +124,8 @@ dependencies {
     implementation(libs.jackson.annotations)
     implementation(libs.jackson.kotlin)
     implementation(libs.jackson.jsr310)
+    implementation(libs.opentelemetry.api)
+    implementation(libs.opentelemetry.instrumentation.annotations)
 
     swaggerUI(libs.swagger.ui)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ jsonschema2pojo = "1.2.1"
 openapi = "3.10.0"
 openapi-generator = "7.5.0"
 opentelemetry = "1.37.0"
+opentelemetry-instrumentation = "2.3.0"
 node-gradle = "7.0.2"
 taskinfo = "2.2.0"
 swagger-generator = "2.19.2"
@@ -122,7 +123,8 @@ jackson-annotations = { group = "com.fasterxml.jackson.core", name = "jackson-an
 jackson-jsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jackson" }
 jackson-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
 
-opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api", version.ref = "opentelemetry"}
+opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api", version.ref = "opentelemetry" }
+opentelemetry-instrumentation-annotations = { group = "io.opentelemetry.instrumentation", name = "opentelemetry-instrumentation-annotations", version.ref = "opentelemetry-instrumentation" }
 
 # dependencies provided by Wildfly
 # update these versions when upgrading WildFly


### PR DESCRIPTION
See: https://opentelemetry.io/docs/languages/java/automatic/annotations/ E.g. you can now annotate a method or function with `@WithSpan`. Note that if you want to use these annotations on Kotlin service classes you will need to annotate these classes with the `@AllOpen` annotation.

Solves PZ-2177