### PR TITLE
chore: clean up WireMock SmartDocuments JSON

### DIFF
--- a/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/smartdocuments.json
+++ b/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/smartdocuments.json
@@ -18,14 +18,57 @@
     },
     "bodyPatterns": [
       {
-        "equalToJson": "{\n  \"SmartDocument\": {\n    \"Selection\": {\n      \"TemplateGroup\": \"Melding evenement organiseren behandelen\"\n    }\n  },\n  \"data\": {\n    \"gebruiker\": {\n      \"id\": \"testuser1\",\n      \"naam\": \"Test User1\"\n    },\n    \"startformulier\": {\n      \"data\": {\n        \"omschrijving\": \"Ik heb een vraag over mijn paspoort\",\n        \"naam\": \"Jan Jansen\",\n        \"telefoonnummer\": \"0612345678\"\n      },\n      \"productAanvraagtype\": \"productaanvraag\"\n    },\n    \"zaak\": {\n      \"communicatiekanaal\": \"E-formulier\",\n      \"groep\": \"Test group A\",\n      \"identificatie\": \"ZAAK-2023-0000000001\",\n      \"omschrijving\": \"${json-unit.any-string}\",\n      \"registratiedatum\": \"${json-unit.any-string}\",\n      \"startdatum\": \"25-10-2023\",\n      \"status\": \"Intake\",\n      \"toelichting\": \"\",\n      \"uiterlijkeEinddatumAfdoening\": \"${json-unit.any-string}\",\n      \"vertrouwelijkheidaanduiding\": \"openbaar\",\n      \"zaaktype\": \"Melding evenement organiseren behandelen\"\n    }\n  },\n  \"registratie\": {\n    \"auditToelichting\": \"Door SmartDocuments\",\n    \"bronorganisatie\": \"123443210\",\n    \"creatiedatum\": \"${json-unit.any-string}\",\n    \"informatieobjectStatus\": \"ter_vaststelling\",\n    \"informatieobjecttype\": \"http://openzaak.local:8000/catalogi/api/v1/informatieobjecttypen/b1933137-94d6-49bc-9e12-afe712512276\",\n    \"zaak\": \"${json-unit.any-string}\"\n  }\n}",
+        "equalToJson": {
+          "SmartDocument": {
+            "Selection": {
+              "TemplateGroup": "Melding evenement organiseren behandelen"
+            }
+          },
+          "data": {
+            "gebruiker": {
+              "id": "testuser1",
+              "naam": "Test User1"
+            },
+            "startformulier": {
+              "data": {
+                "omschrijving": "Ik heb een vraag over mijn paspoort",
+                "naam": "Jan Jansen",
+                "telefoonnummer": "0612345678"
+              },
+              "productAanvraagtype": "productaanvraag"
+            },
+            "zaak": {
+              "communicatiekanaal": "E-formulier",
+              "groep": "Test group A",
+              "identificatie": "ZAAK-2023-0000000001",
+              "omschrijving": "${json-unit.any-string}",
+              "registratiedatum": "${json-unit.any-string}",
+              "startdatum": "25-10-2023",
+              "status": "Intake",
+              "toelichting": "",
+              "uiterlijkeEinddatumAfdoening": "${json-unit.any-string}",
+              "vertrouwelijkheidaanduiding": "openbaar",
+              "zaaktype": "Melding evenement organiseren behandelen"
+            }
+          },
+          "registratie": {
+            "auditToelichting": "Door SmartDocuments",
+            "bronorganisatie": "123443210",
+            "creatiedatum": "${json-unit.any-string}",
+            "informatieobjectStatus": "ter_vaststelling",
+            "informatieobjecttype": "http://openzaak.local:8000/catalogi/api/v1/informatieobjecttypen/b1933137-94d6-49bc-9e12-afe712512276",
+            "zaak": "${json-unit.any-string}"
+          }
+        },
         "ignoreArrayOrder": true
       }
     ]
   },
   "response": {
     "status": 200,
-    "body": "{\"ticket\": \"dummySmartdocumentsTicketID\"}",
+    "body": {
+      "ticket": "dummySmartdocumentsTicketID"
+    },
     "headers": {
       "Content-Type": "application/json"
     }


### PR DESCRIPTION
Clean up WireMock SmartDocuments JSON a bit by using a literal JSON string to increase maintainibility.

Solves PZ-2575