### PR TITLE
chore: use GitHub action to skip CodeQL when only Markdown files have been changed

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,13 @@ jobs:
         language: ["java-kotlin", "javascript-typescript"]
 
     steps:
+      - name: Ignore when only Markdown files are changed
+        uses: kunitsucom/github-actions-paths-ignore-alternative@v0.0.4
+        id: paths-ignore
+        with:
+          paths-ignore: |-
+            ^.*\.md$
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -67,6 +74,13 @@ jobs:
       pull-requests: read
     if: ${{ github.event_name == 'pull_request' }}
     steps:
+      - name: Ignore when only Markdown files are changed
+        uses: kunitsucom/github-actions-paths-ignore-alternative@v0.0.4
+        id: paths-ignore
+        with:
+          paths-ignore: |-
+            ^.*\.md$
+
       - name: Check CodeQL Status
         uses: eldrick19/code-scanning-status-checker@v2
         with:


### PR DESCRIPTION
Use https://github.com/kunitsucom/github-actions-paths-ignore-alternative GitHub action to skip CodeQL analysis when only Markdown files have been changed.

Solves PZ-4537