### PR TITLE
chore: disable Kotest autoscanning for integration tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,8 @@
+#
+# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-License-Identifier: EUPL-1.2+
+#
+
 org.gradle.jvmargs=-Xmx2048m
+
+

--- a/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
@@ -25,7 +25,6 @@ import nl.lifely.zac.itest.config.ItestConfiguration.ZAAK_1_IDENTIFICATION
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAK_1_UITERLIJKE_EINDDATUM_AFDOENING
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.lifely.zac.itest.config.ItestConfiguration.zaak1UUID
-import nl.lifely.zac.itest.config.ProjectConfig
 import nl.lifely.zac.itest.config.dockerComposeContainer
 import nl.lifely.zac.itest.util.WebSocketTestListener
 import okhttp3.Headers

--- a/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
@@ -10,7 +10,6 @@ import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.provided.ProjectConfig
 import nl.lifely.zac.itest.client.ItestHttpClient
 import nl.lifely.zac.itest.config.ItestConfiguration
 import nl.lifely.zac.itest.config.ItestConfiguration.OBJECTS_BASE_URI
@@ -26,6 +25,8 @@ import nl.lifely.zac.itest.config.ItestConfiguration.ZAAK_1_IDENTIFICATION
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAK_1_UITERLIJKE_EINDDATUM_AFDOENING
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.lifely.zac.itest.config.ItestConfiguration.zaak1UUID
+import nl.lifely.zac.itest.config.ProjectConfig
+import nl.lifely.zac.itest.config.dockerComposeContainer
 import nl.lifely.zac.itest.util.WebSocketTestListener
 import okhttp3.Headers
 import org.json.JSONObject
@@ -156,7 +157,7 @@ class NotificationsTest : BehaviorSpec({
                 response.code shouldBe HttpStatusCode.NO_CONTENT_204.code()
 
                 // we expect ZAC to log an error message indicating that the resourceURL is invalid
-                ProjectConfig.dockerComposeContainer.waitingFor(
+                dockerComposeContainer.waitingFor(
                     "zac",
                     Wait.forLogMessage(
                         ".* Er is iets fout gegaan in de Zaaktype-handler bij het afhandelen van notificatie: " +

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
@@ -2,8 +2,7 @@
  * SPDX-FileCopyrightText: 2023 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-
-package io.kotest.provided
+package nl.lifely.zac.itest.config
 
 import io.github.oshai.kotlinlogging.DelegatingKLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -36,8 +35,10 @@ import kotlin.time.toJavaDuration
 
 private val logger = KotlinLogging.logger {}
 
-object ProjectConfig : AbstractProjectConfig() {
-    lateinit var dockerComposeContainer: ComposeContainer
+// global variable so that it can be referenced elsewhere
+lateinit var dockerComposeContainer: ComposeContainer
+
+class ProjectConfig : AbstractProjectConfig() {
     private val itestHttpClient = ItestHttpClient()
 
     override suspend fun beforeProject() {

--- a/src/itest/resources/kotest.properties
+++ b/src/itest/resources/kotest.properties
@@ -1,7 +1,8 @@
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 
 # disable Kotest autoscanning for faster test execution
 # see: https://kotest.io/docs/next/framework/project-config.html
 kotest.framework.classpath.scanning.config.disable=true
+kotest.framework.config.fqn=nl.lifely.zac.itest.config.ProjectConfig
 kotest.framework.classpath.scanning.autoscan.disable=true


### PR DESCRIPTION
Disable Kotest autoscanning for integration tests for faster test execution. See: https://kotest.io/docs/next/framework/project-config.html#runtime-detection

Solves PZ-2183