### PR TITLE
chore: check for rights in frontend for bag / betrokkene / initiator

### DIFF
--- a/src/main/app/src/app/klanten/koppel/klanten/klant-koppel.component.ts
+++ b/src/main/app/src/app/klanten/koppel/klanten/klant-koppel.component.ts
@@ -37,7 +37,7 @@ import { KlantKoppelInitiator } from "./klant-koppel-initiator.component";
 
     <!--Initiator-->
     <mat-tab-group mat-stretch-tabs="false" *ngIf="initiator">
-      <mat-tab>
+      <mat-tab *ngIf="allowPersoon">
         <ng-template mat-tab-label>
           <mat-icon>emoji_people</mat-icon>
           {{ "betrokkene.persoon" | translate }}
@@ -47,7 +47,7 @@ import { KlantKoppelInitiator } from "./klant-koppel-initiator.component";
           (klantGegevens)="klantGegevens.emit($event)"
         />
       </mat-tab>
-      <mat-tab>
+      <mat-tab *ngIf="allowBedrijf">
         <ng-template mat-tab-label>
           <mat-icon>business</mat-icon>
           {{ "betrokkene.bedrijf" | translate }}
@@ -61,7 +61,7 @@ import { KlantKoppelInitiator } from "./klant-koppel-initiator.component";
 
     <!--Betrokkene-->
     <mat-tab-group mat-stretch-tabs="false" *ngIf="!initiator">
-      <mat-tab>
+      <mat-tab *ngIf="allowPersoon">
         <ng-template mat-tab-label>
           <mat-icon>emoji_people</mat-icon>
           {{ "betrokkene.persoon" | translate }}
@@ -72,7 +72,7 @@ import { KlantKoppelInitiator } from "./klant-koppel-initiator.component";
           (klantGegevens)="klantGegevens.emit($event)"
         />
       </mat-tab>
-      <mat-tab>
+      <mat-tab *ngIf="allowBedrijf">
         <ng-template mat-tab-label>
           <mat-icon>business</mat-icon>
           {{ "betrokkene.bedrijf" | translate }}
@@ -93,5 +93,7 @@ export class KlantKoppelComponent {
   @Input() initiator = false;
   @Input() zaaktypeUUID: string;
   @Input() sideNav: MatDrawer;
+  @Input() allowPersoon: boolean;
+  @Input() allowBedrijf: boolean;
   @Output() klantGegevens = new EventEmitter<KlantGegevens>();
 }

--- a/src/main/app/src/app/policy/model/zaak-rechten.ts
+++ b/src/main/app/src/app/policy/model/zaak-rechten.ts
@@ -12,4 +12,9 @@ export class ZaakRechten {
   heropenen = false;
   bekijkenZaakdata = false;
   wijzigenDoorlooptijd = false;
+  toevoegenBagObject = false;
+  toevoegenBetrokkeneBedrijf = false;
+  toevoegenBetrokkenePersoon = false;
+  toevoegenInitiatorBedrijf = false;
+  toevoegenInitiatorPersoon = false;
 }

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -12,11 +12,15 @@
         <zac-klant-koppel *ngSwitchCase="sideNavAction.ZOEK_INITIATOR"
                           [sideNav]="actionsSidenav"
                           (klantGegevens)="initiatorGeselecteerd($event.klant)"
-                          [initiator]="true"></zac-klant-koppel>
+                          [initiator]="true"
+                          [allowBedrijf]="zaak.rechten.toevoegenInitiatorBedrijf"
+                          [allowPersoon]="zaak.rechten.toevoegenInitiatorPersoon"></zac-klant-koppel>
         <zac-klant-koppel *ngSwitchCase="sideNavAction.ZOEK_BETROKKENE"
                           (klantGegevens)="betrokkeneGeselecteerd($event)"
                           [sideNav]="actionsSidenav"
-                          [zaaktypeUUID]="zaak.zaaktype.uuid"></zac-klant-koppel>
+                          [zaaktypeUUID]="zaak.zaaktype.uuid"
+                          [allowBedrijf]="zaak.rechten.toevoegenBetrokkeneBedrijf"
+                          [allowPersoon]="zaak.rechten.toevoegenBetrokkenePersoon"></zac-klant-koppel>
         <zac-bag-zoek *ngSwitchCase="sideNavAction.ZOEK_BAG_ADRES"
                       [gekoppeldeBagObjecten]="gekoppeldeBagObjecten"
                       [sideNav]="actionsSidenav"
@@ -70,22 +74,22 @@
         <div class="flex-row flex-wrap gap-10">
             <zac-zaak-initiator-toevoegen class="w100 flex-1"
                                           *ngIf="!zaak.initiatorIdentificatieType"
-                                          [toevoegenToegestaan]="zaak.rechten.behandelen"
+                                          [toevoegenToegestaan]="zaak.rechten.toevoegenInitiatorPersoon || zaak.rechten.toevoegenInitiatorBedrijf"
                                           (add)="addOrEditZaakInitiator()">
             </zac-zaak-initiator-toevoegen>
             <zac-persoongegevens class="w100 flex-1" *ngIf="zaak.initiatorIdentificatieType==='BSN'"
                                  [bsn]="zaak.initiatorIdentificatie"
-                                 [isVerwijderbaar]="zaak.rechten.behandelen"
-                                 [isWijzigbaar]="zaak.rechten.behandelen"
+                                 [isVerwijderbaar]="zaak.rechten.toevoegenInitiatorPersoon"
+                                 [isWijzigbaar]="zaak.rechten.toevoegenInitiatorPersoon"
                                  (edit)="addOrEditZaakInitiator()"
                                  (delete)="deleteInitiator()">
             </zac-persoongegevens>
             <zac-bedrijfsgegevens class="w100 flex-1"
                                   *ngIf="zaak.initiatorIdentificatieType==='VN' || zaak.initiatorIdentificatieType==='RSIN'"
                                   [rsinOfVestigingsnummer]="zaak.initiatorIdentificatie"
-                                  [isVerwijderbaar]="zaak.rechten.behandelen"
+                                  [isVerwijderbaar]="zaak.rechten.toevoegenInitiatorBedrijf"
                                   (edit)="addOrEditZaakInitiator()"
-                                  [isWijzigbaar]="zaak.rechten.behandelen"
+                                  [isWijzigbaar]="zaak.rechten.toevoegenInitiatorBedrijf"
                                   (delete)="deleteInitiator()">
             </zac-bedrijfsgegevens>
 

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -735,7 +735,10 @@ export class ZaakViewComponent
   private createKoppelingenMenuItems(): void {
     if (this.zaak.rechten.behandelen || this.zaak.rechten.wijzigen) {
       this.menu.push(new HeaderMenuItem("koppelingen"));
-      if (this.zaak.rechten.behandelen) {
+      if (
+        this.zaak.rechten.toevoegenBetrokkeneBedrijf ||
+        this.zaak.rechten.toevoegenBetrokkenePersoon
+      ) {
         this.menu.push(
           new ButtonMenuItem(
             "actie.betrokkene.toevoegen",
@@ -746,16 +749,18 @@ export class ZaakViewComponent
             "group_add",
           ),
         );
-        this.menu.push(
-          new ButtonMenuItem(
-            "actie.bagObject.toevoegen",
-            () => {
-              this.actionsSidenav.open();
-              this.action = SideNavAction.ZOEK_BAG_ADRES;
-            },
-            "add_home_work",
-          ),
-        );
+        if (this.zaak.rechten.toevoegenBagObject) {
+          this.menu.push(
+            new ButtonMenuItem(
+              "actie.bagObject.toevoegen",
+              () => {
+                this.actionsSidenav.open();
+                this.action = SideNavAction.ZOEK_BAG_ADRES;
+              },
+              "add_home_work",
+            ),
+          );
+        }
       }
       if (this.zaak.rechten.wijzigen) {
         this.menu.push(

--- a/src/main/java/net/atos/zac/app/policy/converter/RESTRechtenConverter.java
+++ b/src/main/java/net/atos/zac/app/policy/converter/RESTRechtenConverter.java
@@ -48,6 +48,11 @@ public class RESTRechtenConverter {
         restZaakRechten.heropenen = zaakRechten.heropenen();
         restZaakRechten.wijzigenDoorlooptijd = zaakRechten.wijzigenDoorlooptijd();
         restZaakRechten.bekijkenZaakdata = zaakRechten.bekijkenZaakdata();
+        restZaakRechten.toevoegenBagObject = zaakRechten.toevoegenBagObject();
+        restZaakRechten.toevoegenBetrokkeneBedrijf = zaakRechten.toevoegenBetrokkeneBedrijf();
+        restZaakRechten.toevoegenBetrokkenePersoon = zaakRechten.toevoegenBetrokkenePersoon();
+        restZaakRechten.toevoegenInitiatorBedrijf = zaakRechten.toevoegenInitiatorBedrijf();
+        restZaakRechten.toevoegenInitiatorPersoon = zaakRechten.toevoegenInitiatorPersoon();
         return restZaakRechten;
     }
 

--- a/src/main/java/net/atos/zac/app/policy/model/RESTZaakRechten.java
+++ b/src/main/java/net/atos/zac/app/policy/model/RESTZaakRechten.java
@@ -22,4 +22,14 @@ public class RESTZaakRechten {
     public boolean bekijkenZaakdata;
 
     public boolean wijzigenDoorlooptijd;
+
+    public boolean toevoegenBagObject;
+
+    public boolean toevoegenBetrokkeneBedrijf;
+
+    public boolean toevoegenBetrokkenePersoon;
+
+    public boolean toevoegenInitiatorBedrijf;
+
+    public boolean toevoegenInitiatorPersoon;
 }


### PR DESCRIPTION
In earlier stories, we have updated the rights of the different roles in ZAC. Now we hide the functionalities concerning bag / betrokkene / initiator in the front end if the user has no permission to use them.
Solves PZ-2288