### PR TITLE
fix: continue releasing tasks when a specific open task cannot be found

### DIFF
--- a/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
@@ -434,8 +434,7 @@ class TaskServiceTest : BehaviorSpec({
     }
     Given(
         """
-            Two tasks that have not yet been assigned to a specific group and user where the first
-            task is a historical (closed) task and the second an open task
+            Two tasks where the first task is a historical (closed) task and the second an open task
             """
     ) {
         clearAllMocks()


### PR DESCRIPTION
Continue releasing tasks when a specific open task cannot be found. In a future story we should add more error handling here and also send an actual error to the frontend when this happens I suggest.

Solves PZ:2349