### PR TITLE
feature: mark ZAP as lazy

### DIFF
--- a/src/main/kotlin/net/atos/zac/smartdocuments/SmartDocumentsTemplatesService.kt
+++ b/src/main/kotlin/net/atos/zac/smartdocuments/SmartDocumentsTemplatesService.kt
@@ -119,7 +119,7 @@ class SmartDocumentsTemplatesService @Inject constructor(
                                 builder.and(
                                     builder.equal(
                                         root.get<ZaakafhandelParameters>(
-                                            SmartDocumentsTemplate::zaakafhandelParameters.name
+                                            SmartDocumentsTemplateGroup::zaakafhandelParameters.name
                                         )
                                             .get<Long>("id"),
                                         getZaakafhandelParametersId(zaakafhandelParametersUUID)

--- a/src/main/kotlin/net/atos/zac/smartdocuments/templates/model/SmartDocumentsTemplate.kt
+++ b/src/main/kotlin/net/atos/zac/smartdocuments/templates/model/SmartDocumentsTemplate.kt
@@ -7,6 +7,7 @@ package net.atos.zac.smartdocuments.templates.model
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -48,7 +49,7 @@ class SmartDocumentsTemplate {
     @JoinColumn(name = "sjabloon_groep_id", nullable = false)
     lateinit var templateGroup: SmartDocumentsTemplateGroup
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "zaakafhandelparameters_id", nullable = false)
     lateinit var zaakafhandelParameters: ZaakafhandelParameters
 

--- a/src/main/kotlin/net/atos/zac/smartdocuments/templates/model/SmartDocumentsTemplateGroup.kt
+++ b/src/main/kotlin/net/atos/zac/smartdocuments/templates/model/SmartDocumentsTemplateGroup.kt
@@ -56,7 +56,7 @@ class SmartDocumentsTemplateGroup {
     @OneToMany(mappedBy = "templateGroup", fetch = FetchType.EAGER, cascade = [CascadeType.ALL])
     var templates: MutableSet<SmartDocumentsTemplate>? = null
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "zaakafhandelparameters_id", nullable = false)
     lateinit var zaakafhandelParameters: ZaakafhandelParameters
 }


### PR DESCRIPTION
Do not load ZAP when fetching SD template mappings. Reduces SQL queries twice (from 11 to  5)

Solves: PZ-4189