### PR TITLE
fix: don't re-index closed tasks when a case updates

### DIFF
--- a/src/main/java/net/atos/zac/zoeken/IndexeerService.java
+++ b/src/main/java/net/atos/zac/zoeken/IndexeerService.java
@@ -144,7 +144,7 @@ public class IndexeerService {
     public void addOrUpdateZaak(final UUID zaakUUID, boolean inclusiefTaken) {
         indexeerDirect(zaakUUID.toString(), ZAAK, false);
         if (inclusiefTaken) {
-            flowableTaskService.listTasksForZaak(zaakUUID).stream()
+            flowableTaskService.listOpenTasksForZaak(zaakUUID).stream()
                     .map(TaskInfo::getId)
                     .forEach(this::addOrUpdateTaak);
         }


### PR DESCRIPTION
In a few scenarios, closed tasks were being re-indexed so they showed up in the werkvoorraad, causing issues with assignment / releasement
Solves PZ-2425