### PR TITLE
fix: fix SmartDocuments docx media type

### DIFF
--- a/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/download-document.json
+++ b/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/download-document.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "/smartdocuments/result/show?id=dummyFileId&format=DOCX"
+    "url": "/smartdocuments/result/show?id=dummyFileId&format=application%2Fvnd.openxmlformats-officedocument.wordprocessingml.document"
   },
   "response": {
     "status": 200,

--- a/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/wsxmldeposit-wizard.json
+++ b/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/wsxmldeposit-wizard.json
@@ -25,7 +25,7 @@
             "FixedValues": ""
           },
           "Variables": {
-            "OutputFormats": [ { "OutputFormat": "DOCX" } ],
+            "OutputFormats": [ { "OutputFormat": "application/vnd.openxmlformats-officedocument.wordprocessingml.document" } ],
             "RedirectMethod": "POST",
             "RedirectUrl": "${json-unit.any-string}"
           }

--- a/src/main/kotlin/net/atos/zac/documentcreation/DocumentCreationService.kt
+++ b/src/main/kotlin/net/atos/zac/documentcreation/DocumentCreationService.kt
@@ -41,7 +41,7 @@ class DocumentCreationService @Inject constructor(
     private val loggedInUserInstance: Instance<LoggedInUser>
 ) {
     companion object {
-        const val OUTPUT_FORMAT_DOCX = "DOCX"
+        const val OUTPUT_FORMAT_DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         const val REDIRECT_METHOD = "POST"
 
         private val LOG = Logger.getLogger(DocumentCreationService::class.java.name)
@@ -111,8 +111,8 @@ class DocumentCreationService @Inject constructor(
         smartDocumentsService.downloadDocument(fileId).let { file ->
             documentCreationDataConverter.toEnkelvoudigInformatieObjectCreateLockRequest(
                 zaak = zaak,
-                smartDocumentsFile = file,
-                smartDocumentsFileType = OUTPUT_FORMAT_DOCX,
+                file = file,
+                format = OUTPUT_FORMAT_DOCX,
                 smartDocumentsTemplateGroupId = templateGroupId,
                 smartDocumentsTemplateId = templateId,
                 title = title,

--- a/src/main/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverter.kt
+++ b/src/main/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverter.kt
@@ -208,8 +208,8 @@ class DocumentCreationDataConverter @Inject constructor(
 
     fun toEnkelvoudigInformatieObjectCreateLockRequest(
         zaak: Zaak,
-        smartDocumentsFile: File,
-        smartDocumentsFileType: String,
+        file: File,
+        format: String,
         smartDocumentsTemplateGroupId: String,
         smartDocumentsTemplateId: String,
         title: String,
@@ -232,9 +232,9 @@ class DocumentCreationDataConverter @Inject constructor(
         ).let {
             ztcClientService.readInformatieobjecttype(it).url
         }
-        bestandsnaam = smartDocumentsFile.fileName
-        formaat = smartDocumentsFileType
-        inhoud = smartDocumentsFile.document.data
-        bestandsomvang = smartDocumentsFile.document.data?.decodedBase64StringLength()
+        bestandsnaam = file.fileName
+        formaat = format
+        inhoud = file.document.data
+        bestandsomvang = file.document.data?.decodedBase64StringLength()
     }
 }

--- a/src/test/kotlin/net/atos/zac/documentcreation/DocumentCreationServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/documentcreation/DocumentCreationServiceTest.kt
@@ -124,7 +124,7 @@ class DocumentCreationServiceTest : BehaviorSpec({
             documentCreationDataConverter.toEnkelvoudigInformatieObjectCreateLockRequest(
                 zaak,
                 downloadedFile,
-                "DOCX",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                 templateGroupId,
                 templateId,
                 title,

--- a/src/test/kotlin/net/atos/zac/smartdocuments/SmartDocumentsServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/smartdocuments/SmartDocumentsServiceTest.kt
@@ -93,7 +93,7 @@ class SmartDocumentsServiceTest : BehaviorSpec({
             Then("a file object representing the content is returned") {
                 with(file) {
                     fileName shouldBe fileName
-                    outputFormat shouldBe "DOCX"
+                    outputFormat shouldBe "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
                     document.data shouldBe body.toBase64String()
                 }
             }


### PR DESCRIPTION
Fixed SmartDocuments docx media type so that frontend recognizes .docx files created by SmartDocuments as Office documents and shows edit and convert buttons.

Solves PZ-4414