### PR TITLE
chore: map indicatie gebruiksrecht field in REST endpoint to create an enkelvoudiginformatieobject

### DIFF
--- a/src/main/java/net/atos/client/zgw/shared/ZGWApiService.java
+++ b/src/main/java/net/atos/client/zgw/shared/ZGWApiService.java
@@ -224,7 +224,8 @@ public class ZGWApiService {
             final String omschrijvingVoorwaardenGebruiksrechten
     ) {
         final EnkelvoudigInformatieObject newInformatieObjectData = drcClientService.createEnkelvoudigInformatieobject(
-                enkelvoudigInformatieObjectData);
+                enkelvoudigInformatieObjectData
+        );
         final Gebruiksrechten gebruiksrechten = new Gebruiksrechten();
         gebruiksrechten.setInformatieobject(newInformatieObjectData.getUrl());
         gebruiksrechten.setStartdatum(convertToDateTime(newInformatieObjectData.getCreatiedatum()).toOffsetDateTime());

--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
@@ -105,7 +105,8 @@ public class RESTInformatieobjectConverter {
 
     public RESTEnkelvoudigInformatieobject convertToREST(final ZaakInformatieobject zaakInformatieObject) {
         final EnkelvoudigInformatieObject enkelvoudigInformatieObject = drcClientService.readEnkelvoudigInformatieobject(
-                zaakInformatieObject.getInformatieobject());
+                zaakInformatieObject.getInformatieobject()
+        );
         final Zaak zaak = zrcClientService.readZaak(zaakInformatieObject.getZaakUUID());
         return convertToREST(enkelvoudigInformatieObject, zaak);
     }
@@ -128,15 +129,20 @@ public class RESTInformatieobjectConverter {
         restEnkelvoudigInformatieobject.uuid = enkelvoudigInformatieObjectUUID;
         restEnkelvoudigInformatieobject.identificatie = enkelvoudigInformatieObject.getIdentificatie();
         restEnkelvoudigInformatieobject.rechten = rechtenConverter.convert(rechten);
+        restEnkelvoudigInformatieobject.indicatieGebruiksrecht = enkelvoudigInformatieObject.getIndicatieGebruiksrecht();
         restEnkelvoudigInformatieobject.isBesluitDocument = brcClientService.isInformatieObjectGekoppeldAanBesluit(
-                enkelvoudigInformatieObject.getUrl());
+                enkelvoudigInformatieObject.getUrl()
+        );
         if (rechten.lezen()) {
             convertEnkelvoudigInformatieObject(enkelvoudigInformatieObject, lock, restEnkelvoudigInformatieobject);
-            if (enkelvoudigInformatieObject.getOndertekening() != null && enkelvoudigInformatieObject.getOndertekening()
-                    .getSoort() != null &&
-                enkelvoudigInformatieObject.getOndertekening().getDatum() != null) {
-                restEnkelvoudigInformatieobject.ondertekening = restOndertekeningConverter.convert(enkelvoudigInformatieObject
-                        .getOndertekening());
+            if (
+                enkelvoudigInformatieObject.getOndertekening() != null &&
+                enkelvoudigInformatieObject.getOndertekening().getSoort() != null &&
+                enkelvoudigInformatieObject.getOndertekening().getDatum() != null
+            ) {
+                restEnkelvoudigInformatieobject.ondertekening = restOndertekeningConverter.convert(
+                        enkelvoudigInformatieObject.getOndertekening()
+                );
             }
         } else {
             restEnkelvoudigInformatieobject.titel = enkelvoudigInformatieObject.getIdentificatie();
@@ -193,8 +199,9 @@ public class RESTInformatieobjectConverter {
     public EnkelvoudigInformatieObjectData convertZaakObject(
             final RESTEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
     ) {
-        final EnkelvoudigInformatieObjectData enkelvoudigInformatieobjectWithInhoud = buildZaacEnkelvoudigInformatieObjectData(
-                restEnkelvoudigInformatieobject);
+        final EnkelvoudigInformatieObjectData enkelvoudigInformatieobjectWithInhoud = buildEnkelvoudigInformatieObjectData(
+                restEnkelvoudigInformatieobject
+        );
         enkelvoudigInformatieobjectWithInhoud.setInhoud(convertByteArrayToBase64String(restEnkelvoudigInformatieobject.file));
         enkelvoudigInformatieobjectWithInhoud.setBestandsomvang(restEnkelvoudigInformatieobject.file.length);
         enkelvoudigInformatieobjectWithInhoud.setFormaat(restEnkelvoudigInformatieobject.formaat);
@@ -202,18 +209,19 @@ public class RESTInformatieobjectConverter {
     }
 
     @NotNull
-    private EnkelvoudigInformatieObjectData buildZaacEnkelvoudigInformatieObjectData(
+    private EnkelvoudigInformatieObjectData buildEnkelvoudigInformatieObjectData(
             RESTEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
     ) {
         final EnkelvoudigInformatieObjectData enkelvoudigInformatieobjectWithInhoud = new EnkelvoudigInformatieObjectData();
         enkelvoudigInformatieobjectWithInhoud.setBronorganisatie(ConfiguratieService.BRON_ORGANISATIE);
         enkelvoudigInformatieobjectWithInhoud.setCreatiedatum(restEnkelvoudigInformatieobject.creatiedatum);
+        enkelvoudigInformatieobjectWithInhoud.setIndicatieGebruiksrecht(restEnkelvoudigInformatieobject.indicatieGebruiksrecht);
         enkelvoudigInformatieobjectWithInhoud.setTitel(restEnkelvoudigInformatieobject.titel);
         enkelvoudigInformatieobjectWithInhoud.setAuteur(restEnkelvoudigInformatieobject.auteur);
         enkelvoudigInformatieobjectWithInhoud.setTaal(restEnkelvoudigInformatieobject.taal);
         enkelvoudigInformatieobjectWithInhoud.setInformatieobjecttype(
-                ztcClientService.readInformatieobjecttype(restEnkelvoudigInformatieobject.informatieobjectTypeUUID)
-                        .getUrl());
+                ztcClientService.readInformatieobjecttype(restEnkelvoudigInformatieobject.informatieobjectTypeUUID).getUrl()
+        );
         enkelvoudigInformatieobjectWithInhoud.setBestandsnaam(restEnkelvoudigInformatieobject.bestandsnaam);
         enkelvoudigInformatieobjectWithInhoud.setBeschrijving(restEnkelvoudigInformatieobject.beschrijving);
         enkelvoudigInformatieobjectWithInhoud.setStatus(

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/RESTEnkelvoudigInformatieobject.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/RESTEnkelvoudigInformatieobject.java
@@ -87,7 +87,7 @@ public class RESTEnkelvoudigInformatieobject extends RESTEnkelvoudigInformatieFi
     public RESTOndertekening ondertekening;
 
     @FormParam("indicatieGebruiksrecht")
-    public boolean indicatieGebruiksrecht;
+    public Boolean indicatieGebruiksrecht;
 
     public EnumSet<DocumentIndicatie> getIndicaties() {
         final EnumSet<DocumentIndicatie> indicaties = EnumSet.noneOf(DocumentIndicatie.class);

--- a/src/test/kotlin/net/atos/client/zgw/drc/model/DrcFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/drc/model/DrcFixtures.kt
@@ -20,7 +20,8 @@ fun createEnkelvoudigInformatieObject(
     beginRegistratie: OffsetDateTime = OffsetDateTime.now(),
     inhoud: URI = URI("http://example.com/${UUID.randomUUID()}"),
     locked: Boolean = false,
-    bestandsdelen: List<BestandsDeel> = emptyList()
+    bestandsdelen: List<BestandsDeel> = emptyList(),
+    indicatieGebruiksrecht: Boolean? = null
 ) = EnkelvoudigInformatieObject(
     url,
     versie,
@@ -28,7 +29,9 @@ fun createEnkelvoudigInformatieObject(
     inhoud,
     locked,
     bestandsdelen
-)
+).apply {
+    this.indicatieGebruiksrecht = indicatieGebruiksrecht
+}
 
 fun createEnkelvoudigInformatieObjectData(
     url: URI = URI("http://example.com/${UUID.randomUUID()}"),

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverterTest.kt
@@ -188,6 +188,7 @@ class RESTInformatieobjectConverterTest : BehaviorSpec() {
             val uri = URI("https://example.com/informatieobjecten/$expectedUUID")
             val enkelvoudigInformatieObject = createEnkelvoudigInformatieObject(url = uri).apply {
                 informatieobjecttype = uri
+                indicatieGebruiksrecht = true
             }
             val documentRechten = createDocumentRechtenAllDeny(lezen = true)
             val restDocumentRechten = createRESTDocumentRechten()
@@ -220,6 +221,7 @@ class RESTInformatieobjectConverterTest : BehaviorSpec() {
                         informatieobjectTypeUUID shouldBe expectedUUID
                         versie shouldBe 1234
                         bestandsomvang shouldBe 0
+                        indicatieGebruiksrecht shouldBe true
                     }
                 }
             }


### PR DESCRIPTION
Mapped indicatie gebruiksrecht field in REST endpoint to create an enkelvoudiginformatieobject. Note that this field is not set by the ZAC frontend currently so it will always be mapped to null/not set now and that is ok.

Solves PZ-3020