### PR TITLE
fix: turned off Gradle build cache for jacocoIntegrationTestReport to…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -659,6 +659,7 @@ tasks {
         dependsOn("itest")
 
         description = "Generates code coverage report for the integration tests"
+        inputs.files("$rootDir/build/jacoco/itest/jacoco-report/jacoco-it.exec")
         executionData.setFrom("$rootDir/build/jacoco/itest/jacoco-report/jacoco-it.exec")
         // tell JaCoCo to report on our code base
         sourceSets(sourceSets["main"])
@@ -666,6 +667,9 @@ tasks {
             xml.required = true
             html.required = false
         }
+        outputs.dir("$rootDir/build/reports/jacoco/jacocoIntegrationTestReport")
+        // do not use the Gradle build cache for this task
+        outputs.cacheIf { false }
     }
 
     register<Maven>("generateWildflyBootableJar") {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+#
+# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-License-Identifier: EUPL-1.2+
+#
+codecov:
+  notify:
+    # only notify Codecov after two builds because we want to make sure
+    # that the reported coverage from our GitHub workflow includes both
+    # our unit test and integration test coverage
+    after_n_builds: 2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,7 @@
+#
+# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-License-Identifier: EUPL-1.2+
+#
 services:
   keycloak:
     image: quay.io/keycloak/keycloak:23.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: EUPL-1.2+
 #
 
-org.gradle.jvmargs=-Xmx2048m
+# increase Gradle heap size for better build performance
+# see: https://kotlinlang.org/docs/native-improving-compilation-time.html#gradle-configuration
+org.gradle.jvmargs=-Xmx3g
+# enable Gradle build cache
 org.gradle.caching=true
 
 


### PR DESCRIPTION
Turned off Gradle build cache for jacocoIntegrationTestReport to hopefully fix issue with incorrect integration test code coverage reporting on GitHub. Also increased Gradle heap size to 3GB as recommended on https://kotlinlang.org/docs/native-improving-compilation-time.html#gradle-configuration to hopefully increase build speed a bit.

Solves PZ-2636