### PR TITLE
feat: add productaanvraag mapping for other betrokkenen

### DIFF
--- a/scripts/docker-compose/imports/objects-api/fixtures/demodata.json
+++ b/scripts/docker-compose/imports/objects-api/fixtures/demodata.json
@@ -910,6 +910,10 @@
                     {
                         "vestigingsNummer" : "000012345678",
                         "rolOmschrijvingGeneriek" : "initiator"
+                    },
+                    {
+                        "inpBsn" : "999991838",
+                        "rolOmschrijvingGeneriek" : "mede_initiator"
                     }
                 ],
                 "pdf": "http://openzaak.local:8000/documenten/api/v1/enkelvoudiginformatieobjecten/37e16ddc-7992-418c-b5a0-54cf6680329e"

--- a/scripts/docker-compose/imports/objects-api/fixtures/demodata.json
+++ b/scripts/docker-compose/imports/objects-api/fixtures/demodata.json
@@ -860,6 +860,14 @@
                         "indicatieCorrespondentie" : false
                     },
                     {
+                        "inpBsn" : "999991838",
+                        "rolOmschrijvingGeneriek" : "belanghebbende"
+                    },
+                    {
+                        "inpBsn" : "999992958",
+                        "rolOmschrijvingGeneriek" : "belanghebbende"
+                    },
+                    {
                         "medewerkerIdentificatie" : "MDW123",
                         "rolOmschrijvingGeneriek" : "klantcontacter"
                     }

--- a/scripts/docker-compose/imports/objects-api/fixtures/demodata.json
+++ b/scripts/docker-compose/imports/objects-api/fixtures/demodata.json
@@ -922,6 +922,14 @@
                     {
                         "inpBsn" : "999991838",
                         "rolOmschrijvingGeneriek" : "mede_initiator"
+                    },
+                    {
+                        "inpBsn" : "999991838",
+                        "rolOmschrijvingGeneriek" : "belanghebbende"
+                    },
+                    {
+                        "inpBsn" : "999992958",
+                        "rolOmschrijvingGeneriek" : "belanghebbende"
                     }
                 ],
                 "pdf": "http://openzaak.local:8000/documenten/api/v1/enkelvoudiginformatieobjecten/37e16ddc-7992-418c-b5a0-54cf6680329e"

--- a/scripts/docker-compose/imports/objects-api/fixtures/demodata.json
+++ b/scripts/docker-compose/imports/objects-api/fixtures/demodata.json
@@ -930,6 +930,10 @@
                     {
                         "inpBsn" : "999992958",
                         "rolOmschrijvingGeneriek" : "belanghebbende"
+                    },
+                    {
+                        "inpBsn" : "999992958",
+                        "rolOmschrijvingGeneriek" : "adviseur"
                     }
                 ],
                 "pdf": "http://openzaak.local:8000/documenten/api/v1/enkelvoudiginformatieobjecten/37e16ddc-7992-418c-b5a0-54cf6680329e"

--- a/src/itest/kotlin/nl/lifely/zac/itest/ZaakHistorieTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZaakHistorieTest.kt
@@ -12,6 +12,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import nl.lifely.zac.itest.client.ItestHttpClient
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
+import nl.lifely.zac.itest.config.ItestConfiguration.TEST_PERSON_2_BSN
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_PERSON_HENDRIKA_JANSE_BSN
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_TASK_COMPLETED
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_USER_1_NAME
@@ -92,6 +93,13 @@ class ZaakHistorieTest : BehaviorSpec({
                     "nieuweWaarde": "Intake",
                     "toelichting": "Status gewijzigd vanuit Case",
                     "actie": "GEWIJZIGD"
+                  },
+                  {
+                    "attribuutLabel": "Medeaanvrager",
+                    "door": "Functionele gebruiker",
+                    "nieuweWaarde": "$TEST_PERSON_2_BSN",
+                    "toelichting": "",
+                    "actie": "GEKOPPELD"
                   },
                   {
                     "attribuutLabel": "Melder",

--- a/src/itest/kotlin/nl/lifely/zac/itest/ZaakHistorieTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZaakHistorieTest.kt
@@ -13,6 +13,7 @@ import io.kotest.matchers.shouldBe
 import nl.lifely.zac.itest.client.ItestHttpClient
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_PERSON_2_BSN
+import nl.lifely.zac.itest.config.ItestConfiguration.TEST_PERSON_3_BSN
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_PERSON_HENDRIKA_JANSE_BSN
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_TASK_COMPLETED
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_USER_1_NAME
@@ -93,6 +94,20 @@ class ZaakHistorieTest : BehaviorSpec({
                     "nieuweWaarde": "Intake",
                     "toelichting": "Status gewijzigd vanuit Case",
                     "actie": "GEWIJZIGD"
+                  },
+                  {
+                    "actie": "GEKOPPELD",
+                    "attribuutLabel": "Bewindvoerder",
+                    "door": "Functionele gebruiker",
+                    "nieuweWaarde": "$TEST_PERSON_2_BSN",
+                    "toelichting": ""
+                  },
+                  {
+                    "actie": "GEKOPPELD",
+                    "attribuutLabel": "Bewindvoerder",
+                    "door": "Functionele gebruiker",
+                    "nieuweWaarde": "$TEST_PERSON_3_BSN",
+                    "toelichting": ""
                   },
                   {
                     "attribuutLabel": "Medeaanvrager",

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
@@ -80,6 +80,7 @@ object ItestConfiguration {
     const val TEST_PERSON_HENDRIKA_JANSE_PLACE_OF_RESIDENCE =
         "Street ¦ 38 & House ¦ 10, Baghdad, Park Al-Sadoum, Hay Al-Nidhal 103"
     const val TEST_PERSON_2_BSN = "999992958"
+    const val TEST_PERSON_3_BSN = "999991838"
     const val TEST_PDF_FILE_NAME = "dummyTestDocument.pdf"
     const val TEST_PDF_FILE_SIZE = 9268
     const val TEST_TXT_FILE_NAME = "testTextDocument.txt"

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
@@ -79,6 +79,7 @@ object ItestConfiguration {
     const val TEST_PERSON_HENDRIKA_JANSE_PHONE_NUMBER = "0612345678"
     const val TEST_PERSON_HENDRIKA_JANSE_PLACE_OF_RESIDENCE =
         "Street ¦ 38 & House ¦ 10, Baghdad, Park Al-Sadoum, Hay Al-Nidhal 103"
+    const val TEST_PERSON_2_BSN = "999992958"
     const val TEST_PDF_FILE_NAME = "dummyTestDocument.pdf"
     const val TEST_PDF_FILE_SIZE = 9268
     const val TEST_TXT_FILE_NAME = "testTextDocument.txt"

--- a/src/main/java/net/atos/client/zgw/shared/ZGWApiService.java
+++ b/src/main/java/net/atos/client/zgw/shared/ZGWApiService.java
@@ -285,7 +285,7 @@ public class ZGWApiService {
     }
 
     public Optional<Rol<?>> findInitiatorRoleForZaak(final Zaak zaak) {
-        return ztcClientService.findRoletypen(zaak.getZaaktype(), OmschrijvingGeneriekEnum.INITIATOR)
+        return ztcClientService.findRoltypen(zaak.getZaaktype(), OmschrijvingGeneriekEnum.INITIATOR)
                 .stream()
                 // there should be only one initiator role type but in case there are multiple, we take the first one
                 .findFirst()
@@ -298,7 +298,7 @@ public class ZGWApiService {
             final Zaak zaak,
             final BetrokkeneType betrokkeneType
     ) {
-        return ztcClientService.findRoletypen(zaak.getZaaktype(), OmschrijvingGeneriekEnum.BEHANDELAAR)
+        return ztcClientService.findRoltypen(zaak.getZaaktype(), OmschrijvingGeneriekEnum.BEHANDELAAR)
                 .stream()
                 // there should be only one behandelaar role type but in case there are multiple, we take the first one
                 .findFirst()

--- a/src/main/java/net/atos/client/zgw/shared/ZGWApiService.java
+++ b/src/main/java/net/atos/client/zgw/shared/ZGWApiService.java
@@ -285,7 +285,7 @@ public class ZGWApiService {
     }
 
     public Optional<Rol<?>> findInitiatorRoleForZaak(final Zaak zaak) {
-        return ztcClientService.findRoltype(zaak.getZaaktype(), OmschrijvingGeneriekEnum.INITIATOR)
+        return ztcClientService.findRoletypen(zaak.getZaaktype(), OmschrijvingGeneriekEnum.INITIATOR)
                 .stream()
                 // there should be only one initiator role type but in case there are multiple, we take the first one
                 .findFirst()
@@ -298,7 +298,7 @@ public class ZGWApiService {
             final Zaak zaak,
             final BetrokkeneType betrokkeneType
     ) {
-        return ztcClientService.findRoltype(zaak.getZaaktype(), OmschrijvingGeneriekEnum.BEHANDELAAR)
+        return ztcClientService.findRoletypen(zaak.getZaaktype(), OmschrijvingGeneriekEnum.BEHANDELAAR)
                 .stream()
                 // there should be only one behandelaar role type but in case there are multiple, we take the first one
                 .findFirst()

--- a/src/main/java/net/atos/client/zgw/shared/model/Results.java
+++ b/src/main/java/net/atos/client/zgw/shared/model/Results.java
@@ -64,7 +64,7 @@ public class Results<T> {
     }
 
     public List<T> getResults() {
-        return results != null ? results : Collections.EMPTY_LIST;
+        return results != null ? results : Collections.emptyList();
     }
 
     public Optional<T> getSingleResult() {

--- a/src/main/java/net/atos/zac/app/klanten/KlantRestService.java
+++ b/src/main/java/net/atos/zac/app/klanten/KlantRestService.java
@@ -176,8 +176,8 @@ public class KlantRestService {
         return RestRoltypeConverter.convert(
                 ztcClientService.listRoltypen(ztcClientService.readZaaktype(zaaktype).getUrl())
                         .stream()
-                        .filter(roltype -> betrokkenen.contains(roltype.getOmschrijvingGeneriek())
-                        ).sorted(Comparator.comparing(RolType::getOmschrijving))
+                        .filter(roltype -> betrokkenen.contains(roltype.getOmschrijvingGeneriek()))
+                        .sorted(Comparator.comparing(RolType::getOmschrijving))
         );
     }
 

--- a/src/main/java/net/atos/zac/documentcreatie/converter/DocumentCreatieDataConverter.java
+++ b/src/main/java/net/atos/zac/documentcreatie/converter/DocumentCreatieDataConverter.java
@@ -144,14 +144,14 @@ public class DocumentCreatieDataConverter {
                 .map(RolOrganisatorischeEenheid::getNaam)
                 .ifPresent(groep -> zaakData.groep = groep);
 
-        zgwApiService.findBehandelaarForZaak(zaak)
+        zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
                 .map(RolMedewerker::getNaam)
                 .ifPresent(behandelaar -> zaakData.behandelaar = behandelaar);
         return zaakData;
     }
 
     private AanvragerData createAanvragerData(final Zaak zaak) {
-        return zgwApiService.findInitiatorForZaak(zaak)
+        return zgwApiService.findInitiatorRoleForZaak(zaak)
                 .map(this::convertToAanvragerData)
                 .orElse(null);
     }

--- a/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
+++ b/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
@@ -159,7 +159,7 @@ public class MailTemplateHelper {
             if (resolvedTekst.contains(ZAAK_INITIATOR.getVariabele()) ||
                 resolvedTekst.contains(ZAAK_INITIATOR_ADRES.getVariabele())) {
                 resolvedTekst = replaceInitiatorVariabelen(resolvedTekst,
-                        zgwApiService.findInitiatorForZaak(zaak));
+                        zgwApiService.findInitiatorRoleForZaak(zaak));
             }
 
             if (resolvedTekst.contains(ZAAK_BEHANDELAAR_GROEP.getVariabele())) {
@@ -170,7 +170,7 @@ public class MailTemplateHelper {
 
             if (resolvedTekst.contains(ZAAK_BEHANDELAAR_MEDEWERKER.getVariabele())) {
                 resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_BEHANDELAAR_MEDEWERKER,
-                        zgwApiService.findBehandelaarForZaak(zaak)
+                        zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
                                 .map(RolMedewerker::getNaam));
             }
         }

--- a/src/main/java/net/atos/zac/signalering/event/SignaleringEventObserver.java
+++ b/src/main/java/net/atos/zac/signalering/event/SignaleringEventObserver.java
@@ -207,7 +207,7 @@ public class SignaleringEventObserver extends AbstractEventObserver<SignaleringE
     }
 
     private RolType getRoltypeBehandelaar(final Zaak zaak) {
-        return ztcClientService.readRoltype(OmschrijvingGeneriekEnum.BEHANDELAAR, zaak.getZaaktype());
+        return ztcClientService.readRoltype(zaak.getZaaktype(), OmschrijvingGeneriekEnum.BEHANDELAAR);
     }
 
     private Optional<Rol<?>> getRolBehandelaarMedewerker(final Zaak zaak) {

--- a/src/main/java/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.java
+++ b/src/main/java/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.java
@@ -79,7 +79,7 @@ public class ZaakZoekObjectConverter extends AbstractZoekObjectConverter<ZaakZoe
         zaakZoekObject.setPublicatiedatum(DateTimeConverterUtil.convertToDate(zaak.getPublicatiedatum()));
         zaakZoekObject.setVertrouwelijkheidaanduiding(zaak.getVertrouwelijkheidaanduiding().toString());
         zaakZoekObject.setAfgehandeld(!zaak.isOpen());
-        zgwApiService.findInitiatorForZaak(zaak).ifPresent(zaakZoekObject::setInitiator);
+        zgwApiService.findInitiatorRoleForZaak(zaak).ifPresent(zaakZoekObject::setInitiator);
         zaakZoekObject.setLocatie(convertToLocatie(zaak.getZaakgeometrie()));
         zaakZoekObject.setCommunicatiekanaal(zaak.getCommunicatiekanaalNaam());
 
@@ -162,7 +162,7 @@ public class ZaakZoekObjectConverter extends AbstractZoekObjectConverter<ZaakZoe
     }
 
     private User findBehandelaar(final Zaak zaak) {
-        return zgwApiService.findBehandelaarForZaak(zaak)
+        return zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
                 .map(behandelaar -> identityService.readUser(
                         behandelaar.getBetrokkeneIdentificatie().getIdentificatie()))
                 .orElse(null);

--- a/src/main/java/net/atos/zac/zoeken/model/zoekobject/ZaakZoekObject.java
+++ b/src/main/java/net/atos/zac/zoeken/model/zoekobject/ZaakZoekObject.java
@@ -320,10 +320,10 @@ public class ZaakZoekObject implements ZoekObject {
         return initiatorIdentificatie;
     }
 
-    public void setInitiator(final Rol<?> initiator) {
-        if (initiator != null) {
-            this.initiatorIdentificatie = initiator.getIdentificatienummer();
-            this.initiatorType = initiator.getBetrokkeneType().toValue();
+    public void setInitiator(final Rol<?> initiatorRole) {
+        if (initiatorRole != null) {
+            this.initiatorIdentificatie = initiatorRole.getIdentificatienummer();
+            this.initiatorType = initiatorRole.getBetrokkeneType().toValue();
         }
     }
 

--- a/src/main/kotlin/net/atos/client/zgw/ztc/ZtcClientService.kt
+++ b/src/main/kotlin/net/atos/client/zgw/ztc/ZtcClientService.kt
@@ -283,27 +283,28 @@ class ZtcClientService @Inject constructor(
     }
 
     /**
-     * Find the [RolType]s for a [ZaakType] and generic role type description.
+     * Find all [RolType]s for a [ZaakType] and generic role type description.
      *
      * @param zaaktypeURI thr URI of the zaak type
      * @param omschrijvingGeneriekEnum [OmschrijvingG
      * @return the list of [RolType]s; may be empty if no rol types have been defined for the zaak type
      * and generic role type description.
      */
-    fun findRoletypen(zaaktypeURI: URI, omschrijvingGeneriekEnum: OmschrijvingGeneriekEnum): List<RolType> =
+    fun findRoltypen(zaaktypeURI: URI, omschrijvingGeneriekEnum: OmschrijvingGeneriekEnum): List<RolType> =
         uriOmschrijvingGeneriekEnumToRolTypeCache.get("$zaaktypeURI$omschrijvingGeneriekEnum") {
             ztcClient.roltypeList(RoltypeListParameters(zaaktypeURI, omschrijvingGeneriekEnum)).results
         }
 
     /**
      * Retrieves the [RolType] of the specified zaak type and generic role type description.
+     * If there are multiple role types found the first one is returned.
      *
      * @param zaaktypeURI URI of the zaak type
      * @param omschrijvingGeneriekEnum the generic role type description
      * @return [RolType] the first role type for the zaak type and generic role type description
      * @throws RoltypeNotFoundException if no role type could be found
      */
-    fun readRoltype(omschrijvingGeneriekEnum: OmschrijvingGeneriekEnum, zaaktypeURI: URI): RolType =
+    fun readRoltype(zaaktypeURI: URI, omschrijvingGeneriekEnum: OmschrijvingGeneriekEnum): RolType =
         uriOmschrijvingGeneriekEnumToRolTypeCache.get("$zaaktypeURI$omschrijvingGeneriekEnum") {
             ztcClient.roltypeList(RoltypeListParameters(zaaktypeURI, omschrijvingGeneriekEnum)).results
         }.firstOrNull() ?: throw

--- a/src/main/kotlin/net/atos/client/zgw/ztc/ZtcClientService.kt
+++ b/src/main/kotlin/net/atos/client/zgw/ztc/ZtcClientService.kt
@@ -39,7 +39,6 @@ import nl.lifely.zac.util.NoArgConstructor
 import org.eclipse.microprofile.rest.client.inject.RestClient
 import java.net.URI
 import java.time.ZonedDateTime
-import java.util.Optional
 import java.util.UUID
 import java.util.logging.Logger
 
@@ -102,7 +101,7 @@ class ZtcClientService @Inject constructor(
         private val uuidToBesluitTypeCache: Cache<UUID, BesluitType> = createCache("UUID -> BesluitType")
         private val uriToBesluitTypeListCache: Cache<URI, List<BesluitType>> = createCache("URI -> List<BesluitType>")
 
-        private val uriOmschrijvingGeneriekEnumToRolTypeCache: Cache<String, Optional<RolType>> =
+        private val uriOmschrijvingGeneriekEnumToRolTypeCache: Cache<String, List<RolType>> =
             createCache("URI & OmschrijvingGeneriekEnumT -> RolType")
         private val uriToRolTypeListCache: Cache<URI, List<RolType>> = createCache("URI -> List<RolType>")
         private val rolTypeListCache: Cache<String, List<RolType>> = createCache("List<RolType>", 1)
@@ -284,40 +283,39 @@ class ZtcClientService @Inject constructor(
     }
 
     /**
-     * Find [RolType] of [ZaakType] and [OmschrijvingGeneriekEnum].
-     * returns null if the [ResultaatType] can not be found
+     * Find the [RolType]s for a [ZaakType] and generic role type description.
      *
-     * @param zaaktypeURI              URI of [ZaakType].
-     * @param omschrijvingGeneriekEnum [OmschrijvingGeneriekEnum].
-     * @return [RolType] or NULL
+     * @param zaaktypeURI thr URI of the zaak type
+     * @param omschrijvingGeneriekEnum [OmschrijvingG
+     * @return the list of [RolType]s; may be empty if no rol types have been defined for the zaak type
+     * and generic role type description.
      */
-    fun findRoltype(zaaktypeURI: URI, omschrijvingGeneriekEnum: OmschrijvingGeneriekEnum): Optional<RolType> =
+    fun findRoltype(zaaktypeURI: URI, omschrijvingGeneriekEnum: OmschrijvingGeneriekEnum): List<RolType> =
         uriOmschrijvingGeneriekEnumToRolTypeCache.get("$zaaktypeURI$omschrijvingGeneriekEnum") {
-            ztcClient.roltypeList(RoltypeListParameters(zaaktypeURI, omschrijvingGeneriekEnum)).singleResult
+            ztcClient.roltypeList(RoltypeListParameters(zaaktypeURI, omschrijvingGeneriekEnum)).results
         }
 
     /**
-     * Retrieves the [RolType] of the specified zaak type and roltype 'aard'.
+     * Retrieves the [RolType] of the specified zaak type and generic role type description.
      *
-     * @param zaaktypeURI URI of [ZaakType].
-     * @param omschrijvingGeneriekEnum the 'aard' of the [RolType].
-     * @return [RolType]. Never 'null'
-     * @throws RoltypeNotFoundException if no [RolType] could be found.
+     * @param zaaktypeURI URI of the zaak type
+     * @param omschrijvingGeneriekEnum the generic role type description
+     * @return [RolType] the first role type for the zaak type and generic role type description
+     * @throws RoltypeNotFoundException if no role type could be found
      */
     fun readRoltype(omschrijvingGeneriekEnum: OmschrijvingGeneriekEnum, zaaktypeURI: URI): RolType =
         uriOmschrijvingGeneriekEnumToRolTypeCache.get("$zaaktypeURI$omschrijvingGeneriekEnum") {
-            ztcClient.roltypeList(RoltypeListParameters(zaaktypeURI, omschrijvingGeneriekEnum)).singleResult
-        }.orElseThrow {
+            ztcClient.roltypeList(RoltypeListParameters(zaaktypeURI, omschrijvingGeneriekEnum)).results
+        }.firstOrNull() ?: throw
             RoltypeNotFoundException(
                 "Roltype with aard '$omschrijvingGeneriekEnum' not found for zaaktype '$zaaktypeURI':"
             )
-        }
 
     /**
-     * Read [RolType]s of [ZaakType].
+     * Returns all [RolType]s for the specified [ZaakType].
      *
-     * @param zaaktypeURI URI of [ZaakType].
-     * @return list of [RolType]s.
+     * @param zaaktypeURI URI of [ZaakType]
+     * @return list of [RolType]s
      */
     fun listRoltypen(zaaktypeURI: URI): List<RolType> = uriToRolTypeListCache.get(zaaktypeURI) {
         ztcClient.roltypeList(RoltypeListParameters(zaaktypeURI)).results

--- a/src/main/kotlin/net/atos/client/zgw/ztc/ZtcClientService.kt
+++ b/src/main/kotlin/net/atos/client/zgw/ztc/ZtcClientService.kt
@@ -298,6 +298,8 @@ class ZtcClientService @Inject constructor(
     /**
      * Retrieves the [RolType] of the specified zaak type and generic role type description.
      * If there are multiple role types found the first one is returned.
+     * This method should only be used for role type descriptions for which you are sure there is one and only
+     * one role type defined in the zaaktype.
      *
      * @param zaaktypeURI URI of the zaak type
      * @param omschrijvingGeneriekEnum the generic role type description

--- a/src/main/kotlin/net/atos/client/zgw/ztc/ZtcClientService.kt
+++ b/src/main/kotlin/net/atos/client/zgw/ztc/ZtcClientService.kt
@@ -290,7 +290,7 @@ class ZtcClientService @Inject constructor(
      * @return the list of [RolType]s; may be empty if no rol types have been defined for the zaak type
      * and generic role type description.
      */
-    fun findRoltype(zaaktypeURI: URI, omschrijvingGeneriekEnum: OmschrijvingGeneriekEnum): List<RolType> =
+    fun findRoletypen(zaaktypeURI: URI, omschrijvingGeneriekEnum: OmschrijvingGeneriekEnum): List<RolType> =
         uriOmschrijvingGeneriekEnumToRolTypeCache.get("$zaaktypeURI$omschrijvingGeneriekEnum") {
             ztcClient.roltypeList(RoltypeListParameters(zaaktypeURI, omschrijvingGeneriekEnum)).results
         }

--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -1040,7 +1040,7 @@ class ZaakRestService @Inject constructor(
         identificatie: String,
         zaak: Zaak
     ) {
-        val initiator = ztcClientService.readRoltype(OmschrijvingGeneriekEnum.INITIATOR, zaak.zaaktype)
+        val initiator = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR)
         val zaakRechten = policyService.readZaakRechten(zaak)
         when (identificatieType) {
             IdentificatieType.BSN -> {

--- a/src/main/kotlin/net/atos/zac/app/zaak/converter/RESTZaakConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/converter/RESTZaakConverter.kt
@@ -10,7 +10,6 @@ import net.atos.client.zgw.drc.model.generated.VertrouwelijkheidaanduidingEnum
 import net.atos.client.zgw.shared.ZGWApiService
 import net.atos.client.zgw.zrc.ZRCClientService
 import net.atos.client.zgw.zrc.model.BetrokkeneType
-import net.atos.client.zgw.zrc.model.RolMedewerker
 import net.atos.client.zgw.zrc.model.Status
 import net.atos.client.zgw.zrc.model.Verlenging
 import net.atos.client.zgw.zrc.model.Zaak
@@ -98,17 +97,15 @@ class RESTZaakConverter {
     fun convert(zaak: Zaak, status: Status?, statustype: StatusType?): RESTZaak {
         val zaaktype = ztcClientService.readZaaktype(zaak.zaaktype)
         val groep = zgwApiService.findGroepForZaak(zaak)
-            .map { groep -> groupConverter.convertGroupId(groep.betrokkeneIdentificatie.identificatie) }
+            .map { groupConverter.convertGroupId(it.betrokkeneIdentificatie.identificatie) }
             .orElse(null)
         val besluiten = brcClientService.listBesluiten(zaak)
-            .map { besluiten -> besluitConverter.convertToRESTBesluit(besluiten) }
+            .map { besluitConverter.convertToRESTBesluit(it) }
             .orElse(null)
-        val behandelaar = zgwApiService.findBehandelaarForZaak(zaak)
-            .map { behandelaar: RolMedewerker ->
-                userConverter.convertUserId(behandelaar.betrokkeneIdentificatie.identificatie)
-            }
+        val behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
+            .map { userConverter.convertUserId(it.betrokkeneIdentificatie.identificatie) }
             .orElse(null)
-        val initiator = zgwApiService.findInitiatorForZaak(zaak)
+        val initiator = zgwApiService.findInitiatorRoleForZaak(zaak)
         return RESTZaak(
             identificatie = zaak.identificatie,
             uuid = zaak.uuid,

--- a/src/main/kotlin/net/atos/zac/app/zaak/converter/RESTZaakOverzichtConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/converter/RESTZaakOverzichtConverter.kt
@@ -66,7 +66,7 @@ class RESTZaakOverzichtConverter {
                     zrcClientService.readStatus(it).statustype
                 ).omschrijving
             }
-            zgwApiService.findBehandelaarForZaak(zaak)
+            zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
                 .map { userConverter.convertUserId(it.betrokkeneIdentificatie.identificatie) }
                 .ifPresent { restZaakOverzicht.behandelaar = it }
             zgwApiService.findGroepForZaak(zaak)

--- a/src/main/kotlin/net/atos/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/net/atos/zac/productaanvraag/ProductaanvraagService.kt
@@ -171,52 +171,10 @@ class ProductaanvraagService @Inject constructor(
             }
         }
 
-    private fun addBetrokkene(betrokkene: Betrokkene, roltypeOmschrijvingGeneriek: OmschrijvingGeneriekEnum, zaak: Zaak) {
-        ztcClientService.findRoltypen(zaak.zaaktype, roltypeOmschrijvingGeneriek)
-            .also {
-                if (it.isEmpty()) {
-                    LOG.warning(
-                        "No roltypen found for zaaktype '${zaak.zaaktype}' and generic roltype description " +
-                            "'$roltypeOmschrijvingGeneriek'. No betrokkene role created for zaak '$zaak'."
-                    )
-                } else if (it.size > 1) {
-                    LOG.warning(
-                        "Multiple roltypen found for zaaktype '${zaak.zaaktype}', generic roltype description " +
-                            "'$roltypeOmschrijvingGeneriek' and zaak '$zaak'. " +
-                            "Using the first one (description: '${it.first().omschrijving}')."
-                    )
-                }
-            }
-            .firstOrNull()?.let {
-                when {
-                    betrokkene.inpBsn != null -> {
-                        addNatuurlijkPersoonRole(
-                            it,
-                            betrokkene.inpBsn,
-                            zaak.url
-                        )
-                    }
-                    betrokkene.vestigingsNummer != null -> {
-                        addVestigingRole(
-                            it,
-                            betrokkene.vestigingsNummer,
-                            zaak.url
-                        )
-                    }
-                    else -> {
-                        LOG.warning(
-                            "Betrokkene with generic roletype description `$roltypeOmschrijvingGeneriek` " +
-                                "does not contain a BSN or KVK vestigingsnummer. No betrokkene role created for zaak '$zaak'."
-                        )
-                    }
-                }
-            }
-    }
-
     /**
      * Adds all betrokkenen which are present in the provided productaanvraag to the zaak for the set
-     * of (predefined role types)[Betrokkene.RolOmschrijvingGeneriek] but only if the requested role type is defined
-     * in the zaaktype of the provided zaak.
+     * of provided (role types)[Betrokkene.RolOmschrijvingGeneriek] but only for those role types which are defined
+     * in the zaaktype of the specified zaak.
      * An exception is made for betrokkenen of role type (behandelaar)[Betrokkene.RolOmschrijvingGeneriek.BEHANDELAAR]].
      * Behandelaar betrokkenen cannot be set from a productaanvraag.
      *
@@ -266,12 +224,55 @@ class ProductaanvraagService @Inject constructor(
                 }
                 else -> {
                     LOG.warning(
-                        "Betrokkene with role '${it.rolOmschrijvingGeneriek}' is not supported. " +
-                            "No role created for productaanvraag with aanvraaggegevens: '${productaanvraag.aanvraaggegevens}'."
+                        "Betrokkene with role '${it.rolOmschrijvingGeneriek}' is not supported in the mapping " +
+                            "from a productaanvraag. No role created for productaanvraag with aanvraaggegevens: " +
+                            "'${productaanvraag.aanvraaggegevens}'."
                     )
                 }
             }
         }
+    }
+
+    private fun addBetrokkene(betrokkene: Betrokkene, roltypeOmschrijvingGeneriek: OmschrijvingGeneriekEnum, zaak: Zaak) {
+        ztcClientService.findRoltypen(zaak.zaaktype, roltypeOmschrijvingGeneriek)
+            .also {
+                if (it.isEmpty()) {
+                    LOG.warning(
+                        "No roltypen found for zaaktype '${zaak.zaaktype}' and generic roltype description " +
+                            "'$roltypeOmschrijvingGeneriek'. No betrokkene role created for zaak '$zaak'."
+                    )
+                } else if (it.size > 1) {
+                    LOG.warning(
+                        "Multiple roltypen found for zaaktype '${zaak.zaaktype}', generic roltype description " +
+                            "'$roltypeOmschrijvingGeneriek' and zaak '$zaak'. " +
+                            "Using the first one (description: '${it.first().omschrijving}')."
+                    )
+                }
+            }
+            .firstOrNull()?.let {
+                when {
+                    betrokkene.inpBsn != null -> {
+                        addNatuurlijkPersoonRole(
+                            it,
+                            betrokkene.inpBsn,
+                            zaak.url
+                        )
+                    }
+                    betrokkene.vestigingsNummer != null -> {
+                        addVestigingRole(
+                            it,
+                            betrokkene.vestigingsNummer,
+                            zaak.url
+                        )
+                    }
+                    else -> {
+                        LOG.warning(
+                            "Betrokkene with generic roletype description `$roltypeOmschrijvingGeneriek` " +
+                                "does not contain a BSN or KVK vestigingsnummer. No betrokkene role created for zaak '$zaak'."
+                        )
+                    }
+                }
+            }
     }
 
     private fun addNatuurlijkPersoonRole(

--- a/src/main/kotlin/net/atos/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/net/atos/zac/productaanvraag/ProductaanvraagService.kt
@@ -253,9 +253,7 @@ class ProductaanvraagService @Inject constructor(
         zaak: URI,
         zaaktype: URI
         // TODO: readRoltype throws an exception when the roltype is not found
-        // switch to findRoltype and handle null case
-        // also deal with situation when there are multiple results - use the first one..
-        // we can only map on omschrijving generiek but that is not unique..
+        // switch to findRoltype and handle null case ?
     ) = ztcClientService.readRoltype(roltypeOmschrijvingGeneriek, zaaktype).let {
         zrcClientService.createRol(
             RolNatuurlijkPersoon(

--- a/src/main/kotlin/net/atos/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/net/atos/zac/productaanvraag/ProductaanvraagService.kt
@@ -252,6 +252,10 @@ class ProductaanvraagService @Inject constructor(
         bsn: String,
         zaak: URI,
         zaaktype: URI
+        // TODO: readRoltype throws an exception when the roltype is not found
+        // switch to findRoltype and handle null case
+        // also deal with situation when there are multiple results - use the first one..
+        // we can only map on omschrijving generiek but that is not unique..
     ) = ztcClientService.readRoltype(roltypeOmschrijvingGeneriek, zaaktype).let {
         zrcClientService.createRol(
             RolNatuurlijkPersoon(
@@ -483,7 +487,7 @@ class ProductaanvraagService @Inject constructor(
     ) {
         LOG.log(
             Level.WARNING,
-            "Failed to create a zaak of process type: '$processType' for productaanvraag '${productaanvraag.aanvraaggegevens}'",
+            "Failed to create a zaak of process type: '$processType' for productaanvraag with PDF '${productaanvraag.pdf}'",
             exception
         )
     }

--- a/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
@@ -140,8 +140,8 @@ class ZaakService @Inject constructor(
         RolOrganisatorischeEenheid(
             zaak.url,
             ztcClientService.readRoltype(
-                OmschrijvingGeneriekEnum.BEHANDELAAR,
-                zaak.zaaktype
+                zaak.zaaktype,
+                OmschrijvingGeneriekEnum.BEHANDELAAR
             ),
             "Behandelend groep van de zaak",
             OrganisatorischeEenheid().apply {
@@ -154,8 +154,8 @@ class ZaakService @Inject constructor(
         RolMedewerker(
             zaak.url,
             ztcClientService.readRoltype(
-                OmschrijvingGeneriekEnum.BEHANDELAAR,
-                zaak.zaaktype
+                zaak.zaaktype,
+                OmschrijvingGeneriekEnum.BEHANDELAAR
             ),
             "Behandelaar van de zaak",
             Medewerker().apply {

--- a/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
@@ -68,7 +68,7 @@ fun createResultaat(
 )
 
 fun createRolMedewerker(
-    zaak: URI = URI("http://example.com/${UUID.randomUUID()}"),
+    zaak: URI = URI("https://example.com/${UUID.randomUUID()}"),
     rolType: RolType = createRolType(),
     roltoelichting: String = "dummyToelichting",
     betrokkeneIdentificatie: Medewerker = createMedewerker()
@@ -80,8 +80,8 @@ fun createRolMedewerker(
 )
 
 fun createRolNatuurlijkPersoon(
-    zaaktypeURI: URI = URI("http://example.com/${UUID.randomUUID()}"),
-    rolType: RolType = createRolType(zaaktypeURI),
+    zaaktypeURI: URI = URI("https://example.com/${UUID.randomUUID()}"),
+    rolType: RolType = createRolType(zaakTypeUri = zaaktypeURI),
     toelichting: String = "dummyToelichting",
     natuurlijkPersoon: NatuurlijkPersoon = createNatuurlijkPersoon()
 ) = RolNatuurlijkPersoon(
@@ -92,8 +92,8 @@ fun createRolNatuurlijkPersoon(
 )
 
 fun createRolOrganisatorischeEenheid(
-    zaaktypeURI: URI = URI("http://example.com/${UUID.randomUUID()}"),
-    rolType: RolType = createRolType(zaaktypeURI),
+    zaaktypeURI: URI = URI("https://example.com/${UUID.randomUUID()}"),
+    rolType: RolType = createRolType(zaakTypeUri = zaaktypeURI),
     toelichting: String = "dummyToelichting",
     organisatorischeEenheid: OrganisatorischeEenheid = createOrganisatorischeEenheid()
 ) = RolOrganisatorischeEenheid(

--- a/src/test/kotlin/net/atos/client/zgw/ztc/model/ZtcFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/ztc/model/ZtcFixtures.kt
@@ -39,18 +39,30 @@ fun createBesluitType(
         setInformatieobjecttypen(informatieobjecttypen)
     }
 
+@Suppress("LongParameterList")
 fun createRolType(
-    zaakTypeURI: URI = URI("http://example.com/${UUID.randomUUID()}"),
+    beginObject: LocalDate = LocalDate.now(),
+    catalogusUri: URI = URI("https://example.com/catalogus/${UUID.randomUUID()}"),
+    eindeObject: LocalDate = LocalDate.now().plusDays(1),
     omschrijving: String = "dummyOmschrijving",
-    omschrijvingGeneriek: OmschrijvingGeneriekEnum = OmschrijvingGeneriekEnum.INITIATOR
-) = RolType().apply {
-    this.zaaktype = zaakTypeURI
+    omschrijvingGeneriek: OmschrijvingGeneriekEnum = OmschrijvingGeneriekEnum.INITIATOR,
+    uri: URI = URI("https://example.com/roltype/${UUID.randomUUID()}"),
+    zaaktypeIdentificatie: String = "dummyZaaktypeIdentificatie",
+    zaakTypeUri: URI = URI("https://example.com/${UUID.randomUUID()}"),
+) = RolType(
+    uri,
+    zaaktypeIdentificatie,
+    catalogusUri,
+    beginObject,
+    eindeObject
+).apply {
+    this.zaaktype = zaakTypeUri
     this.omschrijving = omschrijving
     this.omschrijvingGeneriek = omschrijvingGeneriek
 }
 
 fun createZaakType(
-    uri: URI = URI("http://example.com/zaaktypes/${UUID.randomUUID()}"),
+    uri: URI = URI("https://example.com/zaaktypes/${UUID.randomUUID()}"),
     omschrijving: String = "dummyZaakTypeOmschrijving",
     informatieObjectTypen: List<URI>? = listOf(URI("dummyInformatieObjectType1"), URI("dummyInformatieObjectType2")),
     identifactie: String = "dummyIdentificatie",

--- a/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
@@ -287,7 +287,7 @@ class ZaakRestServiceTest : BehaviorSpec({
 
         every { zrcClientService.readZaak(restZaakToekennenGegevens.zaakUUID) } returns zaak
         every { zrcClientService.updateRol(zaak, capture(rolSlot), restZaakToekennenGegevens.reden) } just runs
-        every { zgwApiService.findBehandelaarForZaak(zaak) } returns Optional.empty()
+        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns Optional.empty()
         every { identityService.readUser(restZaakToekennenGegevens.behandelaarGebruikersnaam) } returns user
         every { zgwApiService.findGroepForZaak(zaak) } returns Optional.empty()
         every { restZaakConverter.convert(zaak) } returns restZaak

--- a/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
@@ -230,7 +230,7 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { zrcClientService.createZaakobject(zaakObjectOpenbareRuimte) } returns zaakObjectOpenbareRuimte
         every { ztcClientService.readZaaktype(zaakTypeUUID) } returns zaakType
         every {
-            ztcClientService.readRoltype(OmschrijvingGeneriekEnum.INITIATOR, zaak.zaaktype)
+            ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR)
         } returns rolTypeInitiator
         every { zaakService.bepaalRolGroep(group, zaak) } returns rolOrganisatorischeEenheid
         every { zaakService.bepaalRolMedewerker(user, zaak) } returns rolMedewerker

--- a/src/test/kotlin/net/atos/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -183,7 +183,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
     Given(
         """
         a productaanvraag-dimpact object registration object containing zaakgegevens with a point geometry and 
-        a betrokkene with role initiator and type BSN
+        a betrokkene with role initiator and type BSN as well as a betrokkene with role initiator and type vestiging
         """
     ) {
         val productAanvraagObjectUUID = UUID.randomUUID()
@@ -213,6 +213,10 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                     "betrokkenen" to listOf(
                         mapOf(
                             "inpBsn" to bsnNumber,
+                            "rolOmschrijvingGeneriek" to "initiator"
+                        ),
+                        mapOf(
+                            "vestigingsNummer" to "dummyVestigingsNummer",
                             "rolOmschrijvingGeneriek" to "initiator"
                         )
                     )

--- a/src/test/kotlin/net/atos/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -545,7 +545,11 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             zaakTypeUri = zaakType.url,
             omschrijvingGeneriek = OmschrijvingGeneriekEnum.BESLISSER
         )
-        val rolTypeKlantcontacter = createRolType(
+        val rolTypeKlantcontacter1 = createRolType(
+            zaakTypeUri = zaakType.url,
+            omschrijvingGeneriek = OmschrijvingGeneriekEnum.KLANTCONTACTER
+        )
+        val rolTypeKlantcontacter2 = createRolType(
             zaakTypeUri = zaakType.url,
             omschrijvingGeneriek = OmschrijvingGeneriekEnum.KLANTCONTACTER
         )
@@ -612,15 +616,16 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             zaakafhandelParameterBeheerService.findZaaktypeUUIDByProductaanvraagType(productAanvraagType)
         } returns Optional.of(zaakTypeUUID)
         every { ztcClientService.readZaaktype(zaakTypeUUID) } returns zaakType
-        // for this test we assume no role types have been defined for the adviseur role
+        // here we simulate the case that no role types have been defined for the adviseur role
         every { ztcClientService.findRoltypen(any(), OmschrijvingGeneriekEnum.ADVISEUR) } returns emptyList()
         every {
             ztcClientService.findRoltypen(any(), OmschrijvingGeneriekEnum.BELANGHEBBENDE)
         } returns listOf(rolTypeBelanghebbende)
         every { ztcClientService.findRoltypen(any(), OmschrijvingGeneriekEnum.BESLISSER) } returns listOf(rolTypeBeslisser)
+        // here we simulate the case that multiple role types have been defined for the klantcontacter role
         every {
             ztcClientService.findRoltypen(any(), OmschrijvingGeneriekEnum.KLANTCONTACTER)
-        } returns listOf(rolTypeKlantcontacter)
+        } returns listOf(rolTypeKlantcontacter1, rolTypeKlantcontacter2)
         every {
             ztcClientService.findRoltypen(any(), OmschrijvingGeneriekEnum.MEDE_INITIATOR)
         } returns listOf(rolTypeMedeInitiator)
@@ -691,7 +696,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                 with(rolesToBeCreated[4]) {
                     betrokkeneType shouldBe BetrokkeneType.NATUURLIJK_PERSOON
                     identificatienummer shouldBe klantcontacterBsn
-                    roltype shouldBe rolTypeKlantcontacter.url
+                    roltype shouldBe rolTypeKlantcontacter1.url
                 }
                 with(rolesToBeCreated[5]) {
                     betrokkeneType shouldBe BetrokkeneType.NATUURLIJK_PERSOON

--- a/src/test/kotlin/net/atos/zac/zaak/ZaakServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/zaak/ZaakServiceTest.kt
@@ -54,8 +54,8 @@ class ZaakServiceTest : BehaviorSpec({
             every { zrcClientService.readZaak(it.uuid) } returns it
             every {
                 ztcClientService.readRoltype(
-                    OmschrijvingGeneriekEnum.BEHANDELAAR,
-                    it.zaaktype
+                    it.zaaktype,
+                    OmschrijvingGeneriekEnum.BEHANDELAAR
                 )
             } returns rolTypeBehandelaar
             every { zrcClientService.updateRol(it, any(), explanation) } just Runs
@@ -165,8 +165,8 @@ class ZaakServiceTest : BehaviorSpec({
             every { zrcClientService.readZaak(it.uuid) } returns it
             every {
                 ztcClientService.readRoltype(
-                    OmschrijvingGeneriekEnum.BEHANDELAAR,
-                    it.zaaktype
+                    it.zaaktype,
+                    OmschrijvingGeneriekEnum.BEHANDELAAR
                 )
             } returns rolTypeBehandelaar
             every { zrcClientService.updateRol(it, any(), explanation) } just Runs

--- a/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
@@ -73,10 +73,10 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
         val zaakStatusType = createStatusType()
 
         every { zrcClientService.readZaak(zaak.uuid) } returns zaak
-        every { zgwApiService.findInitiatorForZaak(zaak) } returns Optional.of(rolInitiator)
+        every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns Optional.of(rolInitiator)
         every { zrcClientService.listRollen(zaak) } returns rollenZaak
         every { zgwApiService.findGroepForZaak(zaak) } returns Optional.empty()
-        every { zgwApiService.findBehandelaarForZaak(zaak) } returns Optional.of(rolMedewerkerBehandelaar)
+        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns Optional.of(rolMedewerkerBehandelaar)
         every {
             identityService.readUser(rolMedewerkerBehandelaar.betrokkeneIdentificatie.identificatie)
         } returns userBehandelaar
@@ -152,10 +152,10 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
         }
 
         every { zrcClientService.readZaak(zaak.uuid) } returns zaak
-        every { zgwApiService.findInitiatorForZaak(zaak) } returns Optional.of(rolInitiator)
+        every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns Optional.of(rolInitiator)
         every { zrcClientService.listRollen(zaak) } returns rollenZaak
         every { zgwApiService.findGroepForZaak(zaak) } returns Optional.empty()
-        every { zgwApiService.findBehandelaarForZaak(zaak) } returns Optional.of(rolMedewerkerBehandelaar)
+        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns Optional.of(rolMedewerkerBehandelaar)
         every {
             identityService.readUser(rolMedewerkerBehandelaar.betrokkeneIdentificatie.identificatie)
         } returns userBehandelaar


### PR DESCRIPTION
Added support for creating other types of betrokkenen roles (besides initiator) in the productaanvraag-dimpact handling. Extended integration and unit tests. Refactored code and added code documentation. #minor

Solves PZ-2955