### PR TITLE
chore: upgraded Grafana in Docker Compose setup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -443,7 +443,7 @@ services:
 
   # Visualizes metrics and traces data
   grafana:
-    image: grafana/grafana:10.1.1
+    image: grafana/grafana:11.0.1
     volumes:
       - ./scripts/docker-compose/imports/grafana/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
       - ./scripts/docker-compose/volume-data/grafana-data:/var/lib/grafana


### PR DESCRIPTION
Upgraded Grafana in Docker Compose setup. Note: I did not upgrade the OTEL Collector because upgrading that to the latest version (0.104.0) seems to break the ZAC metrics flow to Tempo. To be looked at later.

Solves PZ-3147