### PR TITLE
feat: FE align body styles to Figma design pattern settings

### DIFF
--- a/src/main/app/src/static/smart-documents-result.html
+++ b/src/main/app/src/static/smart-documents-result.html
@@ -54,16 +54,17 @@
         font-family: Roboto;
         font-style: normal;
         font-weight: 400 500;
+        font-display: swap;
         src:
           url("/assets/fonts/Roboto/400.woff2") format("woff2"),
           url("/assets/fonts/Roboto/500.woff2") format("woff2");
       }
 
       body {
-        font-family: "Roboto", sans-serif;
-        font-size: 16px;
+        font-family: Roboto, "Helvetica Neue", sans-serif;
+        font-size: 14px;
         font-weight: 400;
-        line-height: 28px;
+        line-height: 20px;
         color: var(--primary-color);
       }
 
@@ -131,8 +132,6 @@
         justify-content: center;
         align-items: center;
         gap: 10px;
-        font-size: 14px;
-        line-height: 20px;
         padding: 14px 16px;
         margin-bottom: 10px;
         border-radius: 4px;
@@ -170,6 +169,8 @@
       }
 
       .sub-text {
+        font-size: 16px;
+        line-height: 28px;
         text-align: center;
       }
     </style>

--- a/src/main/app/src/styles.less
+++ b/src/main/app/src/styles.less
@@ -22,6 +22,7 @@ body {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: url(/assets/fonts/Roboto/300.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
@@ -32,6 +33,7 @@ body {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url(/assets/fonts/Roboto/400.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
@@ -42,6 +44,7 @@ body {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 500;
+  font-display: swap;
   src: url(/assets/fonts/Roboto/500.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
@@ -66,8 +69,10 @@ body {
   --mdc-radio-state-layer-size: 24px;
   --mdc-typography-button-letter-spacing: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: normal;
   overscroll-behavior-y: contain;
 }
 


### PR DESCRIPTION
FE: align body styles to current Figma design pattern settings; and apply same styles to the SD wizard result page. The font-display swap is adviced for a fast and smooth transition after the Roboto is loaded. Will most probably be just the very first time the Behandelaar visits the app, since cached by the browser (if not already).

Solves: PZ-4348