### PR TITLE
fix: only get active zaakafhandelparameters on user login

### DIFF
--- a/src/main/kotlin/net/atos/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/net/atos/zac/authentication/UserPrincipalFilter.kt
@@ -94,7 +94,7 @@ class UserPrincipalFilter @Inject constructor(
             null
         } else {
             zaakafhandelParameterService.listZaakafhandelParameters()
-                // group by zaakttype omschrijving since this the unique identifier for a zaaktype
+                // group by zaakttype omschrijving since this is the unique identifier for a zaaktype
                 // (not the zaaktype uuid since that changes for every version of a zaaktype)
                 .groupBy { it.zaaktypeOmschrijving }
                 // get the zaakafhandelparameter with the latest creation date (= the active one)

--- a/src/main/kotlin/net/atos/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/net/atos/zac/authentication/UserPrincipalFilter.kt
@@ -87,13 +87,19 @@ class UserPrincipalFilter @Inject constructor(
         }
 
     /**
-     * Returns the zaaktypen for which the user is authorised, or `null` if the user is authorised for all zaaktypen.
+     * Returns the active zaaktypen for which the user is authorised, or `null` if the user is authorised for all zaaktypen.
      */
     private fun getAuthorisedZaaktypen(roles: Set<String>): Set<String>? =
         if (roles.contains(ROL_DOMEIN_ELK_ZAAKTYPE)) {
             null
         } else {
             zaakafhandelParameterService.listZaakafhandelParameters()
+                // group by zaakttype omschrijving since this the unique identifier for a zaaktype
+                // (not the zaaktype uuid since that changes for every version of a zaaktype)
+                .groupBy { it.zaaktypeOmschrijving }
+                // get the zaakafhandelparameter with the latest creation date (= the active one)
+                .map { it.value.maxBy { value -> value.creatiedatum } }
+                // filter out the zaakafhandelparameters that have a domain that is equal to one of the user's (domain) roles
                 .filter { it.domein != null && roles.contains(it.domein) }
                 .map { it.zaaktypeOmschrijving }
                 .toSet()

--- a/src/test/kotlin/net/atos/zac/admin/model/AdminFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/admin/model/AdminFixtures.kt
@@ -5,6 +5,7 @@
 
 package net.atos.zac.admin.model
 
+import java.time.ZonedDateTime
 import java.util.UUID
 
 fun createHumanTaskParameters(
@@ -57,12 +58,14 @@ fun createReferenceTableValue(
 
 fun createZaakafhandelParameters(
     id: Long = 1234L,
+    creationDate: ZonedDateTime = ZonedDateTime.now(),
     domein: String = "dummyDomein",
     zaaktypeUUID: UUID = UUID.randomUUID(),
     zaaktypeOmschrijving: String = "dummyZaaktypeOmschrijving"
 ) =
     ZaakafhandelParameters().apply {
         this.id = id
+        this.creatiedatum = creationDate
         this.domein = domein
         this.zaakTypeUUID = zaaktypeUUID
         this.zaaktypeOmschrijving = zaaktypeOmschrijving


### PR DESCRIPTION
Only get currently active zaakafhandelparameters on user login to determine the list of zaaktypes for which the user is authorised based on their domain role(s).

Solves PZ-3604