### PR TITLE
fix: turn off gradle build cache for jacoco integration test report task

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -245,7 +245,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            build/
+            build
           key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Generate JaCoCo integration test code coverage report

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -251,6 +251,11 @@ jobs:
       - name: Generate JaCoCo integration test code coverage report
         run: ./gradlew jacocoIntegrationTestReport -x itest --info
 
+      - name: TEMPORARY STEP FOR DEBUGGING
+        run: |
+          echo "Code coverage integration test Jacoco report contents:"
+          echo "$(cat build/reports/jacoco/jacocoIntegrationTestReport/jacocoIntegrationTestReport.xml)"
+
       - name: Upload integration test coverage report to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -251,11 +251,6 @@ jobs:
       - name: Generate JaCoCo integration test code coverage report
         run: ./gradlew jacocoIntegrationTestReport -x itest --info
 
-      - name: TEMPORARY STEP FOR DEBUGGING
-        run: |
-          echo "Code coverage integration test Jacoco report contents:"
-          echo "$(cat build/reports/jacoco/jacocoIntegrationTestReport/jacocoIntegrationTestReport.xml)"
-
       - name: Upload integration test coverage report to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -659,6 +659,7 @@ tasks {
         dependsOn("itest")
 
         description = "Generates code coverage report for the integration tests"
+        inputs.files("$rootDir/build/jacoco/itest/jacoco-report/jacoco-it.exec")
         executionData.setFrom("$rootDir/build/jacoco/itest/jacoco-report/jacoco-it.exec")
         // tell JaCoCo to report on our code base
         sourceSets(sourceSets["main"])
@@ -666,6 +667,9 @@ tasks {
             xml.required = true
             html.required = false
         }
+        outputs.dir("$rootDir/build/reports/jacoco/jacocoIntegrationTestReport")
+        // do not use the Gradle build cache for this task
+        outputs.cacheIf { false }
     }
 
     register<Maven>("generateWildflyBootableJar") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -648,11 +648,11 @@ tasks {
 
     register<Test>("itest") {
         inputs.files(project.tasks.findByPath("compileItestKotlin")!!.outputs.files)
-
         testClassesDirs = sourceSets["itest"].output.classesDirs
         classpath = sourceSets["itest"].runtimeClasspath
-
         systemProperty("zacDockerImage", zacDockerImage)
+        // do not use the Gradle build cache for this task
+        outputs.cacheIf { false }
     }
 
     register<JacocoReport>("jacocoIntegrationTestReport") {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+#
+# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-License-Identifier: EUPL-1.2+
+#
+codecov:
+  notify:
+    # only notify Codecov after two builds because we want to make sure
+    # that the reported coverage from our GitHub workflow includes both
+    # our unit test and integration test coverage
+    after_n_builds: 2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,7 @@
+#
+# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-License-Identifier: EUPL-1.2+
+#
 services:
   keycloak:
     image: quay.io/keycloak/keycloak:23.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: EUPL-1.2+
 #
 
-org.gradle.jvmargs=-Xmx2048m
+# increase Gradle heap size for better build performance
+# see: https://kotlinlang.org/docs/native-improving-compilation-time.html#gradle-configuration
+org.gradle.jvmargs=-Xmx3g
+# enable Gradle build cache
 org.gradle.caching=true
 
 


### PR DESCRIPTION
Turn off gradle build cache for jacoco integration test report task. Also added Codecov configuration to tell Codecov to wait until our two code cove results have been uploaded. 

Solves PZ-2636