### PR TITLE
chore: don't allow clearing readonly fields

### DIFF
--- a/src/main/app/src/app/shared/material-form-builder/form-components/input/input.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/input/input.component.html
@@ -5,7 +5,7 @@
 
 <mat-form-field appearance="fill" class="full-width" (click)="clicked()"
 [class]="data.styleClass">
-    @if (data.onClear.observed && data.formControl.value) {
+    @if (data.onClear.observed && data.formControl.value && !data.readonly) {
         <button matSuffix 
                 mat-icon-button 
                 aria-label="Clear" 


### PR DESCRIPTION
We shouldn't allow clearing readonly fields by clicking the `X` icon
Solves PZ-2370