### PR TITLE
fix: information object edit - enable submit button on file select

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
@@ -102,11 +102,13 @@ export class InformatieObjectEditComponent implements OnInit, OnDestroy {
       .id("titel")
       .label("titel")
       .validators(Validators.required)
+      .maxlength(100)
       .build();
 
     const beschrijving = new InputFormFieldBuilder(this.infoObject.beschrijving)
       .id("beschrijving")
       .label("beschrijving")
+      .maxlength(100)
       .build();
 
     const taal = new SelectFormFieldBuilder(this.infoObject.taal)
@@ -196,6 +198,7 @@ export class InformatieObjectEditComponent implements OnInit, OnDestroy {
     this.subscriptions$.push(
       inhoudField.formControl.valueChanges.subscribe((file: File) => {
         titel.formControl.setValue(file?.name?.replace(/\.[^/.]+$/, "") || "");
+        titel.formControl.markAsDirty();
       }),
     );
 


### PR DESCRIPTION
When editing information object, enable submit button on file select. This is achieved by making the title form field dirty.

As well both Title and Description fields now align with create form to have max length of 100.

Solves: PZ-3782