### PR TITLE
chore: check for unnecessary stubs in unit tests

### DIFF
--- a/src/main/java/net/atos/zac/shared/helper/OpschortenZaakHelper.java
+++ b/src/main/java/net/atos/zac/shared/helper/OpschortenZaakHelper.java
@@ -22,23 +22,32 @@ import net.atos.zac.flowable.ZaakVariabelenService;
 import net.atos.zac.policy.PolicyService;
 
 public class OpschortenZaakHelper {
-
     private static final String OPSCHORTING = "Opschorting";
-
     private static final String HERVATTING = "Hervatting";
 
-
-    @Inject
     private PolicyService policyService;
-
-    @Inject
     private ZRCClientService zrcClientService;
-
-    @Inject
     private ZTCClientService ztcClientService;
+    private ZaakVariabelenService zaakVariabelenService;
+
+    /**
+     * Default empty constructor, required by JAX-RS
+     */
+    public OpschortenZaakHelper() {
+    }
 
     @Inject
-    private ZaakVariabelenService zaakVariabelenService;
+    OpschortenZaakHelper(
+            PolicyService policyService,
+            ZRCClientService zrcClientService,
+            ZTCClientService ztcClientService,
+            ZaakVariabelenService zaakVariabelenService
+    ) {
+        this.policyService = policyService;
+        this.zrcClientService = zrcClientService;
+        this.ztcClientService = ztcClientService;
+        this.zaakVariabelenService = zaakVariabelenService;
+    }
 
     public Zaak opschortenZaak(Zaak zaak, final long aantalDagen, final String redenOpschorting) {
         assertPolicy(policyService.readZaakRechten(zaak).behandelen());

--- a/src/main/kotlin/net/atos/zac/task/TaskService.kt
+++ b/src/main/kotlin/net/atos/zac/task/TaskService.kt
@@ -78,7 +78,7 @@ class TaskService @Inject constructor(
             "Started asynchronous job with ID: $screenEventResourceId to assign " +
                 "${restTaakVerdelenGegevens.taken.size} taken."
         }
-        val taakIds = mutableListOf<String>()
+        val taskIds = mutableListOf<String>()
         restTaakVerdelenGegevens.taken.forEach { restTaakVerdelenTaak ->
             val task = flowableTaskService.readOpenTask(restTaakVerdelenTaak.taakId)
             flowableTaskService.assignTaskToGroup(
@@ -95,12 +95,12 @@ class TaskService @Inject constructor(
                 )
             }
             sendScreenEventsOnTaskChange(task, restTaakVerdelenTaak.zaakUuid)
-            taakIds.add(restTaakVerdelenTaak.taakId)
+            taskIds.add(restTaakVerdelenTaak.taakId)
         }
-        indexeerService.indexeerDirect(taakIds, ZoekObjectType.TAAK)
+        indexeerService.indexeerDirect(taskIds, ZoekObjectType.TAAK)
         LOG.fine {
             "Asynchronous assign taken job with job ID '$screenEventResourceId' finished. " +
-                "Successfully assigned ${taakIds.size} taken."
+                "Successfully assigned ${taskIds.size} taken."
         }
         // if a screen event resource ID was specified, send an 'updated zaken_verdelen' screen event
         // with the job UUID so that it can be picked up by a client

--- a/src/test/kotlin/net/atos/zac/app/taken/TakenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/taken/TakenRESTServiceTest.kt
@@ -50,7 +50,6 @@ import net.atos.zac.task.TaskService
 import net.atos.zac.util.DateTimeConverterUtil
 import net.atos.zac.websocket.event.ScreenEvent
 import net.atos.zac.zoeken.IndexeerService
-import org.flowable.identitylink.api.IdentityLinkInfo
 import org.flowable.task.api.Task
 import org.flowable.task.api.history.HistoricTaskInstance
 import org.flowable.task.api.history.createHistoricTaskInstanceEntityImpl
@@ -110,16 +109,11 @@ class TakenRESTServiceTest : BehaviorSpec({
     Given("a task is not yet assigned") {
         val restTaakToekennenGegevens = createRESTTaakToekennenGegevens()
         val task = mockk<Task>()
-        val identityLinkInfo = mockk<IdentityLinkInfo>()
-        val identityLinks = listOf(identityLinkInfo)
-
         every { loggedInUserInstance.get() } returns loggedInUser
         every { flowableTaskService.readOpenTask(restTaakToekennenGegevens.taakId) } returns task
         every { getTaakStatus(task) } returns TaakStatus.NIET_TOEGEKEND
         every { policyService.readTaakRechten(task) } returns createTaakRechten()
         every { task.assignee } returns ""
-        every { task.identityLinks } returns identityLinks
-        every { task.id } returns restTaakToekennenGegevens.taakId
         every {
             taskService.assignTask(
                 restTaakToekennenGegevens,
@@ -257,7 +251,6 @@ class TakenRESTServiceTest : BehaviorSpec({
             every { httpSessionInstance.get() } returns httpSession
             // in this test we assume there was no document uploaded to the http session beforehand
             every { httpSession.getAttribute("_FILE__${restTaak.id}__$restTaakDataKey") } returns null
-            every { httpSession.removeAttribute("_FILE__${restTaak.id}__$restTaakDataKey") } just runs
             every { taakVariabelenService.isZaakHervatten(restTaakData) } returns false
             every { taakVariabelenService.readOndertekeningen(restTaakData) } returns Optional.of(signatureUUID.toString())
             every { drcClientService.readEnkelvoudigInformatieobject(signatureUUID) } returns enkelvoudigInformatieObject

--- a/src/test/kotlin/net/atos/zac/app/taken/TakenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/taken/TakenRESTServiceTest.kt
@@ -100,25 +100,7 @@ class TakenRESTServiceTest : BehaviorSpec({
     val loggedInUser = createLoggedInUser()
 
     beforeEach {
-        checkUnnecessaryStub(
-            drcClientService,
-            enkelvoudigInformatieObjectUpdateService,
-            eventingService,
-            httpSessionInstance,
-            indexeerService,
-            loggedInUserInstance,
-            policyService,
-            taakVariabelenService,
-            restTaakConverter,
-            flowableTaskService,
-            zrcClientService,
-            opschortenZaakHelper,
-            restInformatieobjectConverter,
-            signaleringenService,
-            taakHistorieConverter,
-            zgwApiService,
-            taskService
-        )
+        checkUnnecessaryStub()
     }
 
     afterSpec {

--- a/src/test/kotlin/net/atos/zac/app/zaken/ZakenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaken/ZakenRESTServiceTest.kt
@@ -6,6 +6,8 @@
 package net.atos.zac.app.zaken
 
 import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.just
@@ -158,6 +160,14 @@ class ZakenRESTServiceTest : BehaviorSpec({
         restZaaktypeConverter = restZaaktypeConverter
     )
 
+    beforeEach {
+        checkUnnecessaryStub()
+    }
+
+    afterSpec {
+        clearAllMocks()
+    }
+
     Given("zaak input data is provided") {
         When("createZaak is called for a zaaktype for which the logged in user has permissions") {
             Then("a zaak is created using the ZGW API and a zaak is started in the ZAC CMMN service") {
@@ -224,16 +234,12 @@ class ZakenRESTServiceTest : BehaviorSpec({
                 every { zgwApiService.createZaak(zaak) } returns zaak
                 every { zrcClientService.createRol(any(), any()) } returns rolNatuurlijkPersoon
                 every { zrcClientService.updateRol(zaak, any(), any()) } just runs
-                every { zrcClientService.createZaak(zaak) } returns zaak
                 every { zrcClientService.createZaakobject(zaakObjectPand) } returns zaakObjectPand
                 every { zrcClientService.createZaakobject(zaakObjectOpenbareRuimte) } returns zaakObjectOpenbareRuimte
                 every { ztcClientService.readZaaktype(zaakTypeUUID) } returns zaakType
                 every {
                     ztcClientService.readRoltype(RolType.OmschrijvingGeneriekEnum.INITIATOR, zaak.zaaktype)
                 } returns createRolType(omschrijvingGeneriek = RolType.OmschrijvingGeneriekEnum.INITIATOR)
-                every {
-                    ztcClientService.readRoltype(RolType.OmschrijvingGeneriekEnum.BEHANDELAAR, zaak.zaaktype)
-                } returns createRolType(omschrijvingGeneriek = RolType.OmschrijvingGeneriekEnum.BEHANDELAAR)
                 every { zakenService.bepaalRolGroep(group, zaak) } returns rolOrganisatorischeEenheid
                 every { zakenService.bepaalRolMedewerker(user, zaak) } returns rolMedewerker
 
@@ -291,9 +297,6 @@ class ZakenRESTServiceTest : BehaviorSpec({
                 every { policyService.readZaakRechten(zaak) } returns createZaakRechten()
                 every { zgwApiService.findBehandelaarForZaak(zaak) } returns Optional.empty()
                 every { identityService.readUser(restZaakToekennenGegevens.behandelaarGebruikersnaam) } returns user
-                every {
-                    ztcClientService.readRoltype(RolType.OmschrijvingGeneriekEnum.BEHANDELAAR, zaak.zaaktype)
-                } returns rolType
                 every { zgwApiService.findGroepForZaak(zaak) } returns Optional.empty()
                 every { restZaakConverter.convert(zaak) } returns restZaak
                 every { indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK) } just runs

--- a/src/test/kotlin/net/atos/zac/shared/helper/OpschortenZaakHelperTest.kt
+++ b/src/test/kotlin/net/atos/zac/shared/helper/OpschortenZaakHelperTest.kt
@@ -1,12 +1,11 @@
 package net.atos.zac.shared.helper
 
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.core.test.TestCase
 import io.kotest.matchers.ints.exactly
 import io.kotest.matchers.shouldBe
-import io.mockk.MockKAnnotations
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
@@ -23,138 +22,142 @@ import net.atos.zac.policy.output.createZaakRechten
 import java.time.LocalDate
 import java.util.Optional
 
-class OpschortenZaakHelperTest : BehaviorSpec() {
+class OpschortenZaakHelperTest : BehaviorSpec({
     val policyService = mockk<PolicyService>()
     val zrcClientService = mockk<ZRCClientService>()
     val ztcClientService = mockk<ZTCClientService>()
     val zaakVariabelenService = mockk<ZaakVariabelenService>()
 
-    // We have to use @InjectMockKs since the class under test uses field injection instead of constructor injection.
-    // This is because WildFly does not properly support constructor injection.
-    @InjectMockKs
-    lateinit var opschortenZaakHelper: OpschortenZaakHelper
+    val opschortenZaakHelper = OpschortenZaakHelper(
+        policyService,
+        zrcClientService,
+        ztcClientService,
+        zaakVariabelenService
+    )
 
-    override suspend fun beforeTest(testCase: TestCase) {
-        MockKAnnotations.init(this)
+    beforeEach {
+        checkUnnecessaryStub()
     }
 
-    init {
-        given("a zaak that is open and not yet postponed and does not have an planned end date") {
-            When("the zaak is postponed for x days") {
-                then("the zaak should be postponed and the final date should be extended with x days") {
-                    val numberOfDaysPostponed = 123L
-                    val postPonementReason = "dummyReason"
-                    val zaak = createZaak(
-                        opschorting = createOpschorting(reden = null),
-                        einddatumGepland = null,
-                        uiterlijkeEinddatumAfdoening = LocalDate.now().plusDays(1)
-                    )
-                    val postponedZaak = createZaak(
-                        opschorting = createOpschorting(reden = "dummyReason"),
-                        einddatumGepland = null,
-                        uiterlijkeEinddatumAfdoening = LocalDate.now()
-                            .plusDays(1 + numberOfDaysPostponed)
-                    )
-                    val patchedZaak = slot<Zaak>()
+    beforeSpec {
+        clearAllMocks()
+    }
 
-                    every { policyService.readZaakRechten(zaak) } returns createZaakRechten()
-                    every {
-                        zaakVariabelenService.setDatumtijdOpgeschort(
-                            zaak.uuid,
-                            any()
-                        )
-                    } just runs
-                    every {
-                        zaakVariabelenService.setVerwachteDagenOpgeschort(
-                            zaak.uuid,
-                            numberOfDaysPostponed.toInt()
-                        )
-                    } just runs
-                    every {
-                        zrcClientService.patchZaak(
-                            zaak.uuid,
-                            capture(patchedZaak),
-                            "Opschorting: $postPonementReason"
-                        )
-                    } returns postponedZaak
+    Given("a zaak that is open and not yet postponed and does not have an planned end date") {
+        When("the zaak is postponed for x days") {
+            Then("the zaak should be postponed and the final date should be extended with x days") {
+                val numberOfDaysPostponed = 123L
+                val postPonementReason = "dummyReason"
+                val zaak = createZaak(
+                    opschorting = createOpschorting(reden = null),
+                    einddatumGepland = null,
+                    uiterlijkeEinddatumAfdoening = LocalDate.now().plusDays(1)
+                )
+                val postponedZaak = createZaak(
+                    opschorting = createOpschorting(reden = "dummyReason"),
+                    einddatumGepland = null,
+                    uiterlijkeEinddatumAfdoening = LocalDate.now()
+                        .plusDays(1 + numberOfDaysPostponed)
+                )
+                val patchedZaak = slot<Zaak>()
 
-                    val returnedZaak = opschortenZaakHelper.opschortenZaak(
-                        zaak,
-                        numberOfDaysPostponed,
-                        postPonementReason
+                every { policyService.readZaakRechten(zaak) } returns createZaakRechten()
+                every {
+                    zaakVariabelenService.setDatumtijdOpgeschort(
+                        zaak.uuid,
+                        any()
                     )
+                } just runs
+                every {
+                    zaakVariabelenService.setVerwachteDagenOpgeschort(
+                        zaak.uuid,
+                        numberOfDaysPostponed.toInt()
+                    )
+                } just runs
+                every {
+                    zrcClientService.patchZaak(
+                        zaak.uuid,
+                        capture(patchedZaak),
+                        "Opschorting: $postPonementReason"
+                    )
+                } returns postponedZaak
 
-                    returnedZaak shouldBe postponedZaak
-                    verify(exactly = 1) {
-                        zaakVariabelenService.setDatumtijdOpgeschort(zaak.uuid, any())
-                        zaakVariabelenService.setVerwachteDagenOpgeschort(
-                            zaak.uuid,
-                            numberOfDaysPostponed.toInt()
-                        )
-                        zrcClientService.patchZaak(
-                            zaak.uuid,
-                            any(),
-                            "Opschorting: $postPonementReason"
-                        )
-                    }
-                    with(patchedZaak.captured) {
-                        opschorting.reden shouldBe postPonementReason
-                        einddatumGepland shouldBe null
-                        uiterlijkeEinddatumAfdoening shouldBe postponedZaak.uiterlijkeEinddatumAfdoening
-                    }
+                val returnedZaak = opschortenZaakHelper.opschortenZaak(
+                    zaak,
+                    numberOfDaysPostponed,
+                    postPonementReason
+                )
+
+                returnedZaak shouldBe postponedZaak
+                verify(exactly = 1) {
+                    zaakVariabelenService.setDatumtijdOpgeschort(zaak.uuid, any())
+                    zaakVariabelenService.setVerwachteDagenOpgeschort(
+                        zaak.uuid,
+                        numberOfDaysPostponed.toInt()
+                    )
+                    zrcClientService.patchZaak(
+                        zaak.uuid,
+                        any(),
+                        "Opschorting: $postPonementReason"
+                    )
                 }
-            }
-        }
-        given("a zaak that is postponed and does not have an planned end date") {
-            When("the zaak is resumed") {
-                then("the zaak should be resumed") {
-                    val reasonResumed = "dummyResumeReason"
-                    val zaak = createZaak(
-                        opschorting = createOpschorting(
-                            reden = "dummyPostponementReason",
-                            indicatie = true
-                        ),
-                        einddatumGepland = null,
-                        uiterlijkeEinddatumAfdoening = LocalDate.now().plusDays(1)
-                    )
-                    val resumedZaak = createZaak(
-                        opschorting = createOpschorting(reden = null),
-                        einddatumGepland = null,
-                        uiterlijkeEinddatumAfdoening = LocalDate.now().plusDays(1)
-                    )
-                    val patchedZaak = slot<Zaak>()
-
-                    every { policyService.readZaakRechten(zaak) } returns createZaakRechten()
-                    every { zaakVariabelenService.findDatumtijdOpgeschort(zaak.uuid) } returns Optional.empty()
-                    every { zaakVariabelenService.findVerwachteDagenOpgeschort(zaak.uuid) } returns Optional.empty()
-                    every {
-                        zrcClientService.patchZaak(
-                            zaak.uuid,
-                            capture(patchedZaak),
-                            "Hervatting: $reasonResumed"
-                        )
-                    } returns resumedZaak
-                    every { zaakVariabelenService.removeDatumtijdOpgeschort(zaak.uuid) } just runs
-                    every { zaakVariabelenService.removeVerwachteDagenOpgeschort(zaak.uuid) } just runs
-
-                    opschortenZaakHelper.hervattenZaak(zaak, reasonResumed)
-
-                    verify(exactly = 1) {
-                        zrcClientService.patchZaak(
-                            zaak.uuid,
-                            any(),
-                            "Hervatting: $reasonResumed"
-                        )
-                        zaakVariabelenService.removeDatumtijdOpgeschort(zaak.uuid)
-                        zaakVariabelenService.removeVerwachteDagenOpgeschort(zaak.uuid)
-                    }
-                    with(patchedZaak.captured) {
-                        opschorting.reden shouldBe reasonResumed
-                        einddatumGepland shouldBe null
-                        uiterlijkeEinddatumAfdoening shouldBe resumedZaak.uiterlijkeEinddatumAfdoening
-                    }
+                with(patchedZaak.captured) {
+                    opschorting.reden shouldBe postPonementReason
+                    einddatumGepland shouldBe null
+                    uiterlijkeEinddatumAfdoening shouldBe postponedZaak.uiterlijkeEinddatumAfdoening
                 }
             }
         }
     }
-}
+    Given("a zaak that is postponed and does not have an planned end date") {
+        When("the zaak is resumed") {
+            Then("the zaak should be resumed") {
+                val reasonResumed = "dummyResumeReason"
+                val zaak = createZaak(
+                    opschorting = createOpschorting(
+                        reden = "dummyPostponementReason",
+                        indicatie = true
+                    ),
+                    einddatumGepland = null,
+                    uiterlijkeEinddatumAfdoening = LocalDate.now().plusDays(1)
+                )
+                val resumedZaak = createZaak(
+                    opschorting = createOpschorting(reden = null),
+                    einddatumGepland = null,
+                    uiterlijkeEinddatumAfdoening = LocalDate.now().plusDays(1)
+                )
+                val patchedZaak = slot<Zaak>()
+
+                every { policyService.readZaakRechten(zaak) } returns createZaakRechten()
+                every { zaakVariabelenService.findDatumtijdOpgeschort(zaak.uuid) } returns Optional.empty()
+                every { zaakVariabelenService.findVerwachteDagenOpgeschort(zaak.uuid) } returns Optional.empty()
+                every {
+                    zrcClientService.patchZaak(
+                        zaak.uuid,
+                        capture(patchedZaak),
+                        "Hervatting: $reasonResumed"
+                    )
+                } returns resumedZaak
+                every { zaakVariabelenService.removeDatumtijdOpgeschort(zaak.uuid) } just runs
+                every { zaakVariabelenService.removeVerwachteDagenOpgeschort(zaak.uuid) } just runs
+
+                opschortenZaakHelper.hervattenZaak(zaak, reasonResumed)
+
+                verify(exactly = 1) {
+                    zrcClientService.patchZaak(
+                        zaak.uuid,
+                        any(),
+                        "Hervatting: $reasonResumed"
+                    )
+                    zaakVariabelenService.removeDatumtijdOpgeschort(zaak.uuid)
+                    zaakVariabelenService.removeVerwachteDagenOpgeschort(zaak.uuid)
+                }
+                with(patchedZaak.captured) {
+                    opschorting.reden shouldBe reasonResumed
+                    einddatumGepland shouldBe null
+                    uiterlijkeEinddatumAfdoening shouldBe resumedZaak.uiterlijkeEinddatumAfdoening
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
@@ -40,6 +40,8 @@ class TaskServiceTest : BehaviorSpec({
     )
 
     beforeEach {
+        // only check for unnecessary stubs on our mocked services and not on all mocks
+        // using checkUnnecessaryStub() because that currently breaks the test
         checkUnnecessaryStub(
             flowableTaskService,
             indexeerService,
@@ -66,7 +68,6 @@ class TaskServiceTest : BehaviorSpec({
         every { loggedInUser.id } returns "dummyLoggedInUserId"
         every { task.assignee } returns "dummyCurrentAssignee"
         every { task.id } returns taskId
-        every { updatedTaskAfterAssigningGroup.id } returns taskId
         every { updatedTaskAfterAssigningUser.id } returns taskId
         every { restTaakConverter.extractGroupId(task.identityLinks) } returns groupId
         every {
@@ -133,8 +134,6 @@ class TaskServiceTest : BehaviorSpec({
         every { loggedInUser.id } returns "dummyLoggedInUserId"
         every { task1.id } returns taskId1
         every { task2.id } returns taskId2
-        every { updatedTask1AfterAssigningGroup.id } returns taskId1
-        every { updatedTask2AfterAssigningGroup.id } returns taskId2
         every { updatedTask1AfterAssigningUser.id } returns taskId1
         every { updatedTask2AfterAssigningUser.id } returns taskId2
         every { flowableTaskService.readOpenTask(restTaakVerdelenTaken[0].taakId) } returns task1

--- a/src/test/kotlin/net/atos/zac/util/JsonbConfigurationTest.kt
+++ b/src/test/kotlin/net/atos/zac/util/JsonbConfigurationTest.kt
@@ -7,6 +7,8 @@ package net.atos.zac.util
 
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -19,9 +21,17 @@ class JsonbConfigurationTest : BehaviorSpec({
     val jsonbConfiguration = JsonbConfiguration()
     val contextResolver = jsonbConfiguration.getContext(JsonbConfiguration::class.java)
 
-    given("a JSON date-string with an ISO Z timezone") {
+    beforeEach {
+        checkUnnecessaryStub()
+    }
+
+    afterSpec {
+        clearAllMocks()
+    }
+
+    Given("a JSON date-string with an ISO Z timezone") {
         When("it is parsed with our context resolver") {
-            then("the date-time string is correctly formatted") {
+            Then("the date-time string is correctly formatted") {
                 val datum = contextResolver.fromJson("\"2021-06-23T00:00:00Z\"", LocalDate::class.java)
 
                 datum.format(DateTimeFormatter.ISO_DATE) shouldBe "2021-06-23"
@@ -29,9 +39,9 @@ class JsonbConfigurationTest : BehaviorSpec({
         }
     }
 
-    given("a JSON date-string with a +02:00 timezone") {
+    Given("a JSON date-string with a +02:00 timezone") {
         When("it is parsed with our context resolver") {
-            then("the date-time string is correctly formatted") {
+            Then("the date-time string is correctly formatted") {
                 val datum = contextResolver.fromJson("\"2021-06-23T00:00:00+02:00\"", LocalDate::class.java)
 
                 datum.format(DateTimeFormatter.ISO_DATE) shouldBe "2021-06-23"
@@ -39,9 +49,9 @@ class JsonbConfigurationTest : BehaviorSpec({
         }
     }
 
-    given("a JSON date-string with a -02:00 timezone") {
+    Given("a JSON date-string with a -02:00 timezone") {
         When("it is parsed with our context resolver") {
-            then("the date-time string is correctly formatted") {
+            Then("the date-time string is correctly formatted") {
                 val datum = contextResolver.fromJson("\"2021-06-23T00:00:00-02:00\"", LocalDate::class.java)
 
                 datum.format(DateTimeFormatter.ISO_DATE) shouldBe "2021-06-23"
@@ -49,9 +59,9 @@ class JsonbConfigurationTest : BehaviorSpec({
         }
     }
 
-    given("a JSON date-string without a timezone") {
+    Given("a JSON date-string without a timezone") {
         When("it is parsed with our context resolver") {
-            then("the date-time string is correctly formatted") {
+            Then("the date-time string is correctly formatted") {
                 val datum = contextResolver.fromJson("\"2021-06-23\"", LocalDate::class.java)
 
                 datum.format(DateTimeFormatter.ISO_DATE) shouldBe "2021-06-23"

--- a/src/test/kotlin/net/atos/zac/util/JsonbConfigurationTest.kt
+++ b/src/test/kotlin/net/atos/zac/util/JsonbConfigurationTest.kt
@@ -25,7 +25,7 @@ class JsonbConfigurationTest : BehaviorSpec({
         checkUnnecessaryStub()
     }
 
-    afterSpec {
+    beforeSpec {
         clearAllMocks()
     }
 

--- a/src/test/kotlin/net/atos/zac/websocket/SessionRegistryTest.kt
+++ b/src/test/kotlin/net/atos/zac/websocket/SessionRegistryTest.kt
@@ -26,7 +26,7 @@ class SessionRegistryTest : BehaviorSpec({
         checkUnnecessaryStub()
     }
 
-    afterSpec {
+    beforeSpec {
         clearAllMocks()
     }
 

--- a/src/test/kotlin/net/atos/zac/websocket/SessionRegistryTest.kt
+++ b/src/test/kotlin/net/atos/zac/websocket/SessionRegistryTest.kt
@@ -8,6 +8,8 @@ package net.atos.zac.websocket
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
 import io.mockk.mockk
 import jakarta.websocket.Session
 import net.atos.zac.event.Opcode
@@ -20,9 +22,17 @@ class SessionRegistryTest : BehaviorSpec({
     val screenEventCreatedZaak = createScreenEvent(opcode = Opcode.CREATED, screenEventType = ScreenEventType.ZAAK)
     val screenEventAnyAny = createScreenEvent(opcode = Opcode.ANY, screenEventType = ScreenEventType.ANY)
 
-    given("a new session registry is created") {
+    beforeEach {
+        checkUnnecessaryStub()
+    }
+
+    afterSpec {
+        clearAllMocks()
+    }
+
+    Given("a new session registry is created") {
         When("create is invoked with a new screen event of type CREATED") {
-            then("a session for this event is added to the session registry") {
+            Then("a session for this event is added to the session registry") {
                 val sessionRegistry = SessionRegistry()
 
                 sessionRegistry.create(screenEventCreatedZaak, session1)
@@ -34,7 +44,7 @@ class SessionRegistryTest : BehaviorSpec({
             }
         }
         When("create is invoked with a new screen event of type ANY") {
-            then("a session for this event is _not_ added to the session registry") {
+            Then("a session for this event is _not_ added to the session registry") {
                 val sessionRegistry = SessionRegistry()
                 sessionRegistry.create(screenEventAnyAny, session1)
 
@@ -54,9 +64,9 @@ class SessionRegistryTest : BehaviorSpec({
             }
         }
     }
-    given("a number of events are added to the session registry for a session") {
+    Given("a number of events are added to the session registry for a session") {
         When("delete is invoke for this session and a specific event") {
-            then("all registered events for this session are removed from the registry") {
+            Then("all registered events for this session are removed from the registry") {
                 val sessionRegistry = SessionRegistry()
                 sessionRegistry.create(screenEventCreatedZaak, session1)
                 sessionRegistry.create(screenEventAnyAny, session1)
@@ -69,7 +79,7 @@ class SessionRegistryTest : BehaviorSpec({
             }
         }
         When("deleteAll is invoke for this session") {
-            then("all registered events for this session are removed from the registry") {
+            Then("all registered events for this session are removed from the registry") {
                 val sessionRegistry = SessionRegistry()
                 sessionRegistry.create(screenEventCreatedZaak, session1)
                 sessionRegistry.create(screenEventAnyAny, session1)
@@ -81,9 +91,9 @@ class SessionRegistryTest : BehaviorSpec({
             }
         }
     }
-    given("a number of events are added to the session registry for multiple sessions") {
+    Given("a number of events are added to the session registry for multiple sessions") {
         When("delete is invoke for one session and a specific event") {
-            then("all registered events for this session are removed from the registry") {
+            Then("all registered events for this session are removed from the registry") {
                 val sessionRegistry = SessionRegistry()
                 sessionRegistry.create(screenEventCreatedZaak, session1)
                 sessionRegistry.create(screenEventCreatedZaak, session2)
@@ -97,7 +107,7 @@ class SessionRegistryTest : BehaviorSpec({
             }
         }
         When("deleteAll is invoke for one session") {
-            then("all registered events for this session are removed from the registry") {
+            Then("all registered events for this session are removed from the registry") {
                 val sessionRegistry = SessionRegistry()
                 sessionRegistry.create(screenEventCreatedZaak, session1)
                 sessionRegistry.create(screenEventCreatedZaak, session2)

--- a/src/test/kotlin/net/atos/zac/zaken/ZakenServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/zaken/ZakenServiceTest.kt
@@ -14,6 +14,8 @@ import net.atos.client.zgw.zrc.ZRCClientService
 import net.atos.client.zgw.zrc.model.BetrokkeneType
 import net.atos.client.zgw.zrc.model.createZaak
 import net.atos.client.zgw.ztc.ZTCClientService
+import net.atos.client.zgw.ztc.model.createRolType
+import net.atos.client.zgw.ztc.model.generated.RolType
 import net.atos.zac.event.EventingService
 import net.atos.zac.event.Opcode
 import net.atos.zac.identity.model.createGroup
@@ -22,7 +24,6 @@ import net.atos.zac.websocket.event.ScreenEvent
 import net.atos.zac.websocket.event.ScreenEventType
 import net.atos.zac.zoeken.IndexeerService
 import net.atos.zac.zoeken.model.index.ZoekObjectType
-import java.lang.RuntimeException
 
 class ZakenServiceTest : BehaviorSpec({
     val eventingService = mockk<EventingService>()
@@ -43,12 +44,15 @@ class ZakenServiceTest : BehaviorSpec({
     )
     val group = createGroup()
     val user = createUser()
+    val rolTypeBehandelaar = createRolType(
+        omschrijvingGeneriek = RolType.OmschrijvingGeneriekEnum.BEHANDELAAR
+    )
 
     beforeEach {
         checkUnnecessaryStub()
     }
 
-    afterSpec {
+    beforeSpec {
         clearAllMocks()
     }
 
@@ -56,6 +60,12 @@ class ZakenServiceTest : BehaviorSpec({
         val screenEventSlot = slot<ScreenEvent>()
         zaken.map {
             every { zrcClientService.readZaak(it.uuid) } returns it
+            every {
+                ztcClientService.readRoltype(
+                    RolType.OmschrijvingGeneriekEnum.BEHANDELAAR,
+                    it.zaaktype
+                )
+            } returns rolTypeBehandelaar
             every { zrcClientService.updateRol(it, any(), explanation) } just Runs
             every { indexeerService.indexeerDirect(it.uuid.toString(), ZoekObjectType.ZAAK) } just Runs
             every { eventingService.send(capture(screenEventSlot)) } just Runs
@@ -91,29 +101,29 @@ class ZakenServiceTest : BehaviorSpec({
         }
     }
     Given("A list of zaken") {
+        clearAllMocks()
         val screenEventSlot = slot<ScreenEvent>()
         zaken.map {
             every { zrcClientService.readZaak(it.uuid) } returns it
             every { zrcClientService.deleteRol(it, any(), explanation) } just Runs
             every { indexeerService.indexeerDirect(it.uuid.toString(), ZoekObjectType.ZAAK) } just Runs
-            every { eventingService.send(capture(screenEventSlot)) } just Runs
         }
+        every { eventingService.send(capture(screenEventSlot)) } just Runs
         When(
             """the release zaken async function is called with
                  a screen event resource id"""
         ) {
-            val coroutine = zakenService.releaseZakenAsync(
+            zakenService.releaseZakenAsync(
                 zaakUUIDs = zaken.map { it.uuid },
                 explanation = explanation,
                 screenEventResourceId = screenEventResourceId
-            )
+            ).join()
             Then(
                 """both zaken should no longer have a user assigned
                      but the group should still be assigned
                     and the search index should be updated and
                     a screen event of type 'zaken vrijgeven' should sent"""
             ) {
-                coroutine.join()
                 zaken.map {
                     verify(exactly = 1) {
                         zrcClientService.deleteRol(it, BetrokkeneType.MEDEWERKER, explanation)
@@ -128,6 +138,7 @@ class ZakenServiceTest : BehaviorSpec({
         }
     }
     Given("A list of zaken and a failing ZRC client service when retrieving the second zaak ") {
+        clearAllMocks()
         every { zrcClientService.readZaak(zaken[0].uuid) } returns zaken[0]
         every { zrcClientService.readZaak(zaken[1].uuid) } throws RuntimeException("dummyRuntimeException")
         When(
@@ -141,8 +152,8 @@ class ZakenServiceTest : BehaviorSpec({
                 screenEventResourceId = screenEventResourceId
             ).join()
             Then(
-                """for neither of the zaken the group and user roles 
-                    nor the search index should be updated          
+                """for neither of the zaken the group and user roles
+                    nor the search index should be updated
                     and no screen event of type 'zaken verdelen' should be sent"""
             ) {
                 verify(exactly = 0) {

--- a/src/test/kotlin/net/atos/zac/zaken/ZakenServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/zaken/ZakenServiceTest.kt
@@ -3,6 +3,7 @@ package net.atos.zac.zaken
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.Runs
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
@@ -13,8 +14,6 @@ import net.atos.client.zgw.zrc.ZRCClientService
 import net.atos.client.zgw.zrc.model.BetrokkeneType
 import net.atos.client.zgw.zrc.model.createZaak
 import net.atos.client.zgw.ztc.ZTCClientService
-import net.atos.client.zgw.ztc.model.createRolType
-import net.atos.client.zgw.ztc.model.generated.RolType
 import net.atos.zac.event.EventingService
 import net.atos.zac.event.Opcode
 import net.atos.zac.identity.model.createGroup
@@ -44,11 +43,12 @@ class ZakenServiceTest : BehaviorSpec({
     )
     val group = createGroup()
     val user = createUser()
-    val rolTypeBehandelaar = createRolType(
-        omschrijvingGeneriek = RolType.OmschrijvingGeneriekEnum.BEHANDELAAR
-    )
 
-    afterTest {
+    beforeEach {
+        checkUnnecessaryStub()
+    }
+
+    afterSpec {
         clearAllMocks()
     }
 
@@ -56,12 +56,6 @@ class ZakenServiceTest : BehaviorSpec({
         val screenEventSlot = slot<ScreenEvent>()
         zaken.map {
             every { zrcClientService.readZaak(it.uuid) } returns it
-            every {
-                ztcClientService.readRoltype(
-                    RolType.OmschrijvingGeneriekEnum.BEHANDELAAR,
-                    it.zaaktype
-                )
-            } returns rolTypeBehandelaar
             every { zrcClientService.updateRol(it, any(), explanation) } just Runs
             every { indexeerService.indexeerDirect(it.uuid.toString(), ZoekObjectType.ZAAK) } just Runs
             every { eventingService.send(capture(screenEventSlot)) } just Runs
@@ -100,12 +94,6 @@ class ZakenServiceTest : BehaviorSpec({
         val screenEventSlot = slot<ScreenEvent>()
         zaken.map {
             every { zrcClientService.readZaak(it.uuid) } returns it
-            every {
-                ztcClientService.readRoltype(
-                    RolType.OmschrijvingGeneriekEnum.BEHANDELAAR,
-                    it.zaaktype
-                )
-            } returns rolTypeBehandelaar
             every { zrcClientService.deleteRol(it, any(), explanation) } just Runs
             every { indexeerService.indexeerDirect(it.uuid.toString(), ZoekObjectType.ZAAK) } just Runs
             every { eventingService.send(capture(screenEventSlot)) } just Runs

--- a/src/test/kotlin/net/atos/zac/zoeken/IndexeerServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/zoeken/IndexeerServiceTest.kt
@@ -61,14 +61,9 @@ class IndexeerServiceTest : BehaviorSpec({
         checkUnnecessaryStub()
     }
 
-    afterSpec {
+    beforeSpec {
         clearAllMocks()
     }
-
-    every { zaakZoekObjectConverter.supports(ZoekObjectType.ZAAK) } returns true
-    every { converterInstances.iterator() } returns converterInstancesIterator
-    every { converterInstancesIterator.hasNext() } returns true andThen true andThen false
-    every { converterInstancesIterator.next() } returns zaakZoekObjectConverter andThen zaakZoekObjectConverter
 
     Given(
         """Two zaken"""
@@ -84,6 +79,10 @@ class IndexeerServiceTest : BehaviorSpec({
             createZaakZoekObject()
         )
         val objectIdsSlot = slot<Stream<String>>()
+        every { zaakZoekObjectConverter.supports(ZoekObjectType.ZAAK) } returns true
+        every { converterInstances.iterator() } returns converterInstancesIterator
+        every { converterInstancesIterator.hasNext() } returns true andThen true andThen false
+        every { converterInstancesIterator.next() } returns zaakZoekObjectConverter andThen zaakZoekObjectConverter
         zaken.forEachIndexed { index, zaak ->
             every { zaakZoekObjectConverter.convert(zaak.uuid.toString()) } returns zaakZoekObjecten[index]
         }

--- a/src/test/kotlin/net/atos/zac/zoeken/IndexeerServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/zoeken/IndexeerServiceTest.kt
@@ -3,8 +3,9 @@ package net.atos.zac.zoeken
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.Runs
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
 import io.mockk.every
-import io.mockk.junit5.MockKExtension
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -27,7 +28,6 @@ import org.eclipse.microprofile.config.ConfigProvider
 import java.net.URI
 import java.util.stream.Stream
 
-@MockKExtension.CheckUnnecessaryStub
 class IndexeerServiceTest : BehaviorSpec({
     // add static mocking for config provider because the IndexeerService class
     // references the config provider statically
@@ -56,6 +56,14 @@ class IndexeerServiceTest : BehaviorSpec({
         flowableTaskService,
         indexeerServiceHelper
     )
+
+    beforeEach {
+        checkUnnecessaryStub()
+    }
+
+    afterSpec {
+        clearAllMocks()
+    }
 
     every { zaakZoekObjectConverter.supports(ZoekObjectType.ZAAK) } returns true
     every { converterInstances.iterator() } returns converterInstancesIterator


### PR DESCRIPTION
Check for unnecessary stubs in some of our unit tests using mockk's `checkUnnecessaryStub`. Fixed resulting issues. Added `clearAllMocks` calls after `When` clauses in some of our tests.

Solves PZ-2179