### PR TITLE
fix: ignore major node.js version bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,13 +31,16 @@ updates:
       # Only update minor & patch versions. We want to use LTS version
       types_node:
         patterns:
-          - "@types/node"
+          - "@types/node*"
         update-types:
           - "minor"
           - "patch"
     ignore:
       # ignore major Angular updates since they require manual steps
       - dependency-name: "@angular*"
+        update-types: ["version-update:semver-major"]
+      # ignore major Node.js updates. We want to use LTS version
+      - dependency-name: "@types/node*"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"


### PR DESCRIPTION
We want to use LTS versions only

Solves: PZ-3671