### PR TITLE
fix: specify INFO.nl organisation in Snyk GitHub workflow

### DIFF
--- a/.github/workflows/snyk-code-scan.yml
+++ b/.github/workflows/snyk-code-scan.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org INFO.nl --severity-threshold=high --sarif-file-output=snyk-gradle.sarif
+          args: --org info.nl --severity-threshold=high --sarif-file-output=snyk-gradle.sarif
 
       - name: Upload Snyk Gradle result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/snyk-code-scan.yml
+++ b/.github/workflows/snyk-code-scan.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --severity-threshold=high --sarif-file-output=snyk-gradle.sarif
+          args: --org INFO.nl --severity-threshold=high --sarif-file-output=snyk-gradle.sarif
 
       - name: Upload Snyk Gradle result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/snyk-code-scan.yml
+++ b/.github/workflows/snyk-code-scan.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org info.nl --severity-threshold=high --sarif-file-output=snyk-gradle.sarif
+          args: --org edgarvonk-kow --severity-threshold=high --sarif-file-output=snyk-gradle.sarif
 
       - name: Upload Snyk Gradle result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Specify INFO.nl organisation in Snyk GitHub workflow because the Snyk scan now fails with 'You are not associated with any org.'

Solves PZ-4306