### PR TITLE
chore: upgraded to WildFly 31.0.1 and Galleon 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- please follow the instructions in 'updatingDependencies.md' when upgrading WildFly -->
-        <wildfly.version>31.0.0.Final</wildfly.version>
+        <wildfly.version>31.0.1.Final</wildfly.version>
         <wildfly-jar-maven-plugin.version>11.0.2.Final</wildfly-jar-maven-plugin.version>
-        <wildfly-datasources-galleon-pack.version>7.0.0.Final</wildfly-datasources-galleon-pack.version>
+        <wildfly-datasources-galleon-pack.version>8.0.0.Final</wildfly-datasources-galleon-pack.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Upgraded to WildFly 31.0.1 and Galleon 6. To prepare for the upgrade to WildFly 32.

Solves PZ-2978