### PR TITLE
chore: use a separate GitHub Workflow to download the Trivy databases

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -271,6 +271,11 @@ jobs:
           # or else all vulnerabilities will be reported
           limit-severities-for-sarif: true
           severity: 'CRITICAL,HIGH'
+        env:
+          # skip downloading the Trivy databases since we update the Trivy cache regularly
+          # in another workflow
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023-2024 Lifely
+# SPDX-FileCopyrightText: 2023 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Playwright Tests

--- a/.github/workflows/snyk-code-scan.yml
+++ b/.github/workflows/snyk-code-scan.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 INFO.nl
+# SPDX-FileCopyrightText: 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Snyk Security code scanner

--- a/.github/workflows/snyk-code-scan.yml
+++ b/.github/workflows/snyk-code-scan.yml
@@ -12,6 +12,7 @@ on:
   merge_group:
   schedule:
     - cron: "21 11 * * 0"
+  workflow_dispatch:
 
 permissions:
   # Required for uploading SARIF reports

--- a/.github/workflows/trivy-docker-image-scan.yml
+++ b/.github/workflows/trivy-docker-image-scan.yml
@@ -1,8 +1,12 @@
-name: Scheduled docker container scan
+#
+# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-License-Identifier: EUPL-1.2+
+#
+name: Scheduled Trivy Docker image scan
 
 on:
   schedule:
-    - cron: "0 21 * * 1-5"
+    - cron: "0 22 * * 1-5"
   workflow_dispatch:
 
 env:
@@ -13,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    name: Run docker scan
+    name: Run Trivy Docker image scan
     runs-on: ubuntu-22.04
     steps:
       - name: Pull Docker Image
@@ -29,6 +33,11 @@ jobs:
           # or else all vulnerabilities will be reported
           limit-severities-for-sarif: true
           severity: 'CRITICAL,HIGH'
+        env:
+          # skip downloading the Trivy databases since we update the Trivy cache regularly
+          # in another workflow
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: Upload Trivy Scan Results to GitHub Security Tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/update-trivy-scanner-cache.yml
+++ b/.github/workflows/update-trivy-scanner-cache.yml
@@ -1,0 +1,40 @@
+#
+# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-License-Identifier: EUPL-1.2+
+#
+# Note: This workflow only downloads the Trivy scanner databases and adds them to the cache.
+# See: https://github.com/aquasecurity/trivy-action for details.
+name: Update Trivy Scanner Cache
+
+on:
+  schedule:
+    - cron: "0 21 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  update-trivy-db:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Download and extract the Trivy vulnerability DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
+          oras pull ghcr.io/aquasecurity/trivy-db:2
+          tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+          rm db.tar.gz
+
+      - name: Download and extract the Trivy Java DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
+          oras pull ghcr.io/aquasecurity/trivy-java-db:1
+          tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+          rm javadb.tar.gz
+
+      - name: Cache Trivy DBs
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ steps.date.outputs.date }}


### PR DESCRIPTION
Use a separate GitHub Workflow to download the Trivy databases and add them to the cache. As advised in: https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#cache

Solves PZ-4192