### PR TITLE
chore: upgrade to wildfly 32.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -732,6 +732,9 @@ tasks {
 
         inputs.files(fileTree("$rootDir/src/main/resources/wildfly"))
         inputs.file("$rootDir/build/libs/zaakafhandelcomponent.war")
+        inputs.file("$rootDir/pom.xml")
+        inputs.file("$rootDir/src/main/resources/wildfly/configure-wildfly.cli")
+        inputs.file("$rootDir/src/main/resources/wildfly/deploy-zaakafhandelcomponent.cli")
         outputs.dir("$rootDir/target")
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -701,7 +701,6 @@ tasks {
     register<Test>("itest") {
         dependsOn("buildDockerImage")
 
-        inputs.files(project.tasks.findByPath("compileItestKotlin")!!.outputs.files)
         testClassesDirs = sourceSets["itest"].output.classesDirs
         classpath = sourceSets["itest"].runtimeClasspath
         systemProperty("zacDockerImage", zacDockerImage)

--- a/docs/development/updatingDependencies.md
+++ b/docs/development/updatingDependencies.md
@@ -65,7 +65,7 @@ installed WildFly. To upgrade override the Galleon files in [the Galleon install
 5. Re-install your local WildFly version using the WildFly install script.
 6. If you have configured your IntelliJ IDE to run ZAC in WildFly update the IntelliJ WildFly run configuration using the instructions in [INSTALL.md](INSTALL.md).
 7. Update the WildFly installation directory in the [startupwithenv.sh](../../startupwithenv.sh) file (or [startupwithenv.bat](../../startupwithenv.bat) for windows).
-8. In the [Gradle build file](../../build.gradle.kts) manually upgrade all the 'dependencies provided by Wildfly'.
+8. In the [Gradle Versions Catalog file](../../gradle/libs.versions.toml) manually upgrade all the 'dependencies provided by Wildfly' that are used in the [Gradle build file](../../build.gradle.kts).
 These need to be in sync with the ones provided by the used version of WildFly.
 9. Test ZAC thoroughly to make sure everything still works both by running ZAC locally (in IntelliJ and in Docker Compose)
 and performing manual testing as well as by running our automated tests.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,9 +55,8 @@ eclipse-microprofile-rest-client-api = "3.0.1"
 eclipse-microprofile-config-api = "3.1"
 eclipse-microprofile-health-api = "4.0.1"
 eclipse-microprofile-fault-tolerance-api = "4.0.2"
-
-jboss-resteasy-multipart-provider = "6.2.7.Final"
-wildfly-security-elytron-http-oidc = "2.2.3.Final"
+jboss-resteasy-multipart-provider = "6.2.9.Final"
+wildfly-security-elytron-http-oidc = "2.4.2.Final"
 hibernate-validator = "8.0.1.Final"
 
 eclipse-yasson = "3.0.3"

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
                         <layer>metrics</layer>
                         <layer>microprofile-health</layer>
                         <layer>microprofile-fault-tolerance</layer>
+                        <layer>microprofile-rest-client</layer>
                         <layer>opentelemetry</layer>
                         <layer>postgresql-driver</layer>
                     </layers>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- please follow the instructions in 'updatingDependencies.md' when upgrading WildFly -->
-        <wildfly.version>31.0.1.Final</wildfly.version>
+        <wildfly.version>32.0.1.Final</wildfly.version>
         <wildfly-jar-maven-plugin.version>11.0.2.Final</wildfly-jar-maven-plugin.version>
         <wildfly-datasources-galleon-pack.version>8.0.0.Final</wildfly-datasources-galleon-pack.version>
     </properties>

--- a/src/main/java/net/atos/client/zgw/drc/DrcClientService.java
+++ b/src/main/java/net/atos/client/zgw/drc/DrcClientService.java
@@ -34,9 +34,7 @@ import net.atos.client.zgw.shared.model.audit.AuditTrailRegel;
 import net.atos.client.zgw.shared.util.ZGWClientHeadersFactory;
 import net.atos.zac.configuratie.ConfiguratieService;
 
-/**
- *
- */
+
 @ApplicationScoped
 public class DrcClientService {
 
@@ -61,7 +59,6 @@ public class DrcClientService {
         return drcClient.enkelvoudigInformatieobjectRead(uuid);
     }
 
-
     /**
      * Read {@link EnkelvoudigInformatieObject} via its UUID and version.
      * Throws a RuntimeException if the {@link EnkelvoudigInformatieObject} can not be read.
@@ -76,7 +73,6 @@ public class DrcClientService {
     ) {
         return drcClient.enkelvoudigInformatieobjectReadVersie(uuid, versie);
     }
-
 
     /**
      * DELETE {@link EnkelvoudigInformatieObject} via its UUID.
@@ -116,7 +112,6 @@ public class DrcClientService {
     public String lockEnkelvoudigInformatieobject(final UUID enkelvoudigInformatieobjectUUID) {
         // If the EnkelvoudigInformatieobject is already locked a ValidationException is thrown.
         return drcClient.enkelvoudigInformatieobjectLock(enkelvoudigInformatieobjectUUID, new Lock()).getLock();
-
     }
 
     /**

--- a/startupwithenv.bat
+++ b/startupwithenv.bat
@@ -10,4 +10,4 @@
 @REM # crashes of WildFly/ZAC when running in IntelliJ when you have configured DEBUG logging in WildFly
 @REM # with errors such as: "fatal error: concurrent map read and map write goroutine 2013 [running]:
 @REM # go.1password.io/op/op-cli/command/subprocess/masking.matches.add(...)"
-op run --env-file=".env.tpl" --no-masking -- .\wildfly-31.0.1.Final\bin\standalone.bat
+op run --env-file=".env.tpl" --no-masking -- .\wildfly-32.0.1.Final\bin\standalone.bat

--- a/startupwithenv.sh
+++ b/startupwithenv.sh
@@ -12,4 +12,4 @@
 # crashes of WildFly/ZAC when running in IntelliJ when you have configured DEBUG logging in WildFly
 # with errors such as: "fatal error: concurrent map read and map write goroutine 2013 [running]:
 # go.1password.io/op/op-cli/command/subprocess/masking.matches.add(...)"
-op run --env-file="./.env.tpl" --no-masking -- ./wildfly-31.0.1.Final/bin/standalone.sh
+op run --env-file="./.env.tpl" --no-masking -- ./wildfly-32.0.1.Final/bin/standalone.sh


### PR DESCRIPTION
Upgraded ZAC to WildFly 32.0.1. Still using Galleon CLI tooling and the WildFly JAR Maven Plugin. Those will be upgraded to WildFly Glow and the WildFly Maven Plugin in a future PR 

Solves PZ-2805