### PR TITLE
chore: fix issues with docker compose update GitHub workflow

### DIFF
--- a/.github/workflows/update-docker-compose.yml
+++ b/.github/workflows/update-docker-compose.yml
@@ -34,6 +34,6 @@ jobs:
       - name: simple-compose-service-updates
         uses: sbe-arg/simple-compose-service-updates@v1.1.0
         with:
-          skips: 'ghcr.io/infonl/zaakafhandelcomponent'
+          skips: 'infonl/zaakafhandelcomponent'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-docker-compose.yml
+++ b/.github/workflows/update-docker-compose.yml
@@ -18,14 +18,22 @@ permissions:
   contents: read
 
 jobs:
-  flow:
+  update-docker-compose:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
+      - name: setup-git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"  
+
       - name: simple-compose-service-updates
         uses: sbe-arg/simple-compose-service-updates@v1.1.0
+        with:
+          skips: 'ghcr.io/infonl/zaakafhandelcomponent'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-docker-compose.yml
+++ b/.github/workflows/update-docker-compose.yml
@@ -34,6 +34,8 @@ jobs:
       - name: simple-compose-service-updates
         uses: sbe-arg/simple-compose-service-updates@v1.1.0
         with:
-          skips: 'infonl/zaakafhandelcomponent'
+          # Need to check updates for eugenmayer/kontextwork-converter manually because
+          # simple-compose-service-updates thinks that e.g. version 'v0.3.2' is newer than '1.6.1'
+          skips: 'infonl/zaakafhandelcomponent,eugenmayer/kontextwork-converter'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-docker-compose.yml
+++ b/.github/workflows/update-docker-compose.yml
@@ -4,10 +4,10 @@
 #
 name: Update Docker images in our Docker Compose file
 
-# This workflow uses the Update Gradle Wrapper action to create a Pull Request if there is a new Gradle Wrapper version available.
-# Do note that this PR does _not_ automatically trigger any other workflows.
-# As a workaround to trigger our normal PR workflows you can manually close and then immediately reopen the PR. See:
-# https://github.com/gradle-update/update-gradle-wrapper-action#running-ci-workflows-in-pull-requests-created-by-the-action
+# This workflow creates Pull Requests to update Docker images found in our Docker Compose file if there are newer
+# versions found using https://github.com/sbe-arg/simple-compose-service-updates.
+# It is hopefully a temporary workaround until Dependabot supports updating Docker Compose files.
+# See: https://github.com/dependabot/dependabot-core/issues/390
 
 on:
   workflow_dispatch:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,6 @@ services:
       - DB_VENDOR=postgres
       - DB_ADDR=keycloak-database
       - DB_USER=keycloak
-      - DB_USER=keycloak
       - DB_NAME=keycloak
       - DB_PASSWORD=keycloak
       - LDAP_URL=ldap://openldap:1389

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
       - DB_VENDOR=postgres
       - DB_ADDR=keycloak-database
       - DB_USER=keycloak
+      - DB_USER=keycloak
       - DB_NAME=keycloak
       - DB_PASSWORD=keycloak
       - LDAP_URL=ldap://openldap:1389
@@ -35,7 +36,7 @@ services:
       - "--health-enabled=true"
 
   keycloak-database:
-    image: postgres:16.3
+    image: docker.io/postgres:16.3
     ports:
       - "54326:5432"
     healthcheck:
@@ -52,7 +53,7 @@ services:
       - ./scripts/docker-compose/volume-data/zac-keycloak-database-data:/var/lib/postgresql/data
 
   zac-database:
-    image: postgres:16.3
+    image: docker.io/postgres:16.3
     ports:
       - "54320:5432"
     healthcheck:
@@ -70,7 +71,7 @@ services:
       - ./scripts/docker-compose/volume-data/zac-database-data:/var/lib/postgresql/data
 
   openzaak-database:
-    image: postgis/postgis:16-3.4
+    image: docker.io/postgis/postgis:16-3.4
     ports:
       - "54322:5432"
     platform: linux/amd64
@@ -93,7 +94,7 @@ services:
   # This container name must contain a '.' or else Open Zaak will respond with a 400
   # error on certain API requests caused by an internal 'invalid URL' error.
   openzaak.local:
-    image: openzaak/open-zaak:1.13.0
+    image: docker.io/openzaak/open-zaak:1.13.0
     platform: linux/amd64
     environment:
       - ALLOWED_HOSTS=localhost,host.docker.internal,openzaak.local
@@ -131,7 +132,7 @@ services:
   # This container name must contain a '.' or else Open Zaak will respond with a 400
   # error on certain API requests caused by an internal 'invalid URL' error.
   objecten-api.local:
-    image: maykinmedia/objects-api:2.3.2
+    image: docker.io/maykinmedia/objects-api:2.3.2
     platform: linux/amd64
     ports:
       - "8010:8000"
@@ -156,7 +157,7 @@ services:
         condition: service_healthy
 
   objecten-api-database:
-    image: postgis/postgis:16-3.4
+    image: docker.io/postgis/postgis:16-3.4
     ports:
       - "54323:5432"
     platform: linux/amd64
@@ -172,7 +173,7 @@ services:
       - POSTGRES_DB=objects
 
   objecten-api-import:
-    image: maykinmedia/objects-api:2.3.2
+    image: docker.io/maykinmedia/objects-api:2.3.2
     platform: linux/amd64
     environment: *objects-env
     # in the current version of django it is not possible to create a new user with password without user interaction by using the createsuperuser command
@@ -185,7 +186,7 @@ services:
         condition: service_healthy
 
   objecttypen-api:
-    image: maykinmedia/objecttypes-api:2.1.3
+    image: docker.io/maykinmedia/objecttypes-api:2.1.3
     platform: linux/amd64
     ports:
       - "8011:8000"
@@ -202,7 +203,7 @@ services:
         condition: service_healthy
 
   objecttypen-api-database:
-    image: postgres:16.3
+    image: docker.io/postgres:16.3
     ports:
       - "54324:5432"
     healthcheck:
@@ -217,7 +218,7 @@ services:
       - POSTGRES_DB=objecttypes
 
   objecttypen-api-import:
-    image: maykinmedia/objecttypes-api:2.1.3
+    image: docker.io/maykinmedia/objecttypes-api:2.1.3
     platform: linux/amd64
     environment: *objecttypes-env
     command: sh init/init.sh
@@ -228,7 +229,7 @@ services:
       - objecttypen-api
 
   solr:
-    image: solr:9.6.1-slim
+    image: docker.io/solr:9.6.1-slim
     platform: linux/amd64
     ports:
       - "8983:8983"
@@ -244,13 +245,13 @@ services:
   # Open Policy Agent (OPA)
   opa:
     # Keep this OPA binary version in sync with the one used in the ZAC Helm chart (values.yaml file)
-    image: openpolicyagent/opa:0.69.0-static
+    image: docker.io/openpolicyagent/opa:0.69.0-static
     command: run --server --log-level debug
     ports:
       - "8181:8181"
 
   openldap:
-    image: bitnami/openldap:2.6.8
+    image: docker.io/bitnami/openldap:2.6.8
     ports:
       - "1389:1389"
       - "1636:1636"
@@ -277,7 +278,7 @@ services:
 
   # The GBA mock is required by the BRP proxy
   gbamock:
-    image: ghcr.io/brp-api/haal-centraal-brp-bevragen-gba-mock:2.0.8
+    image: docker.io/ghcr.io/brp-api/haal-centraal-brp-bevragen-gba-mock:2.0.8
     platform: linux/amd64
     environment:
       - ASPNETCORE_ENVIRONMENT=Release
@@ -291,7 +292,7 @@ services:
       - "5010:5010"
 
   brpproxy:
-    image: ghcr.io/brp-api/haal-centraal-brp-bevragen-proxy:2.1.2
+    image: docker.io/ghcr.io/brp-api/haal-centraal-brp-bevragen-proxy:2.1.2
     platform: linux/amd64
     environment:
       - ASPNETCORE_ENVIRONMENT=Release
@@ -307,7 +308,7 @@ services:
       - gbamock
 
   openklant-database:
-    image: postgres:16.3
+    image: docker.io/postgres:16.3
     ports:
       - "54325:5432"
     healthcheck:
@@ -349,7 +350,7 @@ services:
         condition: service_started
 
   smartdocuments-wiremock:
-    image: wiremock/wiremock:3.8.0-1
+    image: docker.io/wiremock/wiremock:3.8.0-1
     volumes:
       # these WireMock mappings are used by the ZAC integration tests
       - ./scripts/docker-compose/imports/smartdocuments-wiremock/mappings:/home/wiremock/mappings
@@ -360,7 +361,7 @@ services:
     profiles: [ "itest" ]
 
   kvk-wiremock:
-    image: wiremock/wiremock:3.8.0-1
+    image: docker.io/wiremock/wiremock:3.8.0-1
     volumes:
       # these WireMock mappings are used by the ZAC integration tests
       - ./scripts/docker-compose/imports/kvk-wiremock/mappings:/home/wiremock/mappings
@@ -372,7 +373,7 @@ services:
 
   opa-tests:
     # Keep this OPA binary version in sync with the one used in the ZAC Helm chart (values.yaml file)
-    image: openpolicyagent/opa:0.69.0
+    image: docker.io/openpolicyagent/opa:0.69.0
     volumes:
       - ./src/test/resources/policies:/home/tests
       - ./src/main/resources/policies:/home/policies
@@ -380,14 +381,14 @@ services:
     profiles: [ "itest" ]
 
   office-converter:
-    image: ghcr.io/eugenmayer/kontextwork-converter:1.5.0
+    image: docker.io/ghcr.io/eugenmayer/kontextwork-converter:1.5.0
     platform: linux/amd64
     ports:
       - "8083:8080"
 
   # Open Telemetry Collector which can receive OTLP observability data sent by ZAC
   otel-collector:
-    image: otel/opentelemetry-collector:0.98.0
+    image: docker.io/otel/opentelemetry-collector:0.98.0
     command: [ --config=/etc/otel-collector.yaml ]
     volumes:
       - ./scripts/docker-compose/imports/otel-collector/otel-collector.yaml:/etc/otel-collector.yaml:Z
@@ -401,7 +402,7 @@ services:
 
   # Observability traces data store
   tempo:
-    image: grafana/tempo:latest
+    image: docker.io/grafana/tempo:latest
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./scripts/docker-compose/imports/tempo/tempo.yaml:/etc/tempo.yaml
@@ -415,7 +416,7 @@ services:
 
   # Observability metrics data store
   prometheus:
-    image: prom/prometheus:latest
+    image: docker.io/prom/prometheus:latest
     command:
       - --config.file=/etc/prometheus.yaml
       - --web.enable-remote-write-receiver
@@ -428,7 +429,7 @@ services:
 
   # Visualizes metrics and traces data
   grafana:
-    image: grafana/grafana:11.0.1
+    image: docker.io/grafana/grafana:11.0.1
     volumes:
       - ./scripts/docker-compose/imports/grafana/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
       - ./scripts/docker-compose/volume-data/grafana-data:/var/lib/grafana
@@ -451,7 +452,7 @@ services:
     profiles: [ "metrics" ]
 
   greenmail:
-    image: greenmail/standalone:2.1.0-rc-1
+    image: docker.io/greenmail/standalone:2.1.0-rc-1
     environment:
       GREENMAIL_OPTS: >-
         -Dgreenmail.smtp.hostname=0.0.0.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -277,7 +277,7 @@ services:
 
   # The GBA mock is required by the BRP proxy
   gbamock:
-    image: docker.io/ghcr.io/brp-api/haal-centraal-brp-bevragen-gba-mock:2.0.8
+    image: ghcr.io/brp-api/haal-centraal-brp-bevragen-gba-mock:2.0.8
     platform: linux/amd64
     environment:
       - ASPNETCORE_ENVIRONMENT=Release
@@ -291,7 +291,7 @@ services:
       - "5010:5010"
 
   brpproxy:
-    image: docker.io/ghcr.io/brp-api/haal-centraal-brp-bevragen-proxy:2.1.2
+    image: ghcr.io/brp-api/haal-centraal-brp-bevragen-proxy:2.1.2
     platform: linux/amd64
     environment:
       - ASPNETCORE_ENVIRONMENT=Release
@@ -380,7 +380,7 @@ services:
     profiles: [ "itest" ]
 
   office-converter:
-    image: docker.io/ghcr.io/eugenmayer/kontextwork-converter:1.5.0
+    image: ghcr.io/eugenmayer/kontextwork-converter:1.5.0
     platform: linux/amd64
     ports:
       - "8083:8080"


### PR DESCRIPTION
Fixed issues with Docker Compose update GitHub workflow. Made all Docker image URLs absolute so that https://github.com/sbe-arg/simple-compose-service-updates can update them. Ignored https://github.com/eugenmayer/officeconverter because that has 'vX.X.X' versions which are deemed newer while they are not.

Solves PZ-4193