### PR TITLE
docker-compose: bump openzaak/open-zaak:1.15.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
   # This container name must contain a '.' or else Open Zaak will respond with a 400
   # error on certain API requests caused by an internal 'invalid URL' error.
   openzaak.local:
-    image: docker.io/openzaak/open-zaak:1.13.0
+    image: docker.io/openzaak/open-zaak:1.15.0
     platform: linux/amd64
     environment:
       - ALLOWED_HOSTS=localhost,host.docker.internal,openzaak.local


### PR DESCRIPTION
Bump open-zaak to 1.15.0 in Docker Compose

Automated PR updated by GitHub Actions