### PR TITLE
fix: do not run codeql on merge-group when only markdown files have changed

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - '**/*.md'
   merge_group:
+    # ignore code analysis when only Markdown files have changed
+    paths-ignore:
+      - '**/*.md'
   schedule:
     - cron: "21 11 * * 0"
 


### PR DESCRIPTION
Do not run codeql on merge-group when only markdown files have changed.

Solves PZ-4497