### PR TITLE
chore: update the BRP proxy and Redis versions to the latest versions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -122,7 +122,7 @@ services:
         condition: service_started
 
   redis:
-    image: redis:6.2.6
+    image: redis:7.2.5
 
   # This container name must contain a '.' or else Open Zaak will respond with a 400
   # error on certain API requests caused by an internal 'invalid URL' error.
@@ -328,7 +328,7 @@ services:
       - "5010:5010"
 
   brpproxy:
-    image: ghcr.io/brp-api/haal-centraal-brp-bevragen-proxy:2.1.1
+    image: ghcr.io/brp-api/haal-centraal-brp-bevragen-proxy:2.1.2
     platform: linux/amd64
     environment:
       - ASPNETCORE_ENVIRONMENT=Release


### PR DESCRIPTION
Updated the BRP proxy and Redis versions to the latest versions. Note that on our test environment we were already using a Redis 7.x version.

Solves PZ-3039