### PR TITLE
feat: improve error message on missing user data

### DIFF
--- a/src/main/java/net/atos/zac/policy/input/UserInput.java
+++ b/src/main/java/net/atos/zac/policy/input/UserInput.java
@@ -5,6 +5,8 @@
 
 package net.atos.zac.policy.input;
 
+import java.util.Objects;
+
 import jakarta.json.bind.annotation.JsonbProperty;
 
 import net.atos.zac.authentication.LoggedInUser;
@@ -15,6 +17,8 @@ public class UserInput {
     private final UserData userData = new UserData();
 
     public UserInput(final LoggedInUser loggedInUser) {
+        Objects.requireNonNull(loggedInUser,
+                "No logged in user found. Please ensure that user did not log out and its session is still active");
         userData.id = loggedInUser.getId();
         userData.rollen = loggedInUser.getRoles();
         userData.zaaktypen = loggedInUser.isGeautoriseerdVoorAlleZaaktypen() ? null : loggedInUser.getGeautoriseerdeZaaktypen();

--- a/src/test/kotlin/net/atos/zac/policy/input/UserInputTest.kt
+++ b/src/test/kotlin/net/atos/zac/policy/input/UserInputTest.kt
@@ -1,0 +1,34 @@
+package net.atos.zac.policy.input
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.string.shouldStartWith
+import net.atos.zac.authentication.createLoggedInUser
+
+class UserInputTest : BehaviorSpec({
+
+    Given("Permission checks constructs user input ") {
+
+        When("no logged in user is provided") {
+            val exception = shouldThrow<NullPointerException> {
+                UserInput(null)
+            }
+
+            Then("it throws exception with correct message") {
+                exception.message shouldStartWith "No logged in user found"
+            }
+        }
+
+        When("logged in user is provided") {
+            val user = createLoggedInUser()
+            val input = UserInput(user)
+
+            Then("no exception is thrown") {
+                input.user.id shouldBeEqual user.id
+                input.user.rollen shouldBeEqual user.roles
+                input.user.zaaktypen shouldBeEqual user.geautoriseerdeZaaktypen
+            }
+        }
+    }
+})


### PR DESCRIPTION
Replaces 
```
Cannot invoke "net.atos.zac.authentication.LoggedInUser.getId()" because "loggedInUser" is null: java.lang.NullPointerException: Cannot invoke "net.atos.zac.authentication.LoggedInUser.getId()" because "loggedInUser" is null
```

with: 
```
java.lang.NullPointerException: No logged in user found. Please ensure that user did not log out and its session is still active
```

Solves: PZ-2487