### PR TITLE
chore: upgraded the KVK OpenAPI specs for the KVK V1 APIs

### DIFF
--- a/src/main/resources/api-specs/kvk/basisprofiel-openapi.yaml
+++ b/src/main/resources/api-specs/kvk/basisprofiel-openapi.yaml
@@ -2,39 +2,39 @@ openapi: 3.0.1
 info:
   title: API Basisprofiel
   description: Documentatie voor API Basisprofiel.
-  version: "1.3"
+  version: "1.4"
 servers:
-  - url: /test/api
-    description: only for testing with Swagger widget
-  - url: https://api.kvk.nl/test/api
-    description: Test API (uses Staat der Nederlanden Private Root CA – G1 certificate
-      chain)
-  - url: https://api.kvk.nl/api
-    description: Production API (uses Staat der Nederlanden Private Root CA – G1 certificate
-      chain)
+- url: /test/api
+  description: only for testing with Swagger widget
+- url: https://api.kvk.nl/test/api
+  description: Test API (uses Staat der Nederlanden Private Root CA – G1 certificate
+    chain)
+- url: https://api.kvk.nl/api
+  description: Production API (uses Staat der Nederlanden Private Root CA – G1 certificate
+    chain)
 tags:
-  - name: Basisprofiel
+- name: Basisprofiel
 paths:
   /v1/basisprofielen/{kvkNummer}:
     get:
       tags:
-        - Basisprofiel
+      - Basisprofiel
       summary: Voor een specifiek bedrijf basisinformatie opvragen.
       operationId: getBasisprofielByKvkNummer
       parameters:
-        - name: kvkNummer
-          in: path
-          description: "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
-          required: true
-          schema:
-            pattern: "^[0-9]{8}$"
-            type: string
-        - name: geoData
-          in: query
-          required: false
-          schema:
-            type: boolean
-            default: false
+      - name: kvkNummer
+        in: path
+        description: "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
+        required: true
+        schema:
+          pattern: "^[0-9]{8}$"
+          type: string
+      - name: geoData
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
       responses:
         default:
           description: default response
@@ -43,27 +43,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/Basisprofiel'
       security:
-        - ApiKeyAuth: [ ]
+      - ApiKeyAuth: []
   /v1/basisprofielen/{kvkNummer}/eigenaar:
     get:
       tags:
-        - Basisprofiel
+      - Basisprofiel
       summary: Voor een specifiek bedrijf eigenaar informatie opvragen.
       operationId: getEigenaar
       parameters:
-        - name: kvkNummer
-          in: path
-          description: "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
-          required: true
-          schema:
-            pattern: "^[0-9]{8}$"
-            type: string
-        - name: geoData
-          in: query
-          required: false
-          schema:
-            type: boolean
-            default: false
+      - name: kvkNummer
+        in: path
+        description: "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
+        required: true
+        schema:
+          pattern: "^[0-9]{8}$"
+          type: string
+      - name: geoData
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
       responses:
         default:
           description: default response
@@ -72,27 +72,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/Eigenaar'
       security:
-        - ApiKeyAuth: [ ]
+      - ApiKeyAuth: []
   /v1/basisprofielen/{kvkNummer}/hoofdvestiging:
     get:
       tags:
-        - Basisprofiel
+      - Basisprofiel
       summary: Voor een specifiek bedrijf hoofdvestigingsinformatie opvragen.
       operationId: getHoofdvestiging
       parameters:
-        - name: kvkNummer
-          in: path
-          description: "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
-          required: true
-          schema:
-            pattern: "^[0-9]{8}$"
-            type: string
-        - name: geoData
-          in: query
-          required: false
-          schema:
-            type: boolean
-            default: false
+      - name: kvkNummer
+        in: path
+        description: "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
+        required: true
+        schema:
+          pattern: "^[0-9]{8}$"
+          type: string
+      - name: geoData
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
       responses:
         default:
           description: default response
@@ -101,21 +101,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/Vestiging'
       security:
-        - ApiKeyAuth: [ ]
+      - ApiKeyAuth: []
   /v1/basisprofielen/{kvkNummer}/vestigingen:
     get:
       tags:
-        - Basisprofiel
+      - Basisprofiel
       summary: Voor een specifiek bedrijf een lijst met vestigingen opvragen.
       operationId: getVestigingen
       parameters:
-        - name: kvkNummer
-          in: path
-          description: "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
-          required: true
-          schema:
-            pattern: "^[0-9]{8}$"
-            type: string
+      - name: kvkNummer
+        in: path
+        description: "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
+        required: true
+        schema:
+          pattern: "^[0-9]{8}$"
+          type: string
       responses:
         default:
           description: default response
@@ -124,7 +124,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/VestigingList'
       security:
-        - ApiKeyAuth: [ ]
+      - ApiKeyAuth: []
 components:
   schemas:
     Adres:
@@ -146,8 +146,6 @@ components:
         huisnummerToevoeging:
           type: string
         huisletter:
-          type: string
-        aanduidingBijHuisnummer:
           type: string
         toevoegingAdres:
           type: string
@@ -227,6 +225,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Adres'
+        websites:
+          type: array
+          items:
+            type: string
         links:
           type: array
           items:
@@ -276,8 +278,7 @@ components:
         volgorde:
           type: integer
           format: int32
-      description: Alle namen waaronder een onderneming of vestiging handelt (op volgorde
-        van registreren)
+      description: Alle namen waaronder een vestiging handelt (op volgorde van registreren)
     Link:
       type: object
       properties:
@@ -359,6 +360,12 @@ components:
         deeltijdWerkzamePersonen:
           type: integer
           description: Aantal deeltijd werkzame personen
+        handelsnamen:
+          type: array
+          description: Alle namen waaronder een vestiging handelt (op volgorde van
+            registreren)
+          items:
+            $ref: '#/components/schemas/Handelsnaam'
         adressen:
           type: array
           items:

--- a/src/main/resources/api-specs/kvk/vestigingsprofiel-openapi.yaml
+++ b/src/main/resources/api-specs/kvk/vestigingsprofiel-openapi.yaml
@@ -4,38 +4,38 @@ info:
   description: Documentatie voor API Vestigingsprofiel.
   version: "1.4"
 servers:
-  - url: /test/api
-    description: only for testing with Swagger widget
-  - url: https://api.kvk.nl/test/api
-    description: Test API (uses Staat der Nederlanden Private Root CA – G1 certificate
-      chain)
-  - url: https://api.kvk.nl/api
-    description: Production API (uses Staat der Nederlanden Private Root CA – G1 certificate
-      chain)
+- url: /test/api
+  description: only for testing with Swagger widget
+- url: https://api.kvk.nl/test/api
+  description: Test API (uses Staat der Nederlanden Private Root CA – G1 certificate
+    chain)
+- url: https://api.kvk.nl/api
+  description: Production API (uses Staat der Nederlanden Private Root CA – G1 certificate
+    chain)
 tags:
-  - name: Vestigingsprofiel
+- name: Vestigingsprofiel
 paths:
   /v1/vestigingsprofielen/{vestigingsnummer}:
     get:
       tags:
-        - Vestigingsprofiel
+      - Vestigingsprofiel
       summary: Voor een specifieke vestiging informatie opvragen.
       operationId: getVestigingByVestigingsnummer
       parameters:
-        - name: vestigingsnummer
-          in: path
-          description: "Vestigingsnummer: uniek nummer dat bestaat uit 12 cijfers"
-          required: true
-          schema:
-            pattern: "^[0-9]{12}$"
-            type: string
-        - name: geoData
-          in: query
-          description: "GeoData: (true/false) geef aan of BAG data opgehaald moet worden"
-          required: false
-          schema:
-            type: boolean
-            default: false
+      - name: vestigingsnummer
+        in: path
+        description: "Vestigingsnummer: uniek nummer dat bestaat uit 12 cijfers"
+        required: true
+        schema:
+          pattern: "^[0-9]{12}$"
+          type: string
+      - name: geoData
+        in: query
+        description: "GeoData: (true/false) geef aan of BAG data opgehaald moet worden"
+        required: false
+        schema:
+          type: boolean
+          default: false
       responses:
         default:
           description: default response
@@ -44,7 +44,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Vestiging'
       security:
-        - ApiKeyAuth: [ ]
+      - ApiKeyAuth: []
 components:
   schemas:
     Adres:

--- a/src/main/resources/api-specs/kvk/zoeken-openapi.yaml
+++ b/src/main/resources/api-specs/kvk/zoeken-openapi.yaml
@@ -2,89 +2,97 @@ openapi: 3.0.1
 info:
   title: API Zoeken
   description: Documentatie voor API Zoeken.
-  version: "1.3"
+  version: "1.6.0"
 servers:
-  - url: /test/api
-    description: only for testing with Swagger widget
-  - url: https://api.kvk.nl/test/api
-    description: Test API (uses Staat der Nederlanden Private Root CA – G1 certificate
-      chain)
-  - url: https://api.kvk.nl/api
-    description: Production API (uses Staat der Nederlanden Private Root CA – G1 certificate
-      chain)
+- url: /test/api
+  description: only for testing with Swagger widget
+- url: https://api.kvk.nl/test/api
+  description: Test API (uses Staat der Nederlanden Private Root CA – G1 certificate
+    chain)
+- url: https://api.kvk.nl/api
+  description: Production API (uses Staat der Nederlanden Private Root CA – G1 certificate
+    chain)
+tags:
+- name: Zoeken
 paths:
   /v1/zoeken:
     get:
       tags:
-        - Zoeken
+      - Zoeken
       summary: Voor een bedrijf zoeken naar basisinformatie.
       description: Er wordt max. 1000 resultaten getoond.
       operationId: getResults
       parameters:
-        - name: kvkNummer
-          in: query
-          description: "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
-          schema:
-            pattern: "^[0-9]{8}$"
-            type: string
-        - name: rsin
-          in: query
-          description: Rechtspersonen Samenwerkingsverbanden Informatie Nummer
-          schema:
-            pattern: "^[0-9]{9}$"
-            type: string
-        - name: vestigingsnummer
-          in: query
-          description: "Vestigingsnummer: uniek nummer dat bestaat uit 12 cijfers"
-          schema:
-            pattern: "^[0-9]{12}$"
-            type: string
-        - name: handelsnaam
-          in: query
-          description: De naam waaronder een vestiging of rechtspersoon handelt
-          schema:
-            type: string
-        - name: straatnaam
-          in: query
-          schema:
-            type: string
-        - name: plaats
-          in: query
-          schema:
-            type: string
-        - name: postcode
-          in: query
-          description: Mag alleen in combinatie met Huisnummer gezocht worden
-          schema:
-            type: string
-        - name: huisnummer
-          in: query
-          description: Mag alleen in combinatie met Postcode gezocht worden
-          schema:
-            type: string
-        - name: type
-          in: query
-          description: "Filter op type: hoofdvestiging, nevenvestiging en/of rechtspersoon"
-          schema:
-            type: string
-        - name: InclusiefInactieveRegistraties
-          in: query
-          description: "Inclusief inactieve registraties: true, false"
-          schema:
-            type: boolean
-        - name: pagina
-          in: query
-          description: "Paginanummer, minimaal 1 en maximaal 1000"
-          schema:
-            type: number
-            default: "1"
-        - name: aantal
-          in: query
-          description: "Kies het aantal resultaten per pagina, minimaal 1 en maximaal\
+      - name: kvkNummer
+        in: query
+        description: "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
+        schema:
+          pattern: "^[0-9]{8}$"
+          type: string
+      - name: rsin
+        in: query
+        description: Rechtspersonen Samenwerkingsverbanden Informatie Nummer
+        schema:
+          pattern: "^[0-9]{9}$"
+          type: string
+      - name: vestigingsnummer
+        in: query
+        description: "Vestigingsnummer: uniek nummer dat bestaat uit 12 cijfers"
+        schema:
+          pattern: "^[0-9]{12}$"
+          type: string
+      - name: handelsnaam
+        in: query
+        description: De naam waaronder een vestiging of rechtspersoon handelt
+        schema:
+          type: string
+      - name: straatnaam
+        in: query
+        schema:
+          type: string
+      - name: plaats
+        in: query
+        schema:
+          type: string
+      - name: postcode
+        in: query
+        description: Mag alleen in combinatie met Huisnummer gezocht worden
+        schema:
+          type: string
+      - name: huisnummer
+        in: query
+        description: Mag alleen in combinatie met Postcode gezocht worden
+        schema:
+          type: string
+      - name: huisnummerToevoeging
+        in: query
+        description: "Optioneel. Alleen in combinatie met huisnummer. Bestaat uit\
+          \ 1 tot 4 karakters (letters, cijfers, tekens: -, +, spatie)"
+        schema:
+          type: string
+      - name: type
+        in: query
+        description: "Filter op type: hoofdvestiging, nevenvestiging en/of rechtspersoon"
+        schema:
+          type: string
+      - name: InclusiefInactieveRegistraties
+        in: query
+        description: "Inclusief inactieve registraties: true, false"
+        schema:
+          type: boolean
+      - name: pagina
+        in: query
+        description: "Paginanummer, minimaal 1 en maximaal 1000"
+        schema:
+          type: number
+          default: 1
+      - name: aantal
+        in: query
+        description: "Kies het aantal resultaten per pagina, minimaal 1 en maximaal\
           \ 100"
-          schema:
-            type: number
-            default: "10"
+        schema:
+          type: number
+          default: 10
       responses:
         default:
           description: default response
@@ -93,7 +101,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Resultaat'
       security:
-        - ApiKeyAuth: [ ]
+      - ApiKeyAuth: []
 components:
   schemas:
     Link:
@@ -162,6 +170,9 @@ components:
         handelsnaam:
           type: string
           description: De naam waaronder een vestiging of rechtspersoon handelt
+        adresType:
+          type: string
+          description: Correspondentieadres of bezoekadres
         straatnaam:
           type: string
         huisnummer:


### PR DESCRIPTION
Upgraded the KVK OpenAPI specs for the KVK V1 APIs. The KVK Zoeken V2 API is a bigger change for a future story. Note that we do not have integration tests yet that make use of the ZAC KVK functionality so this involved manual testing for now.

Solves PZ-3148