### PR TITLE
chore: fix end to end test failing on bag

### DIFF
--- a/src/e2e/features/2-zaken-toevoegen.feature
+++ b/src/e2e/features/2-zaken-toevoegen.feature
@@ -4,5 +4,5 @@ Feature: Zaak
     Given "Bob" navigates to "zac" with path "/"
     When "Bob" wants to create a new zaak
     Then "Bob" sees the created zaak with a delay
-    Given "Bob" navigates to "zac" with path "/zaken/werkvoorraad" with delay after of 5000 ms
+    Given "Bob" navigates to "zac" with path "/zaken/werkvoorraad"
     Then "Bob" sees the created zaak

--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -157,7 +157,7 @@ When(
       .press("Enter");
     await this.page
       .getByRole("row", {
-        name: "Gerelateerde gegevens tonen 0384200000005901 Adres Meelbeskamp 49, 1112GV Diemen Selecteren",
+        name: "Meelbeskamp 49, 1112GV Diemen",
       })
       .getByTitle("Selecteren")
       .click();
@@ -253,7 +253,10 @@ Then(
   async function (this: CustomWorld, user) {
     const caseNumber = this.testStorage.get("caseNumber");
 
-    await this.page.getByText(caseNumber);
+    await this.page
+      .getByText(caseNumber)
+      .first()
+      .waitFor({ timeout: ONE_MINUTE_IN_MS });
   },
 );
 
@@ -261,11 +264,11 @@ Then(
   "{string} sees the created zaak with a delay",
   { timeout: ONE_MINUTE_IN_MS + 15000 },
   async function (this: CustomWorld, user) {
-    // at least a minute and 10 seconds just to be sure
-    await this.page.waitForTimeout(ONE_MINUTE_IN_MS + 10000);
     const caseNumber = this.testStorage.get("caseNumber");
-
-    await this.page.getByText(caseNumber);
+    await this.page
+      .getByText(caseNumber)
+      .first()
+      .waitFor({ timeout: ONE_MINUTE_IN_MS });
   },
 );
 


### PR DESCRIPTION
The end to end tests were failing because an address couldn't be located on the page.
Solves PZ-2410