### PR TITLE
chore: disable reason field when submitting form

### DIFF
--- a/src/main/app/src/app/shared/material-form-builder/form-components/input/input.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/input/input.component.html
@@ -29,7 +29,8 @@
             [id]="data.id + '_tekstfield'" 
             [required]="data.required" 
             matInput
-            [maxlength]="data.maxlength" 
+            [maxlength]="data.maxlength"
+            [readonly]="data.readonly" 
             >
     <mat-hint *ngIf="data.hint" [align]="data.hint.align">{{data.hint.label | translate}}</mat-hint>
     <mat-hint align="end" *ngIf="data.showCount && data.formControl.value && data.formControl.dirty">{{data.formControl.value.length}}

--- a/src/main/app/src/app/taken/taken-verdelen-dialog/taken-verdelen-dialog.component.ts
+++ b/src/main/app/src/app/taken/taken-verdelen-dialog/taken-verdelen-dialog.component.ts
@@ -59,6 +59,7 @@ export class TakenVerdelenDialogComponent implements OnInit {
   }
 
   verdeel(): void {
+    this.redenFormField.readonly = true;
     const toekenning: { groep?: Group; medewerker?: User } =
       this.medewerkerGroepFormField.formControl.value;
     const reden: string = this.redenFormField.formControl.value;

--- a/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.ts
+++ b/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.ts
@@ -38,6 +38,7 @@ export class TakenVrijgevenDialogComponent implements OnInit {
   }
 
   vrijgeven() {
+    this.redenFormField.readonly = true;
     this.dialogRef.disableClose = true;
     this.loading = true;
     const reden: string = this.redenFormField.formControl.value;

--- a/src/main/app/src/app/zaken/zaken-verdelen-dialog/zaken-verdelen-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaken-verdelen-dialog/zaken-verdelen-dialog.component.ts
@@ -59,6 +59,7 @@ export class ZakenVerdelenDialogComponent implements OnInit {
   }
 
   verdeel(): void {
+    this.redenFormField.readonly = true;
     const toekenning: { groep?: Group; medewerker?: User } =
       this.medewerkerGroepFormField.formControl.value;
     this.dialogRef.disableClose = true;

--- a/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.ts
@@ -39,6 +39,7 @@ export class ZakenVrijgevenDialogComponent implements OnInit {
   }
 
   vrijgeven(): void {
+    this.redenFormField.readonly = true;
     this.dialogRef.disableClose = true;
     this.loading = true;
     this.zakenService


### PR DESCRIPTION
Users were still able to fill in the Reason field while the assignment / releasement forms were being submitted.
Solves PZ-2131