### PR TITLE
chore: no longer use the Gradle Docker Plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ node-gradle = "7.0.2"
 taskinfo = "2.2.0"
 swagger-generator = "2.19.2"
 detekt = "1.23.6"
-docker-remote-api = "9.4.0"
 spotless = "6.25.0"
 spotless-eclipse-formatter = "4.21"
 spotless-prettier-base = "3.2.5"
@@ -175,6 +174,5 @@ gradle-node = { id = "com.github.node-gradle.node", version.ref = "node-gradle" 
 taskinfo = { id = "org.barfuin.gradle.taskinfo", version.ref = "taskinfo" }
 swagger-generator = { id = "org.hidetake.swagger.generator", version.ref = "swagger-generator" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-docker-remote-api = { id = "com.bmuschko.docker-remote-api", version.ref = "docker-remote-api" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 opa = { id = "com.bisnode.opa", version.ref = "opa-plugin" }

--- a/scripts/docker/build-docker-image.sh
+++ b/scripts/docker/build-docker-image.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+#
+# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-License-Identifier: EUPL-1.2+
+#
+
+help()
+{
+   echo "Builds the ZAC Docker image"
+   echo
+   echo "Syntax: $0 [-v|b|c|t|h]"
+   echo "options:"
+   echo "-v     Version number"
+   echo "-b     Branch name"
+   echo "-c     Commit hash"
+   echo "-t     Docker Image tag"
+   echo "-h     Print this Help"
+   echo
+}
+
+echoerr() {
+  echo 1>&2;
+  echo "$@" 1>&2;
+  echo 1>&2;
+}
+
+while getopts "v:b:c:t:h" option; do
+   case "$option" in
+       v) versionNumber=${OPTARG};;
+       b) branchName=${OPTARG};;
+       c) commitHash=${OPTARG};;
+       t) tag=${OPTARG};;
+       h)
+           help
+           exit;;
+       \?)
+           echoerr "Error: Invalid option"
+           help
+           exit;;
+   esac
+done
+
+docker build --build-arg versionNumber=$versionNumber --build-arg branchName=$branchName --build-arg commitHash=$commitHash -t $tag .


### PR DESCRIPTION
No longer use the Gradle Docker Plugin because it is no longer actively maintained and because it is much slower compared to using the plain Docker command line command.

Solves PZ-2792