### PR TITLE
chore: no longer run CodeQL on 'push: main:'

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,8 +5,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
     # ignore code analysis when only Markdown files have changed


### PR DESCRIPTION
No longer run CodeQL on 'push: main:' since we already run this workflow as a check in GitHub in the merge queue.

Solves PZ-4463