### PR TITLE
chore: use Gradle build task for npmRunBuild task

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -85,7 +85,7 @@ jobs:
             src/generated/java
           key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
-      - name: Cache built ZAR JAR
+      - name: Cache built ZAC JAR
         uses: actions/cache/save@v4
         with:
           path: |
@@ -180,7 +180,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: Restore Maven build artefacts
+      - name: Restore built ZAC JAR
         uses: actions/cache/restore@v4
         with:
           path: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -594,6 +594,8 @@ tasks {
         inputs.files(fileTree("src/main/app/node_modules"))
         inputs.files(fileTree("src/main/app/src"))
         outputs.dir("src/main/app/dist/zaakafhandelcomponent")
+        outputs.dir("src/main/app/src/generated/types")
+        outputs.cacheIf { true }
     }
 
     register<NpmTask>("npmRunTest") {
@@ -663,10 +665,13 @@ tasks {
         }
     }
 
-    // Simple function to invoke a maven goal, dependent on the os, with optional
     register<Maven>("generateWildflyBootableJar") {
         dependsOn("war")
         execGoal("wildfly-jar:package")
+
+        inputs.files(fileTree("src/main/resources/wildfly"))
+        inputs.file("build/libs/zaakafhandelcomponent.war")
+        outputs.dir("target")
     }
 
     register<Maven>("mavenClean") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -357,7 +357,11 @@ tasks.getByName("spotlessApply").finalizedBy(listOf("detektApply"))
 
 // run npm install task after generating the Java clients because they
 // share the same output folder (= $rootDir)
-tasks.getByName("npmInstall").setMustRunAfter(listOf("generateJavaClients"))
+tasks.getByName("npmInstall") {
+    setMustRunAfter(listOf("generateJavaClients"))
+    inputs.files("src/main/app/package.json")
+    outputs.dir("src/main/app/node_modules")
+}
 tasks.getByName("generateSwaggerUIZaakafhandelcomponent").setDependsOn(listOf("generateOpenApiSpec"))
 
 tasks.getByName("compileItestKotlin") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -355,11 +355,8 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
 }
 tasks.getByName("spotlessApply").finalizedBy(listOf("detektApply"))
 
-// run npm install task after generating the Java clients because they
-// share the same output folder (= $rootDir)
 tasks.getByName("npmInstall") {
-    setMustRunAfter(listOf("generateJavaClients"))
-    inputs.files("src/main/app/package.json")
+    inputs.file("src/main/app/package.json")
     outputs.dir("src/main/app/node_modules")
 }
 tasks.getByName("generateSwaggerUIZaakafhandelcomponent").setDependsOn(listOf("generateOpenApiSpec"))


### PR DESCRIPTION
Use Gradle build task for npmRunBuild task. Also added inputs and output to generateWildflyBootableJar task so that it only gets run when it is needed.

Solves PZ-2521