### PR TITLE
Chore: add schemacrawler erd generation

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -233,6 +233,8 @@ jobs:
           ./gradlew -PzacDockerImage=${ZAC_DOCKER_IMAGE} \
             -x compileJava -x processResources -x compileKotlin -x classes -x buildDockerImage \
             itest --info
+        env:
+          CREATE_ERD_DIAGRAM_IN_ITEST: true
 
       - name: Publish integration test results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.gradle.node.npm.task.NpmTask
+import io.gitlab.arturbosch.detekt.Detekt
 import io.smallrye.openapi.api.OpenApiConfig
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 import java.util.Locale
@@ -81,6 +82,11 @@ val zacDockerImage by extra {
         "ghcr.io/infonl/zaakafhandelcomponent:dev"
     }
 }
+
+val srcGenerated = layout.projectDirectory.dir("src/generated")
+val srcMainResources = layout.projectDirectory.dir("src/main/resources")
+val srcMainApp = layout.projectDirectory.dir("src/main/app")
+val srcE2e = layout.projectDirectory.dir("src/e2e")
 
 sourceSets {
     // create custom integration test source set
@@ -205,26 +211,26 @@ jacoco {
 java {
     // add our generated client code to the main source set
     sourceSets["main"].java
-        .srcDir("$rootDir/src/generated/productaanvraag/java")
-        .srcDir("$rootDir/src/generated/kvk/zoeken/java")
-        .srcDir("$rootDir/src/generated/kvk/basisprofiel/java")
-        .srcDir("$rootDir/src/generated/kvk/vestigingsprofiel/java")
-        .srcDir("$rootDir/src/generated/brp/java")
-        .srcDir("$rootDir/src/generated/bag/java")
-        .srcDir("$rootDir/src/generated/klanten/java")
-        .srcDir("$rootDir/src/generated/zgw/brc/java")
-        .srcDir("$rootDir/src/generated/zgw/drc/java")
-        .srcDir("$rootDir/src/generated/zgw/zrc/java")
-        .srcDir("$rootDir/src/generated/zgw/ztc/java")
-        .srcDir("$rootDir/src/generated/or/objects/java")
-        .srcDir("$rootDir/src/generated/or/objecttypes/java")
+        .srcDir(srcGenerated.dir("productaanvraag/java"))
+        .srcDir(srcGenerated.dir("kvk/zoeken/java"))
+        .srcDir(srcGenerated.dir("kvk/basisprofiel/java"))
+        .srcDir(srcGenerated.dir("kvk/vestigingsprofiel/java"))
+        .srcDir(srcGenerated.dir("brp/java"))
+        .srcDir(srcGenerated.dir("bag/java"))
+        .srcDir(srcGenerated.dir("klanten/java"))
+        .srcDir(srcGenerated.dir("zgw/brc/java"))
+        .srcDir(srcGenerated.dir("zgw/drc/java"))
+        .srcDir(srcGenerated.dir("zgw/zrc/java"))
+        .srcDir(srcGenerated.dir("zgw/ztc/java"))
+        .srcDir(srcGenerated.dir("or/objects/java"))
+        .srcDir(srcGenerated.dir("or/objecttypes/java"))
 }
 
 jsonSchema2Pojo {
     // generates Java model files for the "productaanvraag" JSON schema(s)
-    setSource(files("$rootDir/src/main/resources/json-schemas/productaanvraag"))
+    setSource(srcMainResources.dir("json-schemas/productaanvraag").asFileTree)
     setSourceType("jsonschema")
-    targetDirectory = file("$rootDir/src/generated/productaanvraag/java")
+    targetDirectory = srcGenerated.dir("productaanvraag/java").asFile
     targetPackage = "net.atos.zac.productaanvraag.model.generated"
     setAnnotationStyle("JSONB2")
     dateType = "java.time.LocalDate"
@@ -247,7 +253,7 @@ node {
     download.set(true)
     version.set(libs.versions.nodejs.get())
     distBaseUrl.set("https://nodejs.org/dist")
-    nodeProjectDir.set(file("$rootDir/src/main/app"))
+    nodeProjectDir.set(srcMainApp.asFile)
     if (System.getenv("CI") != null) {
         npmInstallCommand.set("ci")
     } else {
@@ -371,15 +377,15 @@ tasks {
     clean {
         dependsOn("mavenClean")
 
-        delete("$rootDir/src/main/app/dist")
-        delete("$rootDir/src/main/app/reports")
-        delete("$rootDir/src/main/app/coverage")
-        delete("$rootDir/src/generated")
-        delete("$rootDir/src/e2e/reports")
+        delete(srcMainApp.dir("dist"))
+        delete(srcMainApp.dir("reports"))
+        delete(srcMainApp.dir("src/generated"))
+        delete(srcMainApp.dir("coverage"))
+        delete(srcGenerated)
+        delete(srcE2e.dir("reports"))
     }
 
     build {
-
         dependsOn("generateWildflyBootableJar")
     }
 
@@ -410,12 +416,12 @@ tasks {
         exclude("wildfly/**")
     }
 
-    register<io.gitlab.arturbosch.detekt.Detekt>("detektApply") {
+    register<Detekt>("detektApply") {
         description = "Apply detekt fixes."
         autoCorrect = true
         ignoreFailures = true
     }
-    withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+    withType<Detekt>().configureEach {
         config.setFrom("$rootDir/config/detekt.yml")
         setSource(files("src/main/kotlin", "src/test/kotlin", "src/itest/kotlin", "build.gradle.kts"))
         // our Detekt configuration build builds upon the default configuration
@@ -669,7 +675,7 @@ tasks {
         rename {
             "org.jacoco.agent-runtime.jar"
         }
-        into("$rootDir/build/jacoco/itest/jacoco-agent")
+        into(layout.buildDirectory.dir("jacoco/itest/jacoco-agent"))
     }
 
     register<Test>("itest") {
@@ -686,8 +692,9 @@ tasks {
         dependsOn("itest")
 
         description = "Generates code coverage report for the integration tests"
-        inputs.files("$rootDir/build/jacoco/itest/jacoco-report/jacoco-it.exec")
-        executionData.setFrom("$rootDir/build/jacoco/itest/jacoco-report/jacoco-it.exec")
+        val resultFile = layout.buildDirectory.file("jacoco/itest/jacoco-report/jacoco-it.exec").orNull
+        inputs.files(resultFile)
+        executionData.setFrom(resultFile)
         // tell JaCoCo to report on our code base
         sourceSets(sourceSets["main"])
         reports {
@@ -696,19 +703,20 @@ tasks {
         }
         // do not use the Gradle build cache for this task
         outputs.cacheIf { false }
-        outputs.dir("$rootDir/build/reports/jacoco/jacocoIntegrationTestReport")
+        outputs.dir(layout.buildDirectory.dir("reports/jacoco/jacocoIntegrationTestReport"))
     }
 
     register<Maven>("generateWildflyBootableJar") {
         dependsOn("war")
         execGoal("wildfly-jar:package")
 
-        inputs.files(fileTree("$rootDir/src/main/resources/wildfly"))
-        inputs.file("$rootDir/build/libs/zaakafhandelcomponent.war")
-        inputs.file("$rootDir/pom.xml")
-        inputs.file("$rootDir/src/main/resources/wildfly/configure-wildfly.cli")
-        inputs.file("$rootDir/src/main/resources/wildfly/deploy-zaakafhandelcomponent.cli")
-        outputs.dir("$rootDir/target")
+        val wildflyResources = srcMainResources.dir("wildfly")
+        inputs.files(wildflyResources.asFileTree)
+        inputs.file(layout.buildDirectory.file("libs/zaakafhandelcomponent.war"))
+        inputs.file(layout.projectDirectory.file("pom.xml"))
+        inputs.file(wildflyResources.file("configure-wildfly.cli"))
+        inputs.file(wildflyResources.file("deploy-zaakafhandelcomponent.cli"))
+        outputs.dir(layout.projectDirectory.dir("target"))
     }
 
     register<Maven>("mavenClean") {
@@ -717,7 +725,7 @@ tasks {
 }
 
 abstract class Maven : Exec() {
-    // Simple function to invoke a maven goal, dependent on the os, with optional
+    // Simple function to invoke a maven goal, dependent on the os, with optional arguments
     fun execGoal(goal: String, vararg args: String) = commandLine(
         if (System.getProperty("os.name").lowercase(Locale.ROOT).contains("windows")) {
             "./mvnw.cmd"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -519,7 +519,36 @@ services:
           # Set a maximum memory limit for the ZAC container for a more realistic
           # scenario when testing ZAC locally or when running our integration tests.
           memory: 4G
+    healthcheck:
+      test: "bash -c 'printf \"GET /health/ready HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/8080; exit $?;'"
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 20s
     depends_on:
       zac-database:
         condition: service_healthy
     profiles: ["zac"]
+
+  schema-crawler:
+    image: docker.io/schemacrawler/schemacrawler:v16.22.2@sha256:8c3143975d81866e6e02051eeb9caa34d37423a77de3a79231bd24431f43386a
+    entrypoint: ["/opt/schemacrawler/bin/schemacrawler.sh"]
+    command: >
+      --server=postgresql
+      --host=zac-database
+      --port=5432
+      --database=zac
+      --user=zac
+      --password=password
+      --info-level=standard
+      --command=script
+      --script-language=python
+      --script=mermaid.py
+      --output-file=share/zac-database-erd.mmd
+    volumes:
+      - ./output:/home/schcrwlr/share
+    restart: "no"
+    depends_on:
+      zac:
+        condition: service_healthy
+    profiles: ["erd"]

--- a/scripts/docker-compose/docker-compose.linux.override.yml
+++ b/scripts/docker-compose/docker-compose.linux.override.yml
@@ -181,3 +181,10 @@ services:
     # see: https://stackoverflow.com/a/67158212
     extra_hosts:
       - "host.docker.internal:host-gateway"
+
+  schema-crawler:
+    user: "${UID}:${GID}"
+    # Linux workaround for host.docker.internal support
+    # see: https://stackoverflow.com/a/67158212
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/scripts/docker-compose/fix-permissions.sh
+++ b/scripts/docker-compose/fix-permissions.sh
@@ -15,6 +15,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
   echo -e "\nFixing directory permissions ..."
   VOLUMES_DIR=scripts/docker-compose/volume-data
   if [ -d "$VOLUMES_DIR" ]; then
-    sudo chown -R "$USER:$USER" "$VOLUMES_DIR" build/
+    sudo chown -R "$USER:$USER" "$VOLUMES_DIR" build/ output/
   fi
 )

--- a/src/e2e/step-definitions/external-systems.ts
+++ b/src/e2e/step-definitions/external-systems.ts
@@ -4,7 +4,7 @@
  */
 
 import { Then, When } from "@cucumber/cucumber";
-import { expect, Page } from "@playwright/test";
+import { Page, expect } from "@playwright/test";
 import { CustomWorld } from "../support/worlds/world";
 
 const ONE_MINUTE_IN_MS = 60_000;

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
@@ -150,14 +150,18 @@ class ProjectConfig : AbstractProjectConfig() {
     private fun createDockerComposeContainer(): ComposeContainer {
         logger.info { "Using ZAC Docker image: '$zacDockerImage'" }
 
+        val removeDockerComposeVolumes = System.getenv("REMOVE_DOCKER_COMPOSE_VOLUMES")?.toBoolean() ?: true
+        val optionProfileErd = System.getenv("CREATE_ERD_DIAGRAM_IN_ITEST")?.toBoolean() ?: false
+        val options = listOf(
+            "zac", if(optionProfileErd) "erd" else null,
+            "itest")
+            .mapNotNull { "--profile $it" }
+            .toTypedArray()
         return ComposeContainer(File("docker-compose.yaml"))
             .withLocalCompose(true)
-            .withRemoveVolumes(System.getenv("REMOVE_DOCKER_COMPOSE_VOLUMES")?.toBoolean() ?: true)
+            .withRemoveVolumes(removeDockerComposeVolumes)
             .withEnv(dockerComposeEnvironment)
-            .withOptions(
-                "--profile zac",
-                "--profile itest"
-            )
+            .withOptions(*options)
             .withLogConsumer(
                 "solr",
                 Slf4jLogConsumer((logger as DelegatingKLogger<Logger>).underlyingLogger).withPrefix(

--- a/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
@@ -17,7 +17,7 @@ import { MatDialog } from "@angular/material/dialog";
 import { MatDrawer } from "@angular/material/sidenav";
 import { TranslateService } from "@ngx-translate/core";
 import moment from "moment";
-import { BehaviorSubject, firstValueFrom, Subscription } from "rxjs";
+import { BehaviorSubject, Subscription, firstValueFrom } from "rxjs";
 import { first } from "rxjs/operators";
 import { SmartDocumentsService } from "src/app/admin/smart-documents.service";
 import { User } from "src/app/identity/model/user";

--- a/src/main/app/src/app/klanten/zoek/personen/persoon-zoek.component.ts
+++ b/src/main/app/src/app/klanten/zoek/personen/persoon-zoek.component.ts
@@ -8,7 +8,7 @@ import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { MatSidenav } from "@angular/material/sidenav";
 import { MatTableDataSource } from "@angular/material/table";
 import { Router } from "@angular/router";
-import { forkJoin, Subject, Subscription } from "rxjs";
+import { Subject, Subscription, forkJoin } from "rxjs";
 import { ConfiguratieService } from "../../../configuratie/configuratie.service";
 import { UtilService } from "../../../core/service/util.service";
 import { ActionIcon } from "../../../shared/edit/action-icon";


### PR DESCRIPTION
Introduce a schema-crawler container in the docker compose file. That container will only start, and automatically create a mermaid ERD diagram of the database, when the `erd` profile is enabled.

The Integration Tests configuration checks, through an environment variable, if this container should start.
The GitHub action sets this environment variable, and will therefore create an ERD during the integration test phase.

Note that some fixes for warnings in the gradle file and for linting errors have been incorporated here.