### PR TITLE
fix: use HTTP DELETE method in delete old signaleringen cronjob

### DIFF
--- a/helm/templates/signaleren-delete-cron-job.yaml
+++ b/helm/templates/signaleren-delete-cron-job.yaml
@@ -18,4 +18,5 @@ spec:
               imagePullPolicy: IfNotPresent
               args:
                 - -s
+                - -X "DELETE"
                 - {{ printf "http://%s.%s/rest/admin/signaleringen/delete-old" (include "zaakafhandelcomponent.fullname" .) .Release.Namespace }}


### PR DESCRIPTION
Use HTTP DELETE method in delete old signaleringen cronjob.

Solves PZ-2786