### PR TITLE
fix: create-document endpoint

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ItestConfiguration.kt
@@ -27,7 +27,7 @@ object ItestConfiguration {
 
     /**
      * Temporarily increase the HTTP read timeout to 60 seconds to allow for
-     * the slow 'documentcreation/createdocumentunattended' endpoint to complete on slower computers.
+     * the slow 'document-creation/create-document-attended' endpoint to complete on slower computers.
      * In the long run we should change this endpoint to be asynchronous.
      */
     const val HTTP_READ_TIMEOUT_SECONDS = 60L

--- a/src/main/app/src/app/informatie-objecten/informatie-objecten.service.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-objecten.service.ts
@@ -132,7 +132,7 @@ export class InformatieObjectenService {
   ): Observable<DocumentCreationResponse> {
     return this.http
       .post<DocumentCreationResponse>(
-        `rest/documentcreation/createdocumentattended`,
+        `rest/document-creation/create-document-attended`,
         documentCreationData,
       )
       .pipe(


### PR DESCRIPTION
Adapt to the new create-document endpoint name
Note that we now require template and template group, so it errors.

Solves: PZ-3905