### PR TITLE
chore: refactoring to prepare for do not allow multiple betrokkenen of same type in backend

### DIFF
--- a/src/main/kotlin/net/atos/zac/app/klant/KlantRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/klant/KlantRestService.kt
@@ -48,7 +48,7 @@ import net.atos.zac.app.klant.model.personen.toRechtsPersonen
 import net.atos.zac.app.klant.model.personen.toRestPersoon
 import net.atos.zac.app.klant.model.personen.toRestResultaat
 import net.atos.zac.app.shared.RESTResultaat
-import net.atos.zac.zaak.ZaakService.Companion.ZAAK_BETROKKENEN_ENUMSET
+import net.atos.zac.zaak.Betrokkenen.BETROKKENEN_ENUMSET
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import org.hibernate.validator.constraints.Length
@@ -156,7 +156,7 @@ class KlantRestService @Inject constructor(
     @Path("roltype/{zaaktypeUuid}/betrokkene")
     fun listBetrokkeneRoltypen(@PathParam("zaaktypeUuid") zaaktype: UUID): List<RestRoltype> =
         ztcClientService.listRoltypen(ztcClientService.readZaaktype(zaaktype).url)
-            .filter { ZAAK_BETROKKENEN_ENUMSET.contains(it.omschrijvingGeneriek) }
+            .filter { BETROKKENEN_ENUMSET.contains(it.omschrijvingGeneriek) }
             .sortedBy { it.omschrijving }
             .toRestRoltypes()
 

--- a/src/main/kotlin/net/atos/zac/app/klant/KlantRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/klant/KlantRestService.kt
@@ -24,7 +24,6 @@ import net.atos.client.klant.model.ExpandBetrokkene
 import net.atos.client.kvk.KvkClientService
 import net.atos.client.kvk.zoeken.model.generated.ResultaatItem
 import net.atos.client.zgw.ztc.ZtcClientService
-import net.atos.client.zgw.ztc.model.generated.OmschrijvingGeneriekEnum
 import net.atos.zac.app.klant.exception.RechtspersoonNotFoundException
 import net.atos.zac.app.klant.exception.VestigingNotFoundException
 import net.atos.zac.app.klant.model.bedrijven.RestBedrijf
@@ -49,10 +48,10 @@ import net.atos.zac.app.klant.model.personen.toRechtsPersonen
 import net.atos.zac.app.klant.model.personen.toRestPersoon
 import net.atos.zac.app.klant.model.personen.toRestResultaat
 import net.atos.zac.app.shared.RESTResultaat
+import net.atos.zac.zaak.ZaakService.Companion.ZAAK_BETROKKENEN_ENUMSET
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import org.hibernate.validator.constraints.Length
-import java.util.EnumSet
 import java.util.Objects
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
@@ -71,16 +70,6 @@ class KlantRestService @Inject constructor(
     val klantClientService: KlantClientService
 ) {
     companion object {
-        val betrokkenen: EnumSet<OmschrijvingGeneriekEnum> =
-            EnumSet.allOf(OmschrijvingGeneriekEnum::class.java).apply {
-                this.removeAll(
-                    listOf(
-                        OmschrijvingGeneriekEnum.INITIATOR,
-                        OmschrijvingGeneriekEnum.BEHANDELAAR
-                    )
-                )
-            }
-
         const val TELEFOON_SOORT_DIGITAAL_ADRES = "telefoon"
         const val EMAIL_SOORT_DIGITAAL_ADRES = "email"
     }
@@ -167,7 +156,7 @@ class KlantRestService @Inject constructor(
     @Path("roltype/{zaaktypeUuid}/betrokkene")
     fun listBetrokkeneRoltypen(@PathParam("zaaktypeUuid") zaaktype: UUID): List<RestRoltype> =
         ztcClientService.listRoltypen(ztcClientService.readZaaktype(zaaktype).url)
-            .filter { betrokkenen.contains(it.omschrijvingGeneriek) }
+            .filter { ZAAK_BETROKKENEN_ENUMSET.contains(it.omschrijvingGeneriek) }
             .sortedBy { it.omschrijving }
             .toRestRoltypes()
 

--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -1004,12 +1004,20 @@ class ZaakRestService @Inject constructor(
 
             IdentificatieType.VN -> {
                 assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
-                zaakService.addInitiatorVestiging(identificatie, zaak, ROL_TOEVOEGEN_REDEN)
+                zaakService.addInitiatorVestiging(
+                    vestigingsnummer = identificatie,
+                    zaak = zaak,
+                    toelichting = ROL_TOEVOEGEN_REDEN
+                )
             }
 
             IdentificatieType.RSIN -> {
                 assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
-                zaakService.addInitiatorNietNatuurlijkPersoon(identificatie, zaak, ROL_TOEVOEGEN_REDEN)
+                zaakService.addInitiatorNietNatuurlijkPersoon(
+                    rsin = identificatie,
+                    zaak = zaak,
+                    toelichting = ROL_TOEVOEGEN_REDEN
+                )
             }
         }
     }

--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -958,21 +958,11 @@ class ZaakRestService @Inject constructor(
     ) {
         val zaakRechten = policyService.readZaakRechten(zaak)
         when (identificatieType) {
-            IdentificatieType.BSN -> {
-                assertPolicy(zaakRechten.toevoegenBetrokkenePersoon)
-                zaakService.addBetrokkenNatuurlijkPersoon(roltypeUUID, identificatie, zaak, toelichting)
-            }
-
-            IdentificatieType.VN -> {
-                assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
-                zaakService.addBetrokkenVestiging(roltypeUUID, identificatie, zaak, toelichting)
-            }
-
-            IdentificatieType.RSIN -> {
-                assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
-                zaakService.addBetrokkenNietNatuurlijkPersoon(roltypeUUID, identificatie, zaak, toelichting)
-            }
+            IdentificatieType.BSN -> assertPolicy(zaakRechten.toevoegenBetrokkenePersoon)
+            IdentificatieType.VN -> assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
+            IdentificatieType.RSIN -> assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
         }
+        zaakService.addBetrokkeneToZaak(roltypeUUID, identificatieType, identificatie, zaak, toelichting)
     }
 
     private fun addInitiator(

--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -228,10 +228,10 @@ class ZaakRestService @Inject constructor(
     fun addBetrokkene(@Valid gegevens: RESTZaakBetrokkeneGegevens): RestZaak {
         val zaak = zrcClientService.readZaak(gegevens.zaakUUID)
         addBetrokkeneToZaak(
-            roltypeUUID = gegevens.roltypeUUID,
-            identificatieType = gegevens.betrokkeneIdentificatieType,
-            identificatie = gegevens.betrokkeneIdentificatie,
-            toelichting = gegevens.roltoelichting?.ifEmpty { ROL_TOEVOEGEN_REDEN } ?: ROL_TOEVOEGEN_REDEN,
+            roleTypeUUID = gegevens.roltypeUUID,
+            identificationType = gegevens.betrokkeneIdentificatieType,
+            identification = gegevens.betrokkeneIdentificatie,
+            explanation = gegevens.roltoelichting?.ifEmpty { ROL_TOEVOEGEN_REDEN } ?: ROL_TOEVOEGEN_REDEN,
             zaak
         )
         return restZaakConverter.toRestZaak(zaak)
@@ -950,37 +950,43 @@ class ZaakRestService @Inject constructor(
     fun listProcesVariabelen(): List<String> = ZaakVariabelenService.VARS
 
     private fun addBetrokkeneToZaak(
-        roltypeUUID: UUID,
-        identificatieType: IdentificatieType,
-        identificatie: String,
-        toelichting: String,
+        roleTypeUUID: UUID,
+        identificationType: IdentificatieType,
+        identification: String,
+        explanation: String,
         zaak: Zaak
     ) {
         val zaakRechten = policyService.readZaakRechten(zaak)
-        when (identificatieType) {
+        when (identificationType) {
             IdentificatieType.BSN -> assertPolicy(zaakRechten.toevoegenBetrokkenePersoon)
             IdentificatieType.VN -> assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
             IdentificatieType.RSIN -> assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
         }
-        zaakService.addBetrokkeneToZaak(roltypeUUID, identificatieType, identificatie, zaak, toelichting)
+        zaakService.addBetrokkeneToZaak(
+            roleTypeUUID = roleTypeUUID,
+            identificationType = identificationType,
+            identification = identification,
+            zaak = zaak,
+            explanation = explanation
+        )
     }
 
     private fun addInitiator(
-        identificatieType: IdentificatieType,
-        identificatie: String,
+        identificationType: IdentificatieType,
+        identification: String,
         zaak: Zaak
     ) {
         val zaakRechten = policyService.readZaakRechten(zaak)
-        when (identificatieType) {
+        when (identificationType) {
             IdentificatieType.BSN -> assertPolicy(zaakRechten.toevoegenInitiatorPersoon)
             IdentificatieType.VN -> assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
             IdentificatieType.RSIN -> assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
         }
         zaakService.addInitiatorToZaak(
-            identificatieType = identificatieType,
-            identificatie = identificatie,
+            identificationType = identificationType,
+            identification = identification,
             zaak = zaak,
-            toelichting = ROL_TOEVOEGEN_REDEN
+            explanation = ROL_TOEVOEGEN_REDEN
         )
     }
 

--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -972,33 +972,16 @@ class ZaakRestService @Inject constructor(
     ) {
         val zaakRechten = policyService.readZaakRechten(zaak)
         when (identificatieType) {
-            IdentificatieType.BSN -> {
-                assertPolicy(zaakRechten.toevoegenInitiatorPersoon)
-                zaakService.addInitiatorNatuurlijkPersoon(
-                    bsn = identificatie,
-                    zaak = zaak,
-                    toelichting = ROL_TOEVOEGEN_REDEN
-                )
-            }
-
-            IdentificatieType.VN -> {
-                assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
-                zaakService.addInitiatorVestiging(
-                    vestigingsnummer = identificatie,
-                    zaak = zaak,
-                    toelichting = ROL_TOEVOEGEN_REDEN
-                )
-            }
-
-            IdentificatieType.RSIN -> {
-                assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
-                zaakService.addInitiatorNietNatuurlijkPersoon(
-                    rsin = identificatie,
-                    zaak = zaak,
-                    toelichting = ROL_TOEVOEGEN_REDEN
-                )
-            }
+            IdentificatieType.BSN -> assertPolicy(zaakRechten.toevoegenInitiatorPersoon)
+            IdentificatieType.VN -> assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
+            IdentificatieType.RSIN -> assertPolicy(zaakRechten.toevoegenBetrokkeneBedrijf)
         }
+        zaakService.addInitiatorToZaak(
+            identificatieType = identificatieType,
+            identificatie = identificatie,
+            zaak = zaak,
+            toelichting = ROL_TOEVOEGEN_REDEN
+        )
     }
 
     private fun addRelevanteZaak(

--- a/src/main/kotlin/net/atos/zac/zaak/Betrokkenen.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/Betrokkenen.kt
@@ -1,0 +1,22 @@
+package net.atos.zac.zaak
+
+import net.atos.client.zgw.ztc.model.generated.OmschrijvingGeneriekEnum
+import java.util.EnumSet
+
+object Betrokkenen {
+    /**
+     * Defines the set of available 'betrokkenen' as role type descriptions which can be added to a zaak.
+     * These role type descriptions are defined in the ZGW ZTC API.
+     * The 'initiator' and 'behandelaar' roles types are not seen as 'betrokkenen' but rather as very specific
+     * role types with their own business logic.
+     */
+    val BETROKKENEN_ENUMSET: EnumSet<OmschrijvingGeneriekEnum> =
+        EnumSet.allOf(OmschrijvingGeneriekEnum::class.java).apply {
+            this.removeAll(
+                listOf(
+                    OmschrijvingGeneriekEnum.INITIATOR,
+                    OmschrijvingGeneriekEnum.BEHANDELAAR
+                )
+            )
+        }
+}

--- a/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
@@ -29,8 +29,8 @@ import net.atos.zac.event.EventingService
 import net.atos.zac.identity.model.Group
 import net.atos.zac.identity.model.User
 import net.atos.zac.websocket.event.ScreenEventType
+import net.atos.zac.zaak.Betrokkenen.BETROKKENEN_ENUMSET
 import nl.lifely.zac.util.AllOpen
-import java.util.EnumSet
 import java.util.Locale
 import java.util.UUID
 import java.util.logging.Logger
@@ -44,18 +44,6 @@ class ZaakService @Inject constructor(
     private val ztcClientService: ZtcClientService,
     private var eventingService: EventingService,
 ) {
-    companion object {
-        val ZAAK_BETROKKENEN_ENUMSET: EnumSet<OmschrijvingGeneriekEnum> =
-            EnumSet.allOf(OmschrijvingGeneriekEnum::class.java).apply {
-                this.removeAll(
-                    listOf(
-                        OmschrijvingGeneriekEnum.INITIATOR,
-                        OmschrijvingGeneriekEnum.BEHANDELAAR
-                    )
-                )
-            }
-    }
-
     fun addBetrokkeneToZaak(
         roleTypeUUID: UUID,
         identificationType: IdentificatieType,
@@ -172,7 +160,7 @@ class ZaakService @Inject constructor(
     fun listBetrokkenenforZaak(zaak: Zaak): List<Rol<*>> =
         zrcClientService.listRollen(zaak)
             .filter { rol ->
-                ZAAK_BETROKKENEN_ENUMSET.contains(
+                BETROKKENEN_ENUMSET.contains(
                     OmschrijvingGeneriekEnum.valueOf(
                         rol.omschrijvingGeneriek.uppercase(Locale.getDefault())
                     )

--- a/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
@@ -24,6 +24,7 @@ import net.atos.client.zgw.zrc.model.Zaak
 import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.client.zgw.ztc.model.generated.OmschrijvingGeneriekEnum
 import net.atos.client.zgw.ztc.model.generated.RolType
+import net.atos.zac.app.klant.model.klant.IdentificatieType
 import net.atos.zac.event.EventingService
 import net.atos.zac.identity.model.Group
 import net.atos.zac.identity.model.User
@@ -54,18 +55,43 @@ class ZaakService @Inject constructor(
                 )
             }
     }
-    fun addBetrokkenNatuurlijkPersoon(
+
+    fun addBetrokkeneToZaak(
         roltypeUUID: UUID,
-        bsn: String,
+        identificatieType: IdentificatieType,
+        identificatie: String,
         zaak: Zaak,
         toelichting: String
     ) {
-        addBetrokkenNatuurlijkPersoonByRoleType(
-            roltype = ztcClientService.readRoltype(roltypeUUID),
-            bsn = bsn,
-            zaak = zaak,
-            toelichting = toelichting
-        )
+        val rolType = ztcClientService.readRoltype(roltypeUUID)
+        when (identificatieType) {
+            IdentificatieType.BSN -> {
+                addRolNatuurlijkPersoonToZaak(
+                    roltype = rolType,
+                    bsn = identificatie,
+                    zaak = zaak,
+                    toelichting = toelichting
+                )
+            }
+
+            IdentificatieType.VN -> {
+                addRolVestigingToZaak(
+                    roltype = rolType,
+                    vestigingsnummer = identificatie,
+                    zaak = zaak,
+                    toelichting = toelichting
+                )
+            }
+
+            IdentificatieType.RSIN -> {
+                addRolNietNatuurlijkPersoonToZaak(
+                    roltype = rolType,
+                    rsin = identificatie,
+                    zaak = zaak,
+                    toelichting = toelichting
+                )
+            }
+        }
     }
 
     fun addInitiatorNatuurlijkPersoon(
@@ -73,23 +99,9 @@ class ZaakService @Inject constructor(
         zaak: Zaak,
         toelichting: String
     ) {
-        addBetrokkenNatuurlijkPersoonByRoleType(
+        addRolNatuurlijkPersoonToZaak(
             roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
             bsn = bsn,
-            zaak = zaak,
-            toelichting = toelichting
-        )
-    }
-
-    fun addBetrokkenVestiging(
-        roltypeUUID: UUID,
-        vestigingsnummer: String,
-        zaak: Zaak,
-        toelichting: String
-    ) {
-        addBetrokkenVestigingByRoleType(
-            roltype = ztcClientService.readRoltype(roltypeUUID),
-            vestigingsnummer = vestigingsnummer,
             zaak = zaak,
             toelichting = toelichting
         )
@@ -100,23 +112,9 @@ class ZaakService @Inject constructor(
         zaak: Zaak,
         toelichting: String
     ) {
-        addBetrokkenVestigingByRoleType(
+        addRolVestigingToZaak(
             roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
             vestigingsnummer = vestigingsnummer,
-            zaak = zaak,
-            toelichting = toelichting
-        )
-    }
-
-    fun addBetrokkenNietNatuurlijkPersoon(
-        roltypeUUID: UUID,
-        rsin: String,
-        zaak: Zaak,
-        toelichting: String
-    ) {
-        addBetrokkenNietNatuurlijkPersoonByRoleType(
-            roltype = ztcClientService.readRoltype(roltypeUUID),
-            rsin = rsin,
             zaak = zaak,
             toelichting = toelichting
         )
@@ -127,7 +125,7 @@ class ZaakService @Inject constructor(
         zaak: Zaak,
         toelichting: String
     ) {
-        addBetrokkenNietNatuurlijkPersoonByRoleType(
+        addRolNietNatuurlijkPersoonToZaak(
             roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
             rsin = rsin,
             zaak = zaak,
@@ -263,7 +261,7 @@ class ZaakService @Inject constructor(
         }
     }
 
-    private fun addBetrokkenNatuurlijkPersoonByRoleType(
+    private fun addRolNatuurlijkPersoonToZaak(
         roltype: RolType,
         bsn: String,
         zaak: Zaak,
@@ -280,7 +278,7 @@ class ZaakService @Inject constructor(
         )
     }
 
-    private fun addBetrokkenVestigingByRoleType(
+    private fun addRolVestigingToZaak(
         roltype: RolType,
         vestigingsnummer: String,
         zaak: Zaak,
@@ -297,7 +295,7 @@ class ZaakService @Inject constructor(
         )
     }
 
-    private fun addBetrokkenNietNatuurlijkPersoonByRoleType(
+    private fun addRolNietNatuurlijkPersoonToZaak(
         roltype: RolType,
         rsin: String,
         zaak: Zaak,

--- a/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
@@ -94,43 +94,40 @@ class ZaakService @Inject constructor(
         }
     }
 
-    fun addInitiatorNatuurlijkPersoon(
-        bsn: String,
+    fun addInitiatorToZaak(
+        identificatieType: IdentificatieType,
+        identificatie: String,
         zaak: Zaak,
         toelichting: String
     ) {
-        addRolNatuurlijkPersoonToZaak(
-            roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
-            bsn = bsn,
-            zaak = zaak,
-            toelichting = toelichting
-        )
-    }
+        when (identificatieType) {
+            IdentificatieType.BSN -> {
+                addRolNatuurlijkPersoonToZaak(
+                    roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
+                    bsn = identificatie,
+                    zaak = zaak,
+                    toelichting = toelichting
+                )
+            }
 
-    fun addInitiatorVestiging(
-        vestigingsnummer: String,
-        zaak: Zaak,
-        toelichting: String
-    ) {
-        addRolVestigingToZaak(
-            roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
-            vestigingsnummer = vestigingsnummer,
-            zaak = zaak,
-            toelichting = toelichting
-        )
-    }
+            IdentificatieType.VN -> {
+                addRolVestigingToZaak(
+                    roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
+                    vestigingsnummer = identificatie,
+                    zaak = zaak,
+                    toelichting = toelichting
+                )
+            }
 
-    fun addInitiatorNietNatuurlijkPersoon(
-        rsin: String,
-        zaak: Zaak,
-        toelichting: String
-    ) {
-        addRolNietNatuurlijkPersoonToZaak(
-            roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
-            rsin = rsin,
-            zaak = zaak,
-            toelichting = toelichting
-        )
+            IdentificatieType.RSIN -> {
+                addRolNietNatuurlijkPersoonToZaak(
+                    roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
+                    rsin = identificatie,
+                    zaak = zaak,
+                    toelichting = toelichting
+                )
+            }
+        }
     }
 
     /**

--- a/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
@@ -57,77 +57,34 @@ class ZaakService @Inject constructor(
     }
 
     fun addBetrokkeneToZaak(
-        roltypeUUID: UUID,
-        identificatieType: IdentificatieType,
-        identificatie: String,
+        roleTypeUUID: UUID,
+        identificationType: IdentificatieType,
+        identification: String,
         zaak: Zaak,
-        toelichting: String
+        explanation: String
     ) {
-        val rolType = ztcClientService.readRoltype(roltypeUUID)
-        when (identificatieType) {
-            IdentificatieType.BSN -> {
-                addRolNatuurlijkPersoonToZaak(
-                    roltype = rolType,
-                    bsn = identificatie,
-                    zaak = zaak,
-                    toelichting = toelichting
-                )
-            }
-
-            IdentificatieType.VN -> {
-                addRolVestigingToZaak(
-                    roltype = rolType,
-                    vestigingsnummer = identificatie,
-                    zaak = zaak,
-                    toelichting = toelichting
-                )
-            }
-
-            IdentificatieType.RSIN -> {
-                addRolNietNatuurlijkPersoonToZaak(
-                    roltype = rolType,
-                    rsin = identificatie,
-                    zaak = zaak,
-                    toelichting = toelichting
-                )
-            }
-        }
+        addRoleToZaak(
+            roleType = ztcClientService.readRoltype(roleTypeUUID),
+            identificationType = identificationType,
+            identification = identification,
+            zaak = zaak,
+            explanation = explanation
+        )
     }
 
     fun addInitiatorToZaak(
-        identificatieType: IdentificatieType,
-        identificatie: String,
+        identificationType: IdentificatieType,
+        identification: String,
         zaak: Zaak,
-        toelichting: String
+        explanation: String
     ) {
-        when (identificatieType) {
-            IdentificatieType.BSN -> {
-                addRolNatuurlijkPersoonToZaak(
-                    roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
-                    bsn = identificatie,
-                    zaak = zaak,
-                    toelichting = toelichting
-                )
-            }
-
-            IdentificatieType.VN -> {
-                addRolVestigingToZaak(
-                    roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
-                    vestigingsnummer = identificatie,
-                    zaak = zaak,
-                    toelichting = toelichting
-                )
-            }
-
-            IdentificatieType.RSIN -> {
-                addRolNietNatuurlijkPersoonToZaak(
-                    roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
-                    rsin = identificatie,
-                    zaak = zaak,
-                    toelichting = toelichting
-                )
-            }
-        }
+        addRoleToZaak(
+            roleType = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
+            identificationType = identificationType,
+            identification = identification,
+            zaak = zaak,
+            explanation = explanation
+        )
     }
 
     /**
@@ -258,54 +215,38 @@ class ZaakService @Inject constructor(
         }
     }
 
-    private fun addRolNatuurlijkPersoonToZaak(
-        roltype: RolType,
-        bsn: String,
+    private fun addRoleToZaak(
+        roleType: RolType,
+        identificationType: IdentificatieType,
+        identification: String,
         zaak: Zaak,
-        toelichting: String
+        explanation: String
     ) {
-        zrcClientService.createRol(
-            RolNatuurlijkPersoon(
-                zaak.url,
-                roltype,
-                toelichting,
-                NatuurlijkPersoon(bsn)
-            ),
-            toelichting
-        )
-    }
+        val role = when (identificationType) {
+            IdentificatieType.BSN ->
+                RolNatuurlijkPersoon(
+                    zaak.url,
+                    roleType,
+                    explanation,
+                    NatuurlijkPersoon(identification)
+                )
 
-    private fun addRolVestigingToZaak(
-        roltype: RolType,
-        vestigingsnummer: String,
-        zaak: Zaak,
-        toelichting: String
-    ) {
-        zrcClientService.createRol(
-            RolVestiging(
-                zaak.url,
-                roltype,
-                toelichting,
-                Vestiging(vestigingsnummer)
-            ),
-            toelichting
-        )
-    }
+            IdentificatieType.VN ->
+                RolVestiging(
+                    zaak.url,
+                    roleType,
+                    explanation,
+                    Vestiging(identification)
+                )
 
-    private fun addRolNietNatuurlijkPersoonToZaak(
-        roltype: RolType,
-        rsin: String,
-        zaak: Zaak,
-        toelichting: String
-    ) {
-        zrcClientService.createRol(
-            RolNietNatuurlijkPersoon(
-                zaak.url,
-                roltype,
-                toelichting,
-                NietNatuurlijkPersoon(rsin)
-            ),
-            toelichting
-        )
+            IdentificatieType.RSIN ->
+                RolNietNatuurlijkPersoon(
+                    zaak.url,
+                    roleType,
+                    explanation,
+                    NietNatuurlijkPersoon(identification)
+                )
+        }
+        zrcClientService.createRol(role, explanation)
     }
 }

--- a/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
@@ -34,59 +34,90 @@ import java.util.logging.Logger
 private val LOG = Logger.getLogger(ZaakService::class.java.name)
 
 @AllOpen
+@Suppress("TooManyFunctions")
 class ZaakService @Inject constructor(
     private val zrcClientService: ZrcClientService,
     private val ztcClientService: ZtcClientService,
     private var eventingService: EventingService,
 ) {
     fun addBetrokkenNatuurlijkPersoon(
-        roltype: RolType,
+        roltypeUUID: UUID,
         bsn: String,
         zaak: Zaak,
         toelichting: String
     ) {
-        zrcClientService.createRol(
-            RolNatuurlijkPersoon(
-                zaak.url,
-                roltype,
-                toelichting,
-                NatuurlijkPersoon(bsn)
-            ),
-            toelichting
+        addBetrokkenNatuurlijkPersoonByRoleType(
+            roltype = ztcClientService.readRoltype(roltypeUUID),
+            bsn = bsn,
+            zaak = zaak,
+            toelichting = toelichting
+        )
+    }
+
+    fun addInitiatorNatuurlijkPersoon(
+        bsn: String,
+        zaak: Zaak,
+        toelichting: String
+    ) {
+        addBetrokkenNatuurlijkPersoonByRoleType(
+            roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
+            bsn = bsn,
+            zaak = zaak,
+            toelichting = toelichting
         )
     }
 
     fun addBetrokkenVestiging(
-        roltype: RolType,
+        roltypeUUID: UUID,
         vestigingsnummer: String,
         zaak: Zaak,
         toelichting: String
     ) {
-        zrcClientService.createRol(
-            RolVestiging(
-                zaak.url,
-                roltype,
-                toelichting,
-                Vestiging(vestigingsnummer)
-            ),
-            toelichting
+        addBetrokkenVestigingByRoleType(
+            roltype = ztcClientService.readRoltype(roltypeUUID),
+            vestigingsnummer = vestigingsnummer,
+            zaak = zaak,
+            toelichting = toelichting
+        )
+    }
+
+    fun addInitiatorVestiging(
+        vestigingsnummer: String,
+        zaak: Zaak,
+        toelichting: String
+    ) {
+        addBetrokkenVestigingByRoleType(
+            roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
+            vestigingsnummer = vestigingsnummer,
+            zaak = zaak,
+            toelichting = toelichting
         )
     }
 
     fun addBetrokkenNietNatuurlijkPersoon(
-        roltype: RolType,
+        roltypeUUID: UUID,
         rsin: String,
         zaak: Zaak,
         toelichting: String
     ) {
-        zrcClientService.createRol(
-            RolNietNatuurlijkPersoon(
-                zaak.url,
-                roltype,
-                toelichting,
-                NietNatuurlijkPersoon(rsin)
-            ),
-            toelichting
+        addBetrokkenNietNatuurlijkPersoonByRoleType(
+            roltype = ztcClientService.readRoltype(roltypeUUID),
+            rsin = rsin,
+            zaak = zaak,
+            toelichting = toelichting
+        )
+    }
+
+    fun addInitiatorNietNatuurlijkPersoon(
+        rsin: String,
+        zaak: Zaak,
+        toelichting: String
+    ) {
+        addBetrokkenNietNatuurlijkPersoonByRoleType(
+            roltype = ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR),
+            rsin = rsin,
+            zaak = zaak,
+            toelichting = toelichting
         )
     }
 
@@ -206,5 +237,56 @@ class ZaakService @Inject constructor(
             LOG.fine { "Sending 'ZAKEN_VRIJGEVEN' screen event with ID '$it'." }
             eventingService.send(ScreenEventType.ZAKEN_VRIJGEVEN.updated(it))
         }
+    }
+
+    private fun addBetrokkenNatuurlijkPersoonByRoleType(
+        roltype: RolType,
+        bsn: String,
+        zaak: Zaak,
+        toelichting: String
+    ) {
+        zrcClientService.createRol(
+            RolNatuurlijkPersoon(
+                zaak.url,
+                roltype,
+                toelichting,
+                NatuurlijkPersoon(bsn)
+            ),
+            toelichting
+        )
+    }
+
+    private fun addBetrokkenVestigingByRoleType(
+        roltype: RolType,
+        vestigingsnummer: String,
+        zaak: Zaak,
+        toelichting: String
+    ) {
+        zrcClientService.createRol(
+            RolVestiging(
+                zaak.url,
+                roltype,
+                toelichting,
+                Vestiging(vestigingsnummer)
+            ),
+            toelichting
+        )
+    }
+
+    private fun addBetrokkenNietNatuurlijkPersoonByRoleType(
+        roltype: RolType,
+        rsin: String,
+        zaak: Zaak,
+        toelichting: String
+    ) {
+        zrcClientService.createRol(
+            RolNietNatuurlijkPersoon(
+                zaak.url,
+                roltype,
+                toelichting,
+                NietNatuurlijkPersoon(rsin)
+            ),
+            toelichting
+        )
     }
 }

--- a/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
@@ -250,10 +250,10 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { zaakService.bepaalRolMedewerker(user, zaak) } returns rolMedewerker
         every {
             zaakService.addInitiatorToZaak(
-                identificatieType = restZaak.initiatorIdentificatieType!!,
-                identificatie = restZaak.initiatorIdentificatie!!,
+                identificationType = restZaak.initiatorIdentificatieType!!,
+                identification = restZaak.initiatorIdentificatie!!,
                 zaak = zaak,
-                toelichting = "Toegekend door de medewerker tijdens het behandelen van de zaak"
+                explanation = "Toegekend door de medewerker tijdens het behandelen van de zaak"
             )
         } just runs
 

--- a/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
@@ -249,8 +249,9 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { zaakService.bepaalRolGroep(group, zaak) } returns rolOrganisatorischeEenheid
         every { zaakService.bepaalRolMedewerker(user, zaak) } returns rolMedewerker
         every {
-            zaakService.addInitiatorNatuurlijkPersoon(
-                bsn = restZaak.initiatorIdentificatie!!,
+            zaakService.addInitiatorToZaak(
+                identificatieType = restZaak.initiatorIdentificatieType!!,
+                identificatie = restZaak.initiatorIdentificatie!!,
                 zaak = zaak,
                 toelichting = "Toegekend door de medewerker tijdens het behandelen van de zaak"
             )

--- a/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
@@ -194,7 +194,6 @@ class ZaakRestServiceTest : BehaviorSpec({
         )
         val rolMedewerker = createRolMedewerker()
         val rolOrganisatorischeEenheid = createRolOrganisatorischeEenheid()
-        val rolTypeInitiator = createRolType(omschrijvingGeneriek = OmschrijvingGeneriekEnum.INITIATOR)
         val user = createLoggedInUser()
         val zaakAfhandelParameters = createZaakafhandelParameters()
         val zaakObjectPand = createZaakobjectPand()
@@ -247,14 +246,10 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { zrcClientService.createZaakobject(zaakObjectPand) } returns zaakObjectPand
         every { zrcClientService.createZaakobject(zaakObjectOpenbareRuimte) } returns zaakObjectOpenbareRuimte
         every { ztcClientService.readZaaktype(zaakTypeUUID) } returns zaakType
-        every {
-            ztcClientService.readRoltype(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR)
-        } returns rolTypeInitiator
         every { zaakService.bepaalRolGroep(group, zaak) } returns rolOrganisatorischeEenheid
         every { zaakService.bepaalRolMedewerker(user, zaak) } returns rolMedewerker
         every {
-            zaakService.addBetrokkenNatuurlijkPersoon(
-                roltype = rolTypeInitiator,
+            zaakService.addInitiatorNatuurlijkPersoon(
                 bsn = restZaak.initiatorIdentificatie!!,
                 zaak = zaak,
                 toelichting = "Toegekend door de medewerker tijdens het behandelen van de zaak"


### PR DESCRIPTION
Refactoring only to prepare for: 'do not allow multiple betrokkenen of same type in backend'. Moved some more logic from the ZaakRestService to the ZaakService. Translated some stuff to English.

Solves PZ-4518