### PR TITLE
feat: remove kvk search on rsin

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/KlantRestServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/KlantRestServiceTest.kt
@@ -22,7 +22,6 @@ import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_EERSTE_HANDELSNAAM
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_NAAM_1
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_NUMMER_1
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_PLAATS_1
-import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_RSIN_1
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_VESTIGING1_HOOFDACTIVITEIT
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_VESTIGING1_NEVENACTIVITEIT1
 import nl.lifely.zac.itest.config.ItestConfiguration.TEST_KVK_VESTIGING1_NEVENACTIVITEIT2
@@ -228,31 +227,6 @@ class KlantRestServiceTest : BehaviorSpec({
                         }
                       ],
                       "totaal": 2
-                    }
-                """.trimIndent()
-            }
-        }
-        When(
-            """
-                the read rechtspersoon endpoint is called with the RSIN of a test company available in the KVK mock
-                """
-        ) {
-            val response = itestHttpClient.performGetRequest(
-                url = "$ZAC_API_URI/klanten/rechtspersoon/$TEST_KVK_RSIN_1",
-            )
-            Then("the response should be ok and the test company should be returned without contact data") {
-                val responseBody = response.body!!.string()
-                logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
-                responseBody shouldEqualJson """
-                    {
-                      "adres": "$TEST_KVK_ADRES_1, $TEST_KVK_PLAATS_1",
-                      "identificatie": "$TEST_KVK_VESTIGINGSNUMMER_1",
-                      "identificatieType": "$BETROKKENE_IDENTIFACTION_TYPE_VESTIGING",
-                      "kvkNummer": "$TEST_KVK_NUMMER_1",
-                      "naam": "$TEST_KVK_NAAM_1",
-                      "type": "$VESTIGINGTYPE_NEVENVESTIGING",
-                      "vestigingsnummer": "$TEST_KVK_VESTIGINGSNUMMER_1"
                     }
                 """.trimIndent()
             }

--- a/src/main/app/src/app/klanten/bedrijf-view/bedrijf-resolver.service.ts
+++ b/src/main/app/src/app/klanten/bedrijf-view/bedrijf-resolver.service.ts
@@ -20,6 +20,6 @@ export class BedrijfResolverService {
     state: RouterStateSnapshot,
   ): Observable<Bedrijf> {
     const id: string = route.paramMap.get("vesOrRSIN");
-    return this.klantenService.readBedrijf(id);
+    return this.klantenService.readVestiging(id);
   }
 }

--- a/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfsgegevens.component.ts
+++ b/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfsgegevens.component.ts
@@ -22,7 +22,7 @@ import { Vestigingsprofiel } from "../model/bedrijven/vestigingsprofiel";
 export class BedrijfsgegevensComponent implements OnChanges {
   @Input() isVerwijderbaar: boolean;
   @Input() isWijzigbaar: boolean;
-  @Input() rsinOfVestigingsnummer: string;
+  @Input() vestigingsnummer: string;
   @Output() delete = new EventEmitter<Bedrijf>();
   @Output() edit = new EventEmitter<Bedrijf>();
 
@@ -36,9 +36,9 @@ export class BedrijfsgegevensComponent implements OnChanges {
   ngOnChanges(): void {
     this.bedrijf = null;
     this.vestigingsprofiel = null;
-    if (this.rsinOfVestigingsnummer) {
+    if (this.vestigingsnummer) {
       this.klantenService
-        .readBedrijf(this.rsinOfVestigingsnummer)
+        .readVestiging(this.vestigingsnummer)
         .subscribe((bedrijf) => {
           this.bedrijf = bedrijf;
           this.klantExpanded = true;

--- a/src/main/app/src/app/klanten/klanten.service.ts
+++ b/src/main/app/src/app/klanten/klanten.service.ts
@@ -37,12 +37,6 @@ export class KlantenService {
       );
   }
 
-  readBedrijf(rsinOfVestigingsnummer: string): Observable<Bedrijf> {
-    return rsinOfVestigingsnummer.length === 9
-      ? this.readRechtspersoon(rsinOfVestigingsnummer)
-      : this.readVestiging(rsinOfVestigingsnummer);
-  }
-
   readVestiging(vestigingsnummer: string): Observable<Bedrijf> {
     return this.http
       .get<Bedrijf>(`${this.basepath}/vestiging/${vestigingsnummer}`)
@@ -58,14 +52,6 @@ export class KlantenService {
       .get<Vestigingsprofiel>(
         `${this.basepath}/vestigingsprofiel/${vestigingsnummer}`,
       )
-      .pipe(
-        catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
-      );
-  }
-
-  readRechtspersoon(rsin: string): Observable<Bedrijf> {
-    return this.http
-      .get<Bedrijf>(`${this.basepath}/rechtspersoon/${rsin}`)
       .pipe(
         catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
       );

--- a/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.html
+++ b/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.html
@@ -15,11 +15,6 @@
     </div>
   </div>
   <div class="flex-row flex-col-xs gap-10 flex-fill">
-    <div class="flex-1">
-      <mfb-form-field [field]="rsinFormField"></mfb-form-field>
-    </div>
-  </div>
-  <div class="flex-row flex-col-xs gap-10 flex-fill">
     <div class="flex-1 w66">
       <mfb-form-field [field]="naamFormField"></mfb-form-field>
     </div>

--- a/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.ts
+++ b/src/main/app/src/app/klanten/zoek/bedrijven/bedrijf-zoek.component.ts
@@ -41,7 +41,6 @@ export class BedrijfZoekComponent implements OnInit {
 
   kvkFormField: AbstractFormControlField;
   vestigingsnummerFormField: AbstractFormControlField;
-  rsinFormField: AbstractFormControlField;
   naamFormField: AbstractFormControlField;
   typeFormField: AbstractFormControlField;
   postcodeFormField: AbstractFormControlField;
@@ -74,12 +73,6 @@ export class BedrijfZoekComponent implements OnInit {
       .validators(CustomValidators.vestigingsnummer)
       .maxlength(12)
       .build();
-    this.rsinFormField = new InputFormFieldBuilder()
-      .id("rsin")
-      .label("rsin")
-      .validators(CustomValidators.rsin)
-      .maxlength(9)
-      .build();
     this.postcodeFormField = new InputFormFieldBuilder()
       .id("postcode")
       .label("postcode")
@@ -110,7 +103,6 @@ export class BedrijfZoekComponent implements OnInit {
       kvkNummer: this.kvkFormField.formControl,
       naam: this.naamFormField.formControl,
       vestigingsnummer: this.vestigingsnummerFormField.formControl,
-      rsin: this.rsinFormField.formControl,
       postcode: this.postcodeFormField.formControl,
       huisnummer: this.huisnummerFormField.formControl,
       plaats: this.plaatsFormField.formControl,
@@ -125,16 +117,11 @@ export class BedrijfZoekComponent implements OnInit {
     const kvkNummer = this.kvkFormField.formControl.value;
     const bedrijfsnaam = this.naamFormField.formControl.value;
     const vestigingsnummer = this.vestigingsnummerFormField.formControl.value;
-    const rsin = this.rsinFormField.formControl.value;
     const postcode = this.postcodeFormField.formControl.value;
     const huisnummer = this.huisnummerFormField.formControl.value;
 
     return (
-      kvkNummer ||
-      bedrijfsnaam ||
-      vestigingsnummer ||
-      rsin ||
-      (postcode && huisnummer)
+      kvkNummer || bedrijfsnaam || vestigingsnummer || (postcode && huisnummer)
     );
   }
 
@@ -163,7 +150,7 @@ export class BedrijfZoekComponent implements OnInit {
   }
 
   typeChanged(type: any): void {
-    this.rsinFormField.required = type === "RECHTSPERSOON";
+    // nothing to do
   }
 
   openBedrijfPagina(bedrijf: Bedrijf): void {

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -133,7 +133,7 @@
       <zac-bedrijfsgegevens
         class="w100 flex-1"
         *ngIf="zaak.initiatorIdentificatieType==='VN' || zaak.initiatorIdentificatieType==='RSIN'"
-        [rsinOfVestigingsnummer]="zaak.initiatorIdentificatie"
+        [vestigingsnummer]="zaak.initiatorIdentificatie"
         [isVerwijderbaar]="zaak.rechten.verwijderenInitiator"
         (edit)="addOrEditZaakInitiator()"
         [isWijzigbaar]="zaak.rechten.toevoegenInitiatorBedrijf"

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -1418,7 +1418,7 @@ export class ZaakViewComponent
       case "NIET_NATUURLIJK_PERSOON":
       case "VESTIGING":
         this.klantenService
-          .readBedrijf(betrokkene.identificatie)
+          .readVestiging(betrokkene.identificatie)
           .subscribe((bedrijf) => {
             betrokkene["gegevens"] = bedrijf.naam;
             if (bedrijf.adres) {

--- a/src/main/java/net/atos/client/kvk/KvkClientService.java
+++ b/src/main/java/net/atos/client/kvk/KvkClientService.java
@@ -82,10 +82,15 @@ public class KvkClientService {
         return listAsync(zoekParameters).thenApply(this::convertToSingleItem);
     }
 
-    public Optional<ResultaatItem> findRechtspersoon(final String rsin) {
+    /**
+     * Finds a rechtspersoon by RSIN and KVK number.
+     * Note that the RSIN alone does not always uniquely identify a rechtspersoon.
+     */
+    public Optional<ResultaatItem> findRechtspersoon(final String rsin, final String kvkNumber) {
         final KvkZoekenParameters zoekParameters = new KvkZoekenParameters();
         zoekParameters.setType("rechtspersoon");
         zoekParameters.setRsin(rsin);
+        zoekParameters.setKvkNummer(kvkNumber);
         return convertToSingleItem(list(zoekParameters));
     }
 

--- a/src/main/java/net/atos/client/kvk/KvkClientService.java
+++ b/src/main/java/net/atos/client/kvk/KvkClientService.java
@@ -82,18 +82,6 @@ public class KvkClientService {
         return listAsync(zoekParameters).thenApply(this::convertToSingleItem);
     }
 
-    /**
-     * Finds a rechtspersoon by RSIN and KVK number.
-     * Note that the RSIN alone does not always uniquely identify a rechtspersoon.
-     */
-    public Optional<ResultaatItem> findRechtspersoon(final String rsin, final String kvkNumber) {
-        final KvkZoekenParameters zoekParameters = new KvkZoekenParameters();
-        zoekParameters.setType("rechtspersoon");
-        zoekParameters.setRsin(rsin);
-        zoekParameters.setKvkNummer(kvkNumber);
-        return convertToSingleItem(list(zoekParameters));
-    }
-
     private Optional<ResultaatItem> convertToSingleItem(final Resultaat resultaat) {
         return switch (resultaat.getTotaal()) {
             case 0 -> Optional.empty();

--- a/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
+++ b/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
@@ -274,11 +274,7 @@ public class MailTemplateHelper {
                         resolvedTekst,
                         kvkClientService.findVestiging(identificatie)
                 );
-                case NIET_NATUURLIJK_PERSOON -> replaceInitiatorVariabelenResultaatItem(
-                        resolvedTekst,
-                        kvkClientService.findRechtspersoon(identificatie)
-                );
-                default -> throw new IllegalStateException(String.format("unexpected betrokkenetype %s", betrokkene));
+                default -> throw new IllegalStateException(String.format("Unsupported initiator betrokkene type '%s'", betrokkene));
             };
         }
         return replaceInitiatorVariabelen(resolvedTekst, null, null);

--- a/src/main/kotlin/net/atos/zac/app/klant/KlantRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/klant/KlantRestService.kt
@@ -125,7 +125,7 @@ class KlantRestService @Inject constructor(
         }
 
     @GET
-    @Path("rechtspersoon/{rsin}")
+    @Path("rechtspersoon/{rsin}/kvknummer/{kvkNumber}")
     fun readRechtspersoon(@PathParam("rsin") @Length(min = 9, max = 9) rsin: String): RestBedrijf =
         kvkClientService.findRechtspersoon(rsin)
             .map { it.toRestBedrijf() }

--- a/src/main/kotlin/net/atos/zac/app/klant/KlantRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/klant/KlantRestService.kt
@@ -20,7 +20,6 @@ import net.atos.client.kvk.KvkClientService
 import net.atos.client.kvk.zoeken.model.generated.ResultaatItem
 import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.client.zgw.ztc.model.generated.OmschrijvingGeneriekEnum
-import net.atos.zac.app.klant.exception.RechtspersoonNotFoundException
 import net.atos.zac.app.klant.exception.VestigingNotFoundException
 import net.atos.zac.app.klant.model.bedrijven.RestBedrijf
 import net.atos.zac.app.klant.model.bedrijven.RestListBedrijvenParameters
@@ -123,13 +122,6 @@ class KlantRestService @Inject constructor(
                 )
             }
         }
-
-    @GET
-    @Path("rechtspersoon/{rsin}/kvknummer/{kvkNumber}")
-    fun readRechtspersoon(@PathParam("rsin") @Length(min = 9, max = 9) rsin: String): RestBedrijf =
-        kvkClientService.findRechtspersoon(rsin)
-            .map { it.toRestBedrijf() }
-            .orElseThrow { RechtspersoonNotFoundException("Geen rechtspersoon gevonden voor RSIN '$rsin'") }
 
     @GET
     @Path("personen/parameters")

--- a/src/main/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverter.kt
+++ b/src/main/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverter.kt
@@ -114,9 +114,6 @@ class DocumentCreationDataConverter @Inject constructor(
         when (initiator.betrokkeneType) {
             BetrokkeneType.NATUURLIJK_PERSOON -> createAanvragerDataNatuurlijkPersoon(initiator.identificatienummer)
             BetrokkeneType.VESTIGING -> createAanvragerDataVestiging(initiator.identificatienummer)
-            BetrokkeneType.NIET_NATUURLIJK_PERSOON -> createAanvragerDataNietNatuurlijkPersoon(
-                initiator.identificatienummer
-            )
             else -> error(
                 "Initiator of type '${initiator.betrokkeneType.toValue()}' is not supported"
             )
@@ -143,11 +140,6 @@ class DocumentCreationDataConverter @Inject constructor(
 
     private fun createAanvragerDataVestiging(vestigingsnummer: String): AanvragerData? =
         kvkClientService.findVestiging(vestigingsnummer)
-            .map { this.convertToAanvragerDataBedrijf(it) }
-            .orElse(null)
-
-    private fun createAanvragerDataNietNatuurlijkPersoon(rsin: String): AanvragerData? =
-        kvkClientService.findRechtspersoon(rsin)
             .map { this.convertToAanvragerDataBedrijf(it) }
             .orElse(null)
 

--- a/src/test/kotlin/net/atos/zac/zaak/ZaakServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/zaak/ZaakServiceTest.kt
@@ -48,7 +48,7 @@ class ZaakServiceTest : BehaviorSpec({
         checkUnnecessaryStub()
     }
 
-    Given("A list of zaken") {
+    Given("A list of zaken and a group and a user") {
         val screenEventSlot = slot<ScreenEvent>()
         zaken.map {
             every { zrcClientService.readZaak(it.uuid) } returns it
@@ -92,7 +92,7 @@ class ZaakServiceTest : BehaviorSpec({
             }
         }
     }
-    Given("A list of zaken") {
+    Given("A list of zaken and a screen event resource id") {
         val screenEventSlot = slot<ScreenEvent>()
         zaken.map {
             every { zrcClientService.readZaak(it.uuid) } returns it


### PR DESCRIPTION
Removed support for searching on RSIN in the bedrijven KVK search functionality because the concept of rechtspersonen (and other niet-natuurlijke personen) is not implemented properly in ZAC and this causes errors when a rechtspersoon has multiple KVK numbers.

Solves PZ-3631