### PR TITLE
fix: fix e2e tests not starting

### DIFF
--- a/src/e2e/support/worlds/world.ts
+++ b/src/e2e/support/worlds/world.ts
@@ -24,7 +24,12 @@ export class CustomWorld extends World {
 
   constructor(attach: any) {
     const res = worldParametersScheme.parse(attach);
-    super({ attach: res.attach, parameters: res.parameters, log: res.log });
+    super({
+      link(text: string): void {},
+      attach: res.attach,
+      parameters: res.parameters,
+      log: res.log,
+    });
     this.worldParameters = res.parameters;
     this.testStorage = new TestStorageService();
   }


### PR DESCRIPTION
Fixed e2e tests not starting by adding missing argument to World constructor.

Solves PZ-3564