### PR TITLE
fix: index out of range error when comparing array

### DIFF
--- a/src/main/kotlin/net/atos/zac/app/zaken/converter/historie/MapUtils.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/converter/historie/MapUtils.kt
@@ -8,8 +8,10 @@ fun Map<*, *>.diff(other: Map<*, *>): Map<Any?, Pair<Any?, Any?>> = other
 
 private fun compare(left: Any?, right: Any?): Boolean =
     when {
-        left is Map<*, *> && right is Map<*, *> -> left.all { compare(it.value, right[it.key]) }
-        left is List<*> && right is List<*> -> left.withIndex().all { compare(it.value, right[it.index]) }
+        left is Map<*, *> && right is Map<*, *> -> left.all { right.containsKey(it.key) && compare(it.value, right[it.key]) }
+        left is List<*> && right is List<*> -> left.withIndex().all {
+            right.size > it.index && compare(it.value, right[it.index])
+        }
         else -> left == right
     }
 

--- a/src/main/kotlin/net/atos/zac/app/zaken/converter/historie/MapUtils.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/converter/historie/MapUtils.kt
@@ -8,9 +8,11 @@ fun Map<*, *>.diff(other: Map<*, *>): Map<Any?, Pair<Any?, Any?>> = other
 
 private fun compare(left: Any?, right: Any?): Boolean =
     when {
-        left is Map<*, *> && right is Map<*, *> -> left.all { right.containsKey(it.key) && compare(it.value, right[it.key]) }
-        left is List<*> && right is List<*> -> left.withIndex().all {
-            right.size > it.index && compare(it.value, right[it.index])
+        left is Map<*, *> && right is Map<*, *> -> left.all {
+            right.containsKey(it.key) && compare(it.value, right[it.key])
+        }
+        left is List<*> && right is List<*> -> left.size == right.size && left.withIndex().all {
+            compare(it.value, right[it.index])
         }
         else -> left == right
     }

--- a/src/test/kotlin/net/atos/zac/app/zaken/converter/historie/RESTZaakHistorieRegelConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaken/converter/historie/RESTZaakHistorieRegelConverterTest.kt
@@ -435,4 +435,136 @@ class RESTZaakHistorieRegelConverterTest : BehaviorSpec({
             }
         }
     }
+
+    Given("A partial update with a list that has gotten smaller") {
+        val ztcClientService = mockk<ZtcClientService>()
+        val vrlClientService = mockk<VrlClientService>()
+
+        val zrcAuditTrailRegel = createZRCAuditTrailRegel(
+            bron = Bron.AUTORISATIES_API,
+            actie = "partial_update",
+            actieWeergave = "Almost updated",
+            resultaat = 201,
+            hoofdObject = URI("https://example.com/somePath"),
+            resource = "communicatiekanaal",
+            resourceUrl = URI("https://example.com/somePath"),
+            toelichting = "hologram",
+            wijzigingen = Wijzigingen().apply {
+                this.oud = mapOf("my_list" to listOf(1, 2))
+                this.nieuw = mapOf("my_list" to listOf(1))
+            }
+        )
+
+        val restZaakHistorieRegelConverter = RESTZaakHistorieRegelConverter(
+            ztcClientService,
+            RESTZaakHistoriePartialUpdateConverter(vrlClientService)
+        )
+
+        When("converted to REST historie regel") {
+            val listRestRegel = restZaakHistorieRegelConverter.convertZaakRESTHistorieRegel(zrcAuditTrailRegel)
+
+            Then("it should not throw an exception") {
+                listRestRegel.size shouldBe 1
+            }
+        }
+    }
+
+    Given("A partial update with a list that stays the same size but values change") {
+        val ztcClientService = mockk<ZtcClientService>()
+        val vrlClientService = mockk<VrlClientService>()
+
+        val zrcAuditTrailRegel = createZRCAuditTrailRegel(
+            bron = Bron.AUTORISATIES_API,
+            actie = "partial_update",
+            actieWeergave = "Almost updated",
+            resultaat = 201,
+            hoofdObject = URI("https://example.com/somePath"),
+            resource = "communicatiekanaal",
+            resourceUrl = URI("https://example.com/somePath"),
+            toelichting = "hologram",
+            wijzigingen = Wijzigingen().apply {
+                this.oud = mapOf("my_list" to listOf(1, 2))
+                this.nieuw = mapOf("my_list" to listOf(1, 3))
+            }
+        )
+
+        val restZaakHistorieRegelConverter = RESTZaakHistorieRegelConverter(
+            ztcClientService,
+            RESTZaakHistoriePartialUpdateConverter(vrlClientService)
+        )
+
+        When("converted to REST historie regel") {
+            val listRestRegel = restZaakHistorieRegelConverter.convertZaakRESTHistorieRegel(zrcAuditTrailRegel)
+
+            Then("it should not throw an exception") {
+                listRestRegel.size shouldBe 1
+            }
+        }
+    }
+
+    Given("A partial update with a list that stays exactly the same") {
+        val ztcClientService = mockk<ZtcClientService>()
+        val vrlClientService = mockk<VrlClientService>()
+
+        val zrcAuditTrailRegel = createZRCAuditTrailRegel(
+            bron = Bron.AUTORISATIES_API,
+            actie = "partial_update",
+            actieWeergave = "Almost updated",
+            resultaat = 201,
+            hoofdObject = URI("https://example.com/somePath"),
+            resource = "communicatiekanaal",
+            resourceUrl = URI("https://example.com/somePath"),
+            toelichting = "hologram",
+            wijzigingen = Wijzigingen().apply {
+                this.oud = mapOf("my_list" to listOf(1, 2))
+                this.nieuw = mapOf("my_list" to listOf(1, 2))
+            }
+        )
+
+        val restZaakHistorieRegelConverter = RESTZaakHistorieRegelConverter(
+            ztcClientService,
+            RESTZaakHistoriePartialUpdateConverter(vrlClientService)
+        )
+
+        When("converted to REST historie regel") {
+            val listRestRegel = restZaakHistorieRegelConverter.convertZaakRESTHistorieRegel(zrcAuditTrailRegel)
+
+            Then("it should not contain lines") {
+                listRestRegel.size shouldBe 0
+            }
+        }
+    }
+
+    Given("A partial update with a map with a value that changes") {
+        val ztcClientService = mockk<ZtcClientService>()
+        val vrlClientService = mockk<VrlClientService>()
+
+        val zrcAuditTrailRegel = createZRCAuditTrailRegel(
+            bron = Bron.AUTORISATIES_API,
+            actie = "partial_update",
+            actieWeergave = "Almost updated",
+            resultaat = 201,
+            hoofdObject = URI("https://example.com/somePath"),
+            resource = "communicatiekanaal",
+            resourceUrl = URI("https://example.com/somePath"),
+            toelichting = "hologram",
+            wijzigingen = Wijzigingen().apply {
+                this.oud = mapOf("my_map" to mapOf("my_key" to "my_value"))
+                this.nieuw = mapOf("my_list" to mapOf("my_key" to "my_changed_value"))
+            }
+        )
+
+        val restZaakHistorieRegelConverter = RESTZaakHistorieRegelConverter(
+            ztcClientService,
+            RESTZaakHistoriePartialUpdateConverter(vrlClientService)
+        )
+
+        When("converted to REST historie regel") {
+            val listRestRegel = restZaakHistorieRegelConverter.convertZaakRESTHistorieRegel(zrcAuditTrailRegel)
+
+            Then("it should contain a line") {
+                listRestRegel.size shouldBe 1
+            }
+        }
+    }
 })


### PR DESCRIPTION
When comparing arrays in the case history, we should check the length of the array before indexing into it.
Solves PZ-3210