### PR TITLE
fix: no longer perform conventional commit check on the merge queue

### DIFF
--- a/.github/workflows/check-for-conventional-commits.yml
+++ b/.github/workflows/check-for-conventional-commits.yml
@@ -7,7 +7,6 @@ name: Check for conventional commits
 on:
   pull_request:
     types: [opened, edited, synchronize]
-  merge_group:
 
 jobs:
   check-for-conventional-commits:


### PR DESCRIPTION
No longer perform conventional commit check on the merge queue since this now fails with our updated GitHub configuration.

Solves PZ-4430