### PR TITLE
feat: limit proposed version updates in renovate. 

### DIFF
--- a/docs/development/updatingDependencies.md
+++ b/docs/development/updatingDependencies.md
@@ -7,6 +7,10 @@ This document describes how to update dependencies in ZAC and (OpenAPI) API spec
 This is normally done by GitHub Dependabot using the Dependabot workflows in the project.
 This includes updating of backend (Java), frontend (TypeScript) as well as GitHub Action and Docker dependencies.
 
+## Updating docker-compose images
+
+This is done by Renovate and its configuration file renovate.json. The version restrictions are following PodiumD 2.0 development. 
+
 ## Updating (OpenAPI) API specifications used by ZAC
 
 ZAC integrates with various components and external services using APIs.

--- a/docs/development/updatingDependencies.md
+++ b/docs/development/updatingDependencies.md
@@ -11,6 +11,13 @@ This includes updating of backend (Java), frontend (TypeScript) as well as GitHu
 
 This is done by Renovate and its configuration file renovate.json. The version restrictions are following PodiumD 2.0 development. 
 
+### Renovate configuration
+
+The configuration inherits from base settings provided by Renovate, which lay the groundwork for handling updates in a standardized manner. It includes logic to handle major version updates separately and automerges certain updates to reduce manual interventions.
+
+* Pinning Docker Digests: This strategy involves locking Docker images to specific digests. Pinned digests help eliminate the risk of unexpected updates that could introduce breaking changes or vulnerabilities, as you always use a known working image version.
+* Scheduled Digest Updates: Even with pinned digests, it's important to periodically update them to include the latest security patches and features. Therefore, Renovate is configured to check for and apply digest updates weekly during the first week of each month's weekends. These digest updates are configured to be automerged. 
+
 ## Updating (OpenAPI) API specifications used by ZAC
 
 ZAC integrates with various components and external services using APIs.

--- a/renovate.json
+++ b/renovate.json
@@ -28,4 +28,5 @@
       "matchDatasources": ["docker"],
       "allowedVersions": "< 17.0.0"
     }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -19,14 +19,29 @@
       "schedule": ["every weekend on the 1st through 7th day of the month"]
     },
     {
-      "matchPackageNames": ["postgres"],
+      "matchPackageNames": ["quay.io/keycloak/keycloak"],
       "matchDatasources": ["docker"],
-      "allowedVersions": "< 17.0.0"
+      "allowedVersions": "<= 24.0.5"
     },
     {
-      "matchPackageNames": ["postgis/postgis"],
+      "matchPackageNames": ["maykinmedia/objects-api"],
       "matchDatasources": ["docker"],
-      "allowedVersions": "< 17.0.0"
+      "allowedVersions": "<= 2.4.4"
+    },
+    {
+      "matchPackageNames": ["maykinmedia/objecttypes-api"],
+      "matchDatasources": ["docker"],
+      "allowedVersions": "<= 2.2.2"
+    },
+    {
+      "matchPackageNames": ["maykinmedia/open-klant"],
+      "matchDatasources": ["docker"],
+      "allowedVersions": "<= 2.3.0"
+    },
+    {
+      "matchPackageNames": ["openzaak/open-zaak"],
+      "matchDatasources": ["docker"],
+      "allowedVersions": "<= 1.15.0"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:base",
     ":separateMultipleMajorReleases",
+    ":automergeDigest",
     "docker:pinDigests",
     "docker:enableMajor"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,30 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "enabledManagers": ["docker-compose","maven-wrapper","gradle-wrapper"]
+  "extends": [
+    "config:base",
+    ":separateMultipleMajorReleases",
+    "docker:pinDigests",
+    "docker:enableMajor"
+  ],
+  "enabledManagers": [
+    "docker-compose",
+    "maven-wrapper",
+    "gradle-wrapper"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["digest"],
+      "schedule": ["every weekend on the 1st through 7th day of the month"]
+    },
+    {
+      "matchPackageNames": ["postgres"],
+      "matchDatasources": ["docker"],
+      "allowedVersions": "< 17.0.0"
+    },
+    {
+      "matchPackageNames": ["postgis/postgis"],
+      "matchDatasources": ["docker"],
+      "allowedVersions": "< 17.0.0"
+    }
 }


### PR DESCRIPTION
Added renovate configuration that will:
- create pin docker digests
- add a schedule to update the digests once a month (to refresh images with unchanged tags)
- Added package rule for postgres with a upper version limit

closes PZ-4315