### PR TITLE
chore(build): use explicit action versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       skip: ${{ steps.paths-ignore.outputs.skip }}
     steps:
       - name: Skip CodeQL analysis when only Markdown files are changed
-        uses: kunitsucom/github-actions-paths-ignore-alternative@main
+        uses: kunitsucom/github-actions-paths-ignore-alternative@v0.0.4
         id: paths-ignore
         with:
           paths-ignore: |-

--- a/.github/workflows/snyk-code-scan.yml
+++ b/.github/workflows/snyk-code-scan.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Snyk to check for Node vulnerabilities
-        uses: snyk/actions/node@0.4.0
+        uses: snyk/actions/node@cdb760004ba9ea4d525f2e043745dfe85bb9077e
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Snyk to check for Gradle vulnerabilities
-        uses: snyk/actions/gradle@0.4.0
+        uses: snyk/actions/gradle@cdb760004ba9ea4d525f2e043745dfe85bb9077e
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk-code-scan.yml
+++ b/.github/workflows/snyk-code-scan.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Snyk to check for Node vulnerabilities
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@0.4.0
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Snyk to check for Gradle vulnerabilities
-        uses: snyk/actions/gradle@master
+        uses: snyk/actions/gradle@0.4.0
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/trivy-docker-image-scan.yml
+++ b/.github/workflows/trivy-docker-image-scan.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run Snyk to check Docker image for vulnerabilities
         continue-on-error: true
-        uses: snyk/actions/docker@0.4.0
+        uses: snyk/actions/docker@cdb760004ba9ea4d525f2e043745dfe85bb9077e
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:

--- a/.github/workflows/trivy-docker-image-scan.yml
+++ b/.github/workflows/trivy-docker-image-scan.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run Snyk to check Docker image for vulnerabilities
         continue-on-error: true
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@0.4.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:


### PR DESCRIPTION
Instead of the master version, we should use explict version numbers, so that we can track version changes better. And will be able to roll back in case of a break.

Use kunitsucom/github-actions-paths-ignore-alternative version 0.0.4. 
Use snyk/actions/* version 0.4.0.

Solves PZ-4576