### PR TITLE
fix: index zaak vertrouwelijkheidaanduiding in uppercase

### DIFF
--- a/src/main/java/net/atos/zac/solr/schema/SolrSchemaV6.java
+++ b/src/main/java/net/atos/zac/solr/schema/SolrSchemaV6.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Atos
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+package net.atos.zac.solr.schema;
+
+import net.atos.zac.solr.SolrSchemaUpdate;
+import net.atos.zac.zoeken.model.index.ZoekObjectType;
+import org.apache.solr.client.solrj.request.schema.SchemaRequest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static net.atos.zac.solr.FieldType.STRING;
+import static net.atos.zac.solr.SolrSchemaUpdateHelper.addFieldMultiValued;
+
+class SolrSchemaV6 implements SolrSchemaUpdate {
+
+    @Override
+    public int getVersie() {
+        return 6;
+    }
+
+    @Override
+    public Set<ZoekObjectType> getTeHerindexerenZoekObjectTypes() {
+        return Set.of(ZoekObjectType.ZAAK);
+    }
+
+    @Override
+    public List<SchemaRequest.Update> getSchemaUpdates() {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.java
+++ b/src/main/java/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.java
@@ -75,7 +75,8 @@ public class ZaakZoekObjectConverter extends AbstractZoekObjectConverter<ZaakZoe
                 DateTimeConverterUtil.convertToDate(zaak.getUiterlijkeEinddatumAfdoening())
         );
         zaakZoekObject.setPublicatiedatum(DateTimeConverterUtil.convertToDate(zaak.getPublicatiedatum()));
-        zaakZoekObject.setVertrouwelijkheidaanduiding(zaak.getVertrouwelijkheidaanduiding().toString());
+        // make sure to use the enum name and not the value here since the frontend translations rely on the enum name
+        zaakZoekObject.setVertrouwelijkheidaanduiding(zaak.getVertrouwelijkheidaanduiding().name());
         zaakZoekObject.setAfgehandeld(!zaak.isOpen());
         zgwApiService.findInitiatorRoleForZaak(zaak).ifPresent(zaakZoekObject::setInitiator);
         zaakZoekObject.setLocatie(convertToLocatie(zaak.getZaakgeometrie()));

--- a/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
@@ -5,8 +5,8 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.maps.shouldContain
 import io.kotest.matchers.shouldBe
+import io.mockk.checkUnnecessaryStub
 import io.mockk.every
-import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import net.atos.client.zgw.shared.ZGWApiService
 import net.atos.client.zgw.shared.model.createResultsOfZaakObjecten
@@ -32,7 +32,6 @@ import java.time.ZoneId
 import java.util.Date
 import java.util.Optional
 
-@MockKExtension.CheckUnnecessaryStub
 class ZaakZoekObjectConverterTest : BehaviorSpec({
     val zrcClientService = mockk<ZrcClientService>()
     val ztcClientService = mockk<ZtcClientService>()
@@ -47,6 +46,10 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
         identityService,
         flowableTaskService
     )
+
+    beforeEach {
+        checkUnnecessaryStub()
+    }
 
     Given("a zaak with betrokkenen, without open tasks, zaak objecten and communication channels") {
         val zaakType = createZaakType()
@@ -69,8 +72,6 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
         val rolMedewerkerBehandelaar = createRolMedewerker()
         val userBehandelaar = createUser()
         val zaakObjectenList = emptyList<Zaakobject>()
-        val zaakStatus = createZaakStatus()
-        val zaakStatusType = createStatusType()
 
         every { zrcClientService.readZaak(zaak.uuid) } returns zaak
         every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns Optional.of(rolInitiator)
@@ -81,8 +82,6 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
             identityService.readUser(rolMedewerkerBehandelaar.betrokkeneIdentificatie.identificatie)
         } returns userBehandelaar
         every { ztcClientService.readZaaktype(zaak.zaaktype) } returns zaakType
-        every { zrcClientService.readStatus(zaak.status) } returns zaakStatus
-        every { ztcClientService.readStatustype(zaakStatus.statustype) } returns zaakStatusType
         every { flowableTaskService.countOpenTasksForZaak(zaak.uuid) } returns 0
         every { zrcClientService.listZaakobjecten(any()) } returns createResultsOfZaakObjecten(
             list = zaakObjectenList,
@@ -100,7 +99,7 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
                     omschrijving shouldBe zaak.omschrijving
                     toelichting shouldBe zaak.toelichting
                     registratiedatum shouldBe Date.from(zaak.registratiedatum.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant())
-                    vertrouwelijkheidaanduiding shouldBe zaak.vertrouwelijkheidaanduiding.toString()
+                    vertrouwelijkheidaanduiding shouldBe zaak.vertrouwelijkheidaanduiding.name
                     isAfgehandeld shouldBe !zaak.isOpen
                     initiatorIdentificatie shouldBe rolInitiator.identificatienummer
                     // locatie conversion is not implemented (yet?)
@@ -178,7 +177,7 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
                     omschrijving shouldBe zaak.omschrijving
                     toelichting shouldBe zaak.toelichting
                     registratiedatum shouldBe Date.from(zaak.registratiedatum.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant())
-                    vertrouwelijkheidaanduiding shouldBe zaak.vertrouwelijkheidaanduiding.toString()
+                    vertrouwelijkheidaanduiding shouldBe zaak.vertrouwelijkheidaanduiding.name
                     isAfgehandeld shouldBe !zaak.isOpen
                     initiatorIdentificatie shouldBe rolInitiator.identificatienummer
                     // locatie conversion is not implemented (yet?)


### PR DESCRIPTION
Index zaak vertrouwelijkheidaanduiding in uppercase (=enum name because the frontend expects this in the translations and it is used elsewhere in uppercase. Trigger reindexing by adding a new ZAC Solr Schema.

Solves PZ-3636