### PR TITLE
fix: correctly map latitude/longitude to y/x between OpenZaak and the ol map library

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
@@ -22,8 +22,8 @@ import nl.lifely.zac.itest.config.ItestConfiguration.OPEN_FORMULIEREN_FORMULIER_
 import nl.lifely.zac.itest.config.ItestConfiguration.OPEN_FORMULIEREN_FORMULIER_BRON_NAAM
 import nl.lifely.zac.itest.config.ItestConfiguration.OPEN_NOTIFICATIONS_API_SECRET_KEY
 import nl.lifely.zac.itest.config.ItestConfiguration.OPEN_ZAAK_BASE_URI
-import nl.lifely.zac.itest.config.ItestConfiguration.PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_X
-import nl.lifely.zac.itest.config.ItestConfiguration.PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_Y
+import nl.lifely.zac.itest.config.ItestConfiguration.PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_LATITUDE
+import nl.lifely.zac.itest.config.ItestConfiguration.PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_LONGITUDE
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_INITIAL
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAAK_1_IDENTIFICATION
@@ -122,8 +122,8 @@ class NotificationsTest : BehaviorSpec({
                             "met kenmerk '$OPEN_FORMULIEREN_FORMULIER_BRON_KENMERK'"
                         getString("uiterlijkeEinddatumAfdoening") shouldBe ZAAK_1_UITERLIJKE_EINDDATUM_AFDOENING
                         with(getJSONObject("zaakgeometrie").getJSONObject("point")) {
-                            getBigDecimal("x") shouldBe PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_X.toBigDecimal()
-                            getBigDecimal("y") shouldBe PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_Y.toBigDecimal()
+                            getBigDecimal("latitude") shouldBe PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_LATITUDE.toBigDecimal()
+                            getBigDecimal("longitude") shouldBe PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_LONGITUDE.toBigDecimal()
                         }
                         zaak1UUID = getString("uuid").let(UUID::fromString)
                     }

--- a/src/itest/kotlin/nl/lifely/zac/itest/ZakenRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZakenRESTServiceTest.kt
@@ -187,16 +187,16 @@ class ZakenRESTServiceTest : BehaviorSpec({
             }
         }
         When("the 'update Zaak Locatie' endpoint is called with a valid location") {
-            val geometryX = Random.nextFloat()
-            val geometryY = Random.nextFloat()
+            val longitude = Random.nextFloat()
+            val latitude = Random.nextFloat()
             val response = itestHttpClient.performPatchRequest(
                 url = "$ZAC_API_URI/zaken/$zaak2UUID/zaaklocatie",
                 requestBodyAsString = """
                         {
                             "geometrie": {
                                 "point": {
-                                    "x": $geometryX,
-                                    "y": $geometryY
+                                    "longitude": $longitude,
+                                    "latitude": $latitude
                                 },
                                 "type": "Point"
                             },
@@ -215,8 +215,8 @@ class ZakenRESTServiceTest : BehaviorSpec({
                         shouldContainJsonKeyValue("type", "Point")
                         shouldContainJsonKey("point")
                         with(JSONObject(geometrie)["point"].toString()) {
-                            shouldContainJsonKeyValue("x", geometryX)
-                            shouldContainJsonKeyValue("y", geometryY)
+                            shouldContainJsonKeyValue("longitude", longitude)
+                            shouldContainJsonKeyValue("latitude", latitude)
                         }
                     }
                 }

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
@@ -44,8 +44,8 @@ object ItestConfiguration {
     const val OPEN_ZAAK_CLIENT_SECRET = "openzaakZaakafhandelcomponentClientSecret"
     const val PDF_MIME_TYPE = "application/pdf"
     const val PRODUCT_AANVRAAG_TYPE = "productaanvraag"
-    const val PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_X = 52.08968250760225
-    const val PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_Y = 5.114358701512936
+    const val PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_LATITUDE = 52.08968250760225
+    const val PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_LONGITUDE = 5.114358701512936
     const val ROLTYPE_NAME_BETROKKENE = "Belanghebbende"
     const val ROLTYPE_UUID_BELANGHEBBENDE = "4c4cd850-8332-4bb9-adc4-dd046f0614ad"
     const val ROLTYPE_COUNT = 16

--- a/src/main/app/src/app/bag/bag-locatie/bag-locatie.component.ts
+++ b/src/main/app/src/app/bag/bag-locatie/bag-locatie.component.ts
@@ -25,6 +25,7 @@ import * as source from "ol/source.js";
 import * as style from "ol/style.js";
 import WMTSTileGrid from "ol/tilegrid/WMTS.js";
 import proj4 from "proj4";
+import { LocationUtil } from "src/app/shared/location/location-util";
 import { environment } from "src/environments/environment";
 import { Geometry } from "../../zaken/model/geometry";
 import { GeometryType } from "../../zaken/model/geometryType";
@@ -136,13 +137,13 @@ export class BagLocatieComponent implements OnInit, AfterViewInit, OnChanges {
 
   private draw(geometry: Geometry): void {
     if (geometry.type === GeometryType.POINT) {
-      const coordinate: Array<number> = [geometry.point.x, geometry.point.y];
+      const coordinate = LocationUtil.pointToCoordinate(geometry.point);
       this.addPoint(coordinate);
     }
     if (geometry.type === GeometryType.POLYGON) {
       const coordinates: Coordinate[][] = [[]];
       geometry.polygon.forEach((cs) => {
-        coordinates.push(cs.map((c) => [c.x, c.y]));
+        coordinates.push(cs.map(LocationUtil.pointToCoordinate));
       });
       this.addVlak(coordinates);
     }

--- a/src/main/app/src/app/shared/location/location-util.ts
+++ b/src/main/app/src/app/shared/location/location-util.ts
@@ -1,3 +1,4 @@
+import { Coordinate } from "ol/coordinate";
 import { Geometry } from "../../zaken/model/geometry";
 import { GeometryCoordinate } from "../../zaken/model/geometryCoordinate";
 import { GeometryType } from "../../zaken/model/geometryType";
@@ -9,24 +10,31 @@ export class LocationUtil {
    * @private
    */
   public static wktToPoint(wkt: string): Geometry {
-    const geometrie = new Geometry(GeometryType.POINT);
-    const coordinates: string[] = wkt
+    const coordinate = wkt
       .replace("POINT(", "")
       .replace(")", "")
-      .split(" ");
-    geometrie.point = new GeometryCoordinate(+coordinates[0], +coordinates[1]);
+      .split(" ")
+      .map(Number);
+    return this.coordinateToPoint(coordinate);
+  }
+
+  public static coordinateToPoint([x, y]: Coordinate): Geometry {
+    const geometrie = new Geometry(GeometryType.POINT);
+    geometrie.point = new GeometryCoordinate(y, x);
     return geometrie;
   }
 
-  public static coordinateToPoint(coordinate: number[]): Geometry {
-    const geometrie = new Geometry(GeometryType.POINT);
-    geometrie.point = new GeometryCoordinate(coordinate[0], coordinate[1]);
-    return geometrie;
+  public static pointToCoordinate({
+    latitude,
+    longitude,
+  }: GeometryCoordinate): Coordinate {
+    // the map library uses [X,Y] in stead of [latitude, longitude]
+    return [longitude, latitude];
   }
 
   public static format(geometry: Geometry) {
     if (geometry && geometry.type == GeometryType.POINT) {
-      return geometry.point.y + ", " + geometry.point.x;
+      return geometry.point.latitude + ", " + geometry.point.longitude;
     }
     return null;
   }

--- a/src/main/app/src/app/zaken/model/geometryCoordinate.ts
+++ b/src/main/app/src/app/zaken/model/geometryCoordinate.ts
@@ -4,11 +4,8 @@
  */
 
 export class GeometryCoordinate {
-  constructor(x: number, y: number) {
-    this.x = x;
-    this.y = y;
-  }
-
-  x: number;
-  y: number;
+  constructor(
+    public latitude: number,
+    public longitude: number,
+  ) {}
 }

--- a/src/main/app/src/app/zaken/zoek/locatie-zoek/locatie-zoek.component.ts
+++ b/src/main/app/src/app/zaken/zoek/locatie-zoek/locatie-zoek.component.ts
@@ -227,7 +227,9 @@ export class LocatieZoekComponent implements OnInit, AfterViewInit, OnDestroy {
   private setLokatie(geometry: Geometry, fromSearch: boolean) {
     if (geometry && geometry.type == GeometryType.POINT) {
       this.markerLocatie = geometry;
-      const coordinate: Array<number> = [geometry.point.x, geometry.point.y];
+      const coordinate: Coordinate = LocationUtil.pointToCoordinate(
+        geometry.point,
+      );
       this.addMarker(coordinate);
       if (fromSearch) {
         this.zoomToMarker(coordinate);

--- a/src/main/java/net/atos/client/zgw/zrc/model/Point.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Point.java
@@ -31,7 +31,7 @@ public class Point extends Geometry {
 
     @Override
     public String toString() {
-        return String.format("POINT(%s %s)", getCoordinates().getX(), getCoordinates().getY());
+        return String.format("POINT(%s %s)", getCoordinates().getLatitude(), getCoordinates().getLongitude());
     }
 
     @Override

--- a/src/main/java/net/atos/client/zgw/zrc/model/Point2D.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Point2D.java
@@ -21,26 +21,26 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 @JsonbTypeAdapter(Point2D.Adapter.class)
 public class Point2D {
 
-    private final BigDecimal x;
+    private final BigDecimal longitude;
 
-    private final BigDecimal y;
+    private final BigDecimal latitude;
 
-    public Point2D(final BigDecimal x, final BigDecimal y) {
-        this.x = x;
-        this.y = y;
+    public Point2D(final BigDecimal latitude, final BigDecimal longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 
-    public Point2D(final double x, final double y) {
-        this.x = BigDecimal.valueOf(x);
-        this.y = BigDecimal.valueOf(y);
+    public Point2D(final double latitude, final double longitude) {
+        this.latitude = BigDecimal.valueOf(latitude);
+        this.longitude = BigDecimal.valueOf(longitude);
     }
 
-    public BigDecimal getX() {
-        return x;
+    public BigDecimal getLongitude() {
+        return longitude;
     }
 
-    public BigDecimal getY() {
-        return y;
+    public BigDecimal getLatitude() {
+        return latitude;
     }
 
     public static class Adapter implements JsonbAdapter<Point2D, List<BigDecimal>> {
@@ -48,8 +48,8 @@ public class Point2D {
         @Override
         public List<BigDecimal> adaptToJson(final Point2D point2D) {
             final List<BigDecimal> coordinates = new ArrayList<>();
-            coordinates.add(point2D.x);
-            coordinates.add(point2D.y);
+            coordinates.add(point2D.latitude);
+            coordinates.add(point2D.longitude);
             return coordinates;
         }
 
@@ -71,11 +71,11 @@ public class Point2D {
 
         final Point2D point2D = (Point2D) o;
 
-        return new EqualsBuilder().append(x, point2D.getX()).append(y, point2D.getY()).isEquals();
+        return new EqualsBuilder().append(longitude, point2D.getLongitude()).append(latitude, point2D.getLatitude()).isEquals();
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(x, y);
+        return Objects.hash(longitude, latitude);
     }
 }

--- a/src/main/java/net/atos/zac/app/bag/converter/RESTBAGConverter.java
+++ b/src/main/java/net/atos/zac/app/bag/converter/RESTBAGConverter.java
@@ -5,6 +5,9 @@
 
 package net.atos.zac.app.bag.converter;
 
+import java.math.BigDecimal;
+import java.util.List;
+
 import jakarta.inject.Inject;
 
 import org.apache.commons.lang3.NotImplementedException;
@@ -98,7 +101,7 @@ public class RESTBAGConverter {
                 surface.getCoordinates()
                         .stream()
                         .map(coords -> coords.stream()
-                                .map(punt -> new RESTCoordinates(punt.getFirst().doubleValue(), punt.get(1).doubleValue()))
+                                .map(RESTBAGConverter::convertCoordinates)
                                 .toList())
                         .toList(),
                 null
@@ -108,7 +111,7 @@ public class RESTBAGConverter {
     public static RESTGeometry convertPunt(PointGeoJSON punt) {
         return new RESTGeometry(
                 punt.getType().value(),
-                new RESTCoordinates(punt.getCoordinates().get(0).doubleValue(), punt.getCoordinates().get(1).doubleValue()),
+                convertCoordinates(punt.getCoordinates()),
                 null,
                 null);
     }
@@ -120,5 +123,9 @@ public class RESTBAGConverter {
             return convertVlak(puntOfVlak.getVlak());
         }
         return null;
+    }
+
+    public static RESTCoordinates convertCoordinates(List<BigDecimal> coordinates) {
+        return new RESTCoordinates(coordinates.get(1).doubleValue(), coordinates.get(0).doubleValue());
     }
 }

--- a/src/main/kotlin/net/atos/zac/app/zaken/converter/RESTGeometryConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/converter/RESTGeometryConverter.kt
@@ -36,17 +36,24 @@ class RESTGeometryConverter {
         }
 
     private fun createRESTPoint(point: Point) = RESTCoordinates(
-        point.coordinates.x.toDouble(),
-        point.coordinates.y.toDouble()
+        point.coordinates.latitude.toDouble(),
+        point.coordinates.longitude.toDouble(),
     )
 
-    private fun createPoint(restGeometry: RESTGeometry) = Point(Point2D(restGeometry.point!!.x, restGeometry.point!!.y))
+    private fun createPoint(restGeometry: RESTGeometry) = Point(
+        Point2D(restGeometry.point!!.latitude, restGeometry.point!!.longitude)
+    )
 
     private fun createRESTPolygon(polygon: Polygon) =
         polygon.coordinates.stream()
             .map { point2DS ->
                 point2DS.stream()
-                    .map { point2D: Point2D -> RESTCoordinates(point2D.x.toDouble(), point2D.y.toDouble()) }
+                    .map { point2D: Point2D ->
+                        RESTCoordinates(
+                            point2D.latitude.toDouble(),
+                            point2D.longitude.toDouble()
+                        )
+                    }
                     .toList()
             }
             .toList()
@@ -56,7 +63,7 @@ class RESTGeometryConverter {
             restGeometry.polygon!!.stream()
                 .map { polygon ->
                     polygon.stream()
-                        .map { coordinates: RESTCoordinates? -> Point2D(coordinates!!.x, coordinates.y) }
+                        .map { coordinates: RESTCoordinates? -> Point2D(coordinates!!.latitude, coordinates.longitude) }
                         .toList()
                 }
                 .toList()

--- a/src/main/kotlin/net/atos/zac/app/zaken/model/RESTCoordinates.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/model/RESTCoordinates.kt
@@ -10,7 +10,7 @@ import nl.lifely.zac.util.NoArgConstructor
 @NoArgConstructor
 @AllOpen
 data class RESTCoordinates(
-    var x: Double = 0.0,
+    var latitude: Double = 0.0,
 
-    var y: Double = 0.0
+    var longitude: Double = 0.0
 )

--- a/src/test/kotlin/net/atos/zac/aanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/aanvraag/ProductaanvraagServiceTest.kt
@@ -187,8 +187,8 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                     with(zaakgeometrie) {
                         type.toValue() shouldBe Geometry.Type.POINT.value()
                         with((this as Point).coordinates) {
-                            x.toDouble() shouldBe coordinates[0]
-                            y.toDouble() shouldBe coordinates[1]
+                            latitude.toDouble() shouldBe coordinates[0]
+                            longitude.toDouble() shouldBe coordinates[1]
                         }
                     }
                 }


### PR DESCRIPTION
Mixed usage of (X,Y) and (latitude, longitude) coordinates caused confusion and bugs. This is now fixed.
Resolves PZ-2763