### PR TITLE
chore: perform hard Solr commit after assigning and releasing tasks 

### DIFF
--- a/src/main/java/net/atos/zac/zoeken/IndexeerService.java
+++ b/src/main/java/net/atos/zac/zoeken/IndexeerService.java
@@ -5,11 +5,43 @@
 
 package net.atos.zac.zoeken;
 
+import static java.util.logging.Level.WARNING;
+import static net.atos.client.zgw.shared.ZGWApiService.FIRST_PAGE_NUMBER_ZGW_APIS;
+import static net.atos.client.zgw.shared.model.Results.NUM_ITEMS_PER_PAGE;
+import static net.atos.zac.util.UriUtil.uuidFromURI;
+import static net.atos.zac.zoeken.model.index.IndexStatus.ADD;
+import static net.atos.zac.zoeken.model.index.IndexStatus.REMOVE;
+import static net.atos.zac.zoeken.model.index.IndexStatus.UPDATE;
+import static net.atos.zac.zoeken.model.index.ZoekObjectType.DOCUMENT;
+import static net.atos.zac.zoeken.model.index.ZoekObjectType.TAAK;
+import static net.atos.zac.zoeken.model.index.ZoekObjectType.ZAAK;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.transaction.Transactional;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.params.CursorMarkParams;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.flowable.task.api.Task;
+import org.flowable.task.api.TaskInfo;
+
 import net.atos.client.zgw.drc.DRCClientService;
 import net.atos.client.zgw.drc.model.EnkelvoudigInformatieobjectListParameters;
 import net.atos.client.zgw.drc.model.generated.EnkelvoudigInformatieObject;
@@ -27,36 +59,6 @@ import net.atos.zac.zoeken.model.index.HerindexerenInfo;
 import net.atos.zac.zoeken.model.index.IndexResult;
 import net.atos.zac.zoeken.model.index.ZoekIndexEntity;
 import net.atos.zac.zoeken.model.index.ZoekObjectType;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.solr.client.solrj.SolrClient;
-import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.Http2SolrClient;
-import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.common.params.CursorMarkParams;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.flowable.task.api.Task;
-import org.flowable.task.api.TaskInfo;
-
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.logging.Logger;
-import java.util.stream.Stream;
-
-import static java.util.logging.Level.WARNING;
-import static net.atos.client.zgw.shared.ZGWApiService.FIRST_PAGE_NUMBER_ZGW_APIS;
-import static net.atos.client.zgw.shared.model.Results.NUM_ITEMS_PER_PAGE;
-import static net.atos.zac.util.UriUtil.uuidFromURI;
-import static net.atos.zac.zoeken.model.index.IndexStatus.ADD;
-import static net.atos.zac.zoeken.model.index.IndexStatus.REMOVE;
-import static net.atos.zac.zoeken.model.index.IndexStatus.UPDATE;
-import static net.atos.zac.zoeken.model.index.ZoekObjectType.DOCUMENT;
-import static net.atos.zac.zoeken.model.index.ZoekObjectType.TAAK;
-import static net.atos.zac.zoeken.model.index.ZoekObjectType.ZAAK;
 
 @Singleton
 @Transactional
@@ -107,8 +109,8 @@ public class IndexeerService {
      * that the Solr index is updated immediately.
      * Beware that hard Solr commits are relavitely expensive operations.
      *
-     * @param objectId the object id to be indexed
-     * @param objectType the object type
+     * @param objectId      the object id to be indexed
+     * @param objectType    the object type
      * @param performCommit whether to perform a hard Solr commit
      */
     public void indexeerDirect(final String objectId, final ZoekObjectType objectType, final boolean performCommit) {
@@ -120,8 +122,8 @@ public class IndexeerService {
      * that the Solr index is updated immediately.
      * Beware that hard Solr commits are relavitely expensive operations.
      *
-     * @param objectIds the list of object ids to be indexed
-     * @param objectType the object type
+     * @param objectIds     the list of object ids to be indexed
+     * @param objectType    the object type
      * @param performCommit whether to perform a hard Solr commit
      */
     public void indexeerDirect(final List<String> objectIds, final ZoekObjectType objectType, final boolean performCommit) {

--- a/src/main/kotlin/net/atos/zac/app/taken/TakenRESTService.kt
+++ b/src/main/kotlin/net/atos/zac/app/taken/TakenRESTService.kt
@@ -257,7 +257,7 @@ class TakenRESTService @Inject constructor(
             explanation = restTaakToekennenGegevens.reden
         ).let {
             taskService.sendScreenEventsOnTaskChange(it, restTaakToekennenGegevens.zaakUuid)
-            indexeerService.indexeerDirect(restTaakToekennenGegevens.taakId, ZoekObjectType.TAAK)
+            indexeerService.indexeerDirect(restTaakToekennenGegevens.taakId, ZoekObjectType.TAAK, true)
             return it
         }
     }

--- a/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
@@ -570,7 +570,7 @@ class ZakenRESTService @Inject constructor(
             }
 
         if (isUpdated.get()) {
-            indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK)
+            indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK, false)
         }
 
         return restZaakConverter.convert(zaak)
@@ -583,7 +583,7 @@ class ZakenRESTService @Inject constructor(
     ): RESTZaakOverzicht {
         assertPolicy(policyService.readWerklijstRechten().zakenTaken)
         val zaak = ingelogdeMedewerkerToekennenAanZaak(toekennenGegevens)
-        indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK)
+        indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK, false)
         return restZaakOverzichtConverter.convert(zaak)
     }
 

--- a/src/main/kotlin/net/atos/zac/task/TaskService.kt
+++ b/src/main/kotlin/net/atos/zac/task/TaskService.kt
@@ -20,12 +20,10 @@ import net.atos.zac.websocket.event.ScreenEventType
 import net.atos.zac.zoeken.IndexeerService
 import net.atos.zac.zoeken.model.index.ZoekObjectType
 import nl.lifely.zac.opentelemetry.createOpenTelemetrySpanWithoutParent
-import nl.lifely.zac.util.AllOpen
 import org.flowable.task.api.Task
 import java.util.UUID
 import java.util.logging.Logger
 
-@AllOpen
 class TaskService @Inject constructor(
     private val flowableTaskService: FlowableTaskService,
     private val indexeerService: IndexeerService,
@@ -69,7 +67,7 @@ class TaskService @Inject constructor(
         }
         if (changed) {
             sendScreenEventsOnTaskChange(updatedTask, restTaakToekennenGegevens.zaakUuid)
-            indexeerService.indexeerDirect(restTaakToekennenGegevens.taakId, ZoekObjectType.TAAK)
+            indexeerService.indexeerDirect(restTaakToekennenGegevens.taakId, ZoekObjectType.TAAK, true)
         }
     }
 
@@ -111,7 +109,7 @@ class TaskService @Inject constructor(
                     sendScreenEventsOnTaskChange(task, restTaakVerdelenTaak.zaakUuid)
                     taakIds.add(restTaakVerdelenTaak.taakId)
                 }
-                indexeerService.indexeerDirect(taakIds, ZoekObjectType.TAAK)
+                indexeerService.indexeerDirect(taakIds, ZoekObjectType.TAAK, true)
                 openTelemetrySpan.end()
             }
         }
@@ -177,7 +175,7 @@ class TaskService @Inject constructor(
                         taakIds.add(updatedTask.id)
                     }
                 }
-                indexeerService.indexeerDirect(taakIds, ZoekObjectType.TAAK)
+                indexeerService.indexeerDirect(taakIds, ZoekObjectType.TAAK, true)
                 openTelemetrySpan.end()
             }
         }

--- a/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
+++ b/src/main/kotlin/net/atos/zac/zaken/ZakenService.kt
@@ -84,7 +84,8 @@ class ZakenService @Inject constructor(
                         }
                         indexeerService.indexeerDirect(
                             zaak.uuid.toString(),
-                            ZoekObjectType.ZAAK
+                            ZoekObjectType.ZAAK,
+                            false
                         )
                         zakenAssignedList.add(zaak.uuid)
                     }
@@ -153,7 +154,8 @@ class ZakenService @Inject constructor(
                         zrcClientService.deleteRol(it, BetrokkeneType.MEDEWERKER, explanation)
                         indexeerService.indexeerDirect(
                             it.uuid.toString(),
-                            ZoekObjectType.ZAAK
+                            ZoekObjectType.ZAAK,
+                            false
                         )
                     }
                 openTelemetrySpan.end()

--- a/src/test/kotlin/net/atos/zac/app/zaken/ZakenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaken/ZakenRESTServiceTest.kt
@@ -296,7 +296,7 @@ class ZakenRESTServiceTest : BehaviorSpec({
         every { identityService.readUser(restZaakToekennenGegevens.behandelaarGebruikersnaam) } returns user
         every { zgwApiService.findGroepForZaak(zaak) } returns Optional.empty()
         every { restZaakConverter.convert(zaak) } returns restZaak
-        every { indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK) } just runs
+        every { indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK, false) } just runs
         every { zakenService.bepaalRolMedewerker(user, zaak) } returns rolMedewerker
 
         When("toekennen is called") {
@@ -306,7 +306,7 @@ class ZakenRESTServiceTest : BehaviorSpec({
                 assertEquals(returnedRestZaak, restZaak)
                 verify(exactly = 1) {
                     zrcClientService.updateRol(zaak, any(), restZaakToekennenGegevens.reden)
-                    indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK)
+                    indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK, false)
                 }
                 with(rolSlot.captured) {
                     assertEquals(this.betrokkeneType, BetrokkeneType.MEDEWERKER)

--- a/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
@@ -98,7 +98,7 @@ class TaskServiceTest : BehaviorSpec({
         } returns updatedTaskAfterAssigningUser
         every { eventingService.send(capture(taakOpNaamSignaleringEventSlot)) } just runs
         every { eventingService.send(capture(screenEventSlot)) } just runs
-        every { indexeerService.indexeerDirect(restTaakToekennenGegevens.taakId, ZoekObjectType.TAAK) } just runs
+        every { indexeerService.indexeerDirect(restTaakToekennenGegevens.taakId, ZoekObjectType.TAAK, true) } just runs
 
         When("the 'assign task' function is called with REST taak toekennen gegevens with a group and user") {
             taskService.assignTask(
@@ -114,7 +114,7 @@ class TaskServiceTest : BehaviorSpec({
                         restTaakToekennenGegevens.reden
                     )
                     flowableTaskService.assignTaskToUser(any(), any(), any())
-                    indexeerService.indexeerDirect(restTaakToekennenGegevens.taakId, ZoekObjectType.TAAK)
+                    indexeerService.indexeerDirect(restTaakToekennenGegevens.taakId, ZoekObjectType.TAAK, true)
                 }
                 screenEventSlot.size shouldBe 2
                 screenEventSlot.map { it.objectType } shouldContainExactlyInAnyOrder listOf(
@@ -164,7 +164,7 @@ class TaskServiceTest : BehaviorSpec({
         every { eventingService.send(capture(taakOpNaamSignaleringEventSlot)) } just runs
         every { eventingService.send(capture(screenEventSlot)) } just runs
         every {
-            indexeerService.indexeerDirect(restTaakVerdelenTaken.map { it.taakId }.toList(), ZoekObjectType.TAAK)
+            indexeerService.indexeerDirect(restTaakVerdelenTaken.map { it.taakId }.toList(), ZoekObjectType.TAAK, true)
         } just runs
         every { tracer.spanBuilder(any()).setNoParent().startSpan() } returns span
         every { span.makeCurrent() } returns scope
@@ -187,7 +187,8 @@ class TaskServiceTest : BehaviorSpec({
                 verify(exactly = 1) {
                     indexeerService.indexeerDirect(
                         restTaakVerdelenTaken.map { it.taakId }.toList(),
-                        ZoekObjectType.TAAK
+                        ZoekObjectType.TAAK,
+                        true
                     )
                 }
                 // we expect 4 screen events to be sent, 2 for each task
@@ -229,7 +230,7 @@ class TaskServiceTest : BehaviorSpec({
         every { eventingService.send(capture(taakOpNaamSignaleringEventSlot)) } just runs
         every { eventingService.send(capture(screenEventSlot)) } just runs
         every {
-            indexeerService.indexeerDirect(restTaakVerdelenTaken.map { it.taakId }.toList(), ZoekObjectType.TAAK)
+            indexeerService.indexeerDirect(restTaakVerdelenTaken.map { it.taakId }.toList(), ZoekObjectType.TAAK, true)
         } just runs
         every { tracer.spanBuilder(any()).setNoParent().startSpan() } returns span
         every { span.makeCurrent() } returns scope
@@ -252,7 +253,8 @@ class TaskServiceTest : BehaviorSpec({
                 verify(exactly = 1) {
                     indexeerService.indexeerDirect(
                         restTaakVerdelenTaken.map { it.taakId }.toList(),
-                        ZoekObjectType.TAAK
+                        ZoekObjectType.TAAK,
+                        true
                     )
                 }
                 // we expect 4 screen events to be sent, 2 for each task

--- a/src/test/kotlin/net/atos/zac/zaken/ZakenServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/zaken/ZakenServiceTest.kt
@@ -74,7 +74,7 @@ class ZakenServiceTest : BehaviorSpec({
                 )
             } returns rolTypeBehandelaar
             every { zrcClientService.updateRol(it, any(), explanation) } just Runs
-            every { indexeerService.indexeerDirect(it.uuid.toString(), ZoekObjectType.ZAAK) } just Runs
+            every { indexeerService.indexeerDirect(it.uuid.toString(), ZoekObjectType.ZAAK, false) } just Runs
             every { eventingService.send(capture(screenEventSlot)) } just Runs
             every { tracer.spanBuilder(any()).setNoParent().startSpan() } returns span
             every { span.makeCurrent() } returns scope
@@ -117,7 +117,7 @@ class ZakenServiceTest : BehaviorSpec({
         zaken.map {
             every { zrcClientService.readZaak(it.uuid) } returns it
             every { zrcClientService.deleteRol(it, any(), explanation) } just Runs
-            every { indexeerService.indexeerDirect(it.uuid.toString(), ZoekObjectType.ZAAK) } just Runs
+            every { indexeerService.indexeerDirect(it.uuid.toString(), ZoekObjectType.ZAAK, false) } just Runs
         }
         every { eventingService.send(capture(screenEventSlot)) } just Runs
         every { tracer.spanBuilder(any()).setNoParent().startSpan() } returns span

--- a/src/test/kotlin/net/atos/zac/zoeken/IndexeerServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/zoeken/IndexeerServiceTest.kt
@@ -92,7 +92,7 @@ class IndexeerServiceTest : BehaviorSpec({
         When(
             """The indexeer direct method is called to index the two zaken"""
         ) {
-            indexeerService.indexeerDirect(zaken.map { it.uuid.toString() }, ZoekObjectType.ZAAK)
+            indexeerService.indexeerDirect(zaken.map { it.uuid.toString() }, ZoekObjectType.ZAAK, false)
 
             Then(
                 """


### PR DESCRIPTION
Perform hard Solr commit after assigning and releasing tasks so that the Solr index is updated immediately and the user quickly sees the results.

Solves PZ-2196