### PR TITLE
chore: directly map toelichting field to auditToelichting in OpenZaak for Rol

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/ZaakHistorieTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZaakHistorieTest.kt
@@ -41,7 +41,7 @@ class ZaakHistorieTest : BehaviorSpec({
                     "attribuutLabel": "Behandelaar",
                     "door": "$TEST_USER_1_NAME",
                     "nieuweWaarde": "$TEST_USER_1_NAME",
-                    "toelichting": "Behandelaar: null"
+                    "toelichting": ""
                   },
                   {
                     "attribuutLabel": "zaakinformatieobject",
@@ -59,25 +59,25 @@ class ZaakHistorieTest : BehaviorSpec({
                     "attribuutLabel": "Behandelaar",
                     "door": "Functionele gebruiker",
                     "oudeWaarde": "$TEST_USER_1_NAME",
-                    "toelichting": "Behandelaar: dummyLijstVrijgevenReason"
+                    "toelichting": "dummyLijstVrijgevenReason"
                   },
                   {
                     "attribuutLabel": "Behandelaar",
                     "door": "$TEST_USER_1_NAME",
                     "nieuweWaarde": "$TEST_USER_1_NAME",
-                    "toelichting": "Behandelaar: dummyAssignToMeFromListReason"
+                    "toelichting": "dummyAssignToMeFromListReason"
                   },
                   {
                     "attribuutLabel": "Behandelaar",
                     "door": "$TEST_USER_1_NAME",
                     "oudeWaarde": "$TEST_USER_2_NAME",
-                    "toelichting": "Behandelaar: dummyAssignToMeFromListReason"
+                    "toelichting": "dummyAssignToMeFromListReason"
                   },
                   {
                     "attribuutLabel": "Behandelaar",
                     "door": "Functionele gebruiker",
                     "nieuweWaarde": "$TEST_USER_2_NAME",
-                    "toelichting": "Behandelaar: dummyLijstVerdelenReason"
+                    "toelichting": "dummyLijstVerdelenReason"
                   },
                   {
                     "attribuutLabel": "status",
@@ -89,7 +89,7 @@ class ZaakHistorieTest : BehaviorSpec({
                     "attribuutLabel": "Melder",
                     "door": "Functionele gebruiker",
                     "nieuweWaarde": "$TEST_PERSON_HENDRIKA_JANSE_BSN",
-                    "toelichting": "Melder: null"
+                    "toelichting": ""
                   },
                   {
                     "attribuutLabel": "zaakinformatieobject",
@@ -106,7 +106,7 @@ class ZaakHistorieTest : BehaviorSpec({
                     "attribuutLabel": "Behandelaar",
                     "door": "Functionele gebruiker",
                     "nieuweWaarde": "$TEST_GROUP_A_DESCRIPTION",
-                    "toelichting": "Behandelaar: null"
+                    "toelichting": ""
                   },
                   {
                     "attribuutLabel": "zaak",

--- a/src/main/java/net/atos/client/zgw/zrc/ZRCClientService.java
+++ b/src/main/java/net/atos/client/zgw/zrc/ZRCClientService.java
@@ -91,7 +91,7 @@ public class ZRCClientService {
      * @return Created {@link Rol}.
      */
     public Rol<?> createRol(final Rol<?> rol, final String toelichting) {
-        zgwClientHeadersFactory.setAuditToelichting("%s: %s".formatted(rol.getOmschrijving(), toelichting));
+        zgwClientHeadersFactory.setAuditToelichting(toelichting);
         return zrcClient.rolCreate(rol);
     }
 
@@ -102,7 +102,7 @@ public class ZRCClientService {
      * @param toelichting de toelichting
      */
     public void deleteRol(final Rol<?> rol, final String toelichting) {
-        zgwClientHeadersFactory.setAuditToelichting("%s: %s".formatted(rol.getOmschrijving(), toelichting));
+        zgwClientHeadersFactory.setAuditToelichting(toelichting);
         zrcClient.rolDelete(rol.getUuid());
     }
 


### PR DESCRIPTION
Directly map toelichting field to auditToelichting in OpenZaak for Rol, so we don't clutter the Case History.
Resolves PZ-3118