### PR TITLE
feat: add GC logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN date -Iseconds > /build_timestamp.txt
 ENV WILDFLY_OVERRIDING_ENV_VARS 1
 
 # Start zaakafhandelcomponent
-ENTRYPOINT ["java", "-Xms1024m", "-Xmx1024m", "-jar", "zaakafhandelcomponent.jar"]
+ENTRYPOINT ["java", "-Xms1024m", "-Xmx1024m", "-Xlog:gc::time,uptime", "-jar", "zaakafhandelcomponent.jar"]
 EXPOSE 8080 9990
 
 ARG branchName

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -517,7 +517,7 @@ services:
       "sh",
       "-c",
       # entrypoint may be overridden by environment variable to pass on extra arguments
-      "${ZAC_DOCKER_ENTRYPOINT:-java -Xms1024m -Xmx1024m -jar zaakafhandelcomponent.jar}",
+      "${ZAC_DOCKER_ENTRYPOINT:-java -Xms1024m -Xmx1024m -Xlog:gc::time,uptime -jar zaakafhandelcomponent.jar}",
     ]
     deploy:
       resources:


### PR DESCRIPTION
Prints GC logs like:
```
[2024-05-13T11:04:26.757+0000][84.867s] GC(22) Pause Young (Mixed) (G1 Humongous Allocation) 983M->346M(1024M) 14.214ms [2024-05-13T11:04:26.850+0000][84.960s] GC(23) Pause Young (Concurrent Start) (G1 Humongous Allocation) 414M->346M(1024M) 11.180ms 
[2024-05-13T11:04:26.850+0000][84.960s] GC(24) Concurrent Mark Cycle 
[2024-05-13T11:04:26.977+0000][85.087s] GC(24) Pause Remark 744M->744M(1024M) 27.817ms
[2024-05-13T11:04:27.019+0000][85.129s] GC(24) Pause Cleanup 744M->744M(1024M) 0.240ms
[2024-05-13T11:04:27.021+0000][85.131s] GC(24) Concurrent Mark Cycle 170.303ms
```

This helps determine when GC is running and how much memory it reclaims.