### PR TITLE
fix: send websocket message at the very end of notification processing

### DIFF
--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -104,12 +104,12 @@ public class NotificatieReceiver {
         if (isAuthenticated(headers)) {
             LOG.info(() -> "Notificatie ontvangen: %s"
                     .formatted(notificatie.toString()));
-            handleWebsockets(notificatie);
             handleSignaleringen(notificatie);
             handleProductaanvraag(notificatie);
             handleIndexering(notificatie);
             handleInboxDocumenten(notificatie);
             handleZaaktype(notificatie);
+            handleWebsockets(notificatie);
             return noContent().build();
         } else {
             return noContent().status(Response.Status.FORBIDDEN).build();


### PR DESCRIPTION
During the processing of OpenNotificaties, twebsocket messages were sent to the frontend before the indexing was actually done. Now these messages are postponed to the very end of the process.
Solves PZ-2283