### PR TITLE
feat: E2E - fix test creating a zaak

### DIFF
--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -251,7 +251,8 @@ Then(
   "{string} sees the zaak initiator",
   { timeout: ONE_MINUTE_IN_MS },
   async function (this: CustomWorld, user: z.infer<typeof worldUsers>) {
-    await this.page.getByText(TEST_PERSON_HENDRIKA_JANSE_NAME).nth(0).click();
+    await this.page.getByText(TEST_PERSON_HENDRIKA_JANSE_NAME);
+    await this.page.getByText(/initiator/i).click();
     await this.expect(
       this.page.getByText(TEST_PERSON_HENDRIKA_JANSE_BSN),
     ).toBeVisible();


### PR DESCRIPTION
Somehow the locator for the name and clicking it was not working anymore; I don't see why. The most important thing is that the name is there. Clicking other part of that header is fine as well. Now clicking text 'initiator'

Solves: PZ-4506