### PR TITLE
chore: index tasks individually during the assign task process

### DIFF
--- a/src/main/kotlin/net/atos/zac/task/TaskService.kt
+++ b/src/main/kotlin/net/atos/zac/task/TaskService.kt
@@ -92,7 +92,7 @@ class TaskService @Inject constructor(
             assignTasks(restTaakVerdelenGegevens, loggedInUser, succesfullyAssignedTaskIds)
         } finally {
             // always update the search index and send the screen event, also if exceptions were thrown
-            indexeerService.indexeerDirect(succesfullyAssignedTaskIds.stream(), ZoekObjectType.TAAK, true)
+            indexeerService.commit()
             LOG.fine { "Successfully assigned ${succesfullyAssignedTaskIds.size} tasks." }
 
             // if a screen event resource ID was specified, send a screen event
@@ -172,6 +172,7 @@ class TaskService @Inject constructor(
                     assignTaskAndOptionallyReleaseFromAssignee(task, restTaakVerdelenGegevens, loggedInUser)
                     sendScreenEventsOnTaskChange(task, restTaakVerdelenTaak.zaakUuid)
                 }
+                indexeerService.indexeerDirect(restTaakVerdelenTaak.taakId, ZoekObjectType.TAAK, false)
                 succesfullyAssignedTaskIds.add(restTaakVerdelenTaak.taakId)
             } catch (taskNotFoundException: TaskNotFoundException) {
                 // continue assigning remaining tasks if particular open task could not be found

--- a/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/task/TaskServiceTest.kt
@@ -30,7 +30,6 @@ import net.atos.zac.zoeken.IndexeerService
 import net.atos.zac.zoeken.model.index.ZoekObjectType
 import org.flowable.identitylink.api.IdentityLinkInfo
 import org.flowable.task.api.Task
-import java.util.stream.Stream
 
 class TaskServiceTest : BehaviorSpec({
     val flowableTaskService = mockk<FlowableTaskService>()
@@ -155,7 +154,10 @@ class TaskServiceTest : BehaviorSpec({
         every { eventingService.send(capture(taakOpNaamSignaleringEventSlot)) } just runs
         every { eventingService.send(capture(screenEventSlot)) } just runs
         every {
-            indexeerService.indexeerDirect(any<Stream<String>>(), ZoekObjectType.TAAK, true)
+            indexeerService.indexeerDirect(any<String>(), ZoekObjectType.TAAK, false)
+        } just runs
+        every {
+            indexeerService.commit()
         } just runs
 
         When("the 'assign tasks' function is called with REST taak verdelen gegevens") {
@@ -171,11 +173,11 @@ class TaskServiceTest : BehaviorSpec({
                     flowableTaskService.assignTaskToGroup(any(), any(), any())
                     flowableTaskService.assignTaskToUser(any(), any(), any())
                 }
-                verify(exactly = 1) {
+                verify(exactly = 2) {
                     indexeerService.indexeerDirect(
-                        any<Stream<String>>(),
+                        any<String>(),
                         ZoekObjectType.TAAK,
-                        true
+                        false
                     )
                 }
                 // we expect 4 screen events to be sent, 2 for each task
@@ -291,7 +293,10 @@ class TaskServiceTest : BehaviorSpec({
         } returns task1 andThen task2
         every { eventingService.send(capture(screenEventSlot)) } just runs
         every {
-            indexeerService.indexeerDirect(any<Stream<String>>(), ZoekObjectType.TAAK, true)
+            indexeerService.indexeerDirect(any<String>(), ZoekObjectType.TAAK, false)
+        } just runs
+        every {
+            indexeerService.commit()
         } just runs
 
         When(
@@ -349,7 +354,10 @@ class TaskServiceTest : BehaviorSpec({
         } returns task2
         every { eventingService.send(capture(screenEventSlot)) } just runs
         every {
-            indexeerService.indexeerDirect(any<Stream<String>>(), ZoekObjectType.TAAK, true)
+            indexeerService.indexeerDirect(any<String>(), ZoekObjectType.TAAK, false)
+        } just runs
+        every {
+            indexeerService.commit()
         } just runs
 
         When("the 'assign tasks' function is called with REST taak verdelen gegevens") {
@@ -407,7 +415,10 @@ class TaskServiceTest : BehaviorSpec({
         every { flowableTaskService.releaseTask(task1, restTaakVerdelenGegevens.reden) } returns releasedTask1
         every { flowableTaskService.releaseTask(task2, restTaakVerdelenGegevens.reden) } returns releasedTask2
         every {
-            indexeerService.indexeerDirect(any<Stream<String>>(), ZoekObjectType.TAAK, true)
+            indexeerService.indexeerDirect(any<String>(), ZoekObjectType.TAAK, false)
+        } just runs
+        every {
+            indexeerService.commit()
         } just runs
 
         When(
@@ -467,7 +478,10 @@ class TaskServiceTest : BehaviorSpec({
         every { eventingService.send(capture(taakOpNaamSignaleringEventSlot)) } just runs
         every { flowableTaskService.releaseTask(task1, restTaakVerdelenGegevens.reden) } returns releasedTask1
         every {
-            indexeerService.indexeerDirect(any<Stream<String>>(), ZoekObjectType.TAAK, true)
+            indexeerService.indexeerDirect(any<String>(), ZoekObjectType.TAAK, false)
+        } just runs
+        every {
+            indexeerService.commit()
         } just runs
 
         When(
@@ -489,7 +503,7 @@ class TaskServiceTest : BehaviorSpec({
             ) {
                 exception.message shouldBe "dummyError"
                 verify(exactly = 1) {
-                    indexeerService.indexeerDirect(any<Stream<String>>(), ZoekObjectType.TAAK, true)
+                    indexeerService.indexeerDirect(any<String>(), ZoekObjectType.TAAK, false)
                     flowableTaskService.assignTaskToGroup(any(), any(), any())
                 }
                 // we expect two screen events, one for the one succesfully assigned task


### PR DESCRIPTION
By sending tasks to Solr individually during the assign process, we can make it a bit more robust and give a more useful progress indication.
Solves PZ-2585