### PR TITLE
fix: comply with rest conventions for naming

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/SignaleringRestServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/SignaleringRestServiceTest.kt
@@ -329,7 +329,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
     Given("An assigned zaak with information object") {
         When("the list of zaken signaleringen for ZAAK_OP_NAAM is requested") {
             val response = itestHttpClient.performGetRequest(
-                "$ZAC_API_URI/signaleringen/zaken/ZAAK_OP_NAAM?pageNumber=0&pageSize=5"
+                "$ZAC_API_URI/signaleringen/zaken/ZAAK_OP_NAAM?page-number=0&page-size=5"
             )
             val responseBody = response.body!!.string()
             logger.info { "Response: $responseBody" }
@@ -351,7 +351,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
 
         When("the list of zaken signaleringen is requested with wrong page") {
             val response = itestHttpClient.performGetRequest(
-                "$ZAC_API_URI/signaleringen/zaken/ZAAK_DOCUMENT_TOEGEVOEGD?pageNumber=123&pageSize=4567"
+                "$ZAC_API_URI/signaleringen/zaken/ZAAK_DOCUMENT_TOEGEVOEGD?page-number=123&page-size=4567"
             )
             val responseBody = response.body!!.string()
             logger.info { "Response: $responseBody" }

--- a/src/main/kotlin/net/atos/zac/app/signalering/SignaleringRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/signalering/SignaleringRestService.kt
@@ -45,9 +45,13 @@ class SignaleringRestService @Inject constructor(
 
     companion object {
         private const val TOTAL_COUNT_HEADER = "X-Total-Count"
+
         private const val INITIAL_PAGE = "0"
         private const val DEFAULT_PAGE_SIZE = "5"
         private const val BACKWARD_COMPATIBILITY_PAGE_SIZE = "1000"
+
+        private const val PAGE_NUMBER = "page-number"
+        private const val PAGE_SIZE = "page-size"
     }
 
     private fun Instance<LoggedInUser>.getSignaleringInstellingenZoekParameters() =
@@ -83,8 +87,8 @@ class SignaleringRestService @Inject constructor(
     @Path("/zaken/{type}")
     fun listZakenSignaleringen(
         @PathParam("type") signaleringsType: SignaleringType.Type,
-        @QueryParam("pageNumber") @DefaultValue(INITIAL_PAGE) pageNumber: Int,
-        @QueryParam("pageSize") @DefaultValue(DEFAULT_PAGE_SIZE) pageSize: Int
+        @QueryParam(PAGE_NUMBER) @DefaultValue(INITIAL_PAGE) pageNumber: Int,
+        @QueryParam(PAGE_SIZE) @DefaultValue(DEFAULT_PAGE_SIZE) pageSize: Int
     ): Response =
         signaleringService.countZakenSignaleringen(signaleringsType).let { objectsCount ->
             if (pageNumber > objectsCount.maxPages(pageSize)) {
@@ -100,8 +104,8 @@ class SignaleringRestService @Inject constructor(
     @Path("/taken/{type}")
     fun listTakenSignaleringen(
         @PathParam("type") signaleringsType: SignaleringType.Type,
-        @QueryParam("pageNumber") @DefaultValue(INITIAL_PAGE) pageNumber: Int,
-        @QueryParam("pageSize") @DefaultValue(BACKWARD_COMPATIBILITY_PAGE_SIZE) pageSize: Int
+        @QueryParam(PAGE_NUMBER) @DefaultValue(INITIAL_PAGE) pageNumber: Int,
+        @QueryParam(PAGE_SIZE) @DefaultValue(BACKWARD_COMPATIBILITY_PAGE_SIZE) pageSize: Int
     ): Response =
         signaleringService.countTakenSignaleringen(signaleringsType).let { objectsCount ->
             if (pageNumber > objectsCount.maxPages(pageSize)) {
@@ -117,8 +121,8 @@ class SignaleringRestService @Inject constructor(
     @Path("/informatieobjecten/{type}")
     fun listInformatieobjectenSignaleringen(
         @PathParam("type") signaleringsType: SignaleringType.Type,
-        @QueryParam("pageNumber") @DefaultValue(INITIAL_PAGE) pageNumber: Int,
-        @QueryParam("pageSize") @DefaultValue(BACKWARD_COMPATIBILITY_PAGE_SIZE) pageSize: Int
+        @QueryParam(PAGE_NUMBER) @DefaultValue(INITIAL_PAGE) pageNumber: Int,
+        @QueryParam(PAGE_SIZE) @DefaultValue(BACKWARD_COMPATIBILITY_PAGE_SIZE) pageSize: Int
     ): Response =
         signaleringService.countInformatieobjectenSignaleringen(signaleringsType).let { objectsCount ->
             if (pageNumber > objectsCount.maxPages(pageSize)) {


### PR DESCRIPTION
Use dash to split words in query parameters

Solves: PZ-4459