### PR TITLE
chore: updated docs on how we use the openapi-generator Gradle plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -470,9 +470,8 @@ tasks {
                 "useJakartaEe" to "true"
             )
         )
-        // Specify custom Mustache template dir as temporary workaround for the issue where OpenAPI Generator 7.2.0
+        // Specify custom Mustache template dir as temporary workaround for the issue where OpenAPI Generator
         // fails to generate import statements for @JsonbCreator annotations.
-        // Maybe this workaround can be removed when we migrate to OpenAPI Generator 7.3.0.
         templateDir.set("$rootDir/src/main/resources/openapi-generator-templates")
     }
 
@@ -504,7 +503,8 @@ tasks {
     register<GenerateTask>("generateBagClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/bag/openapi.yaml")
         modelPackage.set("net.atos.client.bag.model.generated")
-        // we use a different date library for this client
+        // we need to use the java8-localdatatime date library for this client
+        // or else certain date time fields for this client cannot be deserialized
         configOptions.set(
             mapOf(
                 "library" to "microprofile",

--- a/src/main/resources/openapi-generator-templates/model.mustache
+++ b/src/main/resources/openapi-generator-templates/model.mustache
@@ -1,7 +1,8 @@
-{{! Temporary workaround for the issue where OpenAPI Generator 7.2.0 }}
+{{! Temporary workaround for the issue where the OpenAPI Generator Gradle plugin }}
 {{! fails to generate JsonbCreator import statements for @JsonbCreator annotations. }}
-{{! This template is simply a copy of the Java Microprofile Mustache model template of the main branch of https://github.com/OpenAPITools/openapi-generator }}
-{{! Maybe this workaround can be removed when we migrate to OpenAPI Generator 7.3.0. }}
+{{! This template is based on a copy of the Java Microprofile Mustache model template of the main branch of https://github.com/OpenAPITools/openapi-generator }}
+{{! with the JsonbCreator import statements added (see 'Lifely/INFO workaround' below). }}
+{{! This workaround can be removed once we have migrated to a version of the OpenAPI Generator Gradle plugin that has solved this issue. }}
 {{>licenseInfo}}
 package {{package}};
 


### PR DESCRIPTION
Unfortunately our current workarounds are still required it seems and neither was I able to find a solution to enable our `generateKlantenClient` Gradle task.

Solves PZ-2574