### PR TITLE
chore: add unit test for reference table service

### DIFF
--- a/src/main/java/net/atos/zac/admin/ReferenceTableService.java
+++ b/src/main/java/net/atos/zac/admin/ReferenceTableService.java
@@ -11,8 +11,8 @@ import java.util.List;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
@@ -23,9 +23,18 @@ import net.atos.zac.admin.model.ReferenceTable;
 @ApplicationScoped
 @Transactional(SUPPORTS)
 public class ReferenceTableService {
-
-    @PersistenceContext(unitName = "ZaakafhandelcomponentPU")
     private EntityManager entityManager;
+
+    @Inject
+    public ReferenceTableService(final EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    /**
+     * Default no-arg constructor, required by Weld.
+     */
+    public ReferenceTableService() {
+    }
 
     public List<ReferenceTable> listReferenceTables() {
         final CriteriaBuilder builder = entityManager.getCriteriaBuilder();
@@ -41,14 +50,14 @@ public class ReferenceTableService {
         if (referenceTable != null) {
             return referenceTable;
         } else {
-            throw new RuntimeException("%s with id=%d not found".formatted(ReferenceTable.class.getSimpleName(), id));
+            throw new RuntimeException("Reference table with id '%d' not found".formatted(id));
         }
     }
 
     public ReferenceTable readReferenceTable(final String code) {
         return findReferenceTable(code)
                 .orElseThrow(
-                        () -> new RuntimeException("%s with code='%s' not found".formatted(ReferenceTable.class.getSimpleName(), code))
+                        () -> new RuntimeException("Reference table with code '%s' not found".formatted(code))
                 );
     }
 

--- a/src/main/kotlin/net/atos/zac/signalering/SignaleringService.kt
+++ b/src/main/kotlin/net/atos/zac/signalering/SignaleringService.kt
@@ -9,7 +9,6 @@ import io.opentelemetry.instrumentation.annotations.WithSpan
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.persistence.EntityManager
-import jakarta.persistence.PersistenceContext
 import jakarta.transaction.Transactional
 import jakarta.transaction.Transactional.TxType.REQUIRED
 import jakarta.transaction.Transactional.TxType.SUPPORTS
@@ -49,6 +48,7 @@ import java.util.logging.Logger
 @NoArgConstructor
 @AllOpen
 class SignaleringService @Inject constructor(
+    private val entityManager: EntityManager,
     private val drcClientService: DrcClientService,
     private val eventingService: EventingService,
     private val flowableTaskService: FlowableTaskService,
@@ -61,9 +61,6 @@ class SignaleringService @Inject constructor(
     companion object {
         private val LOG = Logger.getLogger(SignaleringService::class.java.name)
     }
-
-    @PersistenceContext(unitName = "ZaakafhandelcomponentPU")
-    private lateinit var entityManager: EntityManager
 
     /**
      * Factory method for constructing Signalering instances.
@@ -365,16 +362,6 @@ class SignaleringService @Inject constructor(
             LOG.fine { "Sending 'ZAKEN_SIGNALERINGEN' screen event with ID '$it'." }
             eventingService.send(ScreenEventType.ZAKEN_SIGNALERINGEN.updated(it, zakenSignaleringen))
         }
-    }
-
-    /**
-     * Sets the entity manager for this service.
-     * Only meant for testing purposes! In normal usage the entity manager is injected by the CDI container.
-     *
-     * @param entityManager the entity manager to set
-     */
-    fun setEntityManager(entityManager: EntityManager) {
-        this.entityManager = entityManager
     }
 
     private fun getDocument(documentUUID: String) =

--- a/src/main/kotlin/nl/lifely/zac/persistence/EntityManagerProducer.kt
+++ b/src/main/kotlin/nl/lifely/zac/persistence/EntityManagerProducer.kt
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import nl.lifely.zac.util.AllOpen
+
+@AllOpen
+@ApplicationScoped
+class EntityManagerProducer {
+    companion object {
+        const val PERSISTENCE_UNIT_NAME = "ZaakafhandelcomponentPU"
+    }
+
+    @PersistenceContext(unitName = PERSISTENCE_UNIT_NAME)
+    private lateinit var entityManager: EntityManager
+
+    @Produces
+    @ApplicationScoped
+    fun getEntityManager() = entityManager
+}

--- a/src/main/kotlin/nl/lifely/zac/util/NoArgConstructor.kt
+++ b/src/main/kotlin/nl/lifely/zac/util/NoArgConstructor.kt
@@ -5,7 +5,7 @@
 package nl.lifely.zac.util
 
 /**
- * Annotation to add a no-arg constructor to a Kotlin data class so that for example
+ * Annotation to add a no-arg constructor to a Kotlin class so that for example
  * JAX-RS is able to instantiate the class.
  */
 annotation class NoArgConstructor

--- a/src/test/kotlin/net/atos/zac/admin/ReferenceTableServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/admin/ReferenceTableServiceTest.kt
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+package net.atos.zac.admin
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.checkUnnecessaryStub
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.persistence.EntityManager
+import net.atos.zac.admin.model.ReferenceTable
+import net.atos.zac.admin.model.createReferenceTable
+
+class ReferenceTableServiceTest : BehaviorSpec({
+    val entityManager = mockk<EntityManager>()
+    val referenceTableService = ReferenceTableService(entityManager)
+
+    beforeEach {
+        checkUnnecessaryStub()
+    }
+
+    Given("A reference table") {
+        val referenceTableID = 1234L
+        val referenceTable = createReferenceTable()
+        every { entityManager.find(ReferenceTable::class.java, referenceTableID) } returns referenceTable
+
+        When("the reference table is requested by id") {
+            val returnedReferenceTable = referenceTableService.readReferenceTable(referenceTableID)
+
+            Then("the reference table is returned") {
+                returnedReferenceTable shouldBe referenceTable
+            }
+        }
+    }
+
+    Given("No reference table for the given id") {
+        val referenceTableID = 1234L
+        every { entityManager.find(ReferenceTable::class.java, referenceTableID) } returns null
+
+        When("the reference table is requested by id") {
+            val exception = shouldThrow<RuntimeException> {
+                referenceTableService.readReferenceTable(referenceTableID)
+            }
+
+            Then("the reference table is returned") {
+                exception.message shouldBe "Reference table with id '$referenceTableID' not found"
+            }
+        }
+    }
+})

--- a/src/test/kotlin/net/atos/zac/admin/model/AdminFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/admin/model/AdminFixtures.kt
@@ -7,7 +7,7 @@ package net.atos.zac.admin.model
 
 import java.util.UUID
 
-fun createReferentieTabel(
+fun createReferenceTable(
     id: Long = 1234L,
     code: String = "dummyCode",
     naam: String = "dummyReferentieTabel"
@@ -18,7 +18,7 @@ fun createReferentieTabel(
         this.naam = naam
     }
 
-fun createReferentieTabelWaarde(
+fun createReferenceTableValue(
     id: Long = 1234L,
     naam: String = "dummyReferentieTabelWaarde",
     volgorde: Int = 1

--- a/src/test/kotlin/net/atos/zac/app/admin/ReferenceTableRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/admin/ReferenceTableRestServiceTest.kt
@@ -12,8 +12,8 @@ import io.mockk.every
 import io.mockk.mockk
 import net.atos.zac.admin.ReferenceTableAdminService
 import net.atos.zac.admin.ReferenceTableService
-import net.atos.zac.admin.model.createReferentieTabel
-import net.atos.zac.admin.model.createReferentieTabelWaarde
+import net.atos.zac.admin.model.createReferenceTable
+import net.atos.zac.admin.model.createReferenceTableValue
 import net.atos.zac.policy.PolicyService
 
 class ReferenceTableRestServiceTest : BehaviorSpec({
@@ -31,19 +31,19 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
     }
 
     Given("Two communicatiekanalen including E-formulier") {
-        val referentieTabel = createReferentieTabel(
+        val referentieTabel = createReferenceTable(
             id = 1L,
             code = "COMMUNICATIEKANAAL",
             naam = "Communicatiekanalen"
         )
         val referentieWaarde1 = "dummyWaarde1"
         val referentieWaarde2 = "E-formulier"
-        val referentieTabelWaarde1 = createReferentieTabelWaarde(
+        val referentieTabelWaarde1 = createReferenceTableValue(
             id = 1L,
             naam = referentieWaarde1,
             volgorde = 1
         )
-        val referentieTabelWaarde2 = createReferentieTabelWaarde(
+        val referentieTabelWaarde2 = createReferenceTableValue(
             id = 2L,
             naam = referentieWaarde2,
             volgorde = 2
@@ -77,19 +77,19 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
         }
     }
     Given("Two server error page texts") {
-        val referentieTabel = createReferentieTabel(
+        val referentieTabel = createReferenceTable(
             id = 1L,
             code = "SERVER_ERROR_ERROR_PAGINA_TEKST",
             naam = "Server error page text"
         )
         val referentieWaarde1 = "dummyWaarde1"
         val referentieWaarde2 = "dummyWaarde2"
-        val referentieTabelWaarde1 = createReferentieTabelWaarde(
+        val referentieTabelWaarde1 = createReferenceTableValue(
             id = 1L,
             naam = referentieWaarde1,
             volgorde = 1
         )
-        val referentieTabelWaarde2 = createReferentieTabelWaarde(
+        val referentieTabelWaarde2 = createReferenceTableValue(
             id = 2L,
             naam = referentieWaarde2,
             volgorde = 2

--- a/src/test/kotlin/net/atos/zac/signalering/SignaleringServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/signalering/SignaleringServiceTest.kt
@@ -53,6 +53,7 @@ class SignaleringServiceTest : BehaviorSpec({
     val query = mockk<Query>()
 
     val signaleringService = SignaleringService(
+        entityManager = entityManager,
         drcClientService = drcClientService,
         eventingService = eventingService,
         flowableTaskService = flowableTaskService,
@@ -62,7 +63,6 @@ class SignaleringServiceTest : BehaviorSpec({
         zrcClientService = zrcClientService,
         restZaakOverzichtConverter = restZaakOverzichtConverter
     )
-    signaleringService.setEntityManager(entityManager)
 
     beforeEach {
         checkUnnecessaryStub()


### PR DESCRIPTION
Added unit test for reference table service. Added an EntityManagerProducer so that we can use constructor injection for entity managers for easier testing.

Solves PZ-3333