### PR TITLE
fix: fix issue with vertrouwelijkheidsaanduidingenum conversion

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
@@ -178,7 +178,7 @@ export class InformatieObjectEditComponent implements OnInit, OnDestroy {
           this.infoObject.vertrouwelijkheidaanduiding,
         ),
       ),
-      value: this.infoObject.vertrouwelijkheidaanduiding.toUpperCase(),
+      value: this.infoObject.vertrouwelijkheidaanduiding,
     })
       .id("vertrouwelijkheidaanduiding")
       .label("vertrouwelijkheidaanduiding")

--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
@@ -369,9 +369,7 @@ public class RESTInformatieobjectConverter {
         }
         if (restEnkelvoudigInformatieObjectVersieGegevens.vertrouwelijkheidaanduiding != null) {
             enkelvoudigInformatieObjectWithLockData.setVertrouwelijkheidaanduiding(
-                    // always convert provided value to uppercase just to be safe
-                    VertrouwelijkheidaanduidingEnum.valueOf(restEnkelvoudigInformatieObjectVersieGegevens.vertrouwelijkheidaanduiding
-                            .toUpperCase())
+                    VertrouwelijkheidaanduidingEnum.fromValue(restEnkelvoudigInformatieObjectVersieGegevens.vertrouwelijkheidaanduiding)
             );
         }
         if (restEnkelvoudigInformatieObjectVersieGegevens.beschrijving != null) {

--- a/src/main/kotlin/net/atos/zac/app/zaken/converter/RESTZaakConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/converter/RESTZaakConverter.kt
@@ -200,7 +200,7 @@ class RESTZaakConverter {
         restZaak.communicatiekanaal?.let { restCommunicatiekanaal ->
             vrlClientService.findCommunicatiekanaal(restCommunicatiekanaal.uuid)
                 .map { it.url }
-                .ifPresent { communicatiekanaal -> zaak.communicatiekanaal = communicatiekanaal }
+                .ifPresent { zaak.communicatiekanaal = it }
         }
         zaak.vertrouwelijkheidaanduiding = restZaak.vertrouwelijkheidaanduiding?.let {
             VertrouwelijkheidaanduidingEnum.fromValue(it)

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/model/InformatieObjectenRESTFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/model/InformatieObjectenRESTFixtures.kt
@@ -56,14 +56,21 @@ fun createRESTInformatieobjecttype(
     this.concept = concept
 }
 
+@Suppress("LongParameterList")
 fun createRESTEnkelvoudigInformatieObjectVersieGegevens(
     uuid: UUID = UUID.randomUUID(),
-    zaakUuid: UUID,
+    zaakUuid: UUID = UUID.randomUUID(),
     bestandsnaam: String = "dummyFile.txt",
     file: ByteArray = "dummyFile".toByteArray(),
+    formaat: String = "dummyType",
+    informatieobjectTypeUUID: UUID = UUID.randomUUID(),
+    vertrouwelijkheidaanduiding: String = VertrouwelijkheidaanduidingEnum.OPENBAAR.name
 ) = RESTEnkelvoudigInformatieObjectVersieGegevens().apply {
     this.uuid = uuid
     this.zaakUuid = zaakUuid
     this.bestandsnaam = bestandsnaam
+    this.formaat = formaat
     this.file = file
+    this.informatieobjectTypeUUID = informatieobjectTypeUUID
+    this.vertrouwelijkheidaanduiding = vertrouwelijkheidaanduiding
 }


### PR DESCRIPTION
Fixed issue with vertrouwelijkheidsaanduidingenum conversion. Frontend was converting default value to uppercase when creating a new document version but was using lowercase (correctly) elsewhere.

Solves PZ-3043