### PR TITLE
fix: disabled Snyk scan in build pipeline since it is broken at the moment

### DIFF
--- a/.github/workflows/snyk-code-scan.yml
+++ b/.github/workflows/snyk-code-scan.yml
@@ -5,11 +5,6 @@
 name: Snyk Security code scanner
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  merge_group:
   schedule:
     - cron: "21 11 * * 0"
   workflow_dispatch:


### PR DESCRIPTION
Disabled Snyk scan in build pipeline since it is broken at the moment but kept the nightly cron job. Maybe we don't even want to have this as part of the build pipeline.

Solves PZ-4271