### PR TITLE
chore: do not run GitHub build & test workflows in PRs when only Markdown files have been changed

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -31,9 +31,23 @@ permissions:
   security-events: write
 
 jobs:
+  paths-ignore:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.paths-ignore.outputs.skip }}
+    steps:
+      - name: Skip job when only Markdown files are changed
+        uses: kunitsucom/github-actions-paths-ignore-alternative@v0.0.4
+        id: paths-ignore
+        with:
+          paths-ignore: |-
+            ^.*\.md$
+
   build:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    needs: paths-ignore
+    if: ${{ needs.paths-ignore.outputs.skip != 'true' || github.ref == 'refs/heads/main'}}
     outputs:
       branch_name: ${{ steps.gen_branch_name.outputs.BRANCH_NAME }}
       build_number: ${{ steps.gen_build_number.outputs.BUILD_NUMBER }}
@@ -103,7 +117,8 @@ jobs:
           key: zac-jar-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   run-unit-tests:
-    needs: [build]
+    needs: [build, paths-ignore]
+    if: ${{ needs.paths-ignore.outputs.skip != 'true' || github.ref == 'refs/heads/main'}}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:
@@ -165,7 +180,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build-docker-image-and-run-itests:
-    needs: [build]
+    needs: [build, paths-ignore]
+    if: ${{ needs.paths-ignore.outputs.skip != 'true' || github.ref == 'refs/heads/main'}}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:
@@ -406,6 +422,7 @@ jobs:
           allowUpdates: true
           makeLatest: true
           generateReleaseNotes: true
+
   trigger-provision:
     needs: [push-docker-image]
     runs-on: ubuntu-22.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       skip: ${{ steps.paths-ignore.outputs.skip }}
     steps:
-      - name: Skip CodeQL analysis when only Markdown files are changed
+      - name: Skip job when only Markdown files are changed
         uses: kunitsucom/github-actions-paths-ignore-alternative@v0.0.4
         id: paths-ignore
         with:
@@ -40,7 +40,6 @@ jobs:
       fail-fast: false
       matrix:
         language: ["java-kotlin", "javascript-typescript"]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -79,15 +78,8 @@ jobs:
       contents: read
       checks: read
       pull-requests: read
-    if: ${{ needs.paths-ignore.outputs.skip == 'true' && github.event_name == 'pull_request' }}
+    if: ${{ needs.paths-ignore.outputs.skip != 'true' && github.event_name == 'pull_request' }}
     steps:
-      - name: Ignore when only Markdown files are changed
-        uses: kunitsucom/github-actions-paths-ignore-alternative@v0.0.4
-        id: paths-ignore
-        with:
-          paths-ignore: |-
-            ^.*\.md$
-
       - name: Check CodeQL Status
         uses: eldrick19/code-scanning-status-checker@v2
         with:


### PR DESCRIPTION
Do not run GitHub build & test workflows when only Markdown files have been changed _and_ we are not on the main branch.

Solves PZ-4581