### PR TITLE
fix: delete integration tests Docker Compose volumes by default

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
@@ -148,7 +148,7 @@ class ProjectConfig : AbstractProjectConfig() {
 
         return ComposeContainer(File("docker-compose.yaml"))
             .withLocalCompose(true)
-            .withRemoveVolumes(System.getenv("REMOVE_DOCKER_COMPOSE_VOLUMES").toBoolean())
+            .withRemoveVolumes(System.getenv("REMOVE_DOCKER_COMPOSE_VOLUMES")?.toBoolean() ?: true)
             .withEnv(dockerComposeEnvironment)
             .withOptions(
                 "--profile zac",


### PR DESCRIPTION
If `REMOVE_DOCKER_COMPOSE_VOLUMES` not set, delete volumes

Solves: PZ-3181