### PR TITLE
chore: add screenEventResourceId back when assigning / releasing cases

### DIFF
--- a/src/main/app/src/app/zaken/zaken-verdelen-dialog/zaken-verdelen-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaken-verdelen-dialog/zaken-verdelen-dialog.component.ts
@@ -5,6 +5,7 @@
 
 import { Component, Inject, OnInit } from "@angular/core";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { v4 as uuidv4 } from "uuid";
 import { Group } from "../../identity/model/group";
 import { User } from "../../identity/model/user";
 import { InputFormField } from "../../shared/material-form-builder/form-components/input/input-form-field";
@@ -65,6 +66,7 @@ export class ZakenVerdelenDialogComponent implements OnInit {
     this.zakenService
       .verdelenVanuitLijst(
         this.data.map((zaak) => zaak.id),
+        uuidv4(),
         toekenning.groep,
         toekenning.medewerker,
         this.redenFormField.formControl.value,

--- a/src/main/app/src/app/zaken/zaken.service.ts
+++ b/src/main/app/src/app/zaken/zaken.service.ts
@@ -179,6 +179,7 @@ export class ZakenService {
 
   verdelenVanuitLijst(
     uuids: string[],
+    screenEventResourceId: string,
     groep?: Group,
     medewerker?: User,
     reden?: string,
@@ -188,6 +189,7 @@ export class ZakenService {
     verdeelGegevens.groepId = groep?.id;
     verdeelGegevens.behandelaarGebruikersnaam = medewerker?.id;
     verdeelGegevens.reden = reden;
+    verdeelGegevens.screenEventResourceId = screenEventResourceId;
 
     return this.http
       .put<void>(`${this.basepath}/lijst/verdelen`, verdeelGegevens)


### PR DESCRIPTION
For consistency reasons, we want to send a screenEventResourceId when assigning / releasing tasks.
Solves PZ-2338