### PR TITLE
chore: skip documents if not found by uuid in OpenZaak

### DIFF
--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
+import org.eclipse.jetty.http.HttpStatus;
 import org.jetbrains.annotations.NotNull;
 
 import net.atos.client.zgw.brc.BRCClientService;
@@ -390,7 +391,7 @@ public class RESTInformatieobjectConverter {
                         return convertToREST(
                                 drcClientService.readEnkelvoudigInformatieobject(enkelvoudigInformatieobjectUUID), zaak);
                     } catch (FoutException e) {
-                        if (e.getFout().getStatus() != 404) {
+                        if (e.getFout().getStatus() != HttpStatus.NOT_FOUND_404) {
                             throw e;
                         }
                         LOG.warning(() -> "Document niet gevonden: %s".formatted(enkelvoudigInformatieobjectUUID));

--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
@@ -394,7 +394,7 @@ public class RESTInformatieobjectConverter {
                         if (e.getFout().getStatus() != HttpStatus.NOT_FOUND_404) {
                             throw e;
                         }
-                        LOG.warning(() -> "Document niet gevonden: %s".formatted(enkelvoudigInformatieobjectUUID));
+                        LOG.severe(() -> "Document niet gevonden: %s".formatted(enkelvoudigInformatieobjectUUID));
                         return null;
                     }
                 })

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverterTest.kt
@@ -35,6 +35,7 @@ import net.atos.zac.configuratie.ConfiguratieService
 import net.atos.zac.policy.PolicyService
 import net.atos.zac.policy.output.DocumentRechten
 import net.atos.zac.policy.output.createDocumentRechtenAllDeny
+import org.eclipse.jetty.http.HttpStatus
 import java.net.URI
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -264,7 +265,7 @@ class RESTInformatieobjectConverterTest : BehaviorSpec() {
             val uuid = UUID.randomUUID()
             every {
                 drcClientService.readEnkelvoudigInformatieobject(uuid)
-            } throws FoutException(Fout(null, null, null, 404, null, null))
+            } throws FoutException(Fout(null, null, null, HttpStatus.NOT_FOUND_404, null, null))
             When("We try to convert a list with that uuid") {
                 val result = restInformatieobjectConverter.convertUUIDsToREST(ImmutableList.of(uuid), null)
                 Then("An empty list is returned") {


### PR DESCRIPTION
When a document is deleted from OpenZaak directly, we potentially still have a reference to that uuid in cases or tasks. In that case, we want to skip that document in stead of throwing an error.
Solves PZ-2168