### PR TITLE
chore: allow not uploading a file when adding a new document version

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
@@ -94,7 +94,6 @@ export class InformatieObjectEditComponent implements OnInit, OnDestroy {
       .additionalAllowedFileTypes(
         this.configuratieService.readAdditionalAllowedFileTypes(),
       )
-      .validators(Validators.required)
       .build();
 
     const titel = new InputFormFieldBuilder(this.infoObject.titel)
@@ -276,7 +275,7 @@ export class InformatieObjectEditComponent implements OnInit, OnDestroy {
           nieuweVersie[key] = InformatieobjectStatus[value.value.toUpperCase()];
         } else if (key === "vertrouwelijkheidaanduiding") {
           nieuweVersie[key] = value.value;
-        } else if (key === "bestand") {
+        } else if (key === "bestand" && value) {
           nieuweVersie["bestandsnaam"] = value.name;
           nieuweVersie["file"] = value;
           nieuweVersie["formaat"] = value.type;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
@@ -325,11 +325,19 @@ public class RESTInformatieobjectConverter {
     ) {
         final EnkelvoudigInformatieObjectWithLockData enkelvoudigInformatieObjectWithLockData = createEnkelvoudigInformatieObjectWithLockData(
                 restEnkelvoudigInformatieObjectVersieGegevens);
-        enkelvoudigInformatieObjectWithLockData.setInhoud(convertByteArrayToBase64String(
-                restEnkelvoudigInformatieObjectVersieGegevens.file));
-        enkelvoudigInformatieObjectWithLockData.setBestandsnaam(restEnkelvoudigInformatieObjectVersieGegevens.bestandsnaam);
-        enkelvoudigInformatieObjectWithLockData.setBestandsomvang(restEnkelvoudigInformatieObjectVersieGegevens.file.length);
-        enkelvoudigInformatieObjectWithLockData.setFormaat(restEnkelvoudigInformatieObjectVersieGegevens.formaat);
+        if (
+            restEnkelvoudigInformatieObjectVersieGegevens.file != null &&
+            restEnkelvoudigInformatieObjectVersieGegevens.file.length > 0 &&
+            restEnkelvoudigInformatieObjectVersieGegevens.bestandsnaam != null &&
+            restEnkelvoudigInformatieObjectVersieGegevens.formaat != null
+        ) {
+            enkelvoudigInformatieObjectWithLockData.setInhoud(convertByteArrayToBase64String(
+                    restEnkelvoudigInformatieObjectVersieGegevens.file));
+            enkelvoudigInformatieObjectWithLockData.setBestandsnaam(restEnkelvoudigInformatieObjectVersieGegevens.bestandsnaam);
+            enkelvoudigInformatieObjectWithLockData.setBestandsomvang(restEnkelvoudigInformatieObjectVersieGegevens.file.length);
+            enkelvoudigInformatieObjectWithLockData.setFormaat(restEnkelvoudigInformatieObjectVersieGegevens.formaat);
+        }
+
         enkelvoudigInformatieObjectWithLockData.setInformatieobjecttype(ztcClientService.readInformatieobjecttype(
                 restEnkelvoudigInformatieObjectVersieGegevens.informatieobjectTypeUUID)
                 .getUrl());

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/RESTEnkelvoudigInformatieFileUpload.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/RESTEnkelvoudigInformatieFileUpload.java
@@ -1,6 +1,5 @@
 package net.atos.zac.app.informatieobjecten.model;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.FormParam;
 
 import net.atos.zac.app.informatieobjecten.model.validation.ValidRestEnkelvoudigInformatieFileUploadForm;
@@ -11,7 +10,7 @@ public abstract class RESTEnkelvoudigInformatieFileUpload {
     @FormParam("file")
     public byte[] file;
 
-    @NotNull @FormParam("bestandsnaam")
+    @FormParam("bestandsnaam")
     public String bestandsnaam;
 
 }


### PR DESCRIPTION
It should be possible to create a new document version without uploading a new file.
Solves PZ-2644