### PR TITLE
feat: reset form after document is sent

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
@@ -240,7 +240,6 @@ export class InformatieObjectCreateAttendedComponent
             window.open(documentCreatieResponse.redirectURL);
             this.sideNav.close();
             this.document.emit(documentCreateData);
-            this.form.reset();
             this.sideNav.close();
           } else {
             this.dialog.open(NotificationDialogComponent, {

--- a/src/main/app/src/app/informatie-objecten/informatie-object-verzenden/informatie-object-verzenden.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-verzenden/informatie-object-verzenden.component.ts
@@ -38,7 +38,7 @@ import { DocumentVerzendGegevens } from "../model/document-verzend-gegevens";
 export class InformatieObjectVerzendenComponent implements OnInit, OnChanges {
   @Input() zaak: Zaak;
   @Input() sideNav: MatDrawer;
-  @Output() documentVerzonden = new EventEmitter<void>();
+  @Output() documentSent = new EventEmitter<void>();
 
   @ViewChild(FormComponent) form: FormComponent;
 
@@ -110,7 +110,7 @@ export class InformatieObjectVerzendenComponent implements OnInit, OnChanges {
             ? "msg.documenten.verzenden.uitgevoerd"
             : "msg.document.verzenden.uitgevoerd",
         );
-        this.documentVerzonden.emit();
+        this.documentSent.emit();
         this.sideNav.close();
       });
     } else {

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -156,9 +156,9 @@
       <mat-card class="zaken-card w50 flex-1">
         <mat-card-header class="flex-row space-between">
           <mat-card-title>{{ zaak.identificatie }}</mat-card-title>
-          <mat-card-subtitle>{{
-            zaak.zaaktype.omschrijving
-          }}</mat-card-subtitle>
+          <mat-card-subtitle
+            >{{ zaak.zaaktype.omschrijving }}</mat-card-subtitle
+          >
           <div class="flex-row">
             <zac-zaak-indicaties
               [layout]="indicatiesLayout.VIEW"
@@ -689,10 +689,8 @@
                       {{ "type" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let bagObjectGegevens">
-                      {{
-                        "objecttype." +
-                          bagObjectGegevens.bagObject.bagObjectType | translate
-                      }}
+                      {{ "objecttype." +
+                      bagObjectGegevens.bagObject.bagObjectType | translate }}
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="omschrijving">

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -70,7 +70,7 @@
       *ngSwitchCase="sideNavAction.DOCUMENT_VERZENDEN"
       [sideNav]="actionsSidenav"
       [zaak]="zaak"
-      (documentVerzonden)="updateZaak()"
+      (documentVerzonden)="documentVerzonden()"
     ></zac-informatie-verzenden>
     <zac-human-task-do
       *ngSwitchCase="sideNavAction.TAAK_STARTEN"

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -58,7 +58,7 @@
       *ngSwitchCase="sideNavAction.DOCUMENT_MAKEN"
       [sideNav]="actionsSidenav"
       [zaak]="zaak"
-      (document)="documentToegevoegd()"
+      (document)="documentCreated()"
     ></zac-informatie-object-create-attended>
     <zac-informatie-object-add
       *ngSwitchCase="sideNavAction.DOCUMENT_TOEVOEGEN"
@@ -70,7 +70,7 @@
       *ngSwitchCase="sideNavAction.DOCUMENT_VERZENDEN"
       [sideNav]="actionsSidenav"
       [zaak]="zaak"
-      (documentVerzonden)="documentVerzonden()"
+      (documentSent)="documentSent()"
     ></zac-informatie-verzenden>
     <zac-human-task-do
       *ngSwitchCase="sideNavAction.TAAK_STARTEN"
@@ -156,9 +156,9 @@
       <mat-card class="zaken-card w50 flex-1">
         <mat-card-header class="flex-row space-between">
           <mat-card-title>{{ zaak.identificatie }}</mat-card-title>
-          <mat-card-subtitle
-            >{{ zaak.zaaktype.omschrijving }}</mat-card-subtitle
-          >
+          <mat-card-subtitle>{{
+            zaak.zaaktype.omschrijving
+          }}</mat-card-subtitle>
           <div class="flex-row">
             <zac-zaak-indicaties
               [layout]="indicatiesLayout.VIEW"
@@ -689,8 +689,10 @@
                       {{ "type" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let bagObjectGegevens">
-                      {{ "objecttype." +
-                      bagObjectGegevens.bagObject.bagObjectType | translate }}
+                      {{
+                        "objecttype." +
+                          bagObjectGegevens.bagObject.bagObjectType | translate
+                      }}
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="omschrijving">

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -1334,7 +1334,12 @@ export class ZaakViewComponent
     this.updateZaak();
   }
 
-  documentVerzonden(): void {
+  documentCreated(): void {
+    this.sluitSidenav();
+    this.updateZaak();
+  }
+
+  documentSent(): void {
     this.sluitSidenav();
     this.updateZaak();
   }

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -1299,6 +1299,11 @@ export class ZaakViewComponent
     SessionStorageUtil.setItem("toonAfgerondeTaken", this.toonAfgerondeTaken);
   }
 
+  sluitSidenav(): void {
+    this.action = null;
+    this.actionsSidenav.close();
+  }
+
   taakGestart(): void {
     this.actiefPlanItem = null;
     this.sluitSidenav();
@@ -1309,11 +1314,6 @@ export class ZaakViewComponent
     this.actiefPlanItem = null;
     this.sluitSidenav();
     this.updateZaak();
-  }
-
-  sluitSidenav(): void {
-    this.action = null;
-    this.actionsSidenav.close();
   }
 
   mailVerstuurd(mailVerstuurd: boolean): void {
@@ -1331,6 +1331,11 @@ export class ZaakViewComponent
   }
 
   documentToegevoegd(): void {
+    this.updateZaak();
+  }
+
+  documentVerzonden(): void {
+    this.sluitSidenav();
     this.updateZaak();
   }
 


### PR DESCRIPTION
The form gets fully reloaded after the sidebar is closed. The same fix applied for the Document Create form.

Solves: PZ-3740