### PR TITLE
feat: send SKIPPED screen event for closed zaken during releasing zaken from the list

### DIFF
--- a/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
@@ -191,9 +191,8 @@ class ZaakService @Inject constructor(
             .map(zrcClientService::readZaak)
             .filter {
                 if (!it.isOpen) {
-                    LOG.fine(
-                        "Zaak with UUID '${it.uuid} is not open. Therefore it is not released."
-                    )
+                    LOG.fine("Zaak with UUID '${it.uuid} is not open. Therefore it is not released.")
+                    eventingService.send(ScreenEventType.ZAAK_ROLLEN.skipped(it))
                 }
                 it.isOpen
             }


### PR DESCRIPTION
Send SKIPPED screen event for closed zaken during releasing zaken from the list.

Solves PZ-4468