### PR TITLE
fix: enable overriding of WildFly env vars 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY target/zaakafhandelcomponent.jar /
 # Copy build timestamp (used by HealthCheckService.java)
 RUN date -Iseconds > /build_timestamp.txt
 
-# Add system property to enable overriding WildFly settings using environment variables
+# Turn on ability to be able to override WildFly settings using environment variables
 ENV WILDFLY_OVERRIDING_ENV_VARS 1
 
 # Start zaakafhandelcomponent

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ COPY target/zaakafhandelcomponent.jar /
 # Copy build timestamp (used by HealthCheckService.java)
 RUN date -Iseconds > /build_timestamp.txt
 
+# Add system property to enable overriding WildFly settings using environment variables
+ENV WILDFLY_OVERRIDING_ENV_VARS 1
+
 # Start zaakafhandelcomponent
 ENTRYPOINT ["java", "-Xms1024m", "-Xmx1024m", "-jar", "zaakafhandelcomponent.jar"]
 EXPOSE 8080 9990

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -591,8 +591,6 @@ services:
       - SUBSYSTEM_OPENTELEMETRY__SAMPLER_TYPE=${SUBSYSTEM_OPENTELEMETRY__SAMPLER_TYPE:-off}
       - SUBSYSTEM_OPENTELEMETRY__ENDPOINT=http://otel-collector:4317
       - VRL_API_CLIENT_MP_REST_URL=http://zgw-referentielijsten.local:8000/
-      # Enable the ability to override WildFly settings using environment variables
-      - WILDFLY_OVERRIDING_ENV_VARS=1
       - ZGW_API_CLIENT_MP_REST_URL=http://openzaak.local:8000/
       - ZGW_API_CLIENTID=zac_client
       - ZGW_API_SECRET=openzaakZaakafhandelcomponentClientSecret


### PR DESCRIPTION
Enable overriding of WildFly env vars by setting the WILDFLY_OVERRIDING_ENV_VARS env var in our Dockerfile.

Solves PZ-2218