### PR TITLE
chore: fix front end tests after dependabot merge

### DIFF
--- a/src/main/app/package-lock.json
+++ b/src/main/app/package-lock.json
@@ -61,7 +61,8 @@
         "openapi-typescript": "^6.7.6",
         "protractor": "~7.0.0",
         "ts-node": "~10.9.2",
-        "typescript": "^5.4.5"
+        "typescript": "^5.4.5",
+        "whatwg-fetch": "^3.6.20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -20647,6 +20648,12 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -36071,6 +36078,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "dev": true
     },
     "which": {

--- a/src/main/app/package.json
+++ b/src/main/app/package.json
@@ -69,6 +69,7 @@
     "openapi-typescript": "^6.7.6",
     "protractor": "~7.0.0",
     "ts-node": "~10.9.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "whatwg-fetch": "^3.6.20"
   }
 }

--- a/src/main/app/src/app/shared/http/zac.http-.client.spec.ts
+++ b/src/main/app/src/app/shared/http/zac.http-.client.spec.ts
@@ -9,7 +9,7 @@ import { TestBed } from "@angular/core/testing";
 
 import { Paths, ZacHttpClient } from "./zac-http-client";
 
-describe("HttpClient testing", () => {
+describe("HttpClientTesting", () => {
   let zacHttpClient: ZacHttpClient;
   let httpTestingController: HttpTestingController;
 

--- a/src/main/app/src/setupJest.ts
+++ b/src/main/app/src/setupJest.ts
@@ -1,2 +1,3 @@
 // setupJest.ts
 import "jest-preset-angular/setup-jest";
+import "whatwg-fetch";


### PR DESCRIPTION
A dependabot merge concerning `openapi-fetch` caused our front end tests to fail, because `jsdom` does not offer an implementation of `fetch` and it's `Request` class. To fix this, we import a fetch polyfill while running the tests.
Solves PZ-2591