### PR TITLE
chore: add missing default constructors for Polygon and GeometryCollection Java classes 

### DIFF
--- a/src/main/java/net/atos/client/zgw/zrc/model/GeometryCollection.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/GeometryCollection.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/GeometryCollection.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/GeometryCollection.java
@@ -10,12 +10,14 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
-/**
- *
- */
+
 public class GeometryCollection extends Geometry {
 
-    private final List<Geometry> geometries;
+    private List<Geometry> geometries;
+
+    public GeometryCollection() {
+        super(GeometryType.GEOMETRYCOLLECTION);
+    }
 
     public GeometryCollection(final List<Geometry> geometries) {
         super(GeometryType.GEOMETRYCOLLECTION);

--- a/src/main/java/net/atos/client/zgw/zrc/model/Point.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Point.java
@@ -9,11 +9,8 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
-/**
- *
- */
-public class Point extends Geometry {
 
+public class Point extends Geometry {
     private Point2D coordinates;
 
     public Point() {

--- a/src/main/java/net/atos/client/zgw/zrc/model/Point2D.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Point2D.java
@@ -15,14 +15,10 @@ import jakarta.json.bind.annotation.JsonbTypeAdapter;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
-/**
- *
- */
+
 @JsonbTypeAdapter(Point2D.Adapter.class)
 public class Point2D {
-
     private final BigDecimal longitude;
-
     private final BigDecimal latitude;
 
     public Point2D(final BigDecimal latitude, final BigDecimal longitude) {

--- a/src/main/java/net/atos/client/zgw/zrc/model/Polygon.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Polygon.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/Polygon.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Polygon.java
@@ -12,8 +12,11 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 
 
 public class Polygon extends Geometry {
+    private List<List<Point2D>> coordinates;
 
-    private final List<List<Point2D>> coordinates;
+    public Polygon() {
+        super(GeometryType.POLYGON);
+    }
 
     public Polygon(final List<List<Point2D>> coordinates) {
         super(GeometryType.POLYGON);

--- a/src/main/java/net/atos/client/zgw/zrc/util/GeometryJsonbDeserializer.java
+++ b/src/main/java/net/atos/client/zgw/zrc/util/GeometryJsonbDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 


### PR DESCRIPTION
Added missing default constructors for Polygon and GeometryCollection Java classes so that the deserialization proces at least can instantiate these classes and gives a better exception message. This avoids the 'could not find default constructor' errors and now gives an error that shows what is really going wrong.

Solves PZ-3823