### PR TITLE
fix: do not change fatal date of additional info tasks

### DIFF
--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -187,6 +187,7 @@ class ZaakRestService @Inject constructor(
         private const val AANMAKEN_ZAAK_REDEN = "Aanmaken zaak"
         private const val VERLENGING = "Verlenging"
         private const val AANMAKEN_BESLUIT_TOELICHTING = "Aanmaken besluit"
+        const val AANVULLENDE_INFORMATIE_TASK_NAME = "Aanvullende informatie"
     }
 
     @GET
@@ -326,7 +327,7 @@ class ZaakRestService @Inject constructor(
         )
 
         if (durationDays != null) {
-            if (verlengOpenTaken(zaakUUID, durationDays) > 0) {
+            if (verlengOpenTaken(zaakUUID, durationDays, AANVULLENDE_INFORMATIE_TASK_NAME) > 0) {
                 eventingService.send(ScreenEventType.ZAAK_TAKEN.updated(updatedZaak))
             }
         }
@@ -1191,9 +1192,10 @@ class ZaakRestService @Inject constructor(
             Speciaal.MEDEWERKER -> loggedInUserInstance.get().email
         }
 
-    private fun verlengOpenTaken(zaakUUID: UUID, duurDagen: Long): Int =
+    private fun verlengOpenTaken(zaakUUID: UUID, duurDagen: Long, excludeTaskName: String? = null): Int =
         flowableTaskService.listOpenTasksForZaak(zaakUUID)
             .filter { task -> task.dueDate != null }
+            .filter { task -> if (task.name != null) task.name != excludeTaskName else true }
             .run {
                 forEach { task ->
                     task.dueDate = DateTimeConverterUtil.convertToDate(

--- a/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
@@ -44,6 +44,7 @@ import net.atos.zac.admin.model.createZaakafhandelParameters
 import net.atos.zac.app.audit.converter.RESTHistorieRegelConverter
 import net.atos.zac.app.bag.converter.RESTBAGConverter
 import net.atos.zac.app.besluit.BesluitService
+import net.atos.zac.app.zaak.ZaakRestService.Companion.AANVULLENDE_INFORMATIE_TASK_NAME
 import net.atos.zac.app.zaak.converter.RESTGeometryConverter
 import net.atos.zac.app.zaak.converter.RestBesluitConverter
 import net.atos.zac.app.zaak.converter.RestZaakConverter
@@ -436,8 +437,9 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { policyService.readZaakRechten(zaak) } returns createZaakRechten()
         every { restZaakConverter.convertToPatch(restZaak) } returns patchedZaak
         every { zrcClientService.patchZaak(zaak.uuid, patchedZaak, changeDescription) } returns patchedZaak
-        every { flowableTaskService.listOpenTasksForZaak(zaak.uuid) } returns listOf(task, task)
+        every { flowableTaskService.listOpenTasksForZaak(zaak.uuid) } returns listOf(task, task, task)
         every { task.dueDate } returns zaak.uiterlijkeEinddatumAfdoening.toDate()
+        every { task.name } returnsMany listOf("dummyTask", AANVULLENDE_INFORMATIE_TASK_NAME, "another task")
         every { task.dueDate = newZaakFinalDate.toDate() } just runs
         every { flowableTaskService.updateTask(task) } returns task
         every { task.id } returns "id"


### PR DESCRIPTION
Additional Information tasks are not affected from zaak fatal date change

Solves: PZ-3678