### PR TITLE
feature: bump node to 22.5.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.0.20"
 kotlinx-coroutines = "1.8.1"
-nodejs = "20.11.1"
+nodejs = "22.5.1"
 jsonschema2pojo = "1.2.1"
 kotlin-csv = "1.10.0"
 openapi = "3.12.0"


### PR DESCRIPTION
Use the same node version as the @types in e2e and app

Solves: PZ-3671