### PR TITLE
feat: improve error handling for server policy exceptions

### DIFF
--- a/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
+++ b/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
@@ -144,7 +144,8 @@ export class FoutAfhandelingService {
         errorDetail = err.message;
       }
       // only show server error texts in case of a server error (500 family of errors)
-      const showServerErrorTexts = err.status >= 500;
+      // or in case of a 403 Forbidden error
+      const showServerErrorTexts = err.status >= 500 || err.status === 403;
 
       // show error in context and do not redirect to error page
       return this.openFoutDetailedDialog(

--- a/src/main/app/src/assets/i18n/en.json
+++ b/src/main/app/src/assets/i18n/en.json
@@ -713,6 +713,7 @@
   "msg.error.group.invalid.id": "The identification of this group is too long. Please change it to a maximum of {{max}} characters.",
   "msg.error.group.invalid.name": "The name of this group is too long. Please change it to a maximum of {{max}} characters.",
   "msg.error.server.generic": "Unfortunately a technical error has occurred.",
+  "msg.error.server.forbidden": "You do not have permission to perform this action.",
   "msg.error.bag.client.exception": "Unfortunately a technical error has occurred. No BAG objects could be retrieved.",
   "msg.error.brc.client.exception": "Unfortunately a technical error has occurred. No decisions could be retrieved.",
   "msg.error.brp.client.exception": "Unfortunately a technical error has occurred. No persons could be retrieved.",

--- a/src/main/app/src/assets/i18n/nl.json
+++ b/src/main/app/src/assets/i18n/nl.json
@@ -713,6 +713,7 @@
   "msg.error.group.invalid.id": "De identificatie van deze groep is te lang. Gelieve deze te wijzigen naar maximaal {{max}} tekens.",
   "msg.error.group.invalid.name": "De naam van deze groep is te lang. Gelieve deze te wijzigen naar maximaal {{max}} tekens.",
   "msg.error.server.generic": "Er heeft zich helaas een technische fout voor gedaan.",
+  "msg.error.server.forbidden": "U heeft helaas onvoldoende rechten om deze actie uit te voeren.",
   "msg.error.bag.client.exception": "Er heeft zich helaas een technische fout voor gedaan. Er kunnen geen BAG objecten worden opgehaald.",
   "msg.error.brc.client.exception": "Er heeft zich helaas een technische fout voor gedaan. Er kunnen geen besluiten worden opgehaald.",
   "msg.error.brp.client.exception": "Er heeft zich helaas een technische fout voor gedaan. Er kunnen geen personen worden opgehaald.",

--- a/src/main/java/net/atos/zac/policy/output/OverigeRechten.java
+++ b/src/main/java/net/atos/zac/policy/output/OverigeRechten.java
@@ -10,9 +10,11 @@ import jakarta.json.bind.annotation.JsonbProperty;
 
 import net.atos.zac.util.SerializableByYasson;
 
-public record OverigeRechten(boolean startenZaak, boolean beheren,
-                             boolean zoeken) implements SerializableByYasson {
-
+public record OverigeRechten(
+                             boolean startenZaak,
+                             boolean beheren,
+                             boolean zoeken
+) implements SerializableByYasson {
     @JsonbCreator
     public OverigeRechten(
             @JsonbProperty("starten_zaak") final boolean startenZaak,

--- a/src/main/kotlin/net/atos/zac/app/zaak/model/RestZaakAssignmentData.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/model/RestZaakAssignmentData.kt
@@ -4,6 +4,7 @@
  */
 package net.atos.zac.app.zaak.model
 
+import jakarta.json.bind.annotation.JsonbProperty
 import jakarta.validation.constraints.Size
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
@@ -20,9 +21,12 @@ data class RestZaakAssignmentData(
      * we need to make sure it adheres to the same constraints.
      */
     @field:Size(max = 24)
-    var groepId: String? = null,
+    @field:JsonbProperty("groepId")
+    var groupId: String,
 
-    var behandelaarGebruikersnaam: String? = null,
+    @field:JsonbProperty("behandelaarGebruikersnaam")
+    var assigneeUserName: String? = null,
 
-    var reden: String? = null
+    @field:JsonbProperty("reden")
+    var reason: String? = null
 )

--- a/src/main/kotlin/net/atos/zac/app/zaak/model/RestZaakAssignmentToLoggedInUserData.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/model/RestZaakAssignmentToLoggedInUserData.kt
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package net.atos.zac.app.zaak.model
+
+import jakarta.json.bind.annotation.JsonbProperty
+import nl.lifely.zac.util.AllOpen
+import nl.lifely.zac.util.NoArgConstructor
+import java.util.UUID
+
+@AllOpen
+@NoArgConstructor
+data class RestZaakAssignmentToLoggedInUserData(
+    var zaakUUID: UUID,
+
+    @field:JsonbProperty("reden")
+    var reason: String? = null
+)

--- a/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
@@ -299,9 +299,9 @@ class ZaakRestServiceTest : BehaviorSpec({
         val rolMedewerker = createRolMedewerker()
 
         every { zrcClientService.readZaak(restZaakToekennenGegevens.zaakUUID) } returns zaak
-        every { zrcClientService.updateRol(zaak, capture(rolSlot), restZaakToekennenGegevens.reden) } just runs
+        every { zrcClientService.updateRol(zaak, capture(rolSlot), restZaakToekennenGegevens.reason) } just runs
         every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns Optional.empty()
-        every { identityService.readUser(restZaakToekennenGegevens.behandelaarGebruikersnaam!!) } returns user
+        every { identityService.readUser(restZaakToekennenGegevens.assigneeUserName!!) } returns user
         every { zgwApiService.findGroepForZaak(zaak) } returns Optional.empty()
         every { restZaakConverter.convert(zaak) } returns restZaak
         every { indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK, false) } just runs
@@ -315,7 +315,7 @@ class ZaakRestServiceTest : BehaviorSpec({
             Then("the zaak is updated, and the zaken search index is updated") {
                 returnedRestZaak shouldBe restZaak
                 verify(exactly = 1) {
-                    zrcClientService.updateRol(zaak, any(), restZaakToekennenGegevens.reden)
+                    zrcClientService.updateRol(zaak, any(), restZaakToekennenGegevens.reason)
                     indexeerService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK, false)
                 }
                 with(rolSlot.captured) {

--- a/src/test/kotlin/net/atos/zac/app/zaak/model/RestZakenFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/model/RestZakenFixtures.kt
@@ -172,9 +172,9 @@ fun createRESTZaakToekennenGegevens(
     reden: String = "dummyReden"
 ) = RestZaakAssignmentData(
     zaakUUID = zaakUUID,
-    groepId = groepId,
-    behandelaarGebruikersnaam = behandelaarGebruikersnaam,
-    reden = reden
+    groupId = groepId,
+    assigneeUserName = behandelaarGebruikersnaam,
+    reason = reden
 )
 
 fun createRESTZakenVerdeelGegevens(


### PR DESCRIPTION
Improved error handling for server policy exceptions. These are now transformed into 403 Forbidden HTTP responses and a appropriate generic error message is shown to the user.

Solves PZ-3565