### PR TITLE
chore: make sure generate Java clients Gradle tasks can be cached

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -492,48 +492,36 @@ tasks {
     register<GenerateTask>("generateKvkZoekenClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/kvk/zoeken-openapi.yaml")
         outputDir.set("$rootDir/src/generated/kvk/zoeken/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/kvk/zoeken/java"))
         modelPackage.set("net.atos.client.kvk.zoeken.model.generated")
     }
 
     register<GenerateTask>("generateKvkBasisProfielClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/kvk/basisprofiel-openapi.yaml")
         outputDir.set("$rootDir/src/generated/kvk/basisprofiel/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/kvk/basisprofiel/java"))
         modelPackage.set("net.atos.client.kvk.basisprofiel.model.generated")
     }
 
     register<GenerateTask>("generateKvkVestigingsProfielClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/kvk/vestigingsprofiel-openapi.yaml")
         outputDir.set("$rootDir/src/generated/kvk/vestigingsprofiel/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/kvk/vestigingsprofiel/java"))
         modelPackage.set("net.atos.client.kvk.vestigingsprofiel.model.generated")
     }
 
     register<GenerateTask>("generateBrpClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/brp/brp-openapi.yaml")
         outputDir.set("$rootDir/src/generated/brp/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/brp/java"))
         modelPackage.set("net.atos.client.brp.model.generated")
     }
 
     register<GenerateTask>("generateVrlClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/vrl/vrl-openapi.yaml")
         outputDir.set("$rootDir/src/generated/vrl/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/vrl/java"))
         modelPackage.set("net.atos.client.vrl.model.generated")
     }
 
     register<GenerateTask>("generateBagClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/bag/bag-openapi.yaml")
         outputDir.set("$rootDir/src/generated/bag/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/bag/java"))
         modelPackage.set("net.atos.client.bag.model.generated")
         // we need to use the java8-localdatetime date library for this client
         // or else certain date time fields for this client cannot be deserialized
@@ -559,64 +547,48 @@ tasks {
 
         inputSpec.set("$rootDir/src/main/resources/api-specs/klanten/klanten-openapi.yaml")
         outputDir.set("$rootDir/src/generated/klanten/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/klanten/java"))
         modelPackage.set("net.atos.client.klanten.model.generated")
     }
 
     register<GenerateTask>("generateContactMomentenClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/contactmomenten/contactmomenten-openapi.yaml")
         outputDir.set("$rootDir/src/generated/contactmomenten/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/contactmomenten/java"))
         modelPackage.set("net.atos.client.contactmomenten.model.generated")
     }
 
     register<GenerateTask>("generateZgwBrcClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/zgw/brc-openapi.yaml")
         outputDir.set("$rootDir/src/generated/zgw/brc/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/zgw/brc/java"))
         modelPackage.set("net.atos.client.zgw.brc.model.generated")
     }
 
     register<GenerateTask>("generateZgwDrcClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/zgw/drc-openapi.yaml")
         outputDir.set("$rootDir/src/generated/zgw/drc/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/zgw/drc/java"))
         modelPackage.set("net.atos.client.zgw.drc.model.generated")
     }
 
     register<GenerateTask>("generateZrcDrcClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/zgw/zrc-openapi.yaml")
         outputDir.set("$rootDir/src/generated/zgw/zrc/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/zgw/zrc/java"))
         modelPackage.set("net.atos.client.zgw.zrc.model.generated")
     }
 
     register<GenerateTask>("generateZtcDrcClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/zgw/ztc-openapi.yaml")
         outputDir.set("$rootDir/src/generated/zgw/ztc/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/zgw/ztc/java"))
         modelPackage.set("net.atos.client.zgw.ztc.model.generated")
     }
 
     register<GenerateTask>("generateOrObjectsClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/or/objects-openapi.yaml")
         outputDir.set("$rootDir/src/generated/or/objects/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/or/objects/java"))
         modelPackage.set("net.atos.client.or.objects.model.generated")
     }
 
     register<GenerateTask>("generateOrObjectTypesClient") {
         inputSpec.set("$rootDir/src/main/resources/api-specs/or/objecttypes-openapi.yaml")
         outputDir.set("$rootDir/src/generated/or/objecttypes/java")
-        // need to set outputs as file tree or else empty output folder will be cached by Gradle
-        outputs.files(fileTree("$rootDir/src/generated/or/objecttypes/java"))
         modelPackage.set("net.atos.client.or.objecttypes.model.generated")
     }
 


### PR DESCRIPTION
Remove outputs setting in generate Java clients Gradle tasks again as this seems not needed after all and makes the tasks uncacheable by Gradle..

Solves PZ-2997