### PR TITLE
feature(build): set trivy action version to 0.27.0

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -264,7 +264,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.27.0
         with:
           image-ref: '${{ env.ZAC_DOCKER_IMAGE }}'
           format: 'sarif'

--- a/.github/workflows/trivy-docker-image-scan.yml
+++ b/.github/workflows/trivy-docker-image-scan.yml
@@ -24,7 +24,7 @@ jobs:
         run: docker pull ${{ env.ZAC_IMAGE_URL }}
 
       - name: Run Trivy Vulnerability Scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.27.0
         with:
           image-ref: ${{ env.ZAC_IMAGE_URL }}
           format: 'sarif'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Create runtime image fase
-FROM docker.io/eclipse-temurin:21-ubi9-minimal AS runtime
+FROM docker.io/eclipse-temurin:21.0.5_11-jre-ubi9-minimal@sha256:cba199ee5623602c6cfb2a2b8cbf014b4425a7d5611834eeae348b8b9af4050f AS runtime
 
 LABEL name="zaakafhandelcomponent"
 LABEL summary="Zaakafhandelcomponent (ZAC) developed for Dimpact"


### PR DESCRIPTION

The latest trivy scanning fails. Downgrading the trivy action from master (0.28.0) to 0.27.0.