### PR TITLE
chore: clean up asynchronous zaken & tasks code after latest code refactoring

### DIFF
--- a/src/main/kotlin/net/atos/zac/app/taken/TakenRESTService.kt
+++ b/src/main/kotlin/net/atos/zac/app/taken/TakenRESTService.kt
@@ -161,7 +161,7 @@ class TakenRESTService @Inject constructor(
         assertPolicy(policyService.readWerklijstRechten().zakenTakenVerdelen)
         // this can be a long-running operation so run it asynchronously
         ioCoroutineScope.launch {
-            taskService.releaseTasksAsync(
+            taskService.releaseTasks(
                 restTaakVrijgevenGegevens = restTaakVrijgevenGegevens,
                 loggedInUser = loggedInUserInstance.get(),
                 screenEventResourceId = restTaakVrijgevenGegevens.screenEventResourceId

--- a/src/main/kotlin/net/atos/zac/task/TaskService.kt
+++ b/src/main/kotlin/net/atos/zac/task/TaskService.kt
@@ -68,7 +68,7 @@ class TaskService @Inject constructor(
     }
 
     /**
-     * Asynchronously assigns a list of tasks to a group and optionally also to a user,
+     * Assigns a list of tasks to a group and optionally also to a user,
      * sends corresponding screen events and updates the search index.
      * This can be a long-running operation.
      */
@@ -79,8 +79,8 @@ class TaskService @Inject constructor(
         screenEventResourceId: String? = null,
     ) {
         LOG.fine {
-            "Started asynchronous job with ID: $screenEventResourceId to assign " +
-                "${restTaakVerdelenGegevens.taken.size} tasks."
+            "Started to assign ${restTaakVerdelenGegevens.taken.size} tasks " +
+                "with screen event resource ID: '$screenEventResourceId'."
         }
         val taskIds = mutableListOf<String>()
         restTaakVerdelenGegevens.taken.forEach { restTaakVerdelenTaak ->
@@ -102,14 +102,13 @@ class TaskService @Inject constructor(
             taskIds.add(restTaakVerdelenTaak.taakId)
         }
         indexeerService.indexeerDirect(taskIds, ZoekObjectType.TAAK, true)
-        LOG.fine {
-            "Asynchronous assign tasks job with ID '$screenEventResourceId' finished. " +
-                "Successfully assigned ${taskIds.size} tasks."
-        }
+        LOG.fine { "Successfully assigned ${taskIds.size} tasks." }
+
         // if a screen event resource ID was specified, send a screen event
         // with the provided job ID so that it can be picked up by a client
         // that has created a websocket subscription to this event
         screenEventResourceId?.let {
+            LOG.fine { "Sending 'TAKEN_VERDELEN' screen event with ID '$it'." }
             eventingService.send(ScreenEventType.TAKEN_VERDELEN.updated(it))
         }
     }
@@ -138,14 +137,14 @@ class TaskService @Inject constructor(
      * This can be a long-running operation.
      */
     @WithSpan
-    fun releaseTasksAsync(
+    fun releaseTasks(
         restTaakVrijgevenGegevens: RESTTaakVrijgevenGegevens,
         loggedInUser: LoggedInUser,
         screenEventResourceId: String? = null
     ) {
         LOG.fine {
-            "Started asynchronous job with ID: '$screenEventResourceId' to release " +
-                "${restTaakVrijgevenGegevens.taken.size} tasks."
+            "Started to assign ${restTaakVrijgevenGegevens.taken.size} tasks " +
+                "with screen event resource ID: '$screenEventResourceId'."
         }
         val taskIds = mutableListOf<String>()
         restTaakVrijgevenGegevens.taken.forEach {
@@ -159,14 +158,13 @@ class TaskService @Inject constructor(
             }
         }
         indexeerService.indexeerDirect(taskIds, ZoekObjectType.TAAK, true)
-        LOG.fine {
-            "Asynchronous release tasks job with ID '$screenEventResourceId' finished. " +
-                "Successfully released ${taskIds.size} tasks."
-        }
+        LOG.fine { "Successfully released ${taskIds.size} tasks." }
+
         // if a screen event resource ID was specified, send a screen event
         // with the provided job ID so that it can be picked up by a client
         // that has created a websocket subscription to this event
         screenEventResourceId?.let {
+            LOG.fine { "Sending 'TAKEN_VRIJGEVEN' screen event with ID '$it'." }
             eventingService.send(ScreenEventType.TAKEN_VRIJGEVEN.updated(it))
         }
     }

--- a/src/test/kotlin/net/atos/zac/app/taken/TakenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/taken/TakenRESTServiceTest.kt
@@ -357,7 +357,7 @@ class TakenRESTServiceTest : BehaviorSpec({
         val werklijstRechten = createWerklijstRechten()
         every { policyService.readWerklijstRechten() } returns werklijstRechten
         coEvery {
-            taskService.releaseTasksAsync(restTaakVrijgevenGegevens, loggedInUser, screenEventResourceId)
+            taskService.releaseTasks(restTaakVrijgevenGegevens, loggedInUser, screenEventResourceId)
         } just Runs
 
         When("the 'verdelen vanuit lijst' function is called") {
@@ -365,7 +365,7 @@ class TakenRESTServiceTest : BehaviorSpec({
 
             Then("the tasks are assigned to the group and user") {
                 coVerify(exactly = 1) {
-                    taskService.releaseTasksAsync(restTaakVrijgevenGegevens, loggedInUser, screenEventResourceId)
+                    taskService.releaseTasks(restTaakVrijgevenGegevens, loggedInUser, screenEventResourceId)
                 }
             }
         }

--- a/src/test/kotlin/net/atos/zac/app/zaken/ZakenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaken/ZakenRESTServiceTest.kt
@@ -74,9 +74,9 @@ import net.atos.zac.policy.output.createOverigeRechtenAllDeny
 import net.atos.zac.policy.output.createZaakRechtenAllDeny
 import net.atos.zac.shared.helper.OpschortenZaakHelper
 import net.atos.zac.signalering.SignaleringenService
+import net.atos.zac.zaak.ZaakService
 import net.atos.zac.zaaksturing.ZaakafhandelParameterService
 import net.atos.zac.zaaksturing.model.createZaakafhandelParameters
-import net.atos.zac.zaken.ZakenService
 import net.atos.zac.zoeken.IndexeerService
 import net.atos.zac.zoeken.model.index.ZoekObjectType
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -115,7 +115,7 @@ class ZakenRESTServiceTest : BehaviorSpec({
     val vrlClientService: VRLClientService = mockk<VRLClientService>()
     val zaakafhandelParameterService: ZaakafhandelParameterService = mockk<ZaakafhandelParameterService>()
     val zaakVariabelenService: ZaakVariabelenService = mockk<ZaakVariabelenService>()
-    val zakenService: ZakenService = mockk<ZakenService>()
+    val zaakService: ZaakService = mockk<ZaakService>()
     val zgwApiService: ZGWApiService = mockk<ZGWApiService>()
     val zrcClientService: ZRCClientService = mockk<ZRCClientService>()
     val ztcClientService: ZTCClientService = mockk<ZTCClientService>()
@@ -135,7 +135,7 @@ class ZakenRESTServiceTest : BehaviorSpec({
         zaakVariabelenService = zaakVariabelenService,
         zrcClientService = zrcClientService,
         ztcClientService = ztcClientService,
-        zakenService = zakenService,
+        zaakService = zaakService,
         indexeerService = indexeerService,
         restHistorieRegelConverter = restHistorieRegelConverter,
         restBesluitConverter = restBesluitConverter,
@@ -234,8 +234,8 @@ class ZakenRESTServiceTest : BehaviorSpec({
         every {
             ztcClientService.readRoltype(RolType.OmschrijvingGeneriekEnum.INITIATOR, zaak.zaaktype)
         } returns createRolType(omschrijvingGeneriek = RolType.OmschrijvingGeneriekEnum.INITIATOR)
-        every { zakenService.bepaalRolGroep(group, zaak) } returns rolOrganisatorischeEenheid
-        every { zakenService.bepaalRolMedewerker(user, zaak) } returns rolMedewerker
+        every { zaakService.bepaalRolGroep(group, zaak) } returns rolOrganisatorischeEenheid
+        every { zaakService.bepaalRolMedewerker(user, zaak) } returns rolMedewerker
 
         When("createZaak is called for a zaaktype for which the logged in user has permissions") {
             every { policyService.readOverigeRechten() } returns createOverigeRechtenAllDeny(startenZaak = true)
@@ -299,7 +299,7 @@ class ZakenRESTServiceTest : BehaviorSpec({
         every { zgwApiService.findGroepForZaak(zaak) } returns Optional.empty()
         every { restZaakConverter.convert(zaak) } returns restZaak
         every { indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK, false) } just runs
-        every { zakenService.bepaalRolMedewerker(user, zaak) } returns rolMedewerker
+        every { zaakService.bepaalRolMedewerker(user, zaak) } returns rolMedewerker
 
         When("toekennen is called from user with access") {
             every { policyService.readZaakRechten(zaak) } returns createZaakRechtenAllDeny(toekennen = true)

--- a/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
@@ -226,7 +226,7 @@ class TaskServiceTest : BehaviorSpec({
                 the 'release tasks' function is called with REST taak vrijgeven gegevens               
             """
         ) {
-            taskService.releaseTasksAsync(restTaakVrijgevenGegevens, loggedInUser)
+            taskService.releaseTasks(restTaakVrijgevenGegevens, loggedInUser)
 
             Then(
                 """taken are released, the index is updated and signalering and signaleringen and screen events are sent"""

--- a/src/test/kotlin/net/atos/zac/zaak/ZakenServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/zaak/ZakenServiceTest.kt
@@ -1,4 +1,4 @@
-package net.atos.zac.zaken
+package net.atos.zac.zaak
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -28,7 +28,7 @@ class ZakenServiceTest : BehaviorSpec({
     val eventingService = mockk<EventingService>()
     val zrcClientService = mockk<ZRCClientService>()
     val ztcClientService = mockk<ZTCClientService>()
-    val zakenService = ZakenService(
+    val zaakService = ZaakService(
         eventingService = eventingService,
         zrcClientService = zrcClientService,
         ztcClientService = ztcClientService
@@ -67,10 +67,10 @@ class ZakenServiceTest : BehaviorSpec({
             every { eventingService.send(capture(screenEventSlot)) } just Runs
         }
         When(
-            """the assign zaken async function is called with a group, a user
+            """the assign zaken function is called with a group, a user
                 and a screen event resource id"""
         ) {
-            zakenService.assignZakenAsync(
+            zaakService.assignZaken(
                 zaakUUIDs = zaken.map { it.uuid },
                 explanation = explanation,
                 group = group,
@@ -106,10 +106,10 @@ class ZakenServiceTest : BehaviorSpec({
         }
         every { eventingService.send(capture(screenEventSlot)) } just Runs
         When(
-            """the release zaken async function is called with
+            """the release zaken function is called with
                  a screen event resource id"""
         ) {
-            zakenService.releaseZaken(
+            zaakService.releaseZaken(
                 zaakUUIDs = zaken.map { it.uuid },
                 explanation = explanation,
                 screenEventResourceId = screenEventResourceId
@@ -143,11 +143,11 @@ class ZakenServiceTest : BehaviorSpec({
         every { zrcClientService.readZaak(zaken[0].uuid) } returns zaken[0]
         every { zrcClientService.readZaak(zaken[1].uuid) } throws RuntimeException("dummyRuntimeException")
         When(
-            """the assign zaken async function is called with a group
+            """the assign zaken function is called with a group
                 and a screen event resource id"""
         ) {
             shouldThrow<RuntimeException> {
-                zakenService.assignZakenAsync(
+                zaakService.assignZaken(
                     zaakUUIDs = zaken.map { it.uuid },
                     explanation = explanation,
                     group = group,


### PR DESCRIPTION
Clean up asynchronous zaken & tasks code after latest code refactoring. Also renamed ZakenService to ZaakService.

Solves PZ-2251