### PR TITLE
fix: do not reuse Kotlin coroutine scope at class level 

### DIFF
--- a/src/main/kotlin/net/atos/zac/app/taken/TakenRESTService.kt
+++ b/src/main/kotlin/net/atos/zac/app/taken/TakenRESTService.kt
@@ -97,7 +97,6 @@ class TakenRESTService @Inject constructor(
     private val opschortenZaakHelper: OpschortenZaakHelper
 ) {
     companion object {
-        private val ioCoroutineScope = CoroutineScope(Dispatchers.IO)
         private const val REDEN_ZAAK_HERVATTEN = "Aanvullende informatie geleverd"
         private const val REDEN_TAAK_AFGESLOTEN = "Afgesloten"
     }
@@ -146,7 +145,7 @@ class TakenRESTService @Inject constructor(
     fun verdelenVanuitLijst(@Valid restTaakVerdelenGegevens: RESTTaakVerdelenGegevens) {
         assertPolicy(policyService.readWerklijstRechten().zakenTakenVerdelen)
         // this can be a long-running operation so run it asynchronously
-        ioCoroutineScope.launch {
+        CoroutineScope(Dispatchers.IO).launch {
             taskService.assignTasks(
                 restTaakVerdelenGegevens = restTaakVerdelenGegevens,
                 loggedInUser = loggedInUserInstance.get(),
@@ -160,7 +159,7 @@ class TakenRESTService @Inject constructor(
     fun vrijgevenVanuitLijst(@Valid restTaakVrijgevenGegevens: RESTTaakVrijgevenGegevens) {
         assertPolicy(policyService.readWerklijstRechten().zakenTakenVerdelen)
         // this can be a long-running operation so run it asynchronously
-        ioCoroutineScope.launch {
+        CoroutineScope(Dispatchers.IO).launch {
             taskService.releaseTasks(
                 restTaakVrijgevenGegevens = restTaakVrijgevenGegevens,
                 loggedInUser = loggedInUserInstance.get(),

--- a/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
@@ -196,7 +196,6 @@ class ZakenRESTService @Inject constructor(
 ) {
     companion object {
         private val LOG = Logger.getLogger(ZakenRESTService::class.java.name)
-        private val ioCoroutineScope = CoroutineScope(Dispatchers.IO)
 
         private const val ROL_VERWIJDER_REDEN = "Verwijderd door de medewerker tijdens het behandelen van de zaak"
         private const val ROL_TOEVOEGEN_REDEN = "Toegekend door de medewerker tijdens het behandelen van de zaak"
@@ -596,7 +595,7 @@ class ZakenRESTService @Inject constructor(
     fun verdelenVanuitLijst(@Valid restZakenVerdeelGegevens: RESTZakenVerdeelGegevens) {
         assertPolicy(policyService.readWerklijstRechten().zakenTakenVerdelen)
         // this can be a long-running operation so run it asynchronously
-        ioCoroutineScope.launch {
+        CoroutineScope(Dispatchers.IO).launch {
             zaakService.assignZaken(
                 zaakUUIDs = restZakenVerdeelGegevens.uuids,
                 explanation = restZakenVerdeelGegevens.reden,
@@ -618,7 +617,7 @@ class ZakenRESTService @Inject constructor(
     fun vrijgevenVanuitLijst(@Valid restZakenVrijgevenGegevens: RESTZakenVrijgevenGegevens) {
         assertPolicy(policyService.readWerklijstRechten().zakenTakenVerdelen)
         // this can be a long-running operation so run it asynchronously
-        ioCoroutineScope.launch {
+        CoroutineScope(Dispatchers.IO).launch {
             zaakService.releaseZaken(
                 zaakUUIDs = restZakenVrijgevenGegevens.uuids,
                 explanation = restZakenVrijgevenGegevens.reden,

--- a/src/main/kotlin/net/atos/zac/signalering/SignaleringenService.kt
+++ b/src/main/kotlin/net/atos/zac/signalering/SignaleringenService.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import net.atos.client.zgw.zrc.ZRCClientService
 import net.atos.zac.app.zaken.converter.RESTZaakOverzichtConverter
 import net.atos.zac.app.zaken.model.RESTZaakOverzicht
@@ -63,7 +62,6 @@ class SignaleringenService @Inject constructor(
         private fun signaleringTypeInstance(signaleringsType: SignaleringType.Type?): SignaleringType =
             entityManager.find(SignaleringType::class.java, signaleringsType.toString())
 
-        private val defaultCoroutineScope = CoroutineScope(Dispatchers.Default)
         private val LOG = Logger.getLogger(SignaleringenService::class.java.name)
     }
 
@@ -323,16 +321,13 @@ class SignaleringenService @Inject constructor(
         signaleringsType: SignaleringType.Type,
         screenEventResourceId: String
     ) {
-        defaultCoroutineScope.launch(CoroutineName("ListZakenSignaleringen")) {
+        CoroutineScope(Dispatchers.IO).launch(CoroutineName("ListZakenSignaleringen")) {
             LOG.fine {
                 "Started asynchronous job with ID $screenEventResourceId to list zaken signaleringen of" +
                     " type $signaleringsType"
             }
 
-            val zakenSignaleringen: List<RESTZaakOverzicht>
-            withContext(Dispatchers.IO) {
-                zakenSignaleringen = listZakenSignaleringen(user, signaleringsType)
-            }
+            val zakenSignaleringen = listZakenSignaleringen(user, signaleringsType)
 
             LOG.fine {
                 "Asynchronous list zaken signaleringen job with ID $screenEventResourceId finished. " +


### PR DESCRIPTION
Do not reuse Kotlin coroutine scope at class level because in case of exceptions the entire scope gets cancelled and cannot be reused.

Solves PZ-2337