### PR TITLE
chore(actions): set pr title in update-gradle-wrapper

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -23,3 +23,5 @@ jobs:
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1
+        with:
+          pr-title-template: 'chore(deps): Bump Gradle Wrapper from %sourceVersion% to %targetVersion%'


### PR DESCRIPTION
The GitHub action to update the Gradle Wrapper should use conventional commit format.

The `pr-title-template` is configured so that the title of PRs will match conventional commit checks. 