### PR TITLE
feat: indicate when unlinked documents are locked

### DIFF
--- a/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.html
+++ b/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.html
@@ -99,10 +99,13 @@
                            title="{{ 'actie.downloaden' | translate}}">
                             <mat-icon>download</mat-icon>
                         </a>
-                        <button *ngIf="werklijstRechten.ontkoppeldeDocumentenVerwijderen" mat-icon-button (click)="documentVerwijderen(row)"
+                        <button *ngIf="werklijstRechten.ontkoppeldeDocumentenVerwijderen && !row.isVergrendeld" mat-icon-button (click)="documentVerwijderen(row)"
                                 title="{{ 'actie.verwijderen' | translate}}">
                             <mat-icon>delete</mat-icon>
                         </button>
+                        <mat-icon title="{{ 'indicatie.VERGRENDELD' | translate }}" *ngIf="row.isVergrendeld" class="mat-mdc-standard-chip mat-mdc-chip-highlighted mat-accent lock-icon">
+                            lock
+                        </mat-icon>
                         <button mat-icon-button [disabled]="isDocumentVerplaatsenDisabled(row)" (click)="documentVerplaatsen(row)"
                                 title="{{ 'actie.document.verplaatsen' | translate}}">
                             <mat-icon>content_cut</mat-icon>

--- a/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.less
+++ b/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.less
@@ -22,3 +22,10 @@
 .mat-column-actions {
   width: 170px;
 }
+
+.lock-icon {
+  color: var(--mdc-chip-label-text-color);
+  block-size: fit-content;
+  margin-block: auto;
+  padding: .125em;
+}

--- a/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/converter/RESTOntkoppeldDocumentConverter.java
+++ b/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/converter/RESTOntkoppeldDocumentConverter.java
@@ -13,11 +13,16 @@ import jakarta.inject.Inject;
 import net.atos.zac.app.identity.converter.RESTUserConverter;
 import net.atos.zac.app.ontkoppeldedocumenten.model.RESTOntkoppeldDocument;
 import net.atos.zac.documenten.model.OntkoppeldDocument;
+import net.atos.zac.enkelvoudiginformatieobject.EnkelvoudigInformatieObjectLockService;
+import net.atos.zac.enkelvoudiginformatieobject.model.EnkelvoudigInformatieObjectLock;
 
 public class RESTOntkoppeldDocumentConverter {
 
     @Inject
     private RESTUserConverter userConverter;
+
+    @Inject
+    private EnkelvoudigInformatieObjectLockService lockService;
 
     public RESTOntkoppeldDocument convert(final OntkoppeldDocument document) {
         final RESTOntkoppeldDocument restDocument = new RESTOntkoppeldDocument();
@@ -31,6 +36,8 @@ public class RESTOntkoppeldDocumentConverter {
         restDocument.ontkoppeldDoor = userConverter.convertUserId(document.getOntkoppeldDoor());
         restDocument.ontkoppeldOp = document.getOntkoppeldOp();
         restDocument.reden = document.getReden();
+        final EnkelvoudigInformatieObjectLock lock = lockService.findLock(document.getDocumentUUID());
+        restDocument.isVergrendeld = lock != null && lock.getLock() != null;
         return restDocument;
     }
 

--- a/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/model/RESTOntkoppeldDocument.java
+++ b/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/model/RESTOntkoppeldDocument.java
@@ -32,4 +32,6 @@ public class RESTOntkoppeldDocument {
     public ZonedDateTime ontkoppeldOp;
 
     public String reden;
+
+    public boolean isVergrendeld;
 }


### PR DESCRIPTION
When unlinked documents are locked, they first need to be unlocked before they can be deleted. We want to indicate this to the user.
Resolves PZ-2922