### PR TITLE
fix: typo in e2e test for task assignment

### DIFF
--- a/src/e2e/step-definitions/taken-verdelen.ts
+++ b/src/e2e/step-definitions/taken-verdelen.ts
@@ -54,7 +54,7 @@ Then(
   { timeout: ONE_MINUTE_IN_MS },
   async function (this: CustomWorld, s: string) {
     await this.page
-      .getByText(`${_noOfTaken} zaken zijn verdeeld`)
+      .getByText(`${_noOfTaken} taken zijn verdeeld`)
       .waitFor({ timeout: ONE_MINUTE_IN_MS });
   },
 );


### PR DESCRIPTION
The end to end tests were counting on a typo in ZAC.
Solves PZ-2229