### PR TITLE
chore: changed schedule of Trivy update cache and scanner GitHub workflows

### DIFF
--- a/.github/workflows/trivy-docker-image-scan.yml
+++ b/.github/workflows/trivy-docker-image-scan.yml
@@ -6,7 +6,7 @@ name: Scheduled Trivy Docker image scan
 
 on:
   schedule:
-    - cron: "0 22 * * 1-5"
+    - cron: "0 3 * * 1-5"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/update-trivy-scanner-cache.yml
+++ b/.github/workflows/update-trivy-scanner-cache.yml
@@ -8,7 +8,7 @@ name: Update Trivy Scanner Cache
 
 on:
   schedule:
-    - cron: "0 21 * * 1-5"
+    - cron: "0 2 * * 1-5"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Changed schedule of Trivy update cache and scanner from evening to morning because other stuff is already running in the evening and because we want Trivy to run on Monday morning before the working week starts.

Solves PZ-4252