### PR TITLE
chore: use naam instead of handelsnaam for kvk vestiging

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/KlantRestServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/KlantRestServiceTest.kt
@@ -15,7 +15,7 @@ import nl.lifely.zac.itest.config.ItestConfiguration.BETROKKENE_IDENTIFACTION_TY
 import nl.lifely.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.lifely.zac.itest.config.ItestConfiguration.ROLTYPE_COUNT
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_ADRES_1
-import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_HANDELSNAAM_1
+import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_NAAM_1
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_NUMMER_1
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_PLAATS_1
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_VESTIGINGSNUMMER_1
@@ -91,11 +91,10 @@ class KlantRestServiceTest : BehaviorSpec({
                 logger.info { "Response: $responseBody" }
                 with(responseBody) {
                     shouldContainJsonKeyValue("adres", "$TEST_KVK_ADRES_1, $TEST_KVK_PLAATS_1")
-                    shouldContainJsonKeyValue("handelsnaam", TEST_KVK_HANDELSNAAM_1)
                     shouldContainJsonKeyValue("identificatie", TEST_KVK_VESTIGINGSNUMMER_1)
                     shouldContainJsonKeyValue("identificatieType", BETROKKENE_IDENTIFACTION_TYPE_VESTIGING)
                     shouldContainJsonKeyValue("kvkNummer", TEST_KVK_NUMMER_1)
-                    shouldContainJsonKeyValue("naam", TEST_KVK_HANDELSNAAM_1)
+                    shouldContainJsonKeyValue("naam", TEST_KVK_NAAM_1)
                     shouldContainJsonKeyValue("type", VESTIGINGTYPE_NEVENVESTIGING)
                     shouldContainJsonKeyValue("vestigingsnummer", TEST_KVK_VESTIGINGSNUMMER_1)
                 }

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
@@ -108,7 +108,7 @@ object ItestConfiguration {
      * Constants used in the KVK WireMock template response
      */
     const val TEST_KVK_ADRES_1 = "dummyStraatnaam1"
-    const val TEST_KVK_HANDELSNAAM_1 = "dummyNaam1"
+    const val TEST_KVK_NAAM_1 = "dummyNaam1"
     const val TEST_KVK_NUMMER_1 = "12345678"
     const val TEST_KVK_PLAATS_1 = "dummyPlaats1"
     const val TEST_KVK_VESTIGINGSNUMMER_1 = "000012345678"

--- a/src/main/app/src/app/klanten/bedrijf-view/bedrijf-view.component.html
+++ b/src/main/app/src/app/klanten/bedrijf-view/bedrijf-view.component.html
@@ -4,52 +4,88 @@
   -->
 
 <mat-drawer-container class="inner-sidenav-container tablet-bottom-toolbar">
-    <mat-drawer-content>
-        <div class="flex-row flex-wrap">
-            <mat-card class="flex-1">
-                <mat-card-header>
-                    <mat-card-title>{{'bedrijfsgegevens' | translate}}</mat-card-title>
-                    <button mat-icon-button [disabled]="!vestigingsprofielOphalenMogelijk"
-                            title="{{ 'bedrijf.profiel.ophalen' | translate }}" (click)="ophalenVestigingsprofiel()">
-                        <mat-icon outlined>other_admission</mat-icon>
-                    </button>
-                </mat-card-header>
-                <mat-card-content>
-                        <div id="bedrijfsgegevens" class="content flex-row flex-wrap space-between">
-                            <zac-static-text [label]="'bedrijfsnaam' | translate"
-                                             [value]="bedrijf.naam"></zac-static-text>
-                            <zac-static-text [label]="'kvknummer' | translate"
-                                             [value]="bedrijf.kvkNummer"></zac-static-text>
-                            <zac-static-text *ngIf="bedrijf.vestigingsnummer" [label]="'vestigingsnummer' | translate"
-                                             [value]="bedrijf.vestigingsnummer"></zac-static-text>
-                            <zac-static-text *ngIf="bedrijf.rsin" [label]="'rsin' | translate"
-                                             [value]="bedrijf.rsin"></zac-static-text>
-                            <zac-static-text [label]="'type' | translate"
-                                             [value]="bedrijf.type | translate"></zac-static-text>
-                            <zac-static-text *ngIf="!vestigingsprofiel" [label]="'adres' | translate"
-                                             [value]="bedrijf.adres | empty"></zac-static-text>
-                            <zac-static-text
-                                    *ngFor="let adres of vestigingsprofiel?.adressen" [label]="adres.type | titlecase"
-                                    [value]="adres.volledigAdres | empty"></zac-static-text>
-                            <zac-static-text [label]="'telefoonnummer' | translate"
-                                             [value]="bedrijf.telefoonnummer | empty"></zac-static-text>
-                            <zac-static-text [label]="'emailadres' | translate"
-                                             [value]="bedrijf.emailadres | empty"></zac-static-text>
-                            <zac-static-text *ngIf="vestigingsprofiel"
-                                             [label]="'totaalWerkzamePersonen' | translate"
-                                             [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"></zac-static-text>
-                            <zac-static-text *ngIf="vestigingsprofiel"
-                                             [label]="'hoofdactiviteit' | translate"
-                                             [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"></zac-static-text>
-                            <zac-static-text *ngIf="vestigingsprofiel"
-                                             [label]="'activiteiten' | translate"
-                                             [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "></zac-static-text>
-                            <zac-static-text *ngIf="vestigingsprofiel"
-                                             [label]="'website' | translate"
-                                             [value]="vestigingsprofiel.website | empty"></zac-static-text>
-                        </div>
-                </mat-card-content>
-            </mat-card>
+  <mat-drawer-content>
+    <div class="flex-row flex-wrap">
+      <mat-card class="flex-1">
+        <mat-card-header>
+          <mat-card-title>{{'bedrijfsgegevens' | translate}}</mat-card-title>
+          <button
+            mat-icon-button
+            [disabled]="!vestigingsprofielOphalenMogelijk"
+            title="{{ 'bedrijf.profiel.ophalen' | translate }}"
+            (click)="ophalenVestigingsprofiel()"
+          >
+            <mat-icon outlined>other_admission</mat-icon>
+          </button>
+        </mat-card-header>
+        <mat-card-content>
+          <div
+            id="bedrijfsgegevens"
+            class="content flex-row flex-wrap space-between"
+          >
+            <zac-static-text
+              [label]="'bedrijfsnaam' | translate"
+              [value]="bedrijf.naam"
+            ></zac-static-text>
+            <zac-static-text
+              [label]="'kvknummer' | translate"
+              [value]="bedrijf.kvkNummer"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="bedrijf.vestigingsnummer"
+              [label]="'vestigingsnummer' | translate"
+              [value]="bedrijf.vestigingsnummer"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="bedrijf.rsin"
+              [label]="'rsin' | translate"
+              [value]="bedrijf.rsin"
+            ></zac-static-text>
+            <zac-static-text
+              [label]="'type' | translate"
+              [value]="bedrijf.type | translate"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="!vestigingsprofiel"
+              [label]="'adres' | translate"
+              [value]="bedrijf.adres | empty"
+            ></zac-static-text>
+            <zac-static-text
+              *ngFor="let adres of vestigingsprofiel?.adressen"
+              [label]="adres.type | titlecase"
+              [value]="adres.volledigAdres | empty"
+            ></zac-static-text>
+            <zac-static-text
+              [label]="'telefoonnummer' | translate"
+              [value]="bedrijf.telefoonnummer | empty"
+            ></zac-static-text>
+            <zac-static-text
+              [label]="'emailadres' | translate"
+              [value]="bedrijf.emailadres | empty"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="vestigingsprofiel"
+              [label]="'totaalWerkzamePersonen' | translate"
+              [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="vestigingsprofiel"
+              [label]="'hoofdactiviteit' | translate"
+              [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="vestigingsprofiel"
+              [label]="'activiteiten' | translate"
+              [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="vestigingsprofiel"
+              [label]="'website' | translate"
+              [value]="vestigingsprofiel.website | empty"
+            ></zac-static-text>
+          </div>
+        </mat-card-content>
+      </mat-card>
 
       <div class="flex-1 w75">
         <zac-klant-zaken-tabel

--- a/src/main/app/src/app/klanten/bedrijf-view/bedrijf-view.component.html
+++ b/src/main/app/src/app/klanten/bedrijf-view/bedrijf-view.component.html
@@ -4,98 +4,59 @@
   -->
 
 <mat-drawer-container class="inner-sidenav-container tablet-bottom-toolbar">
-  <mat-drawer-content>
-    <div class="flex-row flex-wrap">
-      <mat-card class="flex-1">
-        <mat-card-header>
-          <mat-card-title>{{'bedrijfsgegevens' | translate}}</mat-card-title>
-          <button
-            mat-icon-button
-            [disabled]="!vestigingsprofielOphalenMogelijk"
-            title="{{ 'bedrijf.profiel.ophalen' | translate }}"
-            (click)="ophalenVestigingsprofiel()"
-          >
-            <mat-icon outlined>other_admission</mat-icon>
-          </button>
-        </mat-card-header>
-        <mat-card-content>
-          <div
-            id="bedrijfsgegevens"
-            class="content flex-row flex-wrap space-between"
-          >
-            <zac-static-text
-              [label]="'handelsnaam' | translate"
-              [value]="bedrijf.naam"
-            ></zac-static-text>
-            <zac-static-text
-              [label]="'kvknummer' | translate"
-              [value]="bedrijf.kvkNummer"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="bedrijf.vestigingsnummer"
-              [label]="'vestigingsnummer' | translate"
-              [value]="bedrijf.vestigingsnummer"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="bedrijf.rsin"
-              [label]="'rsin' | translate"
-              [value]="bedrijf.rsin"
-            ></zac-static-text>
-            <zac-static-text
-              [label]="'type' | translate"
-              [value]="bedrijf.type | translate"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="!vestigingsprofiel"
-              [label]="'adres' | translate"
-              [value]="bedrijf.adres | empty"
-            ></zac-static-text>
-            <zac-static-text
-              *ngFor="let adres of vestigingsprofiel?.adressen"
-              [label]="adres.type | titlecase"
-              [value]="adres.volledigAdres | empty"
-            ></zac-static-text>
-            <zac-static-text
-              [label]="'telefoonnummer' | translate"
-              [value]="bedrijf.telefoonnummer | empty"
-            ></zac-static-text>
-            <zac-static-text
-              [label]="'emailadres' | translate"
-              [value]="bedrijf.emailadres | empty"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="vestigingsprofiel"
-              [label]="'totaalWerkzamePersonen' | translate"
-              [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="vestigingsprofiel"
-              [label]="'hoofdactiviteit' | translate"
-              [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="vestigingsprofiel"
-              [label]="'activiteiten' | translate"
-              [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="vestigingsprofiel"
-              [label]="'website' | translate"
-              [value]="vestigingsprofiel.website | empty"
-            ></zac-static-text>
-          </div>
-        </mat-card-content>
-      </mat-card>
+    <mat-drawer-content>
+        <div class="flex-row flex-wrap">
+            <mat-card class="flex-1">
+                <mat-card-header>
+                    <mat-card-title>{{'bedrijfsgegevens' | translate}}</mat-card-title>
+                    <button mat-icon-button [disabled]="!vestigingsprofielOphalenMogelijk"
+                            title="{{ 'bedrijf.profiel.ophalen' | translate }}" (click)="ophalenVestigingsprofiel()">
+                        <mat-icon outlined>other_admission</mat-icon>
+                    </button>
+                </mat-card-header>
+                <mat-card-content>
+                        <div id="bedrijfsgegevens" class="content flex-row flex-wrap space-between">
+                            <zac-static-text [label]="'bedrijfsnaam' | translate"
+                                             [value]="bedrijf.naam"></zac-static-text>
+                            <zac-static-text [label]="'kvknummer' | translate"
+                                             [value]="bedrijf.kvkNummer"></zac-static-text>
+                            <zac-static-text *ngIf="bedrijf.vestigingsnummer" [label]="'vestigingsnummer' | translate"
+                                             [value]="bedrijf.vestigingsnummer"></zac-static-text>
+                            <zac-static-text *ngIf="bedrijf.rsin" [label]="'rsin' | translate"
+                                             [value]="bedrijf.rsin"></zac-static-text>
+                            <zac-static-text [label]="'type' | translate"
+                                             [value]="bedrijf.type | translate"></zac-static-text>
+                            <zac-static-text *ngIf="!vestigingsprofiel" [label]="'adres' | translate"
+                                             [value]="bedrijf.adres | empty"></zac-static-text>
+                            <zac-static-text
+                                    *ngFor="let adres of vestigingsprofiel?.adressen" [label]="adres.type | titlecase"
+                                    [value]="adres.volledigAdres | empty"></zac-static-text>
+                            <zac-static-text [label]="'telefoonnummer' | translate"
+                                             [value]="bedrijf.telefoonnummer | empty"></zac-static-text>
+                            <zac-static-text [label]="'emailadres' | translate"
+                                             [value]="bedrijf.emailadres | empty"></zac-static-text>
+                            <zac-static-text *ngIf="vestigingsprofiel"
+                                             [label]="'totaalWerkzamePersonen' | translate"
+                                             [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"></zac-static-text>
+                            <zac-static-text *ngIf="vestigingsprofiel"
+                                             [label]="'hoofdactiviteit' | translate"
+                                             [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"></zac-static-text>
+                            <zac-static-text *ngIf="vestigingsprofiel"
+                                             [label]="'activiteiten' | translate"
+                                             [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "></zac-static-text>
+                            <zac-static-text *ngIf="vestigingsprofiel"
+                                             [label]="'website' | translate"
+                                             [value]="vestigingsprofiel.website | empty"></zac-static-text>
+                        </div>
+                </mat-card-content>
+            </mat-card>
 
-      <div class="flex-1 w75">
-        <zac-klant-zaken-tabel
-          [klantIdentificatie]="bedrijf.identificatie"
-        ></zac-klant-zaken-tabel>
-        <zac-klant-contactmomenten-tabel
-          *ngIf="bedrijf.vestigingsnummer"
-          [vestigingsnummer]="bedrijf.vestigingsnummer"
-        ></zac-klant-contactmomenten-tabel>
-      </div>
-    </div>
-  </mat-drawer-content>
+            <div class="flex-1 w75">
+                <zac-klant-zaken-tabel [klantIdentificatie]="bedrijf.identificatie"></zac-klant-zaken-tabel>
+                <zac-klant-contactmomenten-tabel *ngIf="bedrijf.vestigingsnummer"
+                                                 [vestigingsnummer]="bedrijf.vestigingsnummer"></zac-klant-contactmomenten-tabel>
+            </div>
+        </div>
+
+    </mat-drawer-content>
 </mat-drawer-container>

--- a/src/main/app/src/app/klanten/bedrijf-view/bedrijf-view.component.html
+++ b/src/main/app/src/app/klanten/bedrijf-view/bedrijf-view.component.html
@@ -4,59 +4,98 @@
   -->
 
 <mat-drawer-container class="inner-sidenav-container tablet-bottom-toolbar">
-    <mat-drawer-content>
-        <div class="flex-row flex-wrap">
-            <mat-card class="flex-1">
-                <mat-card-header>
-                    <mat-card-title>{{'bedrijfsgegevens' | translate}}</mat-card-title>
-                    <button mat-icon-button [disabled]="!vestigingsprofielOphalenMogelijk"
-                            title="{{ 'bedrijf.profiel.ophalen' | translate }}" (click)="ophalenVestigingsprofiel()">
-                        <mat-icon outlined>other_admission</mat-icon>
-                    </button>
-                </mat-card-header>
-                <mat-card-content>
-                        <div id="bedrijfsgegevens" class="content flex-row flex-wrap space-between">
-                            <zac-static-text [label]="'bedrijfsnaam' | translate"
-                                             [value]="bedrijf.naam"></zac-static-text>
-                            <zac-static-text [label]="'kvknummer' | translate"
-                                             [value]="bedrijf.kvkNummer"></zac-static-text>
-                            <zac-static-text *ngIf="bedrijf.vestigingsnummer" [label]="'vestigingsnummer' | translate"
-                                             [value]="bedrijf.vestigingsnummer"></zac-static-text>
-                            <zac-static-text *ngIf="bedrijf.rsin" [label]="'rsin' | translate"
-                                             [value]="bedrijf.rsin"></zac-static-text>
-                            <zac-static-text [label]="'type' | translate"
-                                             [value]="bedrijf.type | translate"></zac-static-text>
-                            <zac-static-text *ngIf="!vestigingsprofiel" [label]="'adres' | translate"
-                                             [value]="bedrijf.adres | empty"></zac-static-text>
-                            <zac-static-text
-                                    *ngFor="let adres of vestigingsprofiel?.adressen" [label]="adres.type | titlecase"
-                                    [value]="adres.volledigAdres | empty"></zac-static-text>
-                            <zac-static-text [label]="'telefoonnummer' | translate"
-                                             [value]="bedrijf.telefoonnummer | empty"></zac-static-text>
-                            <zac-static-text [label]="'emailadres' | translate"
-                                             [value]="bedrijf.emailadres | empty"></zac-static-text>
-                            <zac-static-text *ngIf="vestigingsprofiel"
-                                             [label]="'totaalWerkzamePersonen' | translate"
-                                             [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"></zac-static-text>
-                            <zac-static-text *ngIf="vestigingsprofiel"
-                                             [label]="'hoofdactiviteit' | translate"
-                                             [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"></zac-static-text>
-                            <zac-static-text *ngIf="vestigingsprofiel"
-                                             [label]="'activiteiten' | translate"
-                                             [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "></zac-static-text>
-                            <zac-static-text *ngIf="vestigingsprofiel"
-                                             [label]="'website' | translate"
-                                             [value]="vestigingsprofiel.website | empty"></zac-static-text>
-                        </div>
-                </mat-card-content>
-            </mat-card>
+  <mat-drawer-content>
+    <div class="flex-row flex-wrap">
+      <mat-card class="flex-1">
+        <mat-card-header>
+          <mat-card-title>{{'bedrijfsgegevens' | translate}}</mat-card-title>
+          <button
+            mat-icon-button
+            [disabled]="!vestigingsprofielOphalenMogelijk"
+            title="{{ 'bedrijf.profiel.ophalen' | translate }}"
+            (click)="ophalenVestigingsprofiel()"
+          >
+            <mat-icon outlined>other_admission</mat-icon>
+          </button>
+        </mat-card-header>
+        <mat-card-content>
+          <div
+            id="bedrijfsgegevens"
+            class="content flex-row flex-wrap space-between"
+          >
+            <zac-static-text
+              [label]="'handelsnaam' | translate"
+              [value]="bedrijf.naam"
+            ></zac-static-text>
+            <zac-static-text
+              [label]="'kvknummer' | translate"
+              [value]="bedrijf.kvkNummer"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="bedrijf.vestigingsnummer"
+              [label]="'vestigingsnummer' | translate"
+              [value]="bedrijf.vestigingsnummer"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="bedrijf.rsin"
+              [label]="'rsin' | translate"
+              [value]="bedrijf.rsin"
+            ></zac-static-text>
+            <zac-static-text
+              [label]="'type' | translate"
+              [value]="bedrijf.type | translate"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="!vestigingsprofiel"
+              [label]="'adres' | translate"
+              [value]="bedrijf.adres | empty"
+            ></zac-static-text>
+            <zac-static-text
+              *ngFor="let adres of vestigingsprofiel?.adressen"
+              [label]="adres.type | titlecase"
+              [value]="adres.volledigAdres | empty"
+            ></zac-static-text>
+            <zac-static-text
+              [label]="'telefoonnummer' | translate"
+              [value]="bedrijf.telefoonnummer | empty"
+            ></zac-static-text>
+            <zac-static-text
+              [label]="'emailadres' | translate"
+              [value]="bedrijf.emailadres | empty"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="vestigingsprofiel"
+              [label]="'totaalWerkzamePersonen' | translate"
+              [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="vestigingsprofiel"
+              [label]="'hoofdactiviteit' | translate"
+              [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="vestigingsprofiel"
+              [label]="'activiteiten' | translate"
+              [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "
+            ></zac-static-text>
+            <zac-static-text
+              *ngIf="vestigingsprofiel"
+              [label]="'website' | translate"
+              [value]="vestigingsprofiel.website | empty"
+            ></zac-static-text>
+          </div>
+        </mat-card-content>
+      </mat-card>
 
-            <div class="flex-1 w75">
-                <zac-klant-zaken-tabel [klantIdentificatie]="bedrijf.identificatie"></zac-klant-zaken-tabel>
-                <zac-klant-contactmomenten-tabel *ngIf="bedrijf.vestigingsnummer"
-                                                 [vestigingsnummer]="bedrijf.vestigingsnummer"></zac-klant-contactmomenten-tabel>
-            </div>
-        </div>
-
-    </mat-drawer-content>
+      <div class="flex-1 w75">
+        <zac-klant-zaken-tabel
+          [klantIdentificatie]="bedrijf.identificatie"
+        ></zac-klant-zaken-tabel>
+        <zac-klant-contactmomenten-tabel
+          *ngIf="bedrijf.vestigingsnummer"
+          [vestigingsnummer]="bedrijf.vestigingsnummer"
+        ></zac-klant-contactmomenten-tabel>
+      </div>
+    </div>
+  </mat-drawer-content>
 </mat-drawer-container>

--- a/src/main/app/src/app/klanten/bedrijf-view/bedrijf-view.component.html
+++ b/src/main/app/src/app/klanten/bedrijf-view/bedrijf-view.component.html
@@ -4,88 +4,52 @@
   -->
 
 <mat-drawer-container class="inner-sidenav-container tablet-bottom-toolbar">
-  <mat-drawer-content>
-    <div class="flex-row flex-wrap">
-      <mat-card class="flex-1">
-        <mat-card-header>
-          <mat-card-title>{{'bedrijfsgegevens' | translate}}</mat-card-title>
-          <button
-            mat-icon-button
-            [disabled]="!vestigingsprofielOphalenMogelijk"
-            title="{{ 'bedrijf.profiel.ophalen' | translate }}"
-            (click)="ophalenVestigingsprofiel()"
-          >
-            <mat-icon outlined>other_admission</mat-icon>
-          </button>
-        </mat-card-header>
-        <mat-card-content>
-          <div
-            id="bedrijfsgegevens"
-            class="content flex-row flex-wrap space-between"
-          >
-            <zac-static-text
-              [label]="'handelsnaam' | translate"
-              [value]="bedrijf.naam"
-            ></zac-static-text>
-            <zac-static-text
-              [label]="'kvknummer' | translate"
-              [value]="bedrijf.kvkNummer"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="bedrijf.vestigingsnummer"
-              [label]="'vestigingsnummer' | translate"
-              [value]="bedrijf.vestigingsnummer"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="bedrijf.rsin"
-              [label]="'rsin' | translate"
-              [value]="bedrijf.rsin"
-            ></zac-static-text>
-            <zac-static-text
-              [label]="'type' | translate"
-              [value]="bedrijf.type | translate"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="!vestigingsprofiel"
-              [label]="'adres' | translate"
-              [value]="bedrijf.adres | empty"
-            ></zac-static-text>
-            <zac-static-text
-              *ngFor="let adres of vestigingsprofiel?.adressen"
-              [label]="adres.type | titlecase"
-              [value]="adres.volledigAdres | empty"
-            ></zac-static-text>
-            <zac-static-text
-              [label]="'telefoonnummer' | translate"
-              [value]="bedrijf.telefoonnummer | empty"
-            ></zac-static-text>
-            <zac-static-text
-              [label]="'emailadres' | translate"
-              [value]="bedrijf.emailadres | empty"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="vestigingsprofiel"
-              [label]="'totaalWerkzamePersonen' | translate"
-              [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="vestigingsprofiel"
-              [label]="'hoofdactiviteit' | translate"
-              [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="vestigingsprofiel"
-              [label]="'activiteiten' | translate"
-              [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "
-            ></zac-static-text>
-            <zac-static-text
-              *ngIf="vestigingsprofiel"
-              [label]="'website' | translate"
-              [value]="vestigingsprofiel.website | empty"
-            ></zac-static-text>
-          </div>
-        </mat-card-content>
-      </mat-card>
+    <mat-drawer-content>
+        <div class="flex-row flex-wrap">
+            <mat-card class="flex-1">
+                <mat-card-header>
+                    <mat-card-title>{{'bedrijfsgegevens' | translate}}</mat-card-title>
+                    <button mat-icon-button [disabled]="!vestigingsprofielOphalenMogelijk"
+                            title="{{ 'bedrijf.profiel.ophalen' | translate }}" (click)="ophalenVestigingsprofiel()">
+                        <mat-icon outlined>other_admission</mat-icon>
+                    </button>
+                </mat-card-header>
+                <mat-card-content>
+                        <div id="bedrijfsgegevens" class="content flex-row flex-wrap space-between">
+                            <zac-static-text [label]="'bedrijfsnaam' | translate"
+                                             [value]="bedrijf.naam"></zac-static-text>
+                            <zac-static-text [label]="'kvknummer' | translate"
+                                             [value]="bedrijf.kvkNummer"></zac-static-text>
+                            <zac-static-text *ngIf="bedrijf.vestigingsnummer" [label]="'vestigingsnummer' | translate"
+                                             [value]="bedrijf.vestigingsnummer"></zac-static-text>
+                            <zac-static-text *ngIf="bedrijf.rsin" [label]="'rsin' | translate"
+                                             [value]="bedrijf.rsin"></zac-static-text>
+                            <zac-static-text [label]="'type' | translate"
+                                             [value]="bedrijf.type | translate"></zac-static-text>
+                            <zac-static-text *ngIf="!vestigingsprofiel" [label]="'adres' | translate"
+                                             [value]="bedrijf.adres | empty"></zac-static-text>
+                            <zac-static-text
+                                    *ngFor="let adres of vestigingsprofiel?.adressen" [label]="adres.type | titlecase"
+                                    [value]="adres.volledigAdres | empty"></zac-static-text>
+                            <zac-static-text [label]="'telefoonnummer' | translate"
+                                             [value]="bedrijf.telefoonnummer | empty"></zac-static-text>
+                            <zac-static-text [label]="'emailadres' | translate"
+                                             [value]="bedrijf.emailadres | empty"></zac-static-text>
+                            <zac-static-text *ngIf="vestigingsprofiel"
+                                             [label]="'totaalWerkzamePersonen' | translate"
+                                             [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"></zac-static-text>
+                            <zac-static-text *ngIf="vestigingsprofiel"
+                                             [label]="'hoofdactiviteit' | translate"
+                                             [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"></zac-static-text>
+                            <zac-static-text *ngIf="vestigingsprofiel"
+                                             [label]="'activiteiten' | translate"
+                                             [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "></zac-static-text>
+                            <zac-static-text *ngIf="vestigingsprofiel"
+                                             [label]="'website' | translate"
+                                             [value]="vestigingsprofiel.website | empty"></zac-static-text>
+                        </div>
+                </mat-card-content>
+            </mat-card>
 
       <div class="flex-1 w75">
         <zac-klant-zaken-tabel

--- a/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfsgegevens.component.html
+++ b/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfsgegevens.component.html
@@ -4,112 +4,69 @@
   -->
 
 <mat-expansion-panel [expanded]="klantExpanded">
-  <mat-expansion-panel-header>
-    <mat-panel-title> {{'initiator.titel'| translate}} </mat-panel-title>
-    <mat-panel-description>
-      {{bedrijf ? bedrijf.naam : ('msg.loading'| translate)}}
-      <div class="flex-row">
-        <button
-          mat-icon-button
-          [disabled]="!vestigingsprofielOphalenMogelijk"
-          title="{{ 'bedrijf.profiel.ophalen' | translate }}"
-          (click)="$event.stopPropagation(); ophalenVestigingsprofiel()"
-        >
-          <mat-icon outlined>other_admission</mat-icon>
-        </button>
-        <button
-          *ngIf="bedrijf && isWijzigbaar"
-          [title]="'actie.initiator.wijzigen' | translate"
-          mat-icon-button
-          (click)="$event.stopPropagation(); edit.emit(bedrijf)"
-        >
-          <mat-icon>edit</mat-icon>
-        </button>
-        <button
-          *ngIf="bedrijf && isVerwijderbaar"
-          [title]="'actie.ontkoppelen' | translate"
-          mat-icon-button
-          (click)="$event.stopPropagation(); delete.emit(bedrijf)"
-        >
-          <mat-icon>link_off</mat-icon>
-        </button>
-        <a
-          *ngIf="bedrijf"
-          mat-icon-button
-          [routerLink]="['/bedrijf', bedrijf.identificatie]"
-          (click)="$event.stopPropagation()"
-          [id]="'bedrijfBekijken_' + bedrijf.identificatie +'_button'"
-          title="{{ 'actie.bedrijf.bekijken' | translate }}"
-        >
-          <mat-icon>visibility</mat-icon>
-        </a>
-      </div>
-    </mat-panel-description>
-  </mat-expansion-panel-header>
-  <div *ngIf="bedrijf" id="bedrijfsgegevens" class="content flex-row flex-wrap">
-    <zac-static-text
-      [label]="'handelsnaam' | translate"
-      [value]="bedrijf.naam"
-    ></zac-static-text>
-    <zac-static-text
-      [label]="'kvknummer' | translate"
-      [value]="bedrijf.kvkNummer"
-    ></zac-static-text>
-    <zac-static-text
-      *ngIf="bedrijf.vestigingsnummer"
-      [label]="'vestigingsnummer' | translate"
-      [value]="bedrijf.vestigingsnummer"
-    ></zac-static-text>
-    <zac-static-text
-      *ngIf="bedrijf.rsin"
-      [label]="'rsin' | translate"
-      [value]="bedrijf.rsin"
-    ></zac-static-text>
-    <zac-static-text
-      [label]="'type' | translate"
-      [value]="bedrijf.type | translate"
-    ></zac-static-text>
-    <zac-static-text
-      *ngIf="!vestigingsprofiel"
-      [label]="'adres' | translate"
-      [value]="bedrijf.adres | empty"
-    ></zac-static-text>
-    <zac-static-text
-      *ngFor="let adres of vestigingsprofiel?.adressen"
-      [label]="adres.type | titlecase"
-      [value]="adres.volledigAdres | empty"
-    ></zac-static-text>
-    <zac-static-text
-      [label]="'telefoonnummer' | translate"
-      [value]="bedrijf.telefoonnummer | empty"
-    ></zac-static-text>
-    <zac-static-text
-      [label]="'telefoonnummer' | translate"
-      [value]="bedrijf.telefoonnummer | empty"
-    ></zac-static-text>
-    <zac-static-text
-      [label]="'emailadres' | translate"
-      [value]="bedrijf.emailadres | empty"
-    ></zac-static-text>
-    <zac-static-text
-      *ngIf="vestigingsprofiel"
-      [label]="'totaalWerkzamePersonen' | translate"
-      [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"
-    ></zac-static-text>
-    <zac-static-text
-      *ngIf="vestigingsprofiel"
-      [label]="'hoofdactiviteit' | translate"
-      [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"
-    ></zac-static-text>
-    <zac-static-text
-      *ngIf="vestigingsprofiel"
-      [label]="'activiteiten' | translate"
-      [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "
-    ></zac-static-text>
-    <zac-static-text
-      *ngIf="vestigingsprofiel"
-      [label]="'website' | translate"
-      [value]="vestigingsprofiel.website | empty"
-    ></zac-static-text>
-  </div>
+    <mat-expansion-panel-header>
+        <mat-panel-title>
+            {{'initiator.titel'| translate}}
+        </mat-panel-title>
+        <mat-panel-description>
+            {{bedrijf ? bedrijf.naam : ('msg.loading'| translate)}}
+            <div class="flex-row">
+                <button mat-icon-button [disabled]="!vestigingsprofielOphalenMogelijk"
+                        title="{{ 'bedrijf.profiel.ophalen' | translate }}"
+                        (click)="$event.stopPropagation(); ophalenVestigingsprofiel()">
+                    <mat-icon outlined>other_admission</mat-icon>
+                </button>
+                <button *ngIf="bedrijf && isWijzigbaar" [title]="'actie.initiator.wijzigen' | translate" mat-icon-button
+                        (click)="$event.stopPropagation(); edit.emit(bedrijf)">
+                    <mat-icon>edit</mat-icon>
+                </button>
+                <button *ngIf="bedrijf && isVerwijderbaar" [title]="'actie.ontkoppelen' | translate" mat-icon-button
+                        (click)="$event.stopPropagation(); delete.emit(bedrijf)">
+                    <mat-icon>link_off</mat-icon>
+                </button>
+                <a *ngIf="bedrijf" mat-icon-button [routerLink]="['/bedrijf', bedrijf.identificatie]"
+                   (click)="$event.stopPropagation()"
+                   [id]="'bedrijfBekijken_' + bedrijf.identificatie +'_button'"
+                   title="{{ 'actie.bedrijf.bekijken' | translate }}">
+                    <mat-icon>visibility</mat-icon>
+                </a>
+            </div>
+        </mat-panel-description>
+    </mat-expansion-panel-header>
+    <div *ngIf="bedrijf" id="bedrijfsgegevens" class="content flex-row flex-wrap">
+        <zac-static-text [label]="'bedrijfsnaam' | translate"
+                         [value]="bedrijf.naam"></zac-static-text>
+        <zac-static-text [label]="'kvknummer' | translate"
+                         [value]="bedrijf.kvkNummer"></zac-static-text>
+        <zac-static-text *ngIf="bedrijf.vestigingsnummer" [label]="'vestigingsnummer' | translate"
+                         [value]="bedrijf.vestigingsnummer"></zac-static-text>
+        <zac-static-text *ngIf="bedrijf.rsin" [label]="'rsin' | translate"
+                         [value]="bedrijf.rsin"></zac-static-text>
+        <zac-static-text [label]="'type' | translate"
+                         [value]="bedrijf.type | translate"></zac-static-text>
+        <zac-static-text *ngIf="!vestigingsprofiel"
+                         [label]="'adres' | translate"
+                         [value]="bedrijf.adres | empty"></zac-static-text>
+        <zac-static-text *ngFor="let adres of vestigingsprofiel?.adressen"
+                         [label]="adres.type | titlecase"
+                         [value]="adres.volledigAdres | empty"></zac-static-text>
+        <zac-static-text [label]="'telefoonnummer' | translate"
+                         [value]="bedrijf.telefoonnummer | empty"></zac-static-text>
+        <zac-static-text [label]="'telefoonnummer' | translate"
+                         [value]="bedrijf.telefoonnummer | empty"></zac-static-text>
+        <zac-static-text [label]="'emailadres' | translate"
+                         [value]="bedrijf.emailadres | empty"></zac-static-text>
+        <zac-static-text *ngIf="vestigingsprofiel"
+                         [label]="'totaalWerkzamePersonen' | translate"
+                         [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"></zac-static-text>
+        <zac-static-text *ngIf="vestigingsprofiel"
+                         [label]="'hoofdactiviteit' | translate"
+                         [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"></zac-static-text>
+        <zac-static-text *ngIf="vestigingsprofiel"
+                         [label]="'activiteiten' | translate"
+                         [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "></zac-static-text>
+        <zac-static-text *ngIf="vestigingsprofiel"
+                         [label]="'website' | translate"
+                         [value]="vestigingsprofiel.website | empty"></zac-static-text>
+    </div>
 </mat-expansion-panel>

--- a/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfsgegevens.component.html
+++ b/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfsgegevens.component.html
@@ -4,69 +4,112 @@
   -->
 
 <mat-expansion-panel [expanded]="klantExpanded">
-    <mat-expansion-panel-header>
-        <mat-panel-title>
-            {{'initiator.titel'| translate}}
-        </mat-panel-title>
-        <mat-panel-description>
-            {{bedrijf ? bedrijf.naam : ('msg.loading'| translate)}}
-            <div class="flex-row">
-                <button mat-icon-button [disabled]="!vestigingsprofielOphalenMogelijk"
-                        title="{{ 'bedrijf.profiel.ophalen' | translate }}"
-                        (click)="$event.stopPropagation(); ophalenVestigingsprofiel()">
-                    <mat-icon outlined>other_admission</mat-icon>
-                </button>
-                <button *ngIf="bedrijf && isWijzigbaar" [title]="'actie.initiator.wijzigen' | translate" mat-icon-button
-                        (click)="$event.stopPropagation(); edit.emit(bedrijf)">
-                    <mat-icon>edit</mat-icon>
-                </button>
-                <button *ngIf="bedrijf && isVerwijderbaar" [title]="'actie.ontkoppelen' | translate" mat-icon-button
-                        (click)="$event.stopPropagation(); delete.emit(bedrijf)">
-                    <mat-icon>link_off</mat-icon>
-                </button>
-                <a *ngIf="bedrijf" mat-icon-button [routerLink]="['/bedrijf', bedrijf.identificatie]"
-                   (click)="$event.stopPropagation()"
-                   [id]="'bedrijfBekijken_' + bedrijf.identificatie +'_button'"
-                   title="{{ 'actie.bedrijf.bekijken' | translate }}">
-                    <mat-icon>visibility</mat-icon>
-                </a>
-            </div>
-        </mat-panel-description>
-    </mat-expansion-panel-header>
-    <div *ngIf="bedrijf" id="bedrijfsgegevens" class="content flex-row flex-wrap">
-        <zac-static-text [label]="'bedrijfsnaam' | translate"
-                         [value]="bedrijf.naam"></zac-static-text>
-        <zac-static-text [label]="'kvknummer' | translate"
-                         [value]="bedrijf.kvkNummer"></zac-static-text>
-        <zac-static-text *ngIf="bedrijf.vestigingsnummer" [label]="'vestigingsnummer' | translate"
-                         [value]="bedrijf.vestigingsnummer"></zac-static-text>
-        <zac-static-text *ngIf="bedrijf.rsin" [label]="'rsin' | translate"
-                         [value]="bedrijf.rsin"></zac-static-text>
-        <zac-static-text [label]="'type' | translate"
-                         [value]="bedrijf.type | translate"></zac-static-text>
-        <zac-static-text *ngIf="!vestigingsprofiel"
-                         [label]="'adres' | translate"
-                         [value]="bedrijf.adres | empty"></zac-static-text>
-        <zac-static-text *ngFor="let adres of vestigingsprofiel?.adressen"
-                         [label]="adres.type | titlecase"
-                         [value]="adres.volledigAdres | empty"></zac-static-text>
-        <zac-static-text [label]="'telefoonnummer' | translate"
-                         [value]="bedrijf.telefoonnummer | empty"></zac-static-text>
-        <zac-static-text [label]="'telefoonnummer' | translate"
-                         [value]="bedrijf.telefoonnummer | empty"></zac-static-text>
-        <zac-static-text [label]="'emailadres' | translate"
-                         [value]="bedrijf.emailadres | empty"></zac-static-text>
-        <zac-static-text *ngIf="vestigingsprofiel"
-                         [label]="'totaalWerkzamePersonen' | translate"
-                         [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"></zac-static-text>
-        <zac-static-text *ngIf="vestigingsprofiel"
-                         [label]="'hoofdactiviteit' | translate"
-                         [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"></zac-static-text>
-        <zac-static-text *ngIf="vestigingsprofiel"
-                         [label]="'activiteiten' | translate"
-                         [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "></zac-static-text>
-        <zac-static-text *ngIf="vestigingsprofiel"
-                         [label]="'website' | translate"
-                         [value]="vestigingsprofiel.website | empty"></zac-static-text>
-    </div>
+  <mat-expansion-panel-header>
+    <mat-panel-title> {{'initiator.titel'| translate}} </mat-panel-title>
+    <mat-panel-description>
+      {{bedrijf ? bedrijf.naam : ('msg.loading'| translate)}}
+      <div class="flex-row">
+        <button
+          mat-icon-button
+          [disabled]="!vestigingsprofielOphalenMogelijk"
+          title="{{ 'bedrijf.profiel.ophalen' | translate }}"
+          (click)="$event.stopPropagation(); ophalenVestigingsprofiel()"
+        >
+          <mat-icon outlined>other_admission</mat-icon>
+        </button>
+        <button
+          *ngIf="bedrijf && isWijzigbaar"
+          [title]="'actie.initiator.wijzigen' | translate"
+          mat-icon-button
+          (click)="$event.stopPropagation(); edit.emit(bedrijf)"
+        >
+          <mat-icon>edit</mat-icon>
+        </button>
+        <button
+          *ngIf="bedrijf && isVerwijderbaar"
+          [title]="'actie.ontkoppelen' | translate"
+          mat-icon-button
+          (click)="$event.stopPropagation(); delete.emit(bedrijf)"
+        >
+          <mat-icon>link_off</mat-icon>
+        </button>
+        <a
+          *ngIf="bedrijf"
+          mat-icon-button
+          [routerLink]="['/bedrijf', bedrijf.identificatie]"
+          (click)="$event.stopPropagation()"
+          [id]="'bedrijfBekijken_' + bedrijf.identificatie +'_button'"
+          title="{{ 'actie.bedrijf.bekijken' | translate }}"
+        >
+          <mat-icon>visibility</mat-icon>
+        </a>
+      </div>
+    </mat-panel-description>
+  </mat-expansion-panel-header>
+  <div *ngIf="bedrijf" id="bedrijfsgegevens" class="content flex-row flex-wrap">
+    <zac-static-text
+      [label]="'handelsnaam' | translate"
+      [value]="bedrijf.naam"
+    ></zac-static-text>
+    <zac-static-text
+      [label]="'kvknummer' | translate"
+      [value]="bedrijf.kvkNummer"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="bedrijf.vestigingsnummer"
+      [label]="'vestigingsnummer' | translate"
+      [value]="bedrijf.vestigingsnummer"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="bedrijf.rsin"
+      [label]="'rsin' | translate"
+      [value]="bedrijf.rsin"
+    ></zac-static-text>
+    <zac-static-text
+      [label]="'type' | translate"
+      [value]="bedrijf.type | translate"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="!vestigingsprofiel"
+      [label]="'adres' | translate"
+      [value]="bedrijf.adres | empty"
+    ></zac-static-text>
+    <zac-static-text
+      *ngFor="let adres of vestigingsprofiel?.adressen"
+      [label]="adres.type | titlecase"
+      [value]="adres.volledigAdres | empty"
+    ></zac-static-text>
+    <zac-static-text
+      [label]="'telefoonnummer' | translate"
+      [value]="bedrijf.telefoonnummer | empty"
+    ></zac-static-text>
+    <zac-static-text
+      [label]="'telefoonnummer' | translate"
+      [value]="bedrijf.telefoonnummer | empty"
+    ></zac-static-text>
+    <zac-static-text
+      [label]="'emailadres' | translate"
+      [value]="bedrijf.emailadres | empty"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="vestigingsprofiel"
+      [label]="'totaalWerkzamePersonen' | translate"
+      [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="vestigingsprofiel"
+      [label]="'hoofdactiviteit' | translate"
+      [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="vestigingsprofiel"
+      [label]="'activiteiten' | translate"
+      [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="vestigingsprofiel"
+      [label]="'website' | translate"
+      [value]="vestigingsprofiel.website | empty"
+    ></zac-static-text>
+  </div>
 </mat-expansion-panel>

--- a/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfsgegevens.component.html
+++ b/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfsgegevens.component.html
@@ -4,69 +4,112 @@
   -->
 
 <mat-expansion-panel [expanded]="klantExpanded">
-    <mat-expansion-panel-header>
-        <mat-panel-title>
-            {{'initiator.titel'| translate}}
-        </mat-panel-title>
-        <mat-panel-description>
-            {{bedrijf ? bedrijf.naam : ('msg.loading'| translate)}}
-            <div class="flex-row">
-                <button mat-icon-button [disabled]="!vestigingsprofielOphalenMogelijk"
-                        title="{{ 'bedrijf.profiel.ophalen' | translate }}"
-                        (click)="$event.stopPropagation(); ophalenVestigingsprofiel()">
-                    <mat-icon outlined>other_admission</mat-icon>
-                </button>
-                <button *ngIf="bedrijf && isWijzigbaar" [title]="'actie.initiator.wijzigen' | translate" mat-icon-button
-                        (click)="$event.stopPropagation(); edit.emit(bedrijf)">
-                    <mat-icon>edit</mat-icon>
-                </button>
-                <button *ngIf="bedrijf && isVerwijderbaar" [title]="'actie.ontkoppelen' | translate" mat-icon-button
-                        (click)="$event.stopPropagation(); delete.emit(bedrijf)">
-                    <mat-icon>link_off</mat-icon>
-                </button>
-                <a *ngIf="bedrijf" mat-icon-button [routerLink]="['/bedrijf', bedrijf.identificatie]"
-                   (click)="$event.stopPropagation()"
-                   [id]="'bedrijfBekijken_' + bedrijf.identificatie +'_button'"
-                   title="{{ 'actie.bedrijf.bekijken' | translate }}">
-                    <mat-icon>visibility</mat-icon>
-                </a>
-            </div>
-        </mat-panel-description>
-    </mat-expansion-panel-header>
-    <div *ngIf="bedrijf" id="bedrijfsgegevens" class="content flex-row flex-wrap">
-        <zac-static-text [label]="'bedrijfsnaam' | translate"
-                         [value]="bedrijf.naam"></zac-static-text>
-        <zac-static-text [label]="'kvknummer' | translate"
-                         [value]="bedrijf.kvkNummer"></zac-static-text>
-        <zac-static-text *ngIf="bedrijf.vestigingsnummer" [label]="'vestigingsnummer' | translate"
-                         [value]="bedrijf.vestigingsnummer"></zac-static-text>
-        <zac-static-text *ngIf="bedrijf.rsin" [label]="'rsin' | translate"
-                         [value]="bedrijf.rsin"></zac-static-text>
-        <zac-static-text [label]="'type' | translate"
-                         [value]="bedrijf.type | translate"></zac-static-text>
-        <zac-static-text *ngIf="!vestigingsprofiel"
-                         [label]="'adres' | translate"
-                         [value]="bedrijf.adres | empty"></zac-static-text>
-        <zac-static-text *ngFor="let adres of vestigingsprofiel?.adressen"
-                         [label]="adres.type | titlecase"
-                         [value]="adres.volledigAdres | empty"></zac-static-text>
-        <zac-static-text [label]="'telefoonnummer' | translate"
-                         [value]="bedrijf.telefoonnummer | empty"></zac-static-text>
-        <zac-static-text [label]="'telefoonnummer' | translate"
-                         [value]="bedrijf.telefoonnummer | empty"></zac-static-text>
-        <zac-static-text [label]="'emailadres' | translate"
-                         [value]="bedrijf.emailadres | empty"></zac-static-text>
-        <zac-static-text *ngIf="vestigingsprofiel"
-                         [label]="'totaalWerkzamePersonen' | translate"
-                         [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"></zac-static-text>
-        <zac-static-text *ngIf="vestigingsprofiel"
-                         [label]="'hoofdactiviteit' | translate"
-                         [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"></zac-static-text>
-        <zac-static-text *ngIf="vestigingsprofiel"
-                         [label]="'activiteiten' | translate"
-                         [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "></zac-static-text>
-        <zac-static-text *ngIf="vestigingsprofiel"
-                         [label]="'website' | translate"
-                         [value]="vestigingsprofiel.website | empty"></zac-static-text>
-    </div>
+  <mat-expansion-panel-header>
+    <mat-panel-title> {{'initiator.titel'| translate}} </mat-panel-title>
+    <mat-panel-description>
+      {{bedrijf ? bedrijf.naam : ('msg.loading'| translate)}}
+      <div class="flex-row">
+        <button
+          mat-icon-button
+          [disabled]="!vestigingsprofielOphalenMogelijk"
+          title="{{ 'bedrijf.profiel.ophalen' | translate }}"
+          (click)="$event.stopPropagation(); ophalenVestigingsprofiel()"
+        >
+          <mat-icon outlined>other_admission</mat-icon>
+        </button>
+        <button
+          *ngIf="bedrijf && isWijzigbaar"
+          [title]="'actie.initiator.wijzigen' | translate"
+          mat-icon-button
+          (click)="$event.stopPropagation(); edit.emit(bedrijf)"
+        >
+          <mat-icon>edit</mat-icon>
+        </button>
+        <button
+          *ngIf="bedrijf && isVerwijderbaar"
+          [title]="'actie.ontkoppelen' | translate"
+          mat-icon-button
+          (click)="$event.stopPropagation(); delete.emit(bedrijf)"
+        >
+          <mat-icon>link_off</mat-icon>
+        </button>
+        <a
+          *ngIf="bedrijf"
+          mat-icon-button
+          [routerLink]="['/bedrijf', bedrijf.identificatie]"
+          (click)="$event.stopPropagation()"
+          [id]="'bedrijfBekijken_' + bedrijf.identificatie +'_button'"
+          title="{{ 'actie.bedrijf.bekijken' | translate }}"
+        >
+          <mat-icon>visibility</mat-icon>
+        </a>
+      </div>
+    </mat-panel-description>
+  </mat-expansion-panel-header>
+  <div *ngIf="bedrijf" id="bedrijfsgegevens" class="content flex-row flex-wrap">
+    <zac-static-text
+      [label]="'bedrijfsnaam' | translate"
+      [value]="bedrijf.naam"
+    ></zac-static-text>
+    <zac-static-text
+      [label]="'kvknummer' | translate"
+      [value]="bedrijf.kvkNummer"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="bedrijf.vestigingsnummer"
+      [label]="'vestigingsnummer' | translate"
+      [value]="bedrijf.vestigingsnummer"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="bedrijf.rsin"
+      [label]="'rsin' | translate"
+      [value]="bedrijf.rsin"
+    ></zac-static-text>
+    <zac-static-text
+      [label]="'type' | translate"
+      [value]="bedrijf.type | translate"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="!vestigingsprofiel"
+      [label]="'adres' | translate"
+      [value]="bedrijf.adres | empty"
+    ></zac-static-text>
+    <zac-static-text
+      *ngFor="let adres of vestigingsprofiel?.adressen"
+      [label]="adres.type | titlecase"
+      [value]="adres.volledigAdres | empty"
+    ></zac-static-text>
+    <zac-static-text
+      [label]="'telefoonnummer' | translate"
+      [value]="bedrijf.telefoonnummer | empty"
+    ></zac-static-text>
+    <zac-static-text
+      [label]="'telefoonnummer' | translate"
+      [value]="bedrijf.telefoonnummer | empty"
+    ></zac-static-text>
+    <zac-static-text
+      [label]="'emailadres' | translate"
+      [value]="bedrijf.emailadres | empty"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="vestigingsprofiel"
+      [label]="'totaalWerkzamePersonen' | translate"
+      [value]="vestigingsprofiel.totaalWerkzamePersonen | empty"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="vestigingsprofiel"
+      [label]="'hoofdactiviteit' | translate"
+      [value]="vestigingsprofiel.sbiHoofdActiviteit | empty"
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="vestigingsprofiel"
+      [label]="'activiteiten' | translate"
+      [value]="vestigingsprofiel.sbiActiviteiten?.join(',\r\n') "
+    ></zac-static-text>
+    <zac-static-text
+      *ngIf="vestigingsprofiel"
+      [label]="'website' | translate"
+      [value]="vestigingsprofiel.website | empty"
+    ></zac-static-text>
+  </div>
 </mat-expansion-panel>

--- a/src/main/app/src/app/klanten/model/bedrijven/bedrijf.ts
+++ b/src/main/app/src/app/klanten/model/bedrijven/bedrijf.ts
@@ -10,7 +10,6 @@ export class Bedrijf implements Klant {
   vestigingsnummer: string;
   kvkNummer: string;
   rsin: string;
-  handelsnaam: string;
   adres: string;
   postcode: string;
   type: string;

--- a/src/main/app/src/app/klanten/model/bedrijven/list-bedrijven-parameters.ts
+++ b/src/main/app/src/app/klanten/model/bedrijven/list-bedrijven-parameters.ts
@@ -7,7 +7,7 @@ export class ListBedrijvenParameters {
   vestigingsnummer: string;
   kvkNummer: string;
   rsin: string;
-  handelsnaam: string;
+  naam: string;
   straatnaam: string;
   huisnummer: string;
   plaats: string;

--- a/src/main/app/src/app/klanten/model/bedrijven/vestigingsprofiel.ts
+++ b/src/main/app/src/app/klanten/model/bedrijven/vestigingsprofiel.ts
@@ -9,7 +9,7 @@ export class Vestigingsprofiel {
   vestigingsnummer: string;
   kvkNummer: string;
   rsin: string;
-  handelsnaam: string;
+  eersteHandelsnaam: string;
   type: string;
   totaalWerkzamePersonen: number;
   deeltijdWerkzamePersonen: number;

--- a/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.html
+++ b/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.html
@@ -4,120 +4,83 @@
   -->
 
 <div class="form">
-  <div class="flex-row flex-col-xs gap-10 flex-fill">
-    <div class="flex-1">
-      <mfb-form-field [field]="kvkFormField"></mfb-form-field>
+    <div class="flex-row flex-col-xs gap-10 flex-fill">
+        <div class="flex-1">
+            <mfb-form-field [field]="kvkFormField"></mfb-form-field>
+        </div>
     </div>
-  </div>
-  <div class="flex-row flex-col-xs gap-10 flex-fill">
-    <div class="flex-1">
-      <mfb-form-field [field]="vestigingsnummerFormField"></mfb-form-field>
+    <div class="flex-row flex-col-xs gap-10 flex-fill">
+        <div class="flex-1">
+            <mfb-form-field [field]="vestigingsnummerFormField"></mfb-form-field>
+        </div>
     </div>
-  </div>
-  <div class="flex-row flex-col-xs gap-10 flex-fill">
-    <div class="flex-1">
-      <mfb-form-field [field]="rsinFormField"></mfb-form-field>
+    <div class="flex-row flex-col-xs gap-10 flex-fill">
+        <div class="flex-1">
+            <mfb-form-field [field]="rsinFormField"></mfb-form-field>
+        </div>
     </div>
-  </div>
-  <div class="flex-row flex-col-xs gap-10 flex-fill">
-    <div class="flex-1 w66">
-      <mfb-form-field [field]="handelsnaamFormField"></mfb-form-field>
+    <div class="flex-row flex-col-xs gap-10 flex-fill">
+        <div class="flex-1 w66">
+            <mfb-form-field [field]="bedrijfsnaamFormField"></mfb-form-field>
+        </div>
+        <div class="flex-1">
+            <mfb-form-field [field]="typeFormField" (valueChanges)="typeChanged($event)"></mfb-form-field>
+        </div>
     </div>
-    <div class="flex-1">
-      <mfb-form-field
-        [field]="typeFormField"
-        (valueChanges)="typeChanged($event)"
-      ></mfb-form-field>
+    <div class="flex-row flex-col-xs gap-10 flex-fill">
+        <div class="flex-1 w66">
+            <mfb-form-field [field]="postcodeFormField"></mfb-form-field>
+        </div>
+        <div class="flex-1">
+            <mfb-form-field [field]="huisnummerFormField"></mfb-form-field>
+        </div>
     </div>
-  </div>
-  <div class="flex-row flex-col-xs gap-10 flex-fill">
-    <div class="flex-1 w66">
-      <mfb-form-field [field]="postcodeFormField"></mfb-form-field>
-    </div>
-    <div class="flex-1">
-      <mfb-form-field [field]="huisnummerFormField"></mfb-form-field>
-    </div>
-  </div>
-  <button
-    mat-flat-button
-    color="primary"
-    [disabled]="!isValid() || loading"
-    (click)="zoekBedrijven()"
-  >
-    {{'actie.zoeken' | translate}}
-  </button>
-  <button mat-flat-button (click)="wissen()">
-    {{'actie.wissen' | translate}}
-  </button>
+    <button mat-flat-button color="primary" [disabled]="!isValid() || loading" (click)="zoekBedrijven()">
+        {{'actie.zoeken' | translate}}
+    </button>
+    <button mat-flat-button (click)="wissen()">{{'actie.wissen' | translate}}</button>
 </div>
 
 <div class="table-wrapper">
-  <table mat-table [dataSource]="bedrijven" matSort>
-    <ng-container matColumnDef="naam">
-      <th *matHeaderCellDef mat-header-cell mat-sort-header>
-        {{'naam' | translate}}
-      </th>
-      <td *matCellDef="let bedrijf" mat-cell>
-        {{bedrijf.handelsnaam | empty}}
-      </td>
-    </ng-container>
-    <ng-container matColumnDef="kvk">
-      <th *matHeaderCellDef mat-header-cell mat-sort-header>
-        {{'kvk' | translate}}
-      </th>
-      <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.kvkNummer | empty}}</td>
-    </ng-container>
-    <ng-container matColumnDef="vestigingsnummer">
-      <th *matHeaderCellDef mat-header-cell mat-sort-header>
-        {{'vestigingsnummer' | translate}}
-      </th>
-      <td *matCellDef="let bedrijf" mat-cell>
-        {{bedrijf.vestigingsnummer | empty}}
-      </td>
-    </ng-container>
-    <ng-container matColumnDef="type">
-      <th *matHeaderCellDef mat-header-cell mat-sort-header>
-        {{'type' | translate}}
-      </th>
-      <td *matCellDef="let bedrijf" mat-cell>
-        {{bedrijf.type | empty | titlecase }}
-      </td>
-    </ng-container>
-    <ng-container matColumnDef="adres">
-      <th *matHeaderCellDef mat-header-cell mat-sort-header>
-        {{'adres' | translate}}
-      </th>
-      <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.adres | empty}}</td>
-    </ng-container>
+    <table mat-table [dataSource]="bedrijven" matSort>
+        <ng-container matColumnDef="naam">
+            <th *matHeaderCellDef mat-header-cell mat-sort-header> {{'naam' | translate}} </th>
+            <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.naam | empty}}</td>
+        </ng-container>
+        <ng-container matColumnDef="kvk">
+            <th *matHeaderCellDef mat-header-cell mat-sort-header> {{'kvk' | translate}} </th>
+            <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.kvkNummer | empty}}</td>
+        </ng-container>
+        <ng-container matColumnDef="vestigingsnummer">
+            <th *matHeaderCellDef mat-header-cell mat-sort-header> {{'vestigingsnummer' | translate}} </th>
+            <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.vestigingsnummer | empty}}</td>
+        </ng-container>
+        <ng-container matColumnDef="type">
+            <th *matHeaderCellDef mat-header-cell mat-sort-header> {{'type' | translate}} </th>
+            <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.type | empty | titlecase }}</td>
+        </ng-container>
+        <ng-container matColumnDef="adres">
+            <th *matHeaderCellDef mat-header-cell mat-sort-header> {{'adres' | translate}} </th>
+            <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.adres | empty}}</td>
+        </ng-container>
 
-    <ng-container matColumnDef="acties" stickyEnd>
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let row">
-        <button
-          *ngIf="bedrijf.observed"
-          mat-icon-button
-          color="primary"
-          (click)="selectBedrijf(row)"
-          title="{{ 'actie.selecteren' | translate}}"
-        >
-          <mat-icon>business</mat-icon>
-        </button>
-        <button
-          *ngIf="!bedrijf.observed"
-          mat-icon-button
-          (click)="openBedrijfPagina(row)"
-          [id]="'bedrijfBekijken_' + row.identificatie +'_button'"
-          title="{{ 'actie.bedrijf.bekijken' | translate }}"
-        >
-          <mat-icon>visibility</mat-icon>
-        </button>
-      </td>
-    </ng-container>
-    <tr mat-header-row *matHeaderRowDef="bedrijfColumns; sticky: true"></tr>
-    <tr mat-row *matRowDef="let row; columns: bedrijfColumns;"></tr>
-  </table>
-  <p *ngIf="bedrijven.data.length == 0 && !loading">
-    {{foutmelding ? foutmelding : 'msg.geen.gegevens.gevonden' | translate}}
-  </p>
-  <p *ngIf="loading ">{{'msg.loading' | translate}}</p>
+        <ng-container matColumnDef="acties" stickyEnd>
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let row">
+                <button *ngIf="bedrijf.observed" mat-icon-button color="primary" (click)="selectBedrijf(row)" title="{{ 'actie.selecteren' | translate}}">
+                    <mat-icon>business</mat-icon>
+                </button>
+                <button *ngIf="!bedrijf.observed" mat-icon-button
+                        (click)="openBedrijfPagina(row)"
+                        [id]="'bedrijfBekijken_' + row.identificatie +'_button'"
+                        title="{{ 'actie.bedrijf.bekijken' | translate }}">
+                    <mat-icon>visibility</mat-icon>
+                </button>
+            </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="bedrijfColumns; sticky: true"></tr>
+        <tr mat-row *matRowDef="let row; columns: bedrijfColumns;"></tr>
+    </table>
+    <p *ngIf="bedrijven.data.length == 0 && !loading">{{foutmelding ? foutmelding : 'msg.geen.gegevens.gevonden' | translate}}</p>
+    <p *ngIf="loading ">{{'msg.loading' | translate}}</p>
 </div>

--- a/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.html
+++ b/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.html
@@ -4,83 +4,120 @@
   -->
 
 <div class="form">
-    <div class="flex-row flex-col-xs gap-10 flex-fill">
-        <div class="flex-1">
-            <mfb-form-field [field]="kvkFormField"></mfb-form-field>
-        </div>
+  <div class="flex-row flex-col-xs gap-10 flex-fill">
+    <div class="flex-1">
+      <mfb-form-field [field]="kvkFormField"></mfb-form-field>
     </div>
-    <div class="flex-row flex-col-xs gap-10 flex-fill">
-        <div class="flex-1">
-            <mfb-form-field [field]="vestigingsnummerFormField"></mfb-form-field>
-        </div>
+  </div>
+  <div class="flex-row flex-col-xs gap-10 flex-fill">
+    <div class="flex-1">
+      <mfb-form-field [field]="vestigingsnummerFormField"></mfb-form-field>
     </div>
-    <div class="flex-row flex-col-xs gap-10 flex-fill">
-        <div class="flex-1">
-            <mfb-form-field [field]="rsinFormField"></mfb-form-field>
-        </div>
+  </div>
+  <div class="flex-row flex-col-xs gap-10 flex-fill">
+    <div class="flex-1">
+      <mfb-form-field [field]="rsinFormField"></mfb-form-field>
     </div>
-    <div class="flex-row flex-col-xs gap-10 flex-fill">
-        <div class="flex-1 w66">
-            <mfb-form-field [field]="bedrijfsnaamFormField"></mfb-form-field>
-        </div>
-        <div class="flex-1">
-            <mfb-form-field [field]="typeFormField" (valueChanges)="typeChanged($event)"></mfb-form-field>
-        </div>
+  </div>
+  <div class="flex-row flex-col-xs gap-10 flex-fill">
+    <div class="flex-1 w66">
+      <mfb-form-field [field]="handelsnaamFormField"></mfb-form-field>
     </div>
-    <div class="flex-row flex-col-xs gap-10 flex-fill">
-        <div class="flex-1 w66">
-            <mfb-form-field [field]="postcodeFormField"></mfb-form-field>
-        </div>
-        <div class="flex-1">
-            <mfb-form-field [field]="huisnummerFormField"></mfb-form-field>
-        </div>
+    <div class="flex-1">
+      <mfb-form-field
+        [field]="typeFormField"
+        (valueChanges)="typeChanged($event)"
+      ></mfb-form-field>
     </div>
-    <button mat-flat-button color="primary" [disabled]="!isValid() || loading" (click)="zoekBedrijven()">
-        {{'actie.zoeken' | translate}}
-    </button>
-    <button mat-flat-button (click)="wissen()">{{'actie.wissen' | translate}}</button>
+  </div>
+  <div class="flex-row flex-col-xs gap-10 flex-fill">
+    <div class="flex-1 w66">
+      <mfb-form-field [field]="postcodeFormField"></mfb-form-field>
+    </div>
+    <div class="flex-1">
+      <mfb-form-field [field]="huisnummerFormField"></mfb-form-field>
+    </div>
+  </div>
+  <button
+    mat-flat-button
+    color="primary"
+    [disabled]="!isValid() || loading"
+    (click)="zoekBedrijven()"
+  >
+    {{'actie.zoeken' | translate}}
+  </button>
+  <button mat-flat-button (click)="wissen()">
+    {{'actie.wissen' | translate}}
+  </button>
 </div>
 
 <div class="table-wrapper">
-    <table mat-table [dataSource]="bedrijven" matSort>
-        <ng-container matColumnDef="naam">
-            <th *matHeaderCellDef mat-header-cell mat-sort-header> {{'naam' | translate}} </th>
-            <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.naam | empty}}</td>
-        </ng-container>
-        <ng-container matColumnDef="kvk">
-            <th *matHeaderCellDef mat-header-cell mat-sort-header> {{'kvk' | translate}} </th>
-            <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.kvkNummer | empty}}</td>
-        </ng-container>
-        <ng-container matColumnDef="vestigingsnummer">
-            <th *matHeaderCellDef mat-header-cell mat-sort-header> {{'vestigingsnummer' | translate}} </th>
-            <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.vestigingsnummer | empty}}</td>
-        </ng-container>
-        <ng-container matColumnDef="type">
-            <th *matHeaderCellDef mat-header-cell mat-sort-header> {{'type' | translate}} </th>
-            <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.type | empty | titlecase }}</td>
-        </ng-container>
-        <ng-container matColumnDef="adres">
-            <th *matHeaderCellDef mat-header-cell mat-sort-header> {{'adres' | translate}} </th>
-            <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.adres | empty}}</td>
-        </ng-container>
+  <table mat-table [dataSource]="bedrijven" matSort>
+    <ng-container matColumnDef="naam">
+      <th *matHeaderCellDef mat-header-cell mat-sort-header>
+        {{'naam' | translate}}
+      </th>
+      <td *matCellDef="let bedrijf" mat-cell>
+        {{bedrijf.handelsnaam | empty}}
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="kvk">
+      <th *matHeaderCellDef mat-header-cell mat-sort-header>
+        {{'kvk' | translate}}
+      </th>
+      <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.kvkNummer | empty}}</td>
+    </ng-container>
+    <ng-container matColumnDef="vestigingsnummer">
+      <th *matHeaderCellDef mat-header-cell mat-sort-header>
+        {{'vestigingsnummer' | translate}}
+      </th>
+      <td *matCellDef="let bedrijf" mat-cell>
+        {{bedrijf.vestigingsnummer | empty}}
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="type">
+      <th *matHeaderCellDef mat-header-cell mat-sort-header>
+        {{'type' | translate}}
+      </th>
+      <td *matCellDef="let bedrijf" mat-cell>
+        {{bedrijf.type | empty | titlecase }}
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="adres">
+      <th *matHeaderCellDef mat-header-cell mat-sort-header>
+        {{'adres' | translate}}
+      </th>
+      <td *matCellDef="let bedrijf" mat-cell>{{bedrijf.adres | empty}}</td>
+    </ng-container>
 
-        <ng-container matColumnDef="acties" stickyEnd>
-            <th mat-header-cell *matHeaderCellDef></th>
-            <td mat-cell *matCellDef="let row">
-                <button *ngIf="bedrijf.observed" mat-icon-button color="primary" (click)="selectBedrijf(row)" title="{{ 'actie.selecteren' | translate}}">
-                    <mat-icon>business</mat-icon>
-                </button>
-                <button *ngIf="!bedrijf.observed" mat-icon-button
-                        (click)="openBedrijfPagina(row)"
-                        [id]="'bedrijfBekijken_' + row.identificatie +'_button'"
-                        title="{{ 'actie.bedrijf.bekijken' | translate }}">
-                    <mat-icon>visibility</mat-icon>
-                </button>
-            </td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="bedrijfColumns; sticky: true"></tr>
-        <tr mat-row *matRowDef="let row; columns: bedrijfColumns;"></tr>
-    </table>
-    <p *ngIf="bedrijven.data.length == 0 && !loading">{{foutmelding ? foutmelding : 'msg.geen.gegevens.gevonden' | translate}}</p>
-    <p *ngIf="loading ">{{'msg.loading' | translate}}</p>
+    <ng-container matColumnDef="acties" stickyEnd>
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let row">
+        <button
+          *ngIf="bedrijf.observed"
+          mat-icon-button
+          color="primary"
+          (click)="selectBedrijf(row)"
+          title="{{ 'actie.selecteren' | translate}}"
+        >
+          <mat-icon>business</mat-icon>
+        </button>
+        <button
+          *ngIf="!bedrijf.observed"
+          mat-icon-button
+          (click)="openBedrijfPagina(row)"
+          [id]="'bedrijfBekijken_' + row.identificatie +'_button'"
+          title="{{ 'actie.bedrijf.bekijken' | translate }}"
+        >
+          <mat-icon>visibility</mat-icon>
+        </button>
+      </td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="bedrijfColumns; sticky: true"></tr>
+    <tr mat-row *matRowDef="let row; columns: bedrijfColumns;"></tr>
+  </table>
+  <p *ngIf="bedrijven.data.length == 0 && !loading">
+    {{foutmelding ? foutmelding : 'msg.geen.gegevens.gevonden' | translate}}
+  </p>
+  <p *ngIf="loading ">{{'msg.loading' | translate}}</p>
 </div>

--- a/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.html
+++ b/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.html
@@ -4,51 +4,41 @@
   -->
 
 <div class="form">
-  <div class="flex-row flex-col-xs gap-10 flex-fill">
-    <div class="flex-1">
-      <mfb-form-field [field]="kvkFormField"></mfb-form-field>
+    <div class="flex-row flex-col-xs gap-10 flex-fill">
+        <div class="flex-1">
+            <mfb-form-field [field]="kvkFormField"></mfb-form-field>
+        </div>
     </div>
-  </div>
-  <div class="flex-row flex-col-xs gap-10 flex-fill">
-    <div class="flex-1">
-      <mfb-form-field [field]="vestigingsnummerFormField"></mfb-form-field>
+    <div class="flex-row flex-col-xs gap-10 flex-fill">
+        <div class="flex-1">
+            <mfb-form-field [field]="vestigingsnummerFormField"></mfb-form-field>
+        </div>
     </div>
-  </div>
-  <div class="flex-row flex-col-xs gap-10 flex-fill">
-    <div class="flex-1">
-      <mfb-form-field [field]="rsinFormField"></mfb-form-field>
+    <div class="flex-row flex-col-xs gap-10 flex-fill">
+        <div class="flex-1">
+            <mfb-form-field [field]="rsinFormField"></mfb-form-field>
+        </div>
     </div>
-  </div>
-  <div class="flex-row flex-col-xs gap-10 flex-fill">
-    <div class="flex-1 w66">
-      <mfb-form-field [field]="handelsnaamFormField"></mfb-form-field>
+    <div class="flex-row flex-col-xs gap-10 flex-fill">
+        <div class="flex-1 w66">
+            <mfb-form-field [field]="bedrijfsnaamFormField"></mfb-form-field>
+        </div>
+        <div class="flex-1">
+            <mfb-form-field [field]="typeFormField" (valueChanges)="typeChanged($event)"></mfb-form-field>
+        </div>
     </div>
-    <div class="flex-1">
-      <mfb-form-field
-        [field]="typeFormField"
-        (valueChanges)="typeChanged($event)"
-      ></mfb-form-field>
+    <div class="flex-row flex-col-xs gap-10 flex-fill">
+        <div class="flex-1 w66">
+            <mfb-form-field [field]="postcodeFormField"></mfb-form-field>
+        </div>
+        <div class="flex-1">
+            <mfb-form-field [field]="huisnummerFormField"></mfb-form-field>
+        </div>
     </div>
-  </div>
-  <div class="flex-row flex-col-xs gap-10 flex-fill">
-    <div class="flex-1 w66">
-      <mfb-form-field [field]="postcodeFormField"></mfb-form-field>
-    </div>
-    <div class="flex-1">
-      <mfb-form-field [field]="huisnummerFormField"></mfb-form-field>
-    </div>
-  </div>
-  <button
-    mat-flat-button
-    color="primary"
-    [disabled]="!isValid() || loading"
-    (click)="zoekBedrijven()"
-  >
-    {{'actie.zoeken' | translate}}
-  </button>
-  <button mat-flat-button (click)="wissen()">
-    {{'actie.wissen' | translate}}
-  </button>
+    <button mat-flat-button color="primary" [disabled]="!isValid() || loading" (click)="zoekBedrijven()">
+        {{'actie.zoeken' | translate}}
+    </button>
+    <button mat-flat-button (click)="wissen()">{{'actie.wissen' | translate}}</button>
 </div>
 
 <div class="table-wrapper">

--- a/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.html
+++ b/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.html
@@ -4,41 +4,51 @@
   -->
 
 <div class="form">
-    <div class="flex-row flex-col-xs gap-10 flex-fill">
-        <div class="flex-1">
-            <mfb-form-field [field]="kvkFormField"></mfb-form-field>
-        </div>
+  <div class="flex-row flex-col-xs gap-10 flex-fill">
+    <div class="flex-1">
+      <mfb-form-field [field]="kvkFormField"></mfb-form-field>
     </div>
-    <div class="flex-row flex-col-xs gap-10 flex-fill">
-        <div class="flex-1">
-            <mfb-form-field [field]="vestigingsnummerFormField"></mfb-form-field>
-        </div>
+  </div>
+  <div class="flex-row flex-col-xs gap-10 flex-fill">
+    <div class="flex-1">
+      <mfb-form-field [field]="vestigingsnummerFormField"></mfb-form-field>
     </div>
-    <div class="flex-row flex-col-xs gap-10 flex-fill">
-        <div class="flex-1">
-            <mfb-form-field [field]="rsinFormField"></mfb-form-field>
-        </div>
+  </div>
+  <div class="flex-row flex-col-xs gap-10 flex-fill">
+    <div class="flex-1">
+      <mfb-form-field [field]="rsinFormField"></mfb-form-field>
     </div>
-    <div class="flex-row flex-col-xs gap-10 flex-fill">
-        <div class="flex-1 w66">
-            <mfb-form-field [field]="bedrijfsnaamFormField"></mfb-form-field>
-        </div>
-        <div class="flex-1">
-            <mfb-form-field [field]="typeFormField" (valueChanges)="typeChanged($event)"></mfb-form-field>
-        </div>
+  </div>
+  <div class="flex-row flex-col-xs gap-10 flex-fill">
+    <div class="flex-1 w66">
+      <mfb-form-field [field]="bedrijfsnaamFormField"></mfb-form-field>
     </div>
-    <div class="flex-row flex-col-xs gap-10 flex-fill">
-        <div class="flex-1 w66">
-            <mfb-form-field [field]="postcodeFormField"></mfb-form-field>
-        </div>
-        <div class="flex-1">
-            <mfb-form-field [field]="huisnummerFormField"></mfb-form-field>
-        </div>
+    <div class="flex-1">
+      <mfb-form-field
+        [field]="typeFormField"
+        (valueChanges)="typeChanged($event)"
+      ></mfb-form-field>
     </div>
-    <button mat-flat-button color="primary" [disabled]="!isValid() || loading" (click)="zoekBedrijven()">
-        {{'actie.zoeken' | translate}}
-    </button>
-    <button mat-flat-button (click)="wissen()">{{'actie.wissen' | translate}}</button>
+  </div>
+  <div class="flex-row flex-col-xs gap-10 flex-fill">
+    <div class="flex-1 w66">
+      <mfb-form-field [field]="postcodeFormField"></mfb-form-field>
+    </div>
+    <div class="flex-1">
+      <mfb-form-field [field]="huisnummerFormField"></mfb-form-field>
+    </div>
+  </div>
+  <button
+    mat-flat-button
+    color="primary"
+    [disabled]="!isValid() || loading"
+    (click)="zoekBedrijven()"
+  >
+    {{'actie.zoeken' | translate}}
+  </button>
+  <button mat-flat-button (click)="wissen()">
+    {{'actie.wissen' | translate}}
+  </button>
 </div>
 
 <div class="table-wrapper">

--- a/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.ts
+++ b/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.ts
@@ -42,7 +42,7 @@ export class BedrijfZoekComponent implements OnInit {
   kvkFormField: AbstractFormControlField;
   vestigingsnummerFormField: AbstractFormControlField;
   rsinFormField: AbstractFormControlField;
-  handelsnaamFormField: AbstractFormControlField;
+  bedrijfsnaamFormField: AbstractFormControlField;
   typeFormField: AbstractFormControlField;
   postcodeFormField: AbstractFormControlField;
   huisnummerFormField: AbstractFormControlField;
@@ -56,11 +56,11 @@ export class BedrijfZoekComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.handelsnaamFormField = new InputFormFieldBuilder()
-      .id("handelsnaam")
-      .label("handelsnaam")
+    this.bedrijfsnaamFormField = new InputFormFieldBuilder()
+      .id("bedrijfsnaam")
+      .label("bedrijfsnaam")
       .maxlength(100)
-      .validators(CustomValidators.handelsnaam)
+      .validators(CustomValidators.bedrijfssnaam)
       .build();
     this.kvkFormField = new InputFormFieldBuilder()
       .id("kvknummer")
@@ -108,7 +108,7 @@ export class BedrijfZoekComponent implements OnInit {
       .build();
     this.formGroup = this.formBuilder.group({
       kvkNummer: this.kvkFormField.formControl,
-      handelsnaam: this.handelsnaamFormField.formControl,
+      bedrijfsnaam: this.bedrijfsnaamFormField.formControl,
       vestigingsnummer: this.vestigingsnummerFormField.formControl,
       rsin: this.rsinFormField.formControl,
       postcode: this.postcodeFormField.formControl,
@@ -123,7 +123,7 @@ export class BedrijfZoekComponent implements OnInit {
       return false;
     }
     const kvkNummer = this.kvkFormField.formControl.value;
-    const handelsnaam = this.handelsnaamFormField.formControl.value;
+    const bedrijfsnaam = this.bedrijfsnaamFormField.formControl.value;
     const vestigingsnummer = this.vestigingsnummerFormField.formControl.value;
     const rsin = this.rsinFormField.formControl.value;
     const postcode = this.postcodeFormField.formControl.value;
@@ -131,7 +131,7 @@ export class BedrijfZoekComponent implements OnInit {
 
     return (
       kvkNummer ||
-      handelsnaam ||
+      bedrijfsnaam ||
       vestigingsnummer ||
       rsin ||
       (postcode && huisnummer)

--- a/src/main/app/src/app/shared/validators/customValidators.ts
+++ b/src/main/app/src/app/shared/validators/customValidators.ts
@@ -14,7 +14,7 @@ export class CustomValidators {
   static rsin = CustomValidators.rsinVFn();
   static email = CustomValidators.emailVFn(false);
   static emails = CustomValidators.emailVFn(true);
-  static handelsnaam = CustomValidators.handelsnaamVFn();
+  static bedrijfssnaam = CustomValidators.bedrijfsnaamVFn();
   static huisnummer = CustomValidators.huisnummerVFn();
 
   private static postcodeRegex = /^[1-9][0-9]{3}(?!sa|sd|ss)[a-z]{2}$/i;
@@ -42,7 +42,7 @@ export class CustomValidators {
   private static emailsRegex = new RegExp(
     "^(" + CustomValidators.EMAIL + ")(;//s*" + CustomValidators.EMAIL + ")*$",
   );
-  private static handelsnaamRegex = new RegExp("[*()]+");
+  private static bedrijfsnaamRegex = new RegExp("[*()]+");
   private static nummerRegex = new RegExp("^[0-9]*$");
 
   private static bsnVFn(): ValidatorFn {
@@ -133,14 +133,14 @@ export class CustomValidators {
     };
   }
 
-  private static handelsnaamVFn(): ValidatorFn {
+  private static bedrijfsnaamVFn(): ValidatorFn {
     return (control: AbstractControl): { [key: string]: boolean } | null => {
       if (!control.value) {
         return null;
       }
       const val = control.value;
-      if (CustomValidators.handelsnaamRegex.test(val)) {
-        return { handelsnaam: true };
+      if (CustomValidators.bedrijfsnaamRegex.test(val)) {
+        return { bedrijfsnaam: true };
       }
     };
   }

--- a/src/main/app/src/assets/i18n/en.json
+++ b/src/main/app/src/assets/i18n/en.json
@@ -855,7 +855,7 @@
   "bsn.vestigingsnummer.rsin": "CSN / Branch code / RSIN",
   "bsn": "CSN",
   "kvknummer": "CoC-number",
-  "handelsnaam": "Trade name",
+  "bedrijfsnaam": "Trade name",
   "totaalWerkzamePersonen": "Number of employed persons",
   "hoofdactiviteit": "Primary activity",
   "activiteiten": "Activities",

--- a/src/main/app/src/assets/i18n/en.json
+++ b/src/main/app/src/assets/i18n/en.json
@@ -855,7 +855,7 @@
   "bsn.vestigingsnummer.rsin": "CSN / Branch code / RSIN",
   "bsn": "CSN",
   "kvknummer": "CoC-number",
-  "bedrijfsnaam": "Trade name",
+  "bedrijfsnaam": "Name",
   "totaalWerkzamePersonen": "Number of employed persons",
   "hoofdactiviteit": "Primary activity",
   "activiteiten": "Activities",

--- a/src/main/app/src/assets/i18n/nl.json
+++ b/src/main/app/src/assets/i18n/nl.json
@@ -855,7 +855,7 @@
   "bsn.vestigingsnummer.rsin": "BSN / Vestigingsnummer / RSIN",
   "bsn": "BSN",
   "kvknummer": "KvK-nummer",
-  "handelsnaam": "Handelsnaam",
+  "bedrijfsnaam": "Naam",
   "totaalWerkzamePersonen": "Aantal werkzame personen",
   "hoofdactiviteit": "Hoofdactiviteit",
   "activiteiten": "Activiteiten",

--- a/src/main/java/net/atos/zac/app/klanten/KlantRestService.java
+++ b/src/main/java/net/atos/zac/app/klanten/KlantRestService.java
@@ -45,9 +45,9 @@ import net.atos.zac.app.klanten.converter.RestBedrijfConverter;
 import net.atos.zac.app.klanten.converter.RestPersoonConverter;
 import net.atos.zac.app.klanten.converter.RestRoltypeConverter;
 import net.atos.zac.app.klanten.converter.RestVestigingsprofielConverter;
-import net.atos.zac.app.klanten.model.bedrijven.RESTVestigingsprofiel;
 import net.atos.zac.app.klanten.model.bedrijven.RestBedrijf;
 import net.atos.zac.app.klanten.model.bedrijven.RestListBedrijvenParameters;
+import net.atos.zac.app.klanten.model.bedrijven.RestVestigingsprofiel;
 import net.atos.zac.app.klanten.model.klant.IdentificatieType;
 import net.atos.zac.app.klanten.model.klant.RestContactGegevens;
 import net.atos.zac.app.klanten.model.klant.RestKlant;
@@ -127,7 +127,7 @@ public class KlantRestService {
 
     @GET
     @Path("vestigingsprofiel/{vestigingsnummer}")
-    public RESTVestigingsprofiel readVestigingsprofiel(@PathParam("vestigingsnummer") final String vestigingsnummer) {
+    public RestVestigingsprofiel readVestigingsprofiel(@PathParam("vestigingsnummer") final String vestigingsnummer) {
         Optional<Vestiging> vestiging = kvkClientService.findVestigingsprofiel(vestigingsnummer);
         if (vestiging.isPresent()) {
             return restVestigingsprofielConverter.convert(vestiging.get());

--- a/src/main/java/net/atos/zac/app/klanten/converter/RestBedrijfConverter.java
+++ b/src/main/java/net/atos/zac/app/klanten/converter/RestBedrijfConverter.java
@@ -36,8 +36,8 @@ public class RestBedrijfConverter {
         if (StringUtils.isNotBlank(restListParameters.rsin)) {
             zoekenParameters.setRsin(restListParameters.rsin);
         }
-        if (StringUtils.isNotBlank(restListParameters.handelsnaam)) {
-            zoekenParameters.setNaam(restListParameters.handelsnaam);
+        if (StringUtils.isNotBlank(restListParameters.naam)) {
+            zoekenParameters.setNaam(restListParameters.naam);
         }
         if (restListParameters.type != null) {
             zoekenParameters.setType(restListParameters.type.getType());
@@ -62,7 +62,7 @@ public class RestBedrijfConverter {
         final RestBedrijf restBedrijf = new RestBedrijf();
         restBedrijf.kvkNummer = bedrijf.getKvkNummer();
         restBedrijf.vestigingsnummer = bedrijf.getVestigingsnummer();
-        restBedrijf.handelsnaam = convertToNaam(bedrijf);
+        restBedrijf.naam = convertToNaam(bedrijf);
         restBedrijf.postcode = bedrijf.getAdres().getBinnenlandsAdres().getPostcode();
         restBedrijf.rsin = bedrijf.getRsin();
         restBedrijf.type = bedrijf.getType().toUpperCase(Locale.getDefault());

--- a/src/main/java/net/atos/zac/app/klanten/converter/RestVestigingsprofielConverter.java
+++ b/src/main/java/net/atos/zac/app/klanten/converter/RestVestigingsprofielConverter.java
@@ -20,7 +20,7 @@ public class RestVestigingsprofielConverter {
         final RESTVestigingsprofiel restVestigingsprofiel = new RESTVestigingsprofiel();
         restVestigingsprofiel.kvkNummer = vestiging.getKvkNummer();
         restVestigingsprofiel.vestigingsnummer = vestiging.getVestigingsnummer();
-        restVestigingsprofiel.handelsnaam = vestiging.getEersteHandelsnaam();
+        restVestigingsprofiel.eersteHandelsnaam = vestiging.getEersteHandelsnaam();
         restVestigingsprofiel.rsin = vestiging.getRsin();
         restVestigingsprofiel.totaalWerkzamePersonen = vestiging.getTotaalWerkzamePersonen();
         restVestigingsprofiel.deeltijdWerkzamePersonen = vestiging.getDeeltijdWerkzamePersonen();

--- a/src/main/java/net/atos/zac/app/klanten/converter/RestVestigingsprofielConverter.java
+++ b/src/main/java/net/atos/zac/app/klanten/converter/RestVestigingsprofielConverter.java
@@ -9,15 +9,15 @@ import org.apache.commons.collections4.CollectionUtils;
 
 import net.atos.client.kvk.vestigingsprofiel.model.generated.SBIActiviteit;
 import net.atos.client.kvk.vestigingsprofiel.model.generated.Vestiging;
-import net.atos.zac.app.klanten.model.bedrijven.RESTVestigingsprofiel;
 import net.atos.zac.app.klanten.model.bedrijven.RestKlantenAdres;
+import net.atos.zac.app.klanten.model.bedrijven.RestVestigingsprofiel;
 
 public class RestVestigingsprofielConverter {
     public static String VESTIGINGTYPE_HOOFDVESTIGING = "HOOFDVESTIGING";
     public static String VESTIGINGTYPE_NEVENVESTIGING = "NEVENVESTIGING";
 
-    public RESTVestigingsprofiel convert(final Vestiging vestiging) {
-        final RESTVestigingsprofiel restVestigingsprofiel = new RESTVestigingsprofiel();
+    public RestVestigingsprofiel convert(final Vestiging vestiging) {
+        final RestVestigingsprofiel restVestigingsprofiel = new RestVestigingsprofiel();
         restVestigingsprofiel.kvkNummer = vestiging.getKvkNummer();
         restVestigingsprofiel.vestigingsnummer = vestiging.getVestigingsnummer();
         restVestigingsprofiel.eersteHandelsnaam = vestiging.getEersteHandelsnaam();

--- a/src/main/java/net/atos/zac/app/klanten/model/bedrijven/RESTVestigingsprofiel.java
+++ b/src/main/java/net/atos/zac/app/klanten/model/bedrijven/RESTVestigingsprofiel.java
@@ -13,7 +13,7 @@ public class RESTVestigingsprofiel {
 
     public String kvkNummer;
 
-    public String handelsnaam;
+    public String eersteHandelsnaam;
 
     public String rsin;
 

--- a/src/main/java/net/atos/zac/app/klanten/model/bedrijven/RestBedrijf.java
+++ b/src/main/java/net/atos/zac/app/klanten/model/bedrijven/RestBedrijf.java
@@ -17,7 +17,7 @@ public class RestBedrijf extends RestKlant {
 
     public String kvkNummer;
 
-    public String handelsnaam;
+    public String naam;
 
     public String rsin;
 
@@ -39,6 +39,6 @@ public class RestBedrijf extends RestKlant {
 
     @Override
     public String getNaam() {
-        return handelsnaam;
+        return naam;
     }
 }

--- a/src/main/java/net/atos/zac/app/klanten/model/bedrijven/RestListBedrijvenParameters.java
+++ b/src/main/java/net/atos/zac/app/klanten/model/bedrijven/RestListBedrijvenParameters.java
@@ -13,7 +13,7 @@ public class RestListBedrijvenParameters {
 
     public String rsin;
 
-    public String handelsnaam;
+    public String naam;
 
     public String postcode;
 

--- a/src/main/java/net/atos/zac/app/klanten/model/bedrijven/RestVestigingsprofiel.java
+++ b/src/main/java/net/atos/zac/app/klanten/model/bedrijven/RestVestigingsprofiel.java
@@ -7,7 +7,7 @@ package net.atos.zac.app.klanten.model.bedrijven;
 
 import java.util.List;
 
-public class RESTVestigingsprofiel {
+public class RestVestigingsprofiel {
 
     public String vestigingsnummer;
 

--- a/src/test/kotlin/net/atos/zac/app/klanten/KlantRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/klanten/KlantRestServiceTest.kt
@@ -66,7 +66,7 @@ class KlantRestServiceTest : BehaviorSpec({
                         "$straatnaam$NON_BREAKING_SPACE$huisnummer$NON_BREAKING_SPACE$huisletter, $postcode, $plaats"
                     }
                     emailadres shouldBe klant.emailadres
-                    handelsnaam shouldBe kvkResultaatItem.naam
+                    naam shouldBe kvkResultaatItem.naam
                     kvkNummer shouldBe kvkResultaatItem.kvkNummer
                     postcode shouldBe kvkResultaatItem.adres.binnenlandsAdres.postcode
                     rsin shouldBe kvkResultaatItem.rsin


### PR DESCRIPTION
Use 'naam' instead of 'handelsnaam' for searching and showing KVK companies since this is how the KVK APIs work (https://developers.kvk.nl/nl/documentation/migration-zoeken-v2). Note that the result of a KVK search is always a 'vestiging' in our case but currently the code does not actually use the 'eersteHandelsnaam' of the vestiging as returned by the 'vestigings profiel'. 

Solves PZ-3186