### PR TITLE
fix: re-enable adding initiator in the create case view

### DIFF
--- a/src/main/app/src/app/zaken/zaak-create/zaak-create.component.html
+++ b/src/main/app/src/app/zaken/zaak-create/zaak-create.component.html
@@ -7,7 +7,9 @@
         <zac-klant-koppel *ngSwitchCase="sideNavAction.ZOEK_INITIATOR"
                           (klantGegevens)="initiatorGeselecteerd($event.klant)"
                           [sideNav]="actionsSidenav"
-                          [initiator]="true"></zac-klant-koppel>
+                          [initiator]="true"
+                          [allowBedrijf]="true"
+                          [allowPersoon]="true"></zac-klant-koppel>
         <zac-bag-zoek *ngSwitchCase="sideNavAction.ZOEK_BAG_ADRES"
                       [gekoppeldeBagObjecten]="bagObjecten"
                       [sideNav]="actionsSidenav"


### PR DESCRIPTION
While working on another story we broke the functionality to add an initiator on the create case view. This is now restored.
Solves PZ-2432