### PR TITLE
chore: skip pr and merge-queue build when only Markdown files have changed

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -6,7 +6,13 @@ name: Build, test & deploy
 
 on:
   pull_request:
+    # ignore code analysis when only Markdown files have changed
+    paths-ignore:
+      - '**/*.md'
   merge_group:
+    # ignore code analysis when only Markdown files have changed
+    paths-ignore:
+      - '**/*.md'
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
Skip pr and merge-queue build when only Markdown files have changed.

Solves PZ-4499