### PR TITLE
chore: decrease log level to get rid of the annoying `Open WebSocket denied for..` errors

### DIFF
--- a/src/main/java/net/atos/zac/websocket/WebSocketServerEndPoint.java
+++ b/src/main/java/net/atos/zac/websocket/WebSocketServerEndPoint.java
@@ -77,7 +77,7 @@ public class WebSocketServerEndPoint {
     }
 
     private void denyAccess(final Session session, final String reason) {
-        LOG.severe(() -> String.format("Open WebSocket denied for %s (%s)", user(session), reason));
+        LOG.fine(() -> String.format("Open WebSocket denied for %s (%s)", user(session), reason));
         try {
             // According to the RFC, this close reason should be used if the other reasons are not applicable.
             session.close(new CloseReason(VIOLATED_POLICY, reason));


### PR DESCRIPTION
Decreased log level to get rid of the annoying `Open WebSocket denied for..` errors.

Solves PZ-2355