### PR TITLE
chore: enable Gradle build cache

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -85,19 +85,19 @@ jobs:
             src/generated/java
           key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
-      - name: Cache Maven build artefacts
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            target
-          key: maven-build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
-
       - name: Cache frontend build artefacts
         uses: actions/cache/save@v4
         with:
           path: |
             src/main/app/dist
           key: frontend-build-artefacts-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
+      - name: Cache Maven build artefacts
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            target
+          key: maven-build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   run-unit-tests:
     needs: [build]

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -92,12 +92,12 @@ jobs:
             src/main/app/dist
           key: frontend-build-artefacts-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
-      - name: Cache Maven build artefacts
+      - name: Cache built ZAR JAR
         uses: actions/cache/save@v4
         with:
           path: |
-            target
-          key: maven-build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+            target/zaakafhandelcomponent.jar
+          key: zac-jar-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   run-unit-tests:
     needs: [build]
@@ -198,8 +198,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            target/
-          key: maven-build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+            target/zaakafhandelcomponent.jar
+          key: zac-jar-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           path: |
             src/main/app/dist
-          key: frontend-build-artefacts--${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+          key: frontend-build-artefacts-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Run unit tests
         run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes -x npmRunBuild test --info

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -85,13 +85,6 @@ jobs:
             src/generated/java
           key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
-      - name: Cache frontend build artefacts
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            src/main/app/dist
-          key: frontend-build-artefacts-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
-
       - name: Cache built ZAR JAR
         uses: actions/cache/save@v4
         with:
@@ -131,13 +124,6 @@ jobs:
           path: |
             build
           key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
-
-      - name: Restore frontend build artefacts
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            src/main/app/dist
-          key: frontend-build-artefacts-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Run unit tests
         run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes test --info

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -140,7 +140,7 @@ jobs:
           key: frontend-build-artefacts-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Run unit tests
-        run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes -x npmRunBuild test --info
+        run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes test --info
 
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: |
-            build/
+            build
           key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Cache generated Java clients
@@ -89,8 +89,15 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: |
-            target/
+            target
           key: maven-build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
+      - name: Cache frontend build artefacts
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            src/main/app/dist
+          key: frontend-build-artefacts-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   run-unit-tests:
     needs: [build]
@@ -122,11 +129,18 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            build/
+            build
           key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
+      - name: Restore frontend build artefacts
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            src/main/app/dist
+          key: frontend-build-artefacts--${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
       - name: Run unit tests
-        run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes test --info
+        run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes -x npmRunBuild test --info
 
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -138,7 +152,7 @@ jobs:
             src/main/app/reports/*.xml
 
       - name: Generate unit test code coverage report
-        run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes -x test -x itest npmRunTestCoverage jacocoTestReport --info
+        run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes -x test -x itest -x npmRunBuild npmRunTestCoverage jacocoTestReport --info
 
       - name: Upload unit test coverage report to Codecov
         uses: codecov/codecov-action@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -357,7 +357,10 @@ tasks.getByName("spotlessApply").finalizedBy(listOf("detektApply"))
 
 // run npm install task after generating the Java clients because they
 // share the same output folder (= $rootDir)
-tasks.getByName("npmInstall").setMustRunAfter(listOf("generateJavaClients"))
+tasks.getByName("npmInstall") {
+    setMustRunAfter(listOf("generateJavaClients"))
+    outputs.cacheIf { true }
+}
 tasks.getByName("generateSwaggerUIZaakafhandelcomponent").setDependsOn(listOf("generateOpenApiSpec"))
 
 tasks.getByName("compileItestKotlin") {
@@ -590,6 +593,7 @@ tasks {
         inputs.file("src/main/app/package.json")
         inputs.file("src/main/app/package-lock.json")
         outputs.dir("src/main/app/dist/zaakafhandelcomponent")
+        outputs.cacheIf { true }
     }
 
     register<NpmTask>("npmRunTest") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -369,7 +369,7 @@ tasks.war {
     dependsOn("npmRunBuild")
 
     // add built frontend resources to WAR archive
-    from("src/main/app/dist/zaakafhandelcomponent")
+    from("src/main/app/dist")
 
     // explicitly add our 'warLib' 'transitive' dependencies that are required in the generated WAR
     classpath(files(configurations["warLib"]))
@@ -587,7 +587,7 @@ tasks {
         // see: https://github.com/node-gradle/gradle-node-plugin/blob/master/docs/faq.md
         inputs.files(fileTree("src/main/app/node_modules"))
         inputs.files(fileTree("src/main/app/src"))
-        outputs.dir("src/main/app/dist/zaakafhandelcomponent")
+        outputs.dir("src/main/app/dist")
         outputs.cacheIf { true }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -357,10 +357,7 @@ tasks.getByName("spotlessApply").finalizedBy(listOf("detektApply"))
 
 // run npm install task after generating the Java clients because they
 // share the same output folder (= $rootDir)
-tasks.getByName("npmInstall") {
-    setMustRunAfter(listOf("generateJavaClients"))
-    outputs.cacheIf { true }
-}
+tasks.getByName("npmInstall").setMustRunAfter(listOf("generateJavaClients"))
 tasks.getByName("generateSwaggerUIZaakafhandelcomponent").setDependsOn(listOf("generateOpenApiSpec"))
 
 tasks.getByName("compileItestKotlin") {
@@ -590,8 +587,6 @@ tasks {
         // see: https://github.com/node-gradle/gradle-node-plugin/blob/master/docs/faq.md
         inputs.files(fileTree("src/main/app/node_modules"))
         inputs.files(fileTree("src/main/app/src"))
-        inputs.file("src/main/app/package.json")
-        inputs.file("src/main/app/package-lock.json")
         outputs.dir("src/main/app/dist/zaakafhandelcomponent")
         outputs.cacheIf { true }
     }
@@ -604,8 +599,6 @@ tasks {
         // see: https://github.com/node-gradle/gradle-node-plugin/blob/master/docs/faq.md
         inputs.files(fileTree("src/main/app/node_modules"))
         inputs.files(fileTree("src/main/app/src"))
-        inputs.file("src/main/app/package.json")
-        inputs.file("src/main/app/package-lock.json")
 
         // directory used by the Jest reporter(s) that we have configured
         outputs.dir("src/main/app/reports")

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,6 @@
 #
 
 org.gradle.jvmargs=-Xmx2048m
+org.gradle.caching=true
 
 


### PR DESCRIPTION
Enable Gradle build cache for faster development speed when working locally (especially when switching branches) and minor improvements to our build scripts.

Solves PZ-2480