### PR TITLE
chore: make add besluit to zaak more robust

### DIFF
--- a/scripts/docker-compose/imports/objects-api/fixtures/demodata.json
+++ b/scripts/docker-compose/imports/objects-api/fixtures/demodata.json
@@ -817,7 +817,7 @@
                     "naam" : "open-forms",
                     "kenmerk" : "a43e84ac-e08b-4d5f-8d5c-5874c6dddf56"
                 },
-                "type": "productaanvraag",
+                "type": "productaanvraag-type-1",
                 "aanvraaggegevens": {
                     "stap1": {
                         "naam" : "Jan Jansen",

--- a/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/wsxmldeposit.json
+++ b/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/wsxmldeposit.json
@@ -37,7 +37,7 @@
               "naam": "Jan Jansen",
               "telefoonnummer": "0612345678"
             },
-            "productAanvraagtype": "productaanvraag"
+            "productAanvraagtype": "productaanvraag-type-1"
           },
           "zaak": {
             "communicatiekanaal": "E-formulier",

--- a/src/itest/kotlin/nl/lifely/zac/itest/PlanItemsRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/PlanItemsRESTServiceTest.kt
@@ -41,8 +41,8 @@ class PlanItemsRESTServiceTest : BehaviorSpec({
                 "$ZAC_API_URI/planitems/zaak/$zaak1UUID/humanTaskPlanItems"
             )
             Then(
-                "the list of human task plan items for this zaak is returned and contains " +
-                    "the task 'aanvullende informatie'"
+                """the list of human task plan items for this zaak is returned and contains 
+                         the task 'aanvullende informatie'"""
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }

--- a/src/itest/kotlin/nl/lifely/zac/itest/ZakenRESTServiceCompleteTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZakenRESTServiceCompleteTest.kt
@@ -6,7 +6,9 @@ import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.assertions.json.shouldNotContainJsonKey
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import nl.lifely.zac.itest.client.ItestHttpClient
 import nl.lifely.zac.itest.client.ZacClient
 import nl.lifely.zac.itest.config.ItestConfiguration.ACTIE_INTAKE_AFRONDEN
@@ -16,16 +18,17 @@ import nl.lifely.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_GROUP_A_ID
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_ZAAK_UPDATED
-import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
+import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import org.json.JSONArray
 import org.json.JSONObject
+import java.time.LocalDate
 import java.util.UUID
 
 const val ONE_SECOND_IN_MILLIS = 1000L
 
 /**
- * This test creates a zaak, adds a task to complete the intake phase, closes the zaak, and then re-opens the zaak.
+ * This test creates a zaak, adds a task to complete the intake phase, closes the zaak, then re-opens and again closes the zaak.
  */
 @Order(TEST_SPEC_ORDER_AFTER_ZAAK_UPDATED)
 class ZakenRESTServiceCompleteTest : BehaviorSpec({
@@ -36,9 +39,10 @@ class ZakenRESTServiceCompleteTest : BehaviorSpec({
     Given("A zaak has been created that has finished the intake phase with the status 'admissible'") {
         lateinit var zaakUUID: UUID
         lateinit var resultaatTypeUuid: UUID
+        lateinit var besluitTypeUuid: UUID
         val intakeId: Int
         zacClient.createZaak(
-            ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID,
+            ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID,
             TEST_GROUP_A_ID,
             TEST_GROUP_A_DESCRIPTION
         ).run {
@@ -71,11 +75,63 @@ class ZakenRESTServiceCompleteTest : BehaviorSpec({
             code shouldBe HTTP_STATUS_NO_CONTENT
         }
         itestHttpClient.performGetRequest(
-            "$ZAC_API_URI/zaken/resultaattypes/$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID"
+            "$ZAC_API_URI/zaken/resultaattypes/$ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID"
         ).run {
             JSONArray(body!!.string()).getJSONObject(0).run {
-                // we do not care about the specific result type so we just take the first one
+                // we do not care about the specific result type, so we just take the first one
                 resultaatTypeUuid = getString("id").let(UUID::fromString)
+            }
+        }
+        itestHttpClient.performGetRequest(
+            "$ZAC_API_URI/zaken/besluittypes/$ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID"
+        ).run {
+            JSONArray(body!!.string()).getJSONObject(0).run {
+                // we do not care about the specific besluit type, so we just take the first one
+                besluitTypeUuid = getString("id").let(UUID::fromString)
+            }
+        }
+
+        When("a besluit has been added to the zaak") {
+            itestHttpClient.performJSONPostRequest(
+                "$ZAC_API_URI/zaken/besluit",
+                requestBodyAsString = """
+            {
+                "zaakUuid":"$zaakUUID",
+                "resultaattypeUuid":"$resultaatTypeUuid",
+                "besluittypeUuid":"$besluitTypeUuid",
+                "toelichting":"dummyToelichting",
+                "ingangsdatum":"${LocalDate.now()}",
+                "vervaldatum":"${LocalDate.now().plusDays(1)}"                
+            }
+                """.trimIndent()
+            ).run {
+                logger.info { "Response: ${body!!.string()}" }
+                code shouldBe HTTP_STATUS_OK
+            }
+
+            Then("the besluit has been created successfully") {
+                itestHttpClient.performGetRequest(
+                    "$ZAC_API_URI/zaken/besluit/zaakUuid/$zaakUUID"
+                ).use { response ->
+                    val responseBody = response.body!!.string()
+                    logger.info { "Response: $responseBody" }
+                    response.code shouldBe HTTP_STATUS_OK
+                    val besluiten = JSONArray(responseBody)
+                    besluiten.shouldHaveSize(1)
+                    besluiten.getJSONObject(0).run {
+                        getString("uuid") shouldNotBe null
+                        getString("toelichting") shouldBe "dummyToelichting"
+                        getString("ingangsdatum") shouldBe LocalDate.now().toString()
+                        getString("vervaldatum") shouldBe LocalDate.now().plusDays(1).toString()
+                        getBoolean("ingetrokken") shouldBe false
+                        getJSONArray("informatieobjecten").shouldHaveSize(0)
+                        getJSONObject("besluittype").run {
+                            getString("id") shouldBe besluitTypeUuid.toString()
+                            getString("naam") shouldBe "Besluit na heroverweging"
+                            getString("toelichting") shouldBe "Besluit na heroverweging"
+                        }
+                    }
+                }
             }
         }
 

--- a/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/client/ZacClient.kt
@@ -5,10 +5,6 @@
 package nl.lifely.zac.itest.client
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import nl.lifely.zac.itest.config.ItestConfiguration.PRODUCT_AANVRAAG_TYPE
-import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION
-import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE
-import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import okhttp3.Response
 import java.util.UUID
@@ -18,10 +14,15 @@ class ZacClient {
     private var itestHttpClient = ItestHttpClient()
 
     @Suppress("LongMethod")
-    fun createZaakAfhandelParameters(): Response {
+    fun createZaakAfhandelParameters(
+        zaakTypeIdentificatie: String,
+        zaakTypeUuid: UUID,
+        zaakTypeDescription: String,
+        productaanvraagType: String
+    ): Response {
         logger.info {
-            "Creating zaakafhandelparameters in ZAC for zaaktype with identificatie: $ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE " +
-                "and UUID: $ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID"
+            "Creating zaakafhandelparameters in ZAC for zaaktype with identificatie: $zaakTypeIdentificatie " +
+                "and UUID: $zaakTypeUuid"
         }
         return itestHttpClient.performPutRequest(
             url = "$ZAC_API_URI/zaakafhandelParameters",
@@ -122,12 +123,12 @@ class ZacClient {
                 "  \"zaakbeeindigParameters\": [],\n" +
                 "  \"zaaktype\": {\n" +
                 "    \"beginGeldigheid\": \"2023-09-21\",\n" +
-                "    \"doel\": \"$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION\",\n" +
-                "    \"identificatie\": \"$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE\",\n" +
+                "    \"doel\": \"$zaakTypeDescription\",\n" +
+                "    \"identificatie\": \"$zaakTypeIdentificatie\",\n" +
                 "    \"nuGeldig\": true,\n" +
-                "    \"omschrijving\": \"$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION\",\n" +
+                "    \"omschrijving\": \"$zaakTypeDescription\",\n" +
                 "    \"servicenorm\": false,\n" +
-                "    \"uuid\": \"$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID\",\n" +
+                "    \"uuid\": \"$zaakTypeUuid\",\n" +
                 "    \"versiedatum\": \"2023-09-21\",\n" +
                 "    \"vertrouwelijkheidaanduiding\": \"openbaar\"\n" +
                 "  },\n" +
@@ -188,7 +189,7 @@ class ZacClient {
                 "  \"defaultBehandelaarId\": null,\n" +
                 "  \"einddatumGeplandWaarschuwing\": null,\n" +
                 "  \"uiterlijkeEinddatumAfdoeningWaarschuwing\": null,\n" +
-                "  \"productaanvraagtype\": \"$PRODUCT_AANVRAAG_TYPE\",\n" +
+                "  \"productaanvraagtype\": \"$productaanvraagType\",\n" +
                 "  \"zaakNietOntvankelijkResultaattype\": {\n" +
                 "    \"archiefNominatie\": \"VERNIETIGEN\",\n" +
                 "    \"archiefTermijn\": \"5 jaren\",\n" +

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
@@ -43,7 +43,8 @@ object ItestConfiguration {
     const val OPEN_ZAAK_CLIENT_ID = "zac_client"
     const val OPEN_ZAAK_CLIENT_SECRET = "openzaakZaakafhandelcomponentClientSecret"
     const val PDF_MIME_TYPE = "application/pdf"
-    const val PRODUCT_AANVRAAG_TYPE = "productaanvraag"
+    const val PRODUCT_AANVRAAG_TYPE_1 = "productaanvraag-type-1"
+    const val PRODUCT_AANVRAAG_TYPE_2 = "productaanvraag-type-2"
     const val PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_LATITUDE = 52.08968250760225
     const val PRODUCT_AANVRAAG_ZAAKGEGEVENS_GEOMETRY_LONGITUDE = 5.114358701512936
     const val ROLTYPE_NAME_BETROKKENE = "Belanghebbende"
@@ -143,9 +144,16 @@ object ItestConfiguration {
     const val ZAC_HEALTH_READY_URL = "$ZAC_MANAGEMENT_URI/health/ready"
     const val ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE = "melding-evenement-organiseren-behandelen"
     const val ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION = "Melding evenement organiseren behandelen"
+    const val ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_IDENTIFICATIE =
+        "indienen-aansprakelijkstelling-door-derden-behandelen"
+    const val ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_DESCRIPTION =
+        "Indienen aansprakelijkstelling door derden behandelen"
+
     const val SMARTDOCUMENTS_MOCK_BASE_URI = "http://smartdocuments-wiremock:8080"
 
     val ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID: UUID = UUID.fromString("448356ff-dcfb-4504-9501-7fe929077c4f")
+    val ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID: UUID =
+        UUID.fromString("fd2bf643-c98a-4b00-b2b3-9ae0c41ed425")
     val START_DATE = LocalDateTime.now()
 
     /**

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
@@ -16,8 +16,16 @@ import nl.lifely.zac.itest.client.KeycloakClient
 import nl.lifely.zac.itest.client.ZacClient
 import nl.lifely.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.lifely.zac.itest.config.ItestConfiguration.KEYCLOAK_HEALTH_READY_URL
+import nl.lifely.zac.itest.config.ItestConfiguration.PRODUCT_AANVRAAG_TYPE_1
+import nl.lifely.zac.itest.config.ItestConfiguration.PRODUCT_AANVRAAG_TYPE_2
 import nl.lifely.zac.itest.config.ItestConfiguration.SMARTDOCUMENTS_MOCK_BASE_URI
 import nl.lifely.zac.itest.config.ItestConfiguration.SMTP_SERVER_PORT
+import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_DESCRIPTION
+import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_IDENTIFICATIE
+import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID
+import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION
+import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE
+import nl.lifely.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_CONTAINER_SERVICE_NAME
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_DEFAULT_DOCKER_IMAGE
 import nl.lifely.zac.itest.config.ItestConfiguration.ZAC_HEALTH_READY_URL
@@ -96,7 +104,20 @@ class ProjectConfig : AbstractProjectConfig() {
 
             KeycloakClient.authenticate()
 
-            ZacClient().createZaakAfhandelParameters().use { response ->
+            ZacClient().createZaakAfhandelParameters(
+                ZAAKTYPE_MELDING_KLEIN_EVENEMENT_IDENTIFICATIE,
+                ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID,
+                ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION,
+                PRODUCT_AANVRAAG_TYPE_1
+            ).use { response ->
+                response.isSuccessful shouldBe true
+            }
+            ZacClient().createZaakAfhandelParameters(
+                ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_IDENTIFICATIE,
+                ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID,
+                ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_DESCRIPTION,
+                PRODUCT_AANVRAAG_TYPE_2
+            ).use { response ->
                 response.isSuccessful shouldBe true
             }
         } catch (exception: ContainerLaunchException) {

--- a/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/ZakenRESTService.kt
@@ -873,7 +873,7 @@ class ZakenRESTService @Inject constructor(
             zgwApiService.createResultaatForZaak(zaak, besluitToevoegenGegevens.resultaattypeUuid, null)
         }
         val restBesluit = restBesluitConverter.convertToRESTBesluit(brcClientService.createBesluit(besluit))
-        besluitToevoegenGegevens.informatieobjecten!!.forEach(
+        besluitToevoegenGegevens.informatieobjecten?.forEach(
             Consumer { documentUri: UUID? ->
                 val informatieobject = drcClientService.readEnkelvoudigInformatieobject(documentUri)
                 val besluitInformatieobject = BesluitInformatieObject()


### PR DESCRIPTION
Made adding a besluit to a zaak more robust by checking if the informatieobjecten in the besluit are present or not. Also added an integration test for adding a besluit to a zaak, using our second zaaktype which has besluittypes configured in OpenZaak.

Solves PZ-3050