### PR TITLE
docker-compose: bump grafana/grafana:11.2.2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -428,7 +428,7 @@ services:
 
   # Visualizes metrics and traces data
   grafana:
-    image: docker.io/grafana/grafana:11.0.1
+    image: docker.io/grafana/grafana:11.2.2
     volumes:
       - ./scripts/docker-compose/imports/grafana/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
       - ./scripts/docker-compose/volume-data/grafana-data:/var/lib/grafana


### PR DESCRIPTION
Bump Grafana to 11.2.2 in Docker Compose

Automated PR created by GitHub Actions
