### PR TITLE
chore: send tasks to solr individually during the releasement process

### DIFF
--- a/src/main/kotlin/net/atos/zac/task/TaskService.kt
+++ b/src/main/kotlin/net/atos/zac/task/TaskService.kt
@@ -143,7 +143,7 @@ class TaskService @Inject constructor(
         try {
             releaseTasks(restTaakVrijgevenGegevens, loggedInUser, taskIds)
         } finally {
-            indexeerService.indexeerDirect(taskIds.stream(), ZoekObjectType.TAAK, true)
+            indexeerService.commit()
             LOG.fine { "Successfully released ${taskIds.size} tasks." }
 
             // if a screen event resource ID was specified, send a screen event
@@ -227,6 +227,7 @@ class TaskService @Inject constructor(
                         loggedInUser = loggedInUser,
                         reden = restTaakVrijgevenGegevens.reden
                     )
+                    indexeerService.indexeerDirect(task.id, ZoekObjectType.TAAK, false)
                     sendScreenEventsOnTaskChange(task, it.zaakUuid)
                     taskIds.add(task.id)
                 }

--- a/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
@@ -224,7 +224,10 @@ class TaskServiceTest : BehaviorSpec({
         every { eventingService.send(capture(taakOpNaamSignaleringEventSlot)) } just runs
         every { eventingService.send(capture(screenEventSlot)) } just runs
         every {
-            indexeerService.indexeerDirect(any<Stream<String>>(), ZoekObjectType.TAAK, true)
+            indexeerService.indexeerDirect(any<String>(), ZoekObjectType.TAAK, false)
+        } just runs
+        every {
+            indexeerService.commit()
         } just runs
 
         When(
@@ -240,11 +243,11 @@ class TaskServiceTest : BehaviorSpec({
                 verify(exactly = 2) {
                     flowableTaskService.releaseTask(any<Task>(), any())
                 }
-                verify(exactly = 1) {
+                verify(exactly = 2) {
                     indexeerService.indexeerDirect(
-                        any<Stream<String>>(),
+                        any<String>(),
                         ZoekObjectType.TAAK,
-                        true
+                        false
                     )
                 }
                 // we expect 4 screen events to be sent, 2 for each task
@@ -532,7 +535,10 @@ class TaskServiceTest : BehaviorSpec({
         every { eventingService.send(capture(screenEventSlot)) } just runs
         every { eventingService.send(capture(taakOpNaamSignaleringEventSlot)) } just runs
         every {
-            indexeerService.indexeerDirect(any<Stream<String>>(), ZoekObjectType.TAAK, true)
+            indexeerService.indexeerDirect(any<String>(), ZoekObjectType.TAAK, false)
+        } just runs
+        every {
+            indexeerService.commit()
         } just runs
 
         When("the 'release tasks' function is called with REST taak vrijgeven gegevens") {
@@ -585,7 +591,10 @@ class TaskServiceTest : BehaviorSpec({
         every { eventingService.send(capture(taakOpNaamSignaleringEventSlot)) } just runs
         every { flowableTaskService.releaseTask(task1, restTaakVerdelenGegevens.reden) } returns releasedTask1
         every {
-            indexeerService.indexeerDirect(any<Stream<String>>(), ZoekObjectType.TAAK, true)
+            indexeerService.indexeerDirect(any<String>(), ZoekObjectType.TAAK, false)
+        } just runs
+        every {
+            indexeerService.commit()
         } just runs
 
         When(
@@ -607,7 +616,7 @@ class TaskServiceTest : BehaviorSpec({
             ) {
                 exception.message shouldBe "dummyError"
                 verify(exactly = 1) {
-                    indexeerService.indexeerDirect(any<Stream<String>>(), ZoekObjectType.TAAK, true)
+                    indexeerService.indexeerDirect(any<String>(), ZoekObjectType.TAAK, false)
                     flowableTaskService.releaseTask(any(), any())
                 }
                 // we expect two screen events, one for the one succesfully released task


### PR DESCRIPTION
By sending tasks to Solr individually during the releasement process, we can make it a bit more robust and give a more useful progress indication.
Solves PZ-2568