### PR TITLE
chore: added Renovate config with only the docker-compose manager enabled

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "enabledManagers": ["docker-compose"]
+}


### PR DESCRIPTION
Added Renovate config with only the docker-compose manager enabled so that we can use the GitHub Renovate App to upgrade dependencies in our Docker Compose file.

Solves PZ-4241