### PR TITLE
chore: use Gradle configuration cache for improved build performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,8 @@
 org.gradle.jvmargs=-Xmx3g
 # enable Gradle build cache
 org.gradle.caching=true
-
+# enable Gradle configuration cache
+org.gradle.configuration-cache=true
+# enable parallel loading of the configuration cache
+org.gradle.configuration-cache.parallel=true
 


### PR DESCRIPTION
Use Gradle configuration cache for improved build performance.

Solves PZ-4505