### PR TITLE
chore: fix typo

### DIFF
--- a/src/main/java/net/atos/zac/app/policy/converter/RESTRechtenConverter.java
+++ b/src/main/java/net/atos/zac/app/policy/converter/RESTRechtenConverter.java
@@ -58,7 +58,7 @@ public class RESTRechtenConverter {
         restZaakRechten.verwijderenBetrokkene = zaakRechten.verwijderenBetrokkene();
         restZaakRechten.verwijderenInitiator = zaakRechten.verwijderenInitiator();
         restZaakRechten.creeerenDocument = zaakRechten.creeerenDocument();
-        restZaakRechten.vesturenEmail = zaakRechten.versturenEmail();
+        restZaakRechten.versturenEmail = zaakRechten.versturenEmail();
         return restZaakRechten;
     }
 

--- a/src/main/java/net/atos/zac/app/policy/model/RESTZaakRechten.java
+++ b/src/main/java/net/atos/zac/app/policy/model/RESTZaakRechten.java
@@ -41,5 +41,5 @@ public class RESTZaakRechten {
 
     public boolean creeerenDocument;
 
-    public boolean vesturenEmail;
+    public boolean versturenEmail;
 }


### PR DESCRIPTION
There was a typo causing the `E-mail versturen` button to never appear
Solves PZ-2984