### PR TITLE
feat: configure smtp via environment variables

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: zaakafhandelcomponent
 description: A Helm chart for installing Zaakafhandelcomponent
-version: 0.3.0
+version: 0.3.1
 appVersion: "latest"
 dependencies:
   - name: opentelemetry-collector

--- a/helm/templates/config.yaml
+++ b/helm/templates/config.yaml
@@ -35,6 +35,8 @@ data:
   OFFICE_CONVERTER_CLIENT_MP_REST_URL: {{ printf "http://%s-office-converter.%s" .Release.Name .Release.Namespace }}
   OPA_API_CLIENT_MP_REST_URL: {{ required "Valid .Values.opa.url entry required!" .Values.opa.url }}
   OPEN_FORMS_URL: {{ required "Valid .Values.openForms.url entry required!" .Values.openForms.url }}
+  SMTP_PORT: {{ required "Valid .Values.mail.smtp.port entry required!" .Values.mail.smtp.port }}
+  SMTP_SERVER: {{ required "Valid .Values.mail.smtp.server entry required!" .Values.mail.smtp.server }}
   {{- if index .Values "opentelemetry-collector" "enabled" }}
   SUBSYSTEM_OPENTELEMETRY__SAMPLER_TYPE: {{ ((.Values.opentelemetry_zaakafhandelcomponent).sampler_type) | default "-off" }}
   SUBSYSTEM_OPENTELEMETRY__ENDPOINT: {{ ((.Values.opentelemetry_zaakafhandelcomponent).endpoint) | default (printf "http://%s-opentelemetry-collector:4317" .Release.Name) }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -5,20 +5,21 @@ metadata:
   labels:
     {{- include "zaakafhandelcomponent.labels" . | nindent 4 }}
 stringData:
-  DB_PASSWORD: {{ required "Valid .Values.db.password entry required!" .Values.db.password | toString }}
   AUTH_SECRET: {{ required "Valid .Values.auth.secret entry required!" .Values.auth.secret | toString }}
-  LDAP_PASSWORD: {{ required "Valid .Values.ldap.password entry required!" .Values.ldap.password | toString }}
-  MAILJET_API_KEY: {{ required "Valid .Values.mail.mailjet.apiKey entry required!" .Values.mail.mailjet.apiKey | toString }}
-  MAILJET_API_SECRET_KEY: {{ required "Valid .Values.mail.mailjet.secretKey required!" .Values.mail.mailjet.secretKey | toString }}
-  ZGW_API_SECRET: {{ required "Valid .Values.zgwApis.secret entry required!" .Values.zgwApis.secret | toString }}
+  BAG_API_KEY: {{ required "Valid .Values.bagApi.apiKey entry required!" .Values.bagApi.apiKey | toString }}
+  BRP_API_KEY: {{ required "Valid .Values.brpApi.apiKey entry required!" .Values.brpApi.apiKey | toString }}
+  CONTACTMOMENTEN_API_SECRET: {{ required "Valid .Values.contactmomentenApi.secret entry required!" .Values.contactmomentenApi.secret | toString }}
+  DB_PASSWORD: {{ required "Valid .Values.db.password entry required!" .Values.db.password | toString }}
   KLANTEN_API_SECRET: {{ required "Valid .Values.klantenApi.secret entry required!" .Values.klantenApi.secret | toString }}
   KVK_API_KEY: {{ required "Valid .Values.kvkApi.apiKey entry required!" .Values.kvkApi.apiKey | toString }}
-  CONTACTMOMENTEN_API_SECRET: {{ required "Valid .Values.contactmomentenApi.secret entry required!" .Values.contactmomentenApi.secret | toString }}
-  OPEN_NOTIFICATIONS_API_SECRET_KEY: {{ required "Valid .Values.notificationsSecretKey entry required!" .Values.notificationsSecretKey | toString }}
+  LDAP_PASSWORD: {{ required "Valid .Values.ldap.password entry required!" .Values.ldap.password | toString }}
+  MAILJET_API_KEY: {{ .Values.mail.mailjet.apiKey | default "" | toString }}
+  MAILJET_API_SECRET_KEY: {{ .Values.mail.mailjet.secretKey | default "" | toString }}
   OBJECTS_API_TOKEN: {{ required "Valid .Values.objectenApi.token entry required!" .Values.objectenApi.token | toString }}
   OBJECTTYPES_API_TOKEN: {{ required "Valid .Values.objecttypenApi.token entry required!" .Values.objecttypenApi.token | toString }}
-  BRP_API_KEY: {{ required "Valid .Values.brpApi.apiKey entry required!" .Values.brpApi.apiKey | toString }}
-  BAG_API_KEY: {{ required "Valid .Values.bagApi.apiKey entry required!" .Values.bagApi.apiKey | toString }}
+  OPEN_NOTIFICATIONS_API_SECRET_KEY: {{ required "Valid .Values.notificationsSecretKey entry required!" .Values.notificationsSecretKey | toString }}
   SD_AUTHENTICATION: {{ required "Valid .Values.smartDocuments.authentication entry required!" .Values.smartDocuments.authentication | toString }}
-
+  SMTP_PASSWORD: {{ .Values.mail.smtp.password | default "" | toString }}
+  SMTP_USERNAME: {{ .Values.mail.smtp.username | default "" | toString }}
+  ZGW_API_SECRET: {{ required "Valid .Values.zgwApis.secret entry required!" .Values.zgwApis.secret | toString }}
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -40,6 +40,12 @@ mail:
   mailjet:
     apiKey: ""
     secretKey: ""
+  # SMTP server and port will be required after phasing out mailjet
+  smtp:
+    server: "" # when using mailjet use in-v3.mailjet.com
+    port: "25" # when using mailjet use port 587
+    username: "" # when using mailjet same as mailjet.apiKey
+    password: "" # when using mailjet same as mailjet.secretKey
 
 # Configuration of ZGW API's provider (Open Zaak)
 zgwApis:


### PR DESCRIPTION
zac should be set up to be able to handle the following environment variables for sendmail instead of mailjet (has not been removed yet):

SMTP_SERVER (required)
SMTP_PORT (required)
SMTP_USERNAME (can be empty)
SMTP_PASSWORD (can be empty)

see values.yml for more descriptions for these fields
zac should preferably not fail or get stuck when sending emails
not using relay servers from k8s always has the risk of 'losing' emails in case of connection issues