### PR TITLE
feat: FE zaken signalering - paginated requests

### DIFF
--- a/src/main/app/src/app/dashboard/zaken-card/zaken-card.component.html
+++ b/src/main/app/src/app/dashboard/zaken-card/zaken-card.component.html
@@ -55,5 +55,9 @@
     </tr>
   </table>
 
-  <mat-paginator [pageSize]="5" [hidePageSize]="true"></mat-paginator>
+  <mat-paginator
+    [pageSize]="5"
+    [hidePageSize]="true"
+    (page)="onPageChange($event)"
+  ></mat-paginator>
 </div>

--- a/src/main/app/src/app/dashboard/zaken-card/zaken-card.component.html
+++ b/src/main/app/src/app/dashboard/zaken-card/zaken-card.component.html
@@ -36,7 +36,6 @@
       <th mat-header-cell *matHeaderCellDef></th>
       <td mat-cell *matCellDef="let zaak">
         <a
-          *ngIf="zaak.rechten.lezen"
           mat-icon-button
           [routerLink]="['/zaken', zaak.identificatie]"
           [id]="'zaakBekijken_' + zaak.uuid +'_button'"


### PR DESCRIPTION
With this PR the web socket providing all the open signals is replaced by paginated requests. On navigating to a next page a new request to the server is executed. And when a general signalering signal arrives, the current page is refetched. Making a new signal shift the whole list. This shifting behaviour is identical to the previous web socket solution behaviour.

Solves: PZ-2612