### PR TITLE
fix: use default UTF8 charset for multipart form data

### DIFF
--- a/scripts/docker-compose/imports/openldap/zac-scripts/zac-ldap-setup-template.ldif
+++ b/scripts/docker-compose/imports/openldap/zac-scripts/zac-ldap-setup-template.ldif
@@ -73,7 +73,7 @@ objectClass: organizationalPerson
 objectClass: person
 objectClass: top
 cn: testuser1
-sn: User1
+sn: User1 Špëçîâl Characters
 givenName: Test
 mail: ${TESTUSER1_EMAIL_ADDRESS}
 userPassword:: e1NTSEF9WVFNNUV2d3F2RHMyR00rSVgzVGtoQzJUWWpScFpRZ0dhdEY5RXc9P

--- a/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/wsxmldeposit.json
+++ b/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/wsxmldeposit.json
@@ -29,7 +29,7 @@
           },
           "gebruiker": {
             "id": "testuser1",
-            "naam": "Test User1"
+            "naam": "Test User1 Špëçîâl Characters"
           },
           "startformulier": {
             "data": {

--- a/src/itest/kotlin/nl/lifely/zac/itest/InformatieObjectenTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/InformatieObjectenTest.kt
@@ -44,7 +44,7 @@ import java.time.format.DateTimeFormatter
 @Order(TEST_SPEC_ORDER_AFTER_TASK_RETRIEVED)
 class InformatieObjectenTest : BehaviorSpec({
     val fileTitle = "dummyTitel"
-    val updatedFileTitle = "updated title"
+    val updatedFileTitle = "updated title with Špëcîål characters"
     val documentVertrouwelijkheidsAanduidingVertrouwelijk = "zaakvertrouwelijk"
     val documentVertrouwelijkheidsAanduidingOpenbaar = "openbaar"
     val documentStatusDefinitief = "definitief"

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
@@ -77,7 +77,7 @@ object ItestConfiguration {
     const val TEST_SPEC_ORDER_AFTER_TASK_COMPLETED = 5
     const val TEST_USER_1_USERNAME = "testuser1"
     const val TEST_USER_1_PASSWORD = "testuser1"
-    const val TEST_USER_1_NAME = "Test User1"
+    const val TEST_USER_1_NAME = "Test User1 Špëçîâl Characters"
     const val TEST_USER_2_ID = "testuser2"
     const val TEST_USER_2_NAME = "Test User2"
     const val TEST_RECORD_MANAGER_1_USERNAME = "recordmanager1"

--- a/src/main/java/net/atos/zac/util/IndexRewriteFilter.java
+++ b/src/main/java/net/atos/zac/util/IndexRewriteFilter.java
@@ -21,27 +21,28 @@ import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * If the requested resource doesn't exist, use index.html
- * more information at https://angular.io/guide/deployment#server-configuration
+ * more information at <a href="https://angular.io/guide/deployment#server-configuration">server configuration</a>
  */
 @WebFilter(filterName = "indexRewriteFilter")
-public class indexRewriteFilter implements Filter {
-
-    private final List<String> resourcePaths = List.of("/assets", "/rest", "/websocket", "/webdav");
-
+public class IndexRewriteFilter implements Filter {
+    private static final List<String> RESOURCE_PATHS = List.of("/assets", "/rest", "/websocket", "/webdav");
     private static final Pattern REGEX_RESOURCES = Pattern.compile(
-            "\\.(js(on|\\.map)?|css|txt|jpe?g|png|gif|svg|ico|webmanifest|eot|ttf|woff2?)$");
+            "\\.(js(on|\\.map)?|css|txt|jpe?g|png|gif|svg|ico|webmanifest|eot|ttf|woff2?)$"
+    );
 
     @Override
-    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException,
-                                                                                                                ServletException {
+    public void doFilter(
+            final ServletRequest request,
+            final ServletResponse response,
+            final FilterChain chain
+    ) throws IOException,
+      ServletException {
         if (request instanceof final HttpServletRequest httpRequest) {
             final String path = httpRequest.getServletPath();
             if (isResourcePath(path) || isResource(path)) {
                 chain.doFilter(request, response);
             } else if (path.equals("/logout")) {
                 logout(httpRequest, (HttpServletResponse) response);
-            } else if (path.startsWith("/startformulieren")) {
-                httpRequest.getRequestDispatcher("/startformulieren/melding-klein-evenement.jsp").forward(request, response);
             } else {
                 httpRequest.getRequestDispatcher("/index.html").forward(request, response);
             }
@@ -54,7 +55,7 @@ public class indexRewriteFilter implements Filter {
     }
 
     private boolean isResourcePath(final String path) {
-        return resourcePaths.stream().anyMatch(path::startsWith);
+        return RESOURCE_PATHS.stream().anyMatch(path::startsWith);
     }
 
     private boolean isResource(final String path) {

--- a/src/main/java/net/atos/zac/util/JsonbConfiguration.java
+++ b/src/main/java/net/atos/zac/util/JsonbConfiguration.java
@@ -14,7 +14,7 @@ import jakarta.ws.rs.ext.Provider;
 @Provider
 public class JsonbConfiguration implements ContextResolver<Jsonb> {
 
-    private Jsonb jsonb;
+    private final Jsonb jsonb;
 
     public JsonbConfiguration() {
         final JsonbConfig jsonbConfig = new JsonbConfig()

--- a/src/main/kotlin/net/atos/zac/app/util/filter/CharsetInterceptorFilter.kt
+++ b/src/main/kotlin/net/atos/zac/app/util/filter/CharsetInterceptorFilter.kt
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+package net.atos.zac.app.util.filter
+
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerRequestFilter
+import jakarta.ws.rs.ext.Provider
+import org.jboss.resteasy.plugins.providers.multipart.InputPart
+
+/**
+ * Filter to set the default charset to UTF-8 for multipart requesr inputs (as used in multipart/formdata).
+ * This fixes the issue where JBoss/RESTEasy does not default (yet) to UTF-8.
+ * See e.g.: https://github.com/quarkusio/quarkus/issues/10323
+ * Once JBoss/RESTEasy has fixed this issue and defaults correctly to UTF-8, as per specification, this filter can be removed.
+ */
+@Provider
+class CharsetInterceptorFilter : ContainerRequestFilter {
+    override fun filter(context: ContainerRequestContext) {
+        context.setProperty(InputPart.DEFAULT_CHARSET_PROPERTY, "UTF-8")
+    }
+}

--- a/src/main/kotlin/net/atos/zac/app/util/filter/CharsetInterceptorFilter.kt
+++ b/src/main/kotlin/net/atos/zac/app/util/filter/CharsetInterceptorFilter.kt
@@ -11,10 +11,11 @@ import jakarta.ws.rs.ext.Provider
 import org.jboss.resteasy.plugins.providers.multipart.InputPart
 
 /**
- * Filter to set the default charset to UTF-8 for multipart requesr inputs (as used in multipart/formdata).
+ * Filter to set the default charset to UTF-8 for multipart request inputs (as used in multipart/formdata).
  * This fixes the issue where JBoss/RESTEasy does not default (yet) to UTF-8.
  * See e.g.: https://github.com/quarkusio/quarkus/issues/10323
- * Once JBoss/RESTEasy has fixed this issue and defaults correctly to UTF-8, as per specification, this filter can be removed.
+ * Once JBoss/RESTEasy has fixed this issue and defaults correctly to UTF-8, as per specification,
+ * this filter can be removed.
  */
 @Provider
 class CharsetInterceptorFilter : ContainerRequestFilter {


### PR DESCRIPTION
Use default UTF8 charset for multipart formdata by adding a ContainerRequestFilter because currently JBoss/RESTEasy does not yet default to UTF8 when the charset is not explicitly set by the client.

Solves PZ-2744