### PR TITLE
fix: fix failing vertrouwelijkheidsaanduiding translation in getting current version of enkelvoudiginformatieobjecttype

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/EnkelvoudigInformatieObjectRestServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/EnkelvoudigInformatieObjectRestServiceTest.kt
@@ -205,6 +205,32 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
                 response.code shouldBe HTTP_STATUS_OK
             }
         }
+        When("the huidigeversie endpoint is called") {
+            val response = itestHttpClient.performGetRequest(
+                url = "$ZAC_API_URI/informatieobjecten/informatieobject/$enkelvoudigInformatieObjectUUID/huidigeversie"
+            )
+            Then(
+                """
+                    the response should be OK and the informatieobject should be returned and
+                    should have the status 'definitief' since it was signed
+                    """
+            ) {
+                val responseBody = response.body!!.string()
+                logger.info { "Response: $responseBody" }
+                response.code shouldBe HTTP_STATUS_OK
+                with(responseBody) {
+                    shouldContainJsonKeyValue("auteur", TEST_USER_1_NAME)
+                    shouldContainJsonKeyValue("status", DOCUMENT_STATUS_DEFINITIEF)
+                    shouldContainJsonKeyValue("titel", DOCUMENT_UPDATED_FILE_TITLE)
+                    shouldContainJsonKeyValue(
+                        "vertrouwelijkheidaanduiding",
+                        DOCUMENT_VERTROUWELIJKHEIDS_AANDUIDING_VERTROUWELIJK
+                    )
+                    shouldContainJsonKey("informatieobjectTypeUUID")
+                    shouldContainJsonKey("bestandsnaam")
+                }
+            }
+        }
     }
 
     Given(

--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjecttypeConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjecttypeConverter.java
@@ -14,15 +14,15 @@ import jakarta.inject.Inject;
 import net.atos.client.zgw.shared.util.URIUtil;
 import net.atos.client.zgw.ztc.ZtcClientService;
 import net.atos.client.zgw.ztc.model.generated.InformatieObjectType;
-import net.atos.zac.app.informatieobjecten.model.RESTInformatieobjecttype;
+import net.atos.zac.app.informatieobjecten.model.RestInformatieobjecttype;
 
 public class RESTInformatieobjecttypeConverter {
 
     @Inject
     private ZtcClientService ztcClientService;
 
-    public RESTInformatieobjecttype convert(final InformatieObjectType type) {
-        final RESTInformatieobjecttype restType = new RESTInformatieobjecttype();
+    public RestInformatieobjecttype convert(final InformatieObjectType type) {
+        final RestInformatieobjecttype restType = new RestInformatieobjecttype();
         restType.uuid = URIUtil.parseUUIDFromResourceURI(type.getUrl());
         restType.concept = type.getConcept();
         restType.omschrijving = type.getOmschrijving();
@@ -30,13 +30,13 @@ public class RESTInformatieobjecttypeConverter {
         return restType;
     }
 
-    public List<RESTInformatieobjecttype> convert(final List<InformatieObjectType> informatieobjecttypen) {
+    public List<RestInformatieobjecttype> convert(final List<InformatieObjectType> informatieobjecttypen) {
         return informatieobjecttypen.stream()
                 .map(this::convert)
                 .collect(Collectors.toList());
     }
 
-    public List<RESTInformatieobjecttype> convertFromUris(final List<URI> informatieobjecttypeUris) {
+    public List<RestInformatieobjecttype> convertFromUris(final List<URI> informatieobjecttypeUris) {
         return informatieobjecttypeUris.stream()
                 .map(ztcClientService::readInformatieobjecttype)
                 .map(this::convert)

--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjectConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjectConverter.java
@@ -36,10 +36,10 @@ import net.atos.client.zgw.zrc.model.Zaak;
 import net.atos.client.zgw.zrc.model.ZaakInformatieobject;
 import net.atos.client.zgw.ztc.ZtcClientService;
 import net.atos.zac.app.configuratie.converter.RESTTaalConverter;
-import net.atos.zac.app.informatieobjecten.model.RESTEnkelvoudigInformatieObjectVersieGegevens;
-import net.atos.zac.app.informatieobjecten.model.RESTEnkelvoudigInformatieobject;
 import net.atos.zac.app.informatieobjecten.model.RESTFileUpload;
-import net.atos.zac.app.informatieobjecten.model.RESTGekoppeldeZaakEnkelvoudigInformatieObject;
+import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieObjectVersieGegevens;
+import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieobject;
+import net.atos.zac.app.informatieobjecten.model.RestGekoppeldeZaakEnkelvoudigInformatieObject;
 import net.atos.zac.app.policy.converter.RestRechtenConverter;
 import net.atos.zac.app.task.model.RestTaskDocumentData;
 import net.atos.zac.app.zaak.model.RelatieType;
@@ -52,8 +52,8 @@ import net.atos.zac.policy.PolicyService;
 import net.atos.zac.policy.output.DocumentRechten;
 import net.atos.zac.util.UriUtil;
 
-public class RESTInformatieobjectConverter {
-    private static final Logger LOG = Logger.getLogger(RESTInformatieobjectConverter.class.getName());
+public class RestInformatieobjectConverter {
+    private static final Logger LOG = Logger.getLogger(RestInformatieobjectConverter.class.getName());
 
     private BrcClientService brcClientService;
     private ConfiguratieService configuratieService;
@@ -70,11 +70,11 @@ public class RESTInformatieobjectConverter {
     /**
      * Default no-arg constructor, required by Weld.
      */
-    public RESTInformatieobjectConverter() {
+    public RestInformatieobjectConverter() {
     }
 
     @Inject
-    public RESTInformatieobjectConverter(
+    public RestInformatieobjectConverter(
             BrcClientService brcClientService,
             ConfiguratieService configuratieService,
             DrcClientService drcClientService,
@@ -100,13 +100,13 @@ public class RESTInformatieobjectConverter {
         this.configuratieService = configuratieService;
     }
 
-    public List<RESTEnkelvoudigInformatieobject> convertToREST(
+    public List<RestEnkelvoudigInformatieobject> convertToREST(
             final List<ZaakInformatieobject> zaakInformatieobjecten
     ) {
         return zaakInformatieobjecten.stream().map(this::convertToREST).toList();
     }
 
-    public RESTEnkelvoudigInformatieobject convertToREST(final ZaakInformatieobject zaakInformatieObject) {
+    public RestEnkelvoudigInformatieobject convertToREST(final ZaakInformatieobject zaakInformatieObject) {
         final EnkelvoudigInformatieObject enkelvoudigInformatieObject = drcClientService.readEnkelvoudigInformatieobject(
                 zaakInformatieObject.getInformatieobject()
         );
@@ -114,13 +114,13 @@ public class RESTInformatieobjectConverter {
         return convertToREST(enkelvoudigInformatieObject, zaak);
     }
 
-    public RESTEnkelvoudigInformatieobject convertToREST(
+    public RestEnkelvoudigInformatieobject convertToREST(
             final EnkelvoudigInformatieObject enkelvoudigInformatieObject
     ) {
         return convertToREST(enkelvoudigInformatieObject, null);
     }
 
-    public RESTEnkelvoudigInformatieobject convertToREST(
+    public RestEnkelvoudigInformatieobject convertToREST(
             final EnkelvoudigInformatieObject enkelvoudigInformatieObject,
             final Zaak zaak
     ) {
@@ -128,7 +128,7 @@ public class RESTInformatieobjectConverter {
         final EnkelvoudigInformatieObjectLock lock = enkelvoudigInformatieObject.getLocked() ?
                 enkelvoudigInformatieObjectLockService.findLock(enkelvoudigInformatieObjectUUID) : null;
         final DocumentRechten rechten = policyService.readDocumentRechten(enkelvoudigInformatieObject, lock, zaak);
-        final RESTEnkelvoudigInformatieobject restEnkelvoudigInformatieobject = new RESTEnkelvoudigInformatieobject();
+        final RestEnkelvoudigInformatieobject restEnkelvoudigInformatieobject = new RestEnkelvoudigInformatieobject();
         restEnkelvoudigInformatieobject.uuid = enkelvoudigInformatieObjectUUID;
         restEnkelvoudigInformatieobject.identificatie = enkelvoudigInformatieObject.getIdentificatie();
         restEnkelvoudigInformatieobject.rechten = restRechtenConverter.convert(rechten);
@@ -155,7 +155,7 @@ public class RESTInformatieobjectConverter {
     private void convertEnkelvoudigInformatieObject(
             EnkelvoudigInformatieObject enkelvoudigInformatieObject,
             EnkelvoudigInformatieObjectLock lock,
-            RESTEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
+            RestEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
     ) {
         restEnkelvoudigInformatieobject.titel = enkelvoudigInformatieObject.getTitel();
         if (enkelvoudigInformatieObject.getBronorganisatie() != null) {
@@ -199,7 +199,7 @@ public class RESTInformatieobjectConverter {
     }
 
     public EnkelvoudigInformatieObjectCreateLockRequest convertZaakObject(
-            final RESTEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
+            final RestEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
     ) {
         final EnkelvoudigInformatieObjectCreateLockRequest enkelvoudigInformatieObjectCreateLockRequest = buildEnkelvoudigInformatieObjectData(
                 restEnkelvoudigInformatieobject
@@ -212,7 +212,7 @@ public class RESTInformatieobjectConverter {
 
     @NotNull
     private EnkelvoudigInformatieObjectCreateLockRequest buildEnkelvoudigInformatieObjectData(
-            RESTEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
+            RestEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
     ) {
         final EnkelvoudigInformatieObjectCreateLockRequest enkelvoudigInformatieobjectWithInhoud = new EnkelvoudigInformatieObjectCreateLockRequest();
         enkelvoudigInformatieobjectWithInhoud.setBronorganisatie(ConfiguratieService.BRON_ORGANISATIE);
@@ -239,7 +239,7 @@ public class RESTInformatieobjectConverter {
     }
 
     public EnkelvoudigInformatieObjectCreateLockRequest convertTaakObject(
-            final RESTEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
+            final RestEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
     ) {
         final EnkelvoudigInformatieObjectCreateLockRequest enkelvoudigInformatieObjectCreateLockRequest = buildTaakEnkelvoudigInformatieObjectData(
                 restEnkelvoudigInformatieobject
@@ -253,7 +253,7 @@ public class RESTInformatieobjectConverter {
 
     @NotNull
     private EnkelvoudigInformatieObjectCreateLockRequest buildTaakEnkelvoudigInformatieObjectData(
-            RESTEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
+            RestEnkelvoudigInformatieobject restEnkelvoudigInformatieobject
     ) {
         final EnkelvoudigInformatieObjectCreateLockRequest enkelvoudigInformatieObjectData = new EnkelvoudigInformatieObjectCreateLockRequest();
         enkelvoudigInformatieObjectData.setBronorganisatie(ConfiguratieService.BRON_ORGANISATIE);
@@ -298,10 +298,10 @@ public class RESTInformatieobjectConverter {
     }
 
 
-    public RESTEnkelvoudigInformatieObjectVersieGegevens convertToRESTEnkelvoudigInformatieObjectVersieGegevens(
+    public RestEnkelvoudigInformatieObjectVersieGegevens convertToRestEnkelvoudigInformatieObjectVersieGegevens(
             final EnkelvoudigInformatieObject informatieobject
     ) {
-        final RESTEnkelvoudigInformatieObjectVersieGegevens restEnkelvoudigInformatieObjectVersieGegevens = new RESTEnkelvoudigInformatieObjectVersieGegevens();
+        final RestEnkelvoudigInformatieObjectVersieGegevens restEnkelvoudigInformatieObjectVersieGegevens = new RestEnkelvoudigInformatieObjectVersieGegevens();
 
         restEnkelvoudigInformatieObjectVersieGegevens.uuid = UriUtil.uuidFromURI(informatieobject.getUrl());
 
@@ -309,8 +309,9 @@ public class RESTInformatieobjectConverter {
             restEnkelvoudigInformatieObjectVersieGegevens.status = informatieobject.getStatus();
         }
         if (informatieobject.getVertrouwelijkheidaanduiding() != null) {
+            // use the name because the frontend expects this value to be in uppercase
             restEnkelvoudigInformatieObjectVersieGegevens.vertrouwelijkheidaanduiding = informatieobject.getVertrouwelijkheidaanduiding()
-                    .name().toLowerCase();
+                    .name();
         }
 
         restEnkelvoudigInformatieObjectVersieGegevens.beschrijving = informatieobject.getBeschrijving();
@@ -329,7 +330,7 @@ public class RESTInformatieobjectConverter {
     }
 
     public EnkelvoudigInformatieObjectWithLockRequest convert(
-            final RESTEnkelvoudigInformatieObjectVersieGegevens restEnkelvoudigInformatieObjectVersieGegevens
+            final RestEnkelvoudigInformatieObjectVersieGegevens restEnkelvoudigInformatieObjectVersieGegevens
     ) {
         final EnkelvoudigInformatieObjectWithLockRequest enkelvoudigInformatieObjectWithLockRequest = createEnkelvoudigInformatieObjectWithLockData(
                 restEnkelvoudigInformatieObjectVersieGegevens);
@@ -353,7 +354,7 @@ public class RESTInformatieobjectConverter {
     }
 
     private static EnkelvoudigInformatieObjectWithLockRequest createEnkelvoudigInformatieObjectWithLockData(
-            RESTEnkelvoudigInformatieObjectVersieGegevens restEnkelvoudigInformatieObjectVersieGegevens
+            RestEnkelvoudigInformatieObjectVersieGegevens restEnkelvoudigInformatieObjectVersieGegevens
     ) {
         final EnkelvoudigInformatieObjectWithLockRequest enkelvoudigInformatieObjectWithLockData = new EnkelvoudigInformatieObjectWithLockRequest();
 
@@ -389,7 +390,7 @@ public class RESTInformatieobjectConverter {
         return enkelvoudigInformatieObjectWithLockData;
     }
 
-    public List<RESTEnkelvoudigInformatieobject> convertUUIDsToREST(
+    public List<RestEnkelvoudigInformatieobject> convertUUIDsToREST(
             final List<UUID> enkelvoudigInformatieobjectUUIDs,
             final Zaak zaak
     ) {
@@ -412,7 +413,7 @@ public class RESTInformatieobjectConverter {
                 .toList();
     }
 
-    public RESTGekoppeldeZaakEnkelvoudigInformatieObject convertToREST(
+    public RestGekoppeldeZaakEnkelvoudigInformatieObject convertToREST(
             final ZaakInformatieobject zaakInformatieObject,
             final RelatieType relatieType,
             final Zaak zaak
@@ -423,7 +424,7 @@ public class RESTInformatieobjectConverter {
         final EnkelvoudigInformatieObjectLock lock = enkelvoudigInformatieObject.getLocked() ?
                 enkelvoudigInformatieObjectLockService.findLock(enkelvoudigInformatieObjectUUID) : null;
         final DocumentRechten rechten = policyService.readDocumentRechten(enkelvoudigInformatieObject, lock, zaak);
-        final RESTGekoppeldeZaakEnkelvoudigInformatieObject restEnkelvoudigInformatieobject = new RESTGekoppeldeZaakEnkelvoudigInformatieObject();
+        final RestGekoppeldeZaakEnkelvoudigInformatieObject restEnkelvoudigInformatieobject = new RestGekoppeldeZaakEnkelvoudigInformatieObject();
         restEnkelvoudigInformatieobject.uuid = enkelvoudigInformatieObjectUUID;
         restEnkelvoudigInformatieobject.identificatie = enkelvoudigInformatieObject.getIdentificatie();
         restEnkelvoudigInformatieobject.rechten = restRechtenConverter.convert(rechten);
@@ -438,7 +439,7 @@ public class RESTInformatieobjectConverter {
         return restEnkelvoudigInformatieobject;
     }
 
-    public List<RESTEnkelvoudigInformatieobject> convertInformatieobjectenToREST(
+    public List<RestEnkelvoudigInformatieobject> convertInformatieobjectenToREST(
             final List<EnkelvoudigInformatieObject> informatieobjecten
     ) {
         return informatieobjecten.stream().map(this::convertToREST).toList();

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/RestEnkelvoudigInformatieFileUpload.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/RestEnkelvoudigInformatieFileUpload.java
@@ -5,7 +5,7 @@ import jakarta.ws.rs.FormParam;
 import net.atos.zac.app.informatieobjecten.model.validation.ValidRestEnkelvoudigInformatieFileUploadForm;
 
 @ValidRestEnkelvoudigInformatieFileUploadForm
-public abstract class RESTEnkelvoudigInformatieFileUpload {
+public abstract class RestEnkelvoudigInformatieFileUpload {
 
     // this can be empty when adding a new version in which only the metadata changes
     @FormParam("file")

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/RestEnkelvoudigInformatieObjectVersieGegevens.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/RestEnkelvoudigInformatieObjectVersieGegevens.java
@@ -14,7 +14,7 @@ import jakarta.ws.rs.FormParam;
 import net.atos.client.zgw.drc.model.generated.StatusEnum;
 import net.atos.zac.app.configuratie.model.RESTTaal;
 
-public class RESTEnkelvoudigInformatieObjectVersieGegevens extends RESTEnkelvoudigInformatieFileUpload {
+public class RestEnkelvoudigInformatieObjectVersieGegevens extends RestEnkelvoudigInformatieFileUpload {
 
     @FormParam("uuid")
     public UUID uuid;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/RestEnkelvoudigInformatieobject.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/RestEnkelvoudigInformatieobject.java
@@ -21,7 +21,7 @@ import net.atos.zac.zoeken.model.DocumentIndicatie;
 /**
  * Representation of an 'enkelvoudig informatieobject' (e.g. a document) in the ZAC REST API.
  */
-public class RESTEnkelvoudigInformatieobject extends RESTEnkelvoudigInformatieFileUpload {
+public class RestEnkelvoudigInformatieobject extends RestEnkelvoudigInformatieFileUpload {
 
     public UUID uuid;
 

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/RestGekoppeldeZaakEnkelvoudigInformatieObject.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/RestGekoppeldeZaakEnkelvoudigInformatieObject.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 import net.atos.zac.app.zaak.model.RelatieType;
 
-public class RESTGekoppeldeZaakEnkelvoudigInformatieObject extends RESTEnkelvoudigInformatieobject {
+public class RestGekoppeldeZaakEnkelvoudigInformatieObject extends RestEnkelvoudigInformatieobject {
 
     public RelatieType relatieType;
 

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/RestInformatieobjecttype.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/RestInformatieobjecttype.java
@@ -7,7 +7,7 @@ package net.atos.zac.app.informatieobjecten.model;
 
 import java.util.UUID;
 
-public class RESTInformatieobjecttype {
+public class RestInformatieobjecttype {
     public UUID uuid;
 
     public String omschrijving;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadFormValidator.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadFormValidator.java
@@ -3,14 +3,14 @@ package net.atos.zac.app.informatieobjecten.model.validation;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-import net.atos.zac.app.informatieobjecten.model.RESTEnkelvoudigInformatieFileUpload;
+import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieFileUpload;
 
 
 public class ValidRestEnkelvoudigInformatieFileUploadFormValidator implements
-                                                                   ConstraintValidator<ValidRestEnkelvoudigInformatieFileUploadForm, RESTEnkelvoudigInformatieFileUpload> {
+                                                                   ConstraintValidator<ValidRestEnkelvoudigInformatieFileUploadForm, RestEnkelvoudigInformatieFileUpload> {
 
     @Override
-    public boolean isValid(RESTEnkelvoudigInformatieFileUpload value, ConstraintValidatorContext context) {
+    public boolean isValid(RestEnkelvoudigInformatieFileUpload value, ConstraintValidatorContext context) {
         if (value.bestandsnaam != null) {
             return value.file != null && value.file.length != 0;
         }

--- a/src/main/kotlin/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestService.kt
@@ -35,18 +35,18 @@ import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.client.zgw.ztc.util.InformatieObjectTypeUtil.isNuGeldig
 import net.atos.zac.app.audit.converter.RESTHistorieRegelConverter
 import net.atos.zac.app.audit.model.RESTHistorieRegel
-import net.atos.zac.app.informatieobjecten.converter.RESTInformatieobjectConverter
 import net.atos.zac.app.informatieobjecten.converter.RESTInformatieobjecttypeConverter
 import net.atos.zac.app.informatieobjecten.converter.RESTZaakInformatieobjectConverter
+import net.atos.zac.app.informatieobjecten.converter.RestInformatieobjectConverter
 import net.atos.zac.app.informatieobjecten.model.RESTDocumentVerplaatsGegevens
 import net.atos.zac.app.informatieobjecten.model.RESTDocumentVerwijderenGegevens
 import net.atos.zac.app.informatieobjecten.model.RESTDocumentVerzendGegevens
-import net.atos.zac.app.informatieobjecten.model.RESTEnkelvoudigInformatieObjectVersieGegevens
-import net.atos.zac.app.informatieobjecten.model.RESTEnkelvoudigInformatieobject
-import net.atos.zac.app.informatieobjecten.model.RESTGekoppeldeZaakEnkelvoudigInformatieObject
 import net.atos.zac.app.informatieobjecten.model.RESTInformatieobjectZoekParameters
 import net.atos.zac.app.informatieobjecten.model.RESTInformatieobjecttype
 import net.atos.zac.app.informatieobjecten.model.RESTZaakInformatieobject
+import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieObjectVersieGegevens
+import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieobject
+import net.atos.zac.app.informatieobjecten.model.RestGekoppeldeZaakEnkelvoudigInformatieObject
 import net.atos.zac.app.zaak.converter.RestGerelateerdeZaakConverter
 import net.atos.zac.app.zaak.model.RelatieType
 import net.atos.zac.authentication.LoggedInUser
@@ -85,7 +85,7 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
     private val enkelvoudigInformatieObjectLockService: EnkelvoudigInformatieObjectLockService,
     private val eventingService: EventingService,
     private val zaakInformatieobjectConverter: RESTZaakInformatieobjectConverter,
-    private val restInformatieobjectConverter: RESTInformatieobjectConverter,
+    private val restInformatieobjectConverter: RestInformatieobjectConverter,
     private val restInformatieobjecttypeConverter: RESTInformatieobjecttypeConverter,
     private val restHistorieRegelConverter: RESTHistorieRegelConverter,
     private val restGerelateerdeZaakConverter: RestGerelateerdeZaakConverter,
@@ -106,7 +106,7 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
     fun readEnkelvoudigInformatieobject(
         @PathParam("uuid") uuid: UUID,
         @QueryParam("zaak") zaakUUID: UUID?
-    ): RESTEnkelvoudigInformatieobject =
+    ): RestEnkelvoudigInformatieobject =
         uuid
             .let(drcClientService::readEnkelvoudigInformatieobject)
             .let { enkelvoudigInformatieObject ->
@@ -120,7 +120,7 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
     fun readEnkelvoudigInformatieobject(
         @PathParam("uuid") uuid: UUID,
         @PathParam("version") version: Int
-    ): RESTEnkelvoudigInformatieobject =
+    ): RestEnkelvoudigInformatieobject =
         uuid
             .let(drcClientService::readEnkelvoudigInformatieobject)
             .let { currentVersion ->
@@ -136,7 +136,7 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
     @Path("informatieobjectenList")
     fun listEnkelvoudigInformatieobjecten(
         zoekParameters: RESTInformatieobjectZoekParameters
-    ): List<RESTEnkelvoudigInformatieobject> {
+    ): List<RestEnkelvoudigInformatieobject> {
         val zaak = zoekParameters.zaakUUID?.let { zrcClientService.readZaak(it) }
         zoekParameters.informatieobjectUUIDs?.let {
             return restInformatieobjectConverter.convertUUIDsToREST(it, zaak)
@@ -162,7 +162,7 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
     @Path("informatieobjecten/zaak/{zaakUuid}/teVerzenden")
     fun listEnkelvoudigInformatieobjectenVoorVerzenden(
         @PathParam("zaakUuid") zaakUuid: UUID
-    ): List<RESTEnkelvoudigInformatieobject> {
+    ): List<RestEnkelvoudigInformatieobject> {
         val zaak = zrcClientService.readZaak(zaakUuid)
         assertPolicy(policyService.readZaakRechten(zaak).lezen)
         return zrcClientService.listZaakinformatieobjecten(zaak)
@@ -200,8 +200,8 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
         @PathParam("zaakUuid") zaakUuid: UUID,
         @PathParam("documentReferenceId") documentReferenceId: String,
         @QueryParam("taakObject") isTaakObject: Boolean,
-        @Valid @MultipartForm restEnkelvoudigInformatieobject: RESTEnkelvoudigInformatieobject
-    ): RESTEnkelvoudigInformatieobject {
+        @Valid @MultipartForm restEnkelvoudigInformatieobject: RestEnkelvoudigInformatieobject
+    ): RestEnkelvoudigInformatieobject {
         val zaak = zrcClientService.readZaak(zaakUuid)
         assertPolicy(policyService.readZaakRechten(zaak).toevoegenDocument)
 
@@ -273,7 +273,7 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
     @Path("zaakinformatieobject/{uuid}/informatieobject")
     fun readEnkelvoudigInformatieobjectByZaakInformatieobjectUUID(
         @PathParam("uuid") uuid: UUID
-    ): RESTEnkelvoudigInformatieobject =
+    ): RestEnkelvoudigInformatieobject =
         zrcClientService.readZaakinformatieobject(uuid).informatieobject
             .let(drcClientService::readEnkelvoudigInformatieobject)
             .let(restInformatieobjectConverter::convertToREST)
@@ -399,19 +399,17 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
     @Path("informatieobject/{uuid}/huidigeversie")
     fun readHuidigeVersieInformatieObject(
         @PathParam("uuid") uuid: UUID
-    ): RESTEnkelvoudigInformatieObjectVersieGegevens = drcClientService.readEnkelvoudigInformatieobject(
-        uuid
-    ).let {
-        assertPolicy(policyService.readDocumentRechten(it).lezen)
-        return restInformatieobjectConverter.convertToRESTEnkelvoudigInformatieObjectVersieGegevens(it)
-    }
+    ): RestEnkelvoudigInformatieObjectVersieGegevens =
+        drcClientService.readEnkelvoudigInformatieobject(uuid)
+            .also { assertPolicy(policyService.readDocumentRechten(it).lezen) }
+            .let(restInformatieobjectConverter::convertToRestEnkelvoudigInformatieObjectVersieGegevens)
 
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Path("/informatieobject/update")
     fun updateEnkelvoudigInformatieobjectAndUploadFile(
-        @Valid @MultipartForm enkelvoudigInformatieObjectVersieGegevens: RESTEnkelvoudigInformatieObjectVersieGegevens
-    ): RESTEnkelvoudigInformatieobject {
+        @Valid @MultipartForm enkelvoudigInformatieObjectVersieGegevens: RestEnkelvoudigInformatieObjectVersieGegevens
+    ): RestEnkelvoudigInformatieobject {
         val document = drcClientService.readEnkelvoudigInformatieobject(
             enkelvoudigInformatieObjectVersieGegevens.uuid
         )
@@ -426,10 +424,10 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
     }
 
     private fun updateEnkelvoudigInformatieobject(
-        enkelvoudigInformatieObjectVersieGegevens: RESTEnkelvoudigInformatieObjectVersieGegevens,
+        enkelvoudigInformatieObjectVersieGegevens: RestEnkelvoudigInformatieObjectVersieGegevens,
         enkelvoudigInformatieObject: EnkelvoudigInformatieObject,
         enkelvoudigInformatieObjectWithLockRequest: EnkelvoudigInformatieObjectWithLockRequest
-    ): RESTEnkelvoudigInformatieobject =
+    ): RestEnkelvoudigInformatieobject =
         enkelvoudigInformatieObjectUpdateService.updateEnkelvoudigInformatieObjectWithLockData(
             URIUtil.parseUUIDFromResourceURI(enkelvoudigInformatieObject.url),
             enkelvoudigInformatieObjectWithLockRequest,
@@ -558,7 +556,7 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
                 MEDIA_TYPE_PDF == informatieobject.formaat
         }
 
-    private fun listEnkelvoudigInformatieobjectenVoorZaak(zaak: Zaak): MutableList<RESTEnkelvoudigInformatieobject> =
+    private fun listEnkelvoudigInformatieobjectenVoorZaak(zaak: Zaak): MutableList<RestEnkelvoudigInformatieobject> =
         zaak.let(zrcClientService::listZaakinformatieobjecten)
             .map(restInformatieobjectConverter::convertToREST)
             .toMutableList()
@@ -566,7 +564,7 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
     private fun listGekoppeldeZaakEnkelvoudigInformatieobjectenVoorZaak(
         zaakURI: URI,
         relatieType: RelatieType
-    ): List<RESTGekoppeldeZaakEnkelvoudigInformatieObject> =
+    ): List<RestGekoppeldeZaakEnkelvoudigInformatieObject> =
         zaakURI.let(zrcClientService::readZaak)
             .let { zaak ->
                 zrcClientService.listZaakinformatieobjecten(zaak)
@@ -576,8 +574,8 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
 
     private fun listGekoppeldeZaakInformatieObjectenVoorZaak(
         zaak: Zaak
-    ): List<RESTGekoppeldeZaakEnkelvoudigInformatieObject> =
-        mutableListOf<RESTGekoppeldeZaakEnkelvoudigInformatieObject>().apply {
+    ): List<RestGekoppeldeZaakEnkelvoudigInformatieObject> =
+        mutableListOf<RestGekoppeldeZaakEnkelvoudigInformatieObject>().apply {
             zaak.deelzaken?.forEach {
                 addAll(listGekoppeldeZaakEnkelvoudigInformatieobjectenVoorZaak(it, RelatieType.DEELZAAK))
             }

--- a/src/main/kotlin/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestService.kt
@@ -42,7 +42,7 @@ import net.atos.zac.app.informatieobjecten.model.RESTDocumentVerplaatsGegevens
 import net.atos.zac.app.informatieobjecten.model.RESTDocumentVerwijderenGegevens
 import net.atos.zac.app.informatieobjecten.model.RESTDocumentVerzendGegevens
 import net.atos.zac.app.informatieobjecten.model.RESTInformatieobjectZoekParameters
-import net.atos.zac.app.informatieobjecten.model.RESTInformatieobjecttype
+import net.atos.zac.app.informatieobjecten.model.RestInformatieobjecttype
 import net.atos.zac.app.informatieobjecten.model.RESTZaakInformatieobject
 import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieObjectVersieGegevens
 import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieobject
@@ -254,14 +254,14 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
 
     @GET
     @Path("informatieobjecttypes/{zaakTypeUuid}")
-    fun listInformatieobjecttypes(@PathParam("zaakTypeUuid") zaakTypeID: UUID): List<RESTInformatieobjecttype> =
+    fun listInformatieobjecttypes(@PathParam("zaakTypeUuid") zaakTypeID: UUID): List<RestInformatieobjecttype> =
         ztcClientService.readZaaktype(zaakTypeID).let {
             restInformatieobjecttypeConverter.convertFromUris(it.informatieobjecttypen)
         }
 
     @GET
     @Path("informatieobjecttypes/zaak/{zaakUuid}")
-    fun listInformatieobjecttypesForZaak(@PathParam("zaakUuid") zaakID: UUID): List<RESTInformatieobjecttype> =
+    fun listInformatieobjecttypesForZaak(@PathParam("zaakUuid") zaakID: UUID): List<RestInformatieobjecttype> =
         zrcClientService.readZaak(zaakID).zaaktype
             .let { ztcClientService.readZaaktype(it).informatieobjecttypen }
             .map { ztcClientService.readInformatieobjecttype(it) }

--- a/src/main/kotlin/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestService.kt
@@ -42,11 +42,11 @@ import net.atos.zac.app.informatieobjecten.model.RESTDocumentVerplaatsGegevens
 import net.atos.zac.app.informatieobjecten.model.RESTDocumentVerwijderenGegevens
 import net.atos.zac.app.informatieobjecten.model.RESTDocumentVerzendGegevens
 import net.atos.zac.app.informatieobjecten.model.RESTInformatieobjectZoekParameters
-import net.atos.zac.app.informatieobjecten.model.RestInformatieobjecttype
 import net.atos.zac.app.informatieobjecten.model.RESTZaakInformatieobject
 import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieObjectVersieGegevens
 import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieobject
 import net.atos.zac.app.informatieobjecten.model.RestGekoppeldeZaakEnkelvoudigInformatieObject
+import net.atos.zac.app.informatieobjecten.model.RestInformatieobjecttype
 import net.atos.zac.app.zaak.converter.RestGerelateerdeZaakConverter
 import net.atos.zac.app.zaak.model.RelatieType
 import net.atos.zac.authentication.LoggedInUser

--- a/src/main/kotlin/net/atos/zac/app/signalering/SignaleringRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/signalering/SignaleringRestService.kt
@@ -18,8 +18,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.atos.client.zgw.drc.DrcClientService
-import net.atos.zac.app.informatieobjecten.converter.RESTInformatieobjectConverter
-import net.atos.zac.app.informatieobjecten.model.RESTEnkelvoudigInformatieobject
+import net.atos.zac.app.informatieobjecten.converter.RestInformatieobjectConverter
+import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieobject
 import net.atos.zac.app.signalering.converter.RestSignaleringInstellingenConverter
 import net.atos.zac.app.signalering.converter.toRestSignaleringTaakSummary
 import net.atos.zac.app.signalering.model.RestSignaleringInstellingen
@@ -47,7 +47,7 @@ class SignaleringRestService @Inject constructor(
     private val flowableTaskService: FlowableTaskService,
     private val drcClientService: DrcClientService,
     private val identityService: IdentityService,
-    private val restInformatieobjectConverter: RESTInformatieobjectConverter,
+    private val restInformatieobjectConverter: RestInformatieobjectConverter,
     private val restSignaleringInstellingenConverter: RestSignaleringInstellingenConverter,
     private val loggedInUserInstance: Instance<LoggedInUser>
 ) {
@@ -96,7 +96,7 @@ class SignaleringRestService @Inject constructor(
     @Path("/informatieobjecten/{type}")
     fun listInformatieobjectenSignaleringen(
         @PathParam("type") signaleringsType: SignaleringType.Type
-    ): List<RESTEnkelvoudigInformatieobject> =
+    ): List<RestEnkelvoudigInformatieobject> =
         loggedInUserInstance.getSignaleringZoekParameters()
             .types(signaleringsType)
             .subjecttype(SignaleringSubject.DOCUMENT)

--- a/src/main/kotlin/net/atos/zac/app/task/TaskRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/task/TaskRestService.kt
@@ -31,7 +31,7 @@ import net.atos.client.zgw.shared.util.URIUtil
 import net.atos.client.zgw.zrc.ZrcClientService
 import net.atos.client.zgw.zrc.model.Zaak
 import net.atos.zac.app.informatieobjecten.EnkelvoudigInformatieObjectUpdateService
-import net.atos.zac.app.informatieobjecten.converter.RESTInformatieobjectConverter
+import net.atos.zac.app.informatieobjecten.converter.RestInformatieobjectConverter
 import net.atos.zac.app.informatieobjecten.model.RESTFileUpload
 import net.atos.zac.app.task.converter.RestTaskConverter
 import net.atos.zac.app.task.converter.RestTaskHistoryConverter
@@ -95,7 +95,7 @@ class TaskRestService @Inject constructor(
     private val loggedInUserInstance: Instance<LoggedInUser>,
     @ActiveSession
     private val httpSession: Instance<HttpSession>,
-    private val restInformatieobjectConverter: RESTInformatieobjectConverter,
+    private val restInformatieobjectConverter: RestInformatieobjectConverter,
     private val zgwApiService: ZGWApiService,
     private val zrcClientService: ZrcClientService,
     private val drcClientService: DrcClientService,

--- a/src/main/kotlin/net/atos/zac/app/task/model/RestTaskDocumentData.kt
+++ b/src/main/kotlin/net/atos/zac/app/task/model/RestTaskDocumentData.kt
@@ -4,7 +4,7 @@
  */
 package net.atos.zac.app.task.model
 
-import net.atos.zac.app.informatieobjecten.model.RESTInformatieobjecttype
+import net.atos.zac.app.informatieobjecten.model.RestInformatieobjecttype
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 
@@ -13,5 +13,5 @@ import nl.lifely.zac.util.NoArgConstructor
 data class RestTaskDocumentData(
     var bestandsnaam: String,
     var documentTitel: String,
-    var documentType: RESTInformatieobjecttype
+    var documentType: RestInformatieobjecttype
 )

--- a/src/main/kotlin/net/atos/zac/app/zaak/converter/RestBesluitConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/converter/RestBesluitConverter.kt
@@ -12,7 +12,7 @@ import net.atos.client.zgw.drc.DrcClientService
 import net.atos.client.zgw.drc.model.generated.EnkelvoudigInformatieObject
 import net.atos.client.zgw.zrc.model.Zaak
 import net.atos.client.zgw.ztc.ZtcClientService
-import net.atos.zac.app.informatieobjecten.converter.RESTInformatieobjectConverter
+import net.atos.zac.app.informatieobjecten.converter.RestInformatieobjectConverter
 import net.atos.zac.app.zaak.model.RestBesluit
 import net.atos.zac.app.zaak.model.RestBesluitVastleggenGegevens
 import net.atos.zac.app.zaak.model.toRestBesluitType
@@ -25,7 +25,7 @@ import java.time.LocalDate
 class RestBesluitConverter @Inject constructor(
     private val brcClientService: BrcClientService,
     private val drcClientService: DrcClientService,
-    private val restInformatieobjectConverter: RESTInformatieobjectConverter,
+    private val restInformatieobjectConverter: RestInformatieobjectConverter,
     private val ztcClientService: ZtcClientService
 ) {
     fun convertToRestBesluit(besluit: Besluit) = RestBesluit(

--- a/src/main/kotlin/net/atos/zac/app/zaak/model/RestBesluit.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/model/RestBesluit.kt
@@ -6,7 +6,7 @@ package net.atos.zac.app.zaak.model
 
 import jakarta.json.bind.annotation.JsonbProperty
 import net.atos.client.zgw.brc.model.generated.VervalredenEnum
-import net.atos.zac.app.informatieobjecten.model.RESTEnkelvoudigInformatieobject
+import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieobject
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import java.net.URI
@@ -39,5 +39,5 @@ data class RestBesluit(
 
     var zaakUuid: UUID? = null,
 
-    var informatieobjecten: List<RESTEnkelvoudigInformatieobject>? = null,
+    var informatieobjecten: List<RestEnkelvoudigInformatieobject>? = null,
 )

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestServiceTest.kt
@@ -30,8 +30,8 @@ import net.atos.zac.app.audit.converter.RESTHistorieRegelConverter
 import net.atos.zac.app.informatieobjecten.converter.RESTInformatieobjecttypeConverter
 import net.atos.zac.app.informatieobjecten.converter.RESTZaakInformatieobjectConverter
 import net.atos.zac.app.informatieobjecten.converter.RestInformatieobjectConverter
-import net.atos.zac.app.informatieobjecten.model.createRESTEnkelvoudigInformatieObjectVersieGegevens
-import net.atos.zac.app.informatieobjecten.model.createRESTEnkelvoudigInformatieobject
+import net.atos.zac.app.informatieobjecten.model.createRestEnkelvoudigInformatieObjectVersieGegevens
+import net.atos.zac.app.informatieobjecten.model.createRestEnkelvoudigInformatieobject
 import net.atos.zac.app.informatieobjecten.model.createRESTFileUpload
 import net.atos.zac.app.informatieobjecten.model.createRESTInformatieobjectZoekParameters
 import net.atos.zac.app.zaak.converter.RestGerelateerdeZaakConverter
@@ -97,8 +97,8 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
     Given("an enkelvoudig informatieobject has been uploaded, and the zaak is open") {
         val zaak = createZaak()
         val documentReferentieId = "dummyDocumentReferentieId"
-        val restEnkelvoudigInformatieobject = createRESTEnkelvoudigInformatieobject()
-        val responseRestEnkelvoudigInformatieobject = createRESTEnkelvoudigInformatieobject()
+        val restEnkelvoudigInformatieobject = createRestEnkelvoudigInformatieobject()
+        val responseRestEnkelvoudigInformatieobject = createRestEnkelvoudigInformatieobject()
         val restFileUpload = createRESTFileUpload()
         val enkelvoudigInformatieObjectData = createEnkelvoudigInformatieObjectCreateLockRequest()
         val zaakInformatieobject = createZaakInformatieobject()
@@ -224,9 +224,9 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
             archiefnominatie = Archiefnominatie.VERNIETIGEN
         )
         val documentReferentieId = "dummyDocumentReferentieId"
-        val restEnkelvoudigInformatieobject = createRESTEnkelvoudigInformatieobject()
+        val restEnkelvoudigInformatieobject = createRestEnkelvoudigInformatieobject()
         val responseRestEnkelvoudigInformatieobject =
-            createRESTEnkelvoudigInformatieobject()
+            createRestEnkelvoudigInformatieobject()
         val enkelvoudigInformatieObjectData = createEnkelvoudigInformatieObjectCreateLockRequest()
         val zaakInformatieobject = createZaakInformatieobject()
 
@@ -273,10 +273,10 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
 
     Given("enkelvoudig informatieobject has been uploaded, and the zaak is open") {
         val zaak = createZaak()
-        val restEnkelvoudigInformatieobject = createRESTEnkelvoudigInformatieobject()
+        val restEnkelvoudigInformatieobject = createRestEnkelvoudigInformatieobject()
         val enkelvoudigInformatieObjectWithLockData = createEnkelvoudigInformatieObjectWithLockRequest()
         val restEnkelvoudigInformatieObjectVersieGegevens =
-            createRESTEnkelvoudigInformatieObjectVersieGegevens(zaakUuid = zaak.uuid)
+            createRestEnkelvoudigInformatieObjectVersieGegevens(zaakUuid = zaak.uuid)
         val enkelvoudigInformatieObject = createEnkelvoudigInformatieObject()
 
         every {
@@ -353,8 +353,8 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
         )
         val zaak = createZaak()
         val restEnkelvoudigInformatieobjecten = listOf(
-            createRESTEnkelvoudigInformatieobject(),
-            createRESTEnkelvoudigInformatieobject()
+            createRestEnkelvoudigInformatieobject(),
+            createRestEnkelvoudigInformatieobject()
         )
 
         every { zrcClientService.readZaak(zaakUuid) } returns zaak
@@ -398,7 +398,7 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
             deelzaken = setOf(deelzaak.url)
         )
         val restEnkelvoudigInformatieobjecten = listOf(
-            createRESTEnkelvoudigInformatieobject(
+            createRestEnkelvoudigInformatieobject(
                 informatieobjectTypeUUID = informatieobjectUUID
             )
         )
@@ -442,7 +442,7 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
         val informatieobjectUUID = UUID.randomUUID()
         val enkelvoudiginformatieobject = createEnkelvoudigInformatieObject()
         val restEnkelvoudigInformatieObjectVersieGegevens =
-            createRESTEnkelvoudigInformatieObjectVersieGegevens(uuid = informatieobjectUUID)
+            createRestEnkelvoudigInformatieObjectVersieGegevens(uuid = informatieobjectUUID)
         every {
             drcClientService.readEnkelvoudigInformatieobject(informatieobjectUUID)
         } returns enkelvoudiginformatieobject

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestServiceTest.kt
@@ -30,10 +30,10 @@ import net.atos.zac.app.audit.converter.RESTHistorieRegelConverter
 import net.atos.zac.app.informatieobjecten.converter.RESTInformatieobjecttypeConverter
 import net.atos.zac.app.informatieobjecten.converter.RESTZaakInformatieobjectConverter
 import net.atos.zac.app.informatieobjecten.converter.RestInformatieobjectConverter
-import net.atos.zac.app.informatieobjecten.model.createRestEnkelvoudigInformatieObjectVersieGegevens
-import net.atos.zac.app.informatieobjecten.model.createRestEnkelvoudigInformatieobject
 import net.atos.zac.app.informatieobjecten.model.createRESTFileUpload
 import net.atos.zac.app.informatieobjecten.model.createRESTInformatieobjectZoekParameters
+import net.atos.zac.app.informatieobjecten.model.createRestEnkelvoudigInformatieObjectVersieGegevens
+import net.atos.zac.app.informatieobjecten.model.createRestEnkelvoudigInformatieobject
 import net.atos.zac.app.zaak.converter.RestGerelateerdeZaakConverter
 import net.atos.zac.authentication.LoggedInUser
 import net.atos.zac.documenten.InboxDocumentenService

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverterTest.kt
@@ -58,19 +58,20 @@ class RESTInformatieobjectConverterTest : BehaviorSpec({
     val zrcClientService = mockk<ZrcClientService>()
     val ztcClientService = mockk<ZtcClientService>()
 
-    val restInformatieobjectConverter = RESTInformatieobjectConverter(
-        brcClientService,
-        configuratieService,
-        drcClientService,
-        enkelvoudigInformatieObjectLockService,
-        identityService,
-        loggedInUserInstance,
-        policyService,
-        restRechtenConverter,
-        restTaalConverter,
-        zrcClientService,
-        ztcClientService
-    )
+    val restInformatieobjectConverter =
+        RestInformatieobjectConverter(
+            brcClientService,
+            configuratieService,
+            drcClientService,
+            enkelvoudigInformatieObjectLockService,
+            identityService,
+            loggedInUserInstance,
+            policyService,
+            restRechtenConverter,
+            restTaalConverter,
+            zrcClientService,
+            ztcClientService
+        )
 
     Given("REST taak document data and REST file upload are provided") {
         val restTaakDocumentData = createRestTaskDocumentData()

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
@@ -21,9 +21,9 @@ import net.atos.client.zgw.zrc.ZrcClientService
 import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.client.zgw.ztc.model.createInformatieObjectType
 import net.atos.zac.app.configuratie.converter.RESTTaalConverter
+import net.atos.zac.app.informatieobjecten.model.createRESTFileUpload
 import net.atos.zac.app.informatieobjecten.model.createRestEnkelvoudigInformatieObjectVersieGegevens
 import net.atos.zac.app.informatieobjecten.model.createRestEnkelvoudigInformatieobject
-import net.atos.zac.app.informatieobjecten.model.createRESTFileUpload
 import net.atos.zac.app.policy.converter.RestRechtenConverter
 import net.atos.zac.app.policy.model.RestDocumentRechten
 import net.atos.zac.app.policy.model.createRESTDocumentRechten

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
@@ -21,8 +21,8 @@ import net.atos.client.zgw.zrc.ZrcClientService
 import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.client.zgw.ztc.model.createInformatieObjectType
 import net.atos.zac.app.configuratie.converter.RESTTaalConverter
-import net.atos.zac.app.informatieobjecten.model.createRESTEnkelvoudigInformatieObjectVersieGegevens
-import net.atos.zac.app.informatieobjecten.model.createRESTEnkelvoudigInformatieobject
+import net.atos.zac.app.informatieobjecten.model.createRestEnkelvoudigInformatieObjectVersieGegevens
+import net.atos.zac.app.informatieobjecten.model.createRestEnkelvoudigInformatieobject
 import net.atos.zac.app.informatieobjecten.model.createRESTFileUpload
 import net.atos.zac.app.policy.converter.RestRechtenConverter
 import net.atos.zac.app.policy.model.RestDocumentRechten
@@ -44,7 +44,7 @@ import java.util.Base64
 import java.util.Optional
 import java.util.UUID
 
-class RESTInformatieobjectConverterTest : BehaviorSpec({
+class RestInformatieobjectConverterTest : BehaviorSpec({
     val brcClientService = mockk<BrcClientService>()
     val configuratieService = mockk<ConfiguratieService>()
     val drcClientService = mockk<DrcClientService>()
@@ -113,7 +113,7 @@ class RESTInformatieobjectConverterTest : BehaviorSpec({
 
     Given("REST enkelvoudig informatie object data and REST file upload are provided for a taak") {
         val restFileUpload = createRESTFileUpload()
-        val restEnkelvoudigInformatieobject = createRESTEnkelvoudigInformatieobject()
+        val restEnkelvoudigInformatieobject = createRestEnkelvoudigInformatieobject()
         val providedInformatieObjectType = createInformatieObjectType()
 
         every { loggedInUserInstance.get() } returns loggedInUser
@@ -150,7 +150,7 @@ class RESTInformatieobjectConverterTest : BehaviorSpec({
     Given("REST enkelvoudig informatie object data and REST file upload are provided for a zaak") {
         // when converting a zaak more fields in the RESTEnkelvoudigInformatieobject are used in the
         // conversion compared to when converting a taak
-        val restEnkelvoudigInformatieobject = createRESTEnkelvoudigInformatieobject(
+        val restEnkelvoudigInformatieobject = createRestEnkelvoudigInformatieobject(
             vertrouwelijkheidaanduiding = "vertrouwelijk",
             creatieDatum = LocalDate.now(),
             auteur = "dummyAuteur",
@@ -298,7 +298,7 @@ class RESTInformatieobjectConverterTest : BehaviorSpec({
 
     Given("A 'REST enkelvoudiginformatieobject versie gegevens' object containing a file, bestandsnaam and formaat") {
         val informatieobjectType = createInformatieObjectType()
-        val restEnkelvoudigInformatieobjectVersieGegevens = createRESTEnkelvoudigInformatieObjectVersieGegevens(
+        val restEnkelvoudigInformatieobjectVersieGegevens = createRestEnkelvoudigInformatieObjectVersieGegevens(
             vertrouwelijkheidaanduiding = VertrouwelijkheidaanduidingEnum.OPENBAAR.name.lowercase()
         )
 

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/model/InformatieObjectenRESTFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/model/InformatieObjectenRESTFixtures.kt
@@ -18,7 +18,7 @@ fun createRESTEnkelvoudigInformatieobject(
     bestandsNaam: String = "dummyFilename",
     formaat: String = "dummyType",
     indicatieGebruiksrecht: Boolean? = null
-) = RESTEnkelvoudigInformatieobject().apply {
+) = RestEnkelvoudigInformatieobject().apply {
     this.uuid = uuid
     this.status = status
     this.vertrouwelijkheidaanduiding = vertrouwelijkheidaanduiding
@@ -65,7 +65,7 @@ fun createRESTEnkelvoudigInformatieObjectVersieGegevens(
     formaat: String = "dummyType",
     informatieobjectTypeUUID: UUID = UUID.randomUUID(),
     vertrouwelijkheidaanduiding: String = VertrouwelijkheidaanduidingEnum.OPENBAAR.name
-) = RESTEnkelvoudigInformatieObjectVersieGegevens().apply {
+) = RestEnkelvoudigInformatieObjectVersieGegevens().apply {
     this.uuid = uuid
     this.zaakUuid = zaakUuid
     this.bestandsnaam = bestandsnaam

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/model/InformatieObjectenRestFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/model/InformatieObjectenRestFixtures.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 @Suppress("LongParameterList")
-fun createRESTEnkelvoudigInformatieobject(
+fun createRestEnkelvoudigInformatieobject(
     uuid: UUID = UUID.randomUUID(),
     status: StatusEnum = StatusEnum.IN_BEWERKING,
     vertrouwelijkheidaanduiding: String? = null,
@@ -44,12 +44,12 @@ fun createRESTFileUpload(
     this.type = type
 }
 
-fun createRESTInformatieobjecttype(
+fun createRestInformatieobjecttype(
     uuid: UUID = UUID.randomUUID(),
     omschrijving: String = "dummyOmschrijving",
     vertrouwelijkheidaanduiding: String = VertrouwelijkheidaanduidingEnum.OPENBAAR.name,
     concept: Boolean = false
-) = RESTInformatieobjecttype().apply {
+) = RestInformatieobjecttype().apply {
     this.uuid = uuid
     this.omschrijving = omschrijving
     this.vertrouwelijkheidaanduiding = vertrouwelijkheidaanduiding
@@ -57,7 +57,7 @@ fun createRESTInformatieobjecttype(
 }
 
 @Suppress("LongParameterList")
-fun createRESTEnkelvoudigInformatieObjectVersieGegevens(
+fun createRestEnkelvoudigInformatieObjectVersieGegevens(
     uuid: UUID = UUID.randomUUID(),
     zaakUuid: UUID = UUID.randomUUID(),
     bestandsnaam: String = "dummyFile.txt",

--- a/src/test/kotlin/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieobjectFileUploadFormValidatorTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieobjectFileUploadFormValidatorTest.kt
@@ -2,7 +2,7 @@ package net.atos.zac.app.informatieobjecten.model.validation
 
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import net.atos.zac.app.informatieobjecten.model.RESTEnkelvoudigInformatieobject
+import net.atos.zac.app.informatieobjecten.model.RestEnkelvoudigInformatieobject
 
 class ValidRestEnkelvoudigInformatieobjectFileUploadFormValidatorTest : BehaviorSpec({
 
@@ -10,9 +10,10 @@ class ValidRestEnkelvoudigInformatieobjectFileUploadFormValidatorTest : Behavior
         ValidRestEnkelvoudigInformatieFileUploadFormValidator()
 
     Given("REST enkelvoudig informatie object") {
-        val restEnkelvoudigInformatieobject = RESTEnkelvoudigInformatieobject().apply {
-            bestandsnaam = "dummyFileName.txt"
-        }
+        val restEnkelvoudigInformatieobject = RestEnkelvoudigInformatieobject()
+            .apply {
+                bestandsnaam = "dummyFileName.txt"
+            }
 
         When("no file content provided") {
 

--- a/src/test/kotlin/net/atos/zac/app/task/TaskRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/task/TaskRestServiceTest.kt
@@ -27,7 +27,7 @@ import net.atos.client.zgw.zrc.model.Zaak
 import net.atos.client.zgw.zrc.model.createZaak
 import net.atos.zac.app.identity.model.createRESTUser
 import net.atos.zac.app.informatieobjecten.EnkelvoudigInformatieObjectUpdateService
-import net.atos.zac.app.informatieobjecten.converter.RESTInformatieobjectConverter
+import net.atos.zac.app.informatieobjecten.converter.RestInformatieobjectConverter
 import net.atos.zac.app.task.converter.RestTaskConverter
 import net.atos.zac.app.task.converter.RestTaskHistoryConverter
 import net.atos.zac.app.task.model.TaakStatus
@@ -78,7 +78,7 @@ class TaskRestServiceTest : BehaviorSpec({
     val flowableTaskService = mockk<FlowableTaskService>()
     val zrcClientService = mockk<ZrcClientService>()
     val opschortenZaakHelper = mockk<OpschortenZaakHelper>()
-    val restInformatieobjectConverter = mockk<RESTInformatieobjectConverter>()
+    val restInformatieobjectConverter = mockk<RestInformatieobjectConverter>()
     val signaleringService = mockk<SignaleringService>()
     val taakHistorieConverter = mockk<RestTaskHistoryConverter>()
     val zgwApiService = mockk<ZGWApiService>()

--- a/src/test/kotlin/net/atos/zac/app/task/model/TaskRestFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/task/model/TaskRestFixtures.kt
@@ -6,8 +6,8 @@
 package net.atos.zac.app.task.model
 
 import net.atos.zac.app.identity.model.RestUser
-import net.atos.zac.app.informatieobjecten.model.RESTInformatieobjecttype
-import net.atos.zac.app.informatieobjecten.model.createRESTInformatieobjecttype
+import net.atos.zac.app.informatieobjecten.model.RestInformatieobjecttype
+import net.atos.zac.app.informatieobjecten.model.createRestInformatieobjecttype
 import net.atos.zac.app.zaak.model.createRestUser
 import java.util.UUID
 
@@ -28,7 +28,7 @@ fun createRestTask(
 fun createRestTaskDocumentData(
     bestandsnaam: String = "dummyBestandsNaam",
     documentTitel: String = "dummyDocumentTitel",
-    documentType: RESTInformatieobjecttype = createRESTInformatieobjecttype()
+    documentType: RestInformatieobjecttype = createRestInformatieobjecttype()
 ) = RestTaskDocumentData(
     bestandsnaam = bestandsnaam,
     documentTitel = documentTitel,

--- a/src/test/kotlin/net/atos/zac/app/zaak/converter/RestBesluitConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/converter/RestBesluitConverterTest.kt
@@ -10,14 +10,14 @@ import net.atos.client.zgw.drc.DrcClientService
 import net.atos.client.zgw.zrc.model.createZaak
 import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.client.zgw.ztc.model.createBesluitType
-import net.atos.zac.app.informatieobjecten.converter.RESTInformatieobjectConverter
+import net.atos.zac.app.informatieobjecten.converter.RestInformatieobjectConverter
 import net.atos.zac.app.zaak.model.createRESTBesluitVastleggenGegevens
 import java.time.LocalDate
 
 class RestBesluitConverterTest : BehaviorSpec({
     val brcClientService = mockk<BrcClientService>()
     val drcClientService = mockk<DrcClientService>()
-    val restInformatieobjectConverter = mockk<RESTInformatieobjectConverter>()
+    val restInformatieobjectConverter = mockk<RestInformatieobjectConverter>()
     val ztcClientService = mockk<ZtcClientService>()
     val restBesluitConverter = RestBesluitConverter(
         brcClientService,


### PR DESCRIPTION
Fix failing vertrouwelijkheidsaanduiding translation due to incorrect enum conversion in getting current version of enkelvoudiginformatieobjecttype. Added tests.

Solves PZ-3768