### PR TITLE
fix: always update search index and send screen event in assigning and releasing tasks

### DIFF
--- a/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
@@ -434,7 +434,8 @@ class TaskServiceTest : BehaviorSpec({
     }
     Given(
         """
-            Two tasks where the first task is a historical (closed) task and the second an open task
+            Two tasks that have not yet been assigned to a specific group and user where the first
+            task is a historical (closed) task and the second an open task
             """
     ) {
         clearAllMocks()


### PR DESCRIPTION
Always update search index and send screen event in assigning and releasing tasks.

Solves PZ-2353