### PR TITLE
chore: only map exceptions in ZGW clients to specific ZGW error messages in specific cases

### DIFF
--- a/src/main/kotlin/net/atos/zac/app/util/exception/RestExceptionMapper.kt
+++ b/src/main/kotlin/net/atos/zac/app/util/exception/RestExceptionMapper.kt
@@ -16,6 +16,8 @@ import net.atos.client.zgw.brc.BrcClientService
 import net.atos.client.zgw.drc.DrcClientService
 import net.atos.client.zgw.zrc.ZRCClientService
 import net.atos.client.zgw.ztc.ZTCClientService
+import org.apache.http.conn.HttpHostConnectException
+import java.net.UnknownHostException
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -48,7 +50,10 @@ class RestExceptionMapper : ExceptionMapper<Exception> {
                 .type(MediaType.APPLICATION_JSON)
                 .entity(getJSONMessage(errorMessage = exception.message ?: ERROR_CODE_GENERIC_SERVER))
                 .build()
-        } else if (exception is ProcessingException) {
+        } else if (exception is ProcessingException && exception.cause?.let {
+                it is HttpHostConnectException || it is UnknownHostException
+            } == true
+        ) {
             handleProcessingException(exception)
         } else {
             generateServerErrorResponse(exception = exception, exceptionMessage = exception.message)

--- a/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
@@ -11,8 +11,12 @@ import jakarta.ws.rs.ProcessingException
 import jakarta.ws.rs.core.MediaType
 import net.atos.client.zgw.brc.BrcClientService
 import net.atos.client.zgw.ztc.ZTCClientService
+import org.apache.http.HttpHost
 import org.apache.http.HttpStatus
+import org.apache.http.conn.HttpHostConnectException
 import org.json.JSONObject
+import java.io.IOException
+import java.net.UnknownHostException
 
 class RestExceptionMapperTest : BehaviorSpec({
     val restExceptionMapper = RestExceptionMapper()
@@ -41,13 +45,18 @@ class RestExceptionMapperTest : BehaviorSpec({
             }
         }
     }
-    Given("A JAX-RS processing exception which contains the BRC client service class name in the stacktrace") {
+    Given(
+        """
+        A JAX-RS processing exception with as root cause a HttpHostConnectException
+        and which contains the BRC client service class name in the stacktrace
+        """
+    ) {
         val exceptionMessage = "DummyProcessingException"
         val exception = ProcessingException(
             exceptionMessage,
-            RuntimeException(
-                "DummyRuntimeException",
-                RuntimeException("Something terrible happened in the ${BrcClientService::class.simpleName}!")
+            HttpHostConnectException(
+                IOException("Something terrible happened in the ${BrcClientService::class.simpleName}!"),
+                HttpHost("localhost", 8080)
             )
         )
 
@@ -71,14 +80,17 @@ class RestExceptionMapperTest : BehaviorSpec({
             }
         }
     }
-    Given("A JAX-RS processing exception which contains the ZTC client service class name in the stacktrace") {
+    Given(
+        """
+        A JAX-RS processing exception with as root cause a UnknownHostException
+        which contains the ZTC client service class name in the stacktrace
+        """
+    ) {
         val exceptionMessage = "DummyProcessingException"
         val exception = ProcessingException(
             exceptionMessage,
-            RuntimeException(
-                "DummyRuntimeException",
-                RuntimeException("Something terrible happened in the ${ZTCClientService::class.simpleName}!")
-            )
+            UnknownHostException(
+               "Something terrible happened in the ${ZTCClientService::class.simpleName}!")
         )
 
         When("the exception is mapped to a response") {

--- a/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
@@ -90,7 +90,8 @@ class RestExceptionMapperTest : BehaviorSpec({
         val exception = ProcessingException(
             exceptionMessage,
             UnknownHostException(
-               "Something terrible happened in the ${ZTCClientService::class.simpleName}!")
+                "Something terrible happened in the ${ZTCClientService::class.simpleName}!"
+            )
         )
 
         When("the exception is mapped to a response") {


### PR DESCRIPTION
Only map exceptions in ZGW clients to specific ZGW error messages when the exception cause is either a HttpHostConnectException or an UnknownHostException. To prevent incorrect error messages when other types of exceptions are thrown in the ZGW clients.

Solves PZ-2965