### PR TITLE
fix: don't wait for notification for a zaak role when no change is expected

### DIFF
--- a/src/main/app/src/app/zaken/zaken-werkvoorraad/zaken-werkvoorraad.component.ts
+++ b/src/main/app/src/app/zaken/zaken-werkvoorraad/zaken-werkvoorraad.component.ts
@@ -327,6 +327,22 @@ export class ZakenWerkvoorraadComponent
             this.zakenLoading.set(false);
             this.zakenState.set({});
           });
+        const notChanged = zaken
+          .filter(
+            (x) =>
+              (!this.toekenning.groep ||
+                this.toekenning.groep.id === x.groepId) &&
+              this.toekenning.medewerker?.id === x.behandelaarGebruikersnaam,
+          )
+          .map(({ id }) => id);
+        this.zakenState.update((old) =>
+          Object.fromEntries(
+            Object.entries(old).map(([k, v]) => [
+              k,
+              v || notChanged.includes(k),
+            ]),
+          ),
+        );
       } else {
         this.websocketService.removeListeners(subscriptions);
       }


### PR DESCRIPTION
The new UI for releasement / assignment of zaken didn't work probably when there were cases unchanged
Solves PZ-2281