### PR TITLE
fix: fix translation regression issue in FilterParameters class

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/ZoekenRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZoekenRESTServiceTest.kt
@@ -352,7 +352,7 @@ class ZoekenRESTServiceTest : BehaviorSpec({
                       "resultaten" : [ {
                         "identificatie" : "$zaakManual2Identification",
                         "type" : "ZAAK",
-                        "aantalOpenstaandeTaken" : 0,
+                        "aantalOpenstaandeTaken" : 1,
                         "afgehandeld" : false,
                         "betrokkenen" : {
                           "Behandelaar" : [ "$TEST_GROUP_A_ID" ]

--- a/src/main/kotlin/net/atos/zac/zoeken/model/FilterParameters.kt
+++ b/src/main/kotlin/net/atos/zac/zoeken/model/FilterParameters.kt
@@ -4,4 +4,9 @@
  */
 package net.atos.zac.zoeken.model
 
+import nl.lifely.zac.util.AllOpen
+import nl.lifely.zac.util.NoArgConstructor
+
+@AllOpen
+@NoArgConstructor
 data class FilterParameters(val values: List<String>, val inverse: Boolean)

--- a/src/main/kotlin/net/atos/zac/zoeken/model/FilterParameters.kt
+++ b/src/main/kotlin/net/atos/zac/zoeken/model/FilterParameters.kt
@@ -4,9 +4,15 @@
  */
 package net.atos.zac.zoeken.model
 
+import jakarta.json.bind.annotation.JsonbProperty
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 
 @AllOpen
 @NoArgConstructor
-data class FilterParameters(val values: List<String>, val inverse: Boolean)
+data class FilterParameters(
+    @field:JsonbProperty("waarden")
+    var values: List<String>,
+
+    var inverse: Boolean
+)


### PR DESCRIPTION
Fixed translation regression issue in FilterParameters class. Frontend still uses 'waarden' instead of 'values'.. (for now anyway).

Solves PZ-4500