### PR TITLE
chore: make file required for new version of document

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
@@ -96,6 +96,7 @@ export class InformatieObjectEditComponent implements OnInit, OnDestroy {
       .additionalAllowedFileTypes(
         this.configuratieService.readAdditionalAllowedFileTypes(),
       )
+      .validators(Validators.required)
       .build();
 
     const titel = new InputFormFieldBuilder(this.infoObject.titel)


### PR DESCRIPTION
The file for a new version of a document needs to be required in the front end, because the server expects it
Solves PZ-2314