### PR TITLE
chore: keep the url in the address bar when a route resolver fails during a full browser navigation

### DIFF
--- a/src/main/app/src/app/shared/navigation/navigation.service.ts
+++ b/src/main/app/src/app/shared/navigation/navigation.service.ts
@@ -51,13 +51,15 @@ export class NavigationService {
       return;
     }
 
-    if (e instanceof NavigationError &&
-      this.router.routerState.snapshot.url === "") {
-        // on a full browser navigation, if a route resolver throws,
-        // Angular by default redirects to the root url.
-        // we want to override this behaviour so the target url remains in the address bar.
-        window.history.replaceState(null, null, e.url);
-      }
+    if (
+      e instanceof NavigationError &&
+      this.router.routerState.snapshot.url === ""
+    ) {
+      // on a full browser navigation, if a route resolver throws,
+      // Angular by default redirects to the root url.
+      // we want to override this behaviour so the target url remains in the address bar.
+      window.history.replaceState(null, null, e.url);
+    }
 
     if (e instanceof NavigationEnd) {
       const history = SessionStorageUtil.getItem(

--- a/src/main/app/src/app/shared/navigation/navigation.service.ts
+++ b/src/main/app/src/app/shared/navigation/navigation.service.ts
@@ -45,35 +45,37 @@ export class NavigationService {
       .subscribe((e) => this.handleRouterEvents(e));
   }
 
-  private handleRouterEvents(e): void {
-    if (e instanceof NavigationStart) {
-      this.utilService.setLoading(true);
-      return;
-    }
+  private handleRouterEvents(e: unknown): void {
+    switch (true) {
+      case e instanceof NavigationStart:
+        this.utilService.setLoading(true);
+        return;
 
-    if (
-      e instanceof NavigationError &&
-      this.router.routerState.snapshot.url === ""
-    ) {
-      // on a full browser navigation, if a route resolver throws,
-      // Angular by default redirects to the root url.
-      // we want to override this behaviour so the target url remains in the address bar.
-      window.history.replaceState(null, null, e.url);
-    }
+      case e instanceof NavigationError &&
+        this.router.routerState.snapshot.url === "":
+        // on a full browser navigation, if a route resolver throws,
+        // Angular by default redirects to the root url.
+        // we want to override this behaviour so the target url remains in the address bar.
+        window.history.replaceState(null, null, e.url);
+        break;
 
-    if (e instanceof NavigationEnd) {
-      const history = SessionStorageUtil.getItem(
-        NavigationService.NAVIGATION_HISTORY,
-        [],
-      );
-      if (
-        history.length === 0 ||
-        history[history.length - 1] !== e.urlAfterRedirects
-      ) {
-        history.push(e.urlAfterRedirects);
-      }
-      SessionStorageUtil.setItem(NavigationService.NAVIGATION_HISTORY, history);
-      this.backDisabled.next(history.length <= 1);
+      case e instanceof NavigationEnd:
+        const history = SessionStorageUtil.getItem(
+          NavigationService.NAVIGATION_HISTORY,
+          [],
+        );
+        if (
+          history.length === 0 ||
+          history[history.length - 1] !== e.urlAfterRedirects
+        ) {
+          history.push(e.urlAfterRedirects);
+        }
+        SessionStorageUtil.setItem(
+          NavigationService.NAVIGATION_HISTORY,
+          history,
+        );
+        this.backDisabled.next(history.length <= 1);
+        break;
     }
 
     this.utilService.setLoading(false);

--- a/src/main/app/src/app/shared/navigation/navigation.service.ts
+++ b/src/main/app/src/app/shared/navigation/navigation.service.ts
@@ -48,27 +48,33 @@ export class NavigationService {
   private handleRouterEvents(e): void {
     if (e instanceof NavigationStart) {
       this.utilService.setLoading(true);
-    } else {
-      if (e instanceof NavigationEnd) {
-        const history = SessionStorageUtil.getItem(
-          NavigationService.NAVIGATION_HISTORY,
-          [],
-        );
-        if (
-          history.length === 0 ||
-          history[history.length - 1] !== e.urlAfterRedirects
-        ) {
-          history.push(e.urlAfterRedirects);
-        }
-        SessionStorageUtil.setItem(
-          NavigationService.NAVIGATION_HISTORY,
-          history,
-        );
-        this.backDisabled.next(history.length <= 1);
+      return;
+    }
+
+    if (e instanceof NavigationError &&
+      this.router.routerState.snapshot.url === "") {
+        // on a full browser navigation, if a route resolver throws,
+        // Angular by default redirects to the root url.
+        // we want to override this behaviour so the target url remains in the address bar.
+        window.history.replaceState(null, null, e.url);
       }
 
-      this.utilService.setLoading(false);
+    if (e instanceof NavigationEnd) {
+      const history = SessionStorageUtil.getItem(
+        NavigationService.NAVIGATION_HISTORY,
+        [],
+      );
+      if (
+        history.length === 0 ||
+        history[history.length - 1] !== e.urlAfterRedirects
+      ) {
+        history.push(e.urlAfterRedirects);
+      }
+      SessionStorageUtil.setItem(NavigationService.NAVIGATION_HISTORY, history);
+      this.backDisabled.next(history.length <= 1);
     }
+
+    this.utilService.setLoading(false);
   }
 
   back(): void {


### PR DESCRIPTION
Keep the url in the address bar when a route resolver fails during a full browser navigation.
Resolves PZ-2988