### PR TITLE
fix: use correct data structure for document-creation

### DIFF
--- a/src/main/app/src/app/informatie-objecten/model/document-creation-data.ts
+++ b/src/main/app/src/app/informatie-objecten/model/document-creation-data.ts
@@ -1,11 +1,11 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
 export class DocumentCreationData {
-  public zaakUUID: string;
+  public zaakUuid: string;
   public taskId: string;
-  public informatieobjecttypeUUID: string;
-  public titel: string;
+  public smartDocumentsTemplateGroupId: string;
+  public smartDocumentsTemplateId: string;
 }

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.ts
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.ts
@@ -286,8 +286,17 @@ export class TaakViewComponent
 
   private createDocumentAttended(): void {
     const documentCreationData = new DocumentCreationData();
-    documentCreationData.zaakUUID = this.taak.zaakUuid;
+    documentCreationData.zaakUuid = this.taak.zaakUuid;
     documentCreationData.taskId = this.taak.id;
+    // We use hardcoded template and template group here to allow e2e tests to pass
+    // The below two should be changed with the correct IDs mapped to the zaak type
+    //
+    // group   : Melding evenement organiseren behandelen
+    // template: Data Test
+    documentCreationData.smartDocumentsTemplateGroupId =
+      "DA3A76D24DFD48C9837B03E47BC701FB";
+    documentCreationData.smartDocumentsTemplateId =
+      "7B7857BB9959470C82974037304E433D";
     this.informatieObjectenService
       .createDocumentAttended(documentCreationData)
       .subscribe((documentCreatieResponse) => {

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -725,7 +725,16 @@ export class ZaakViewComponent
 
   private maakDocument(): void {
     const documentCreatieGegeven = new DocumentCreationData();
-    documentCreatieGegeven.zaakUUID = this.zaak.uuid;
+    documentCreatieGegeven.zaakUuid = this.zaak.uuid;
+    // We use hardcoded template and template group here to allow e2e tests to pass
+    // The below two should be changed with the correct IDs mapped to the zaak type
+    //
+    // group   : Melding evenement organiseren behandelen
+    // template: Data Test
+    documentCreatieGegeven.smartDocumentsTemplateGroupId =
+      "DA3A76D24DFD48C9837B03E47BC701FB";
+    documentCreatieGegeven.smartDocumentsTemplateId =
+      "7B7857BB9959470C82974037304E433D";
     this.informatieObjectenService
       .createDocumentAttended(documentCreatieGegeven)
       .subscribe((documentCreatieResponse) => {


### PR DESCRIPTION
Hardcoded template and template group for Create Document flow
This would be changed once we have a dedicated dialog to override some settings

Solves: PZ-3905