### PR TITLE
chore: cache built frontend artefacts across GitHub workflow jobs

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -85,6 +85,14 @@ jobs:
             src/generated/java
           key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
+      - name: Cache built frontend artefacts
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            src/main/app/dist/zaakafhandelcomponent
+            src/main/app/src/generated/types
+          key: built-frontend-artefacts-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
       - name: Cache built ZAC JAR
         uses: actions/cache/save@v4
         with:
@@ -111,19 +119,26 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: Restore generated Java clients
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            src/generated/java
-          key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
-
       - name: Restore Gradle build artefacts
         uses: actions/cache/restore@v4
         with:
           path: |
             build
           key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
+      - name: Restore built frontend artefacts
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            build
+          key: built-frontend-artefacts-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
+      - name: Restore generated Java clients
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            src/generated/java
+          key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Run unit tests
         run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes test --info


### PR DESCRIPTION
Cache built frontend artefacts across GitHub workflow jobs to hopefully avoid re-running the npmRunBuild task when running unit tests.

Solves PZ-2547