### PR TITLE
feat: disable OPA plugin on Windows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import com.bisnode.opa.configuration.ExecutableMode
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.github.gradle.node.npm.task.NpmTask
 import io.smallrye.openapi.api.OpenApiConfig
+import org.apache.tools.ant.taskdefs.condition.Os
 import java.util.Locale
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
@@ -379,7 +380,9 @@ tasks {
 
     test {
         dependsOn("npmRunTest")
-        dependsOn("testRegoCoverage")
+        if(!Os.isFamily(Os.FAMILY_WINDOWS)) {
+            dependsOn("testRegoCoverage")
+        }
     }
 
     compileJava {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -212,12 +212,14 @@ jacoco {
     toolVersion = libs.versions.jacoco.get()
 }
 
-opa {
-    srcDir = "$rootDir/src/main/resources/policies"
-    testDir = "$rootDir/src/main/resources/policies/tests"
-    version = libs.versions.opa.binary.get()
-    mode = ExecutableMode.DOWNLOAD
-    location = "$rootDir/build/opa/$version/opa"
+if(!Os.isFamily(Os.FAMILY_WINDOWS)) {
+    opa {
+        srcDir = "$rootDir/src/main/resources/policies"
+        testDir = "$rootDir/src/main/resources/policies/tests"
+        version = libs.versions.opa.binary.get()
+        mode = ExecutableMode.DOWNLOAD
+        location = "$rootDir/build/opa/$version/opa"
+    }
 }
 
 java {


### PR DESCRIPTION
OPA does not recognize Windows 10 and 11:
https://github.com/Bisnode/opa-gradle-plugin/pull/120