### PR TITLE
chore: consolidate testcontainers libs version into one in Gradle version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,9 +67,7 @@ kotest-runner-junit5 = "5.8.1"
 kotest-assertions-json = "5.8.1"
 mockk = "1.13.10"
 
-testcontainers-testcontainers = "1.19.7"
-testcontainers-mockserver = "1.19.7"
-testcontainers-postgresql = "1.19.7"
+testcontainers = "1.19.7"
 
 json-json = "20240303"
 slf4j-simple = "2.0.13"
@@ -157,9 +155,9 @@ mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 
 # integration test dependencies
-testcontainers-testcontainers = { group = "org.testcontainers", name = "testcontainers", version.ref = "testcontainers-testcontainers" }
-testcontainers-mockserver = { group = "org.testcontainers", name = "mockserver", version.ref = "testcontainers-mockserver" }
-testcontainers-postgresql = { group = "org.testcontainers", name = "postgresql", version.ref = "testcontainers-postgresql" }
+testcontainers-testcontainers = { group = "org.testcontainers", name = "testcontainers", version.ref = "testcontainers" }
+testcontainers-mockserver = { group = "org.testcontainers", name = "mockserver", version.ref = "testcontainers" }
+testcontainers-postgresql = { group = "org.testcontainers", name = "postgresql", version.ref = "testcontainers" }
 json = { group = "org.json", name = "json", version.ref = "json-json" }
 
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j-simple" }


### PR DESCRIPTION
Consolidate testcontainers libs version into one in Gradle version catalog since they always have the same version.

Solves PZ-2424