### PR TITLE
fix: use code-scanning-status-checker GitHub action

### DIFF
--- a/.github/workflows/check-codeql-status.yml
+++ b/.github/workflows/check-codeql-status.yml
@@ -1,0 +1,26 @@
+#
+# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-License-Identifier: EUPL-1.2+
+#
+
+# This workflow checks the status of the CodeQL analysis and reports the status as a check in the merge queue.
+# It is a workaround for: https://github.com/github/codeql-action/issues/1537
+# For details see: https://github.com/Eldrick19/code-scanning-status-checker
+
+check_codeql_status:
+  name: Check CodeQL Status
+  needs: analyze
+  permissions:
+    contents: read
+    checks: read
+    pull-requests: read
+
+  runs-on: ubuntu-22.04
+  if: ${{ github.event_name == 'pull_request' }}
+  steps:
+    - name: Check CodeQL Status
+      uses: eldrick19/code-scanning-status-checker@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        pr_number: ${{ github.event.pull_request.number }}
+        repo: ${{ github.repository }}


### PR DESCRIPTION
Use https://github.com/Eldrick19/code-scanning-status-checker to be able to use CodeQL as a status check in our main branch with the GitHub Merge Queue. This is a workaround for https://github.com/github/codeql-action/issues/1537

Solves PZ-4431