### PR TITLE
chore: added Gradle Java toolchain resolver plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,3 +4,7 @@
  */
 
 rootProject.name = "zaakafhandelcomponent"
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
+}


### PR DESCRIPTION
Added Gradle Java toolchain resolver plugin so that Gradle will automatically download JDKs if the local JDK is not what we have configured. See: https://kotlinlang.org/docs/gradle-configure-project.html#set-jdk-version-with-the-task-dsl

Solves PZ-4467