### PR TITLE
fix: zaakobjecten mapping regression in case history

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/ZaakHistorieTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZaakHistorieTest.kt
@@ -108,11 +108,6 @@ class ZaakHistorieTest : BehaviorSpec({
                     "actie": "GEKOPPELD"
                   },
                   {
-                    "attribuutLabel": "overige",
-                    "door": "Functionele gebruiker",
-                    "toelichting": ""
-                  },
-                  {
                     "attribuutLabel": "Behandelaar",
                     "door": "Functionele gebruiker",
                     "nieuweWaarde": "$TEST_GROUP_A_DESCRIPTION",

--- a/src/main/kotlin/net/atos/zac/app/zaken/converter/historie/RESTZaakHistorieRegelConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaken/converter/historie/RESTZaakHistorieRegelConverter.kt
@@ -3,6 +3,7 @@ package net.atos.zac.app.zaken.converter.historie
 import jakarta.inject.Inject
 import net.atos.client.zgw.shared.model.audit.ZRCAuditTrailRegel
 import net.atos.client.zgw.shared.util.URIUtil
+import net.atos.client.zgw.zrc.model.Objecttype
 import net.atos.client.zgw.zrc.model.Rol
 import net.atos.client.zgw.zrc.model.zaakobjecten.Zaakobject
 import net.atos.client.zgw.zrc.model.zaakobjecten.ZaakobjectProductaanvraag
@@ -18,7 +19,6 @@ private const val PARTIAL_UPDATE = "partial_update"
 
 private const val IDENTIFICATIE = "identificatie"
 private const val KLANTCONTACT = "klantcontact"
-private const val OBJECT_TYPE = "objectType"
 private const val RESULTAAT = "resultaat"
 private const val RESULTAATTYPE = "resultaattype"
 private const val ROL = "rol"
@@ -51,33 +51,40 @@ class RESTZaakHistorieRegelConverter @Inject constructor(
             auditTrail.actie == CREATE ||
                 auditTrail.actie == UPDATE ||
                 auditTrail.actie == DESTROY
-            -> listOf(convertLine(auditTrail, old, new))
+            -> listOfNotNull(convertLine(auditTrail, old, new))
 
             else -> emptyList()
         }
     }
 
-    private fun convertLine(auditTrail: ZRCAuditTrailRegel, old: Map<*, *>?, new: Map<*, *>?): RESTHistorieRegel =
-        RESTHistorieRegel(
-            (old ?: new)?.let { convertResource(auditTrail.resource, it) },
-            old?.let { convertValue(auditTrail.resource, it, auditTrail.resourceWeergave) },
-            new?.let { convertValue(auditTrail.resource, it, auditTrail.resourceWeergave) }
-        ).apply {
-            datumTijd = auditTrail.aanmaakdatum
-            toelichting = auditTrail.toelichting
-            door = auditTrail.gebruikersWeergave
-            actie = convertActie(auditTrail.resource, auditTrail.actie)
-        }
+    private fun convertLine(auditTrail: ZRCAuditTrailRegel, old: Map<*, *>?, new: Map<*, *>?): RESTHistorieRegel? =
+        (old ?: new)
+            ?.let { convertResource(auditTrail.resource, it) }
+            ?.let { resource ->
+                RESTHistorieRegel(
+                    resource,
+                    old?.let { convertValue(auditTrail.resource, it, auditTrail.resourceWeergave) },
+                    new?.let { convertValue(auditTrail.resource, it, auditTrail.resourceWeergave) }
+                )
+            }
+            ?.apply {
+                datumTijd = auditTrail.aanmaakdatum
+                toelichting = auditTrail.toelichting
+                door = auditTrail.gebruikersWeergave
+                actie = convertActie(auditTrail.resource, auditTrail.actie)
+            }
 
-    private fun convertResource(resource: String, obj: Map<*, *>): String = when (resource) {
+    private fun convertResource(resource: String, obj: Map<*, *>): String? = when (resource) {
         ROL -> obj.stringProperty(ROLTYPE)
             ?.let(URI::create)
             ?.let(URIUtil::parseUUIDFromResourceURI)
             ?.let(ztcClientService::readRoltype)
             ?.omschrijving
-        ZAAKOBJECT -> obj.stringProperty(OBJECT_TYPE)
+        ZAAKOBJECT -> obj.getTypedValue(Zaakobject::class.java)
+            ?.let(::getObjectType)
+            ?.let { "objecttype.$it" }
         else -> resource
-    } ?: resource
+    }
 
     private fun convertValue(resource: String, obj: Map<*, *>, resourceWeergave: String?): String? =
         when (resource) {
@@ -96,7 +103,7 @@ class RESTZaakHistorieRegelConverter @Inject constructor(
             ZAAKOBJECT -> obj.getTypedValue(Zaakobject::class.java).let {
                 when {
                     it is ZaakobjectProductaanvraag -> null
-                    else -> "objecttype.${it?.waarde}"
+                    else -> it?.waarde
                 }
             }
             else -> null
@@ -109,5 +116,11 @@ class RESTZaakHistorieRegelConverter @Inject constructor(
         action == DESTROY -> RESTHistorieActie.ONTKOPPELD
         action == UPDATE || action == PARTIAL_UPDATE -> RESTHistorieActie.GEWIJZIGD
         else -> null
+    }
+
+    private fun getObjectType(obj: Zaakobject): String? = when {
+        obj is ZaakobjectProductaanvraag -> null
+        obj.objectType == Objecttype.OVERIGE -> obj.objectTypeOverige
+        else -> obj.objectType.toString()
     }
 }

--- a/src/test/kotlin/net/atos/zac/app/zaken/converter/historie/RESTZaakHistorieRegelConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaken/converter/historie/RESTZaakHistorieRegelConverterTest.kt
@@ -14,6 +14,7 @@ import net.atos.client.zgw.shared.model.audit.createZRCAuditTrailRegel
 import net.atos.client.zgw.zrc.model.generated.Wijzigingen
 import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.client.zgw.ztc.model.createResultaatType
+import net.atos.client.zgw.ztc.model.createRolType
 import net.atos.client.zgw.ztc.model.createStatusType
 import net.atos.zac.app.audit.model.RESTHistorieActie
 import java.net.URI
@@ -73,8 +74,13 @@ class RESTZaakHistorieRegelConverterTest : BehaviorSpec({
     }
 
     Given("Audit trail has resource rol with action updated") {
+        val uuid = UUID.randomUUID()
+        val rolTypeUri = "https://example.com/roltype/$uuid"
+        val rolType = createRolType()
         val ztcClientService = mockk<ZtcClientService>()
         val vrlClientService = mockk<VrlClientService>()
+
+        every { ztcClientService.readRoltype(uuid) } returns rolType
 
         val zrcAuditTrailRegel = createZRCAuditTrailRegel(
             bron = Bron.AUTORISATIES_API,
@@ -87,6 +93,7 @@ class RESTZaakHistorieRegelConverterTest : BehaviorSpec({
             toelichting = "rol updated",
             wijzigingen = Wijzigingen().apply {
                 nieuw = mapOf(
+                    "roltype" to rolTypeUri,
                     "roltoelichting" to "",
                     "omschrijving" to "dummyOmschrijving",
                     "betrokkeneIdentificatie" to mapOf(
@@ -113,7 +120,7 @@ class RESTZaakHistorieRegelConverterTest : BehaviorSpec({
             Then("it should return correct data") {
                 listRestRegel.size shouldBe 1
                 with(listRestRegel.first()) {
-                    attribuutLabel shouldBe "rol"
+                    attribuutLabel shouldBe rolType.omschrijving
                     oudeWaarde shouldBe null
                     nieuweWaarde shouldBe "dummyVoorletters dummyAchternaam"
                     datumTijd shouldBe zrcAuditTrailRegel.aanmaakdatum
@@ -339,9 +346,9 @@ class RESTZaakHistorieRegelConverterTest : BehaviorSpec({
             Then("it should return correct data") {
                 listRestRegel.size shouldBe 1
                 with(listRestRegel.first()) {
-                    attribuutLabel shouldBe "adres"
+                    attribuutLabel shouldBe "objecttype.ADRES"
                     oudeWaarde shouldBe null
-                    nieuweWaarde shouldBe "objecttype.identity"
+                    nieuweWaarde shouldBe "identity"
                     datumTijd shouldBe zrcAuditTrailRegel.aanmaakdatum
                     door shouldBe zrcAuditTrailRegel.gebruikersWeergave
                     applicatie shouldBe null


### PR DESCRIPTION
In the case history, fixed a regression in the mapping of zaakobjects in the case history. The `object type` / `object type overig` is now correctly used in the resource, the value is no longer prepended and objects of type ProductAanvraag are completely ignored.
Solves PZ-3158