### PR TITLE
feat: use 409 HTTP response when betrokkene was already added to the zaak

### DIFF
--- a/src/main/app/src/assets/i18n/en.json
+++ b/src/main/app/src/assets/i18n/en.json
@@ -732,6 +732,7 @@
   "msg.error.bag.client.exception": "Unfortunately a technical error has occurred. No BAG objects could be retrieved.",
   "msg.error.brc.client.exception": "Unfortunately a technical error has occurred. No decisions could be retrieved.",
   "msg.error.brp.client.exception": "Unfortunately a technical error has occurred. No persons could be retrieved.",
+  "msg.error.betrokkene.was.already.added.to.zaak": "This involved party has already been added to the case with the chosen involvement type.",
   "msg.error.drc.client.exception": "Unfortunately a technical error has occurred. No documents could be retrieved.",
   "msg.error.klanten.client.exception": "Unfortunately a technical error has occurred. No customer data could be retrieved.",
   "msg.error.objects.client.exception": "Unfortunately a technical error has occurred. No objects could be retrieved.",

--- a/src/main/app/src/assets/i18n/nl.json
+++ b/src/main/app/src/assets/i18n/nl.json
@@ -731,6 +731,7 @@
   "msg.error.server.forbidden": "U heeft helaas onvoldoende rechten om deze actie uit te voeren.",
   "msg.error.bag.client.exception": "Er heeft zich helaas een technische fout voor gedaan. Er kunnen geen BAG objecten worden opgehaald.",
   "msg.error.brc.client.exception": "Er heeft zich helaas een technische fout voor gedaan. Er kunnen geen besluiten worden opgehaald.",
+  "msg.error.betrokkene.was.already.added.to.zaak": "Deze betrokkene is al toegevoegd aan de zaak met de gekozen betrokkenheid.",
   "msg.error.brp.client.exception": "Er heeft zich helaas een technische fout voor gedaan. Er kunnen geen personen worden opgehaald.",
   "msg.error.drc.client.exception": "Er heeft zich helaas een technische fout voor gedaan. Er kunnen geen documenten worden opgehaald.",
   "msg.error.klanten.client.exception": "Er heeft zich helaas een technische fout voor gedaan. Er kan geen klantinformatie worden opgehaald.",

--- a/src/main/kotlin/net/atos/zac/app/exception/ErrorCodes.kt
+++ b/src/main/kotlin/net/atos/zac/app/exception/ErrorCodes.kt
@@ -11,6 +11,7 @@ package net.atos.zac.app.exception
 */
 
 const val ERROR_CODE_BAG_CLIENT = "msg.error.bag.client.exception"
+const val ERROR_CODE_BETROKKENE_WAS_ALREADY_ADDED_TO_ZAAK = "msg.error.betrokkene.was.already.added.to.zaak"
 const val ERROR_CODE_BRC_CLIENT = "msg.error.brc.client.exception"
 const val ERROR_CODE_BRP_CLIENT = "msg.error.brp.client.exception"
 const val ERROR_CODE_DRC_CLIENT = "msg.error.drc.client.exception"

--- a/src/main/kotlin/net/atos/zac/app/exception/RestExceptionMapper.kt
+++ b/src/main/kotlin/net/atos/zac/app/exception/RestExceptionMapper.kt
@@ -77,7 +77,7 @@ class RestExceptionMapper : ExceptionMapper<Exception> {
                 exception = exception
             )
             // fall back to generic server error
-            else -> generateServerErrorResponse(exception)
+            else -> generateServerErrorResponse(exception = exception, exceptionMessage = exception.message)
         }
 
     private fun createResponse(exception: WebApplicationException) =
@@ -104,7 +104,8 @@ class RestExceptionMapper : ExceptionMapper<Exception> {
                 exception = exception,
                 errorCode = ERROR_CODE_ZTC_CLIENT
             )
-            else -> generateServerErrorResponse(exception)
+            // fall back to generic server error
+            else -> generateServerErrorResponse(exception = exception, exceptionMessage = exception.message)
         }
 
     /**
@@ -146,11 +147,12 @@ class RestExceptionMapper : ExceptionMapper<Exception> {
     private fun generateServerErrorResponse(
         exception: Exception,
         errorCode: String? = null,
+        exceptionMessage: String? = null
     ) = generateResponse(
         responseStatus = Response.Status.INTERNAL_SERVER_ERROR,
         errorCode = errorCode ?: ERROR_CODE_GENERIC_SERVER,
         exception = exception,
-        exceptionMessage = exception.message
+        exceptionMessage = exceptionMessage
     )
 
     private fun generateResponse(

--- a/src/main/kotlin/net/atos/zac/app/exception/RestExceptionMapper.kt
+++ b/src/main/kotlin/net/atos/zac/app/exception/RestExceptionMapper.kt
@@ -27,6 +27,7 @@ import net.atos.client.zgw.zrc.exception.ZrcRuntimeException
 import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.client.zgw.ztc.exception.ZtcRuntimeException
 import net.atos.zac.policy.exception.PolicyException
+import net.atos.zac.zaak.exception.BetrokkeneIsAlreadyAddedToZaakException
 import java.net.ConnectException
 import java.net.UnknownHostException
 import java.util.concurrent.ExecutionException
@@ -65,8 +66,18 @@ class RestExceptionMapper : ExceptionMapper<Exception> {
             exception is ProcessingException && (exception.cause is ConnectException || exception.cause is UnknownHostException) -> {
                 handleProcessingException(exception)
             }
-            exception is PolicyException -> generateForbiddenResponse(exception = exception)
-            else -> generateServerErrorResponse(exception = exception, exceptionMessage = exception.message)
+            exception is PolicyException -> generateResponse(
+                responseStatus = Response.Status.FORBIDDEN,
+                errorCode = ERROR_CODE_FORBIDDEN,
+                exception = exception
+            )
+            exception is BetrokkeneIsAlreadyAddedToZaakException -> generateResponse(
+                responseStatus = Response.Status.CONFLICT,
+                errorCode = ERROR_CODE_BETROKKENE_WAS_ALREADY_ADDED_TO_ZAAK,
+                exception = exception
+            )
+            // fall back to generic server error
+            else -> generateServerErrorResponse(exception)
         }
 
     private fun createResponse(exception: WebApplicationException) =
@@ -93,7 +104,7 @@ class RestExceptionMapper : ExceptionMapper<Exception> {
                 exception = exception,
                 errorCode = ERROR_CODE_ZTC_CLIENT
             )
-            else -> generateServerErrorResponse(exception = exception, exceptionMessage = exception.message)
+            else -> generateServerErrorResponse(exception)
         }
 
     /**
@@ -128,59 +139,45 @@ class RestExceptionMapper : ExceptionMapper<Exception> {
                     generateServerErrorResponse(exception = exception, errorCode = ERROR_CODE_ZRC_CLIENT)
                 it.contains(ZtcClientService::class.simpleName!!) ->
                     generateServerErrorResponse(exception = exception, errorCode = ERROR_CODE_ZTC_CLIENT)
-                else -> generateServerErrorResponse(exception = exception, exceptionMessage = exception.message)
+                else -> generateServerErrorResponse(exception)
             }
         }
 
     private fun generateServerErrorResponse(
         exception: Exception,
         errorCode: String? = null,
-        exceptionMessage: String? = null
-    ): Response =
-        Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-            .type(MediaType.APPLICATION_JSON)
-            .entity(
-                getJSONMessage(
-                    errorMessage = errorCode ?: ERROR_CODE_GENERIC_SERVER,
-                    exceptionMessage = exceptionMessage
-                )
-            )
-            .build().also {
-                LOG.log(
-                    Level.SEVERE,
-                    exceptionMessage ?: "Exception was thrown. Returning response with error code $errorCode.",
-                    exception
-                )
-            }
+    ) = generateResponse(
+        responseStatus = Response.Status.INTERNAL_SERVER_ERROR,
+        errorCode = errorCode ?: ERROR_CODE_GENERIC_SERVER,
+        exception = exception,
+        exceptionMessage = exception.message
+    )
 
-    private fun generateForbiddenResponse(
+    private fun generateResponse(
+        responseStatus: Response.Status,
+        errorCode: String,
         exception: Exception,
         exceptionMessage: String? = null
-    ): Response =
-        Response.status(Response.Status.FORBIDDEN)
-            .type(MediaType.APPLICATION_JSON)
-            .entity(
-                getJSONMessage(
-                    errorMessage = ERROR_CODE_FORBIDDEN,
-                    exceptionMessage = exceptionMessage
-                )
+    ) = Response.status(responseStatus)
+        .type(MediaType.APPLICATION_JSON)
+        .entity(
+            getJSONMessage(
+                errorMessage = errorCode,
+                exceptionMessage = exceptionMessage
             )
-            .build().also {
-                LOG.log(
-                    Level.FINE,
-                    exceptionMessage ?: "Exception was thrown. Returning response with error code $ERROR_CODE_FORBIDDEN.",
-                    exception
-                )
-            }
+        )
+        .build().also {
+            LOG.log(
+                Level.FINE,
+                exception.message ?: "Exception was thrown. Returning response with error code $errorCode.",
+                exception
+            )
+        }
 
     private fun getJSONMessage(errorMessage: String, exceptionMessage: String? = null) =
         try {
-            val errorJsonHashMap = mutableMapOf(
-                "message" to errorMessage
-            )
-            exceptionMessage?.let {
-                errorJsonHashMap["exception"] = it
-            }
+            val errorJsonHashMap = mutableMapOf("message" to errorMessage)
+            exceptionMessage?.let { errorJsonHashMap["exception"] = it }
             ObjectMapper().writeValueAsString(errorJsonHashMap)
         } catch (jsonProcessingException: JsonProcessingException) {
             LOG.log(Level.SEVERE, JSON_CONVERSION_ERROR_MESSAGE, jsonProcessingException)

--- a/src/main/kotlin/net/atos/zac/app/klant/KlantRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/klant/KlantRestService.kt
@@ -48,7 +48,7 @@ import net.atos.zac.app.klant.model.personen.toRechtsPersonen
 import net.atos.zac.app.klant.model.personen.toRestPersoon
 import net.atos.zac.app.klant.model.personen.toRestResultaat
 import net.atos.zac.app.shared.RESTResultaat
-import net.atos.zac.zaak.Betrokkenen.BETROKKENEN_ENUMSET
+import net.atos.zac.zaak.model.Betrokkenen.BETROKKENEN_ENUMSET
 import nl.lifely.zac.util.AllOpen
 import nl.lifely.zac.util.NoArgConstructor
 import org.hibernate.validator.constraints.Length

--- a/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
@@ -8,7 +8,6 @@ import io.opentelemetry.instrumentation.annotations.SpanAttribute
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import jakarta.inject.Inject
 import net.atos.client.zgw.zrc.ZrcClientService
-import net.atos.client.zgw.zrc.exception.ZrcResponseExceptionMapper
 import net.atos.client.zgw.zrc.model.BetrokkeneType
 import net.atos.client.zgw.zrc.model.Medewerker
 import net.atos.client.zgw.zrc.model.NatuurlijkPersoon
@@ -30,9 +29,9 @@ import net.atos.zac.event.EventingService
 import net.atos.zac.identity.model.Group
 import net.atos.zac.identity.model.User
 import net.atos.zac.websocket.event.ScreenEventType
+import net.atos.zac.zaak.exception.BetrokkeneIsAlreadyAddedToZaakException
 import net.atos.zac.zaak.model.Betrokkenen.BETROKKENEN_ENUMSET
 import nl.lifely.zac.util.AllOpen
-import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
 import java.util.Locale
 import java.util.UUID
 import java.util.logging.Logger
@@ -58,11 +57,10 @@ class ZaakService @Inject constructor(
                 it.identificatienummer == identification && it.roltype == roleType.url
             }
         ) {
-            LOG.info {
-                "Betrokkene of type '$identificationType' and with identification '$identification' " +
-                    "already exists for zaak with UUID '${zaak.uuid}'. Ignoring."
-            }
-            return
+            throw BetrokkeneIsAlreadyAddedToZaakException(
+                "Betrokkene with type '$identificationType' and identification '$identification' " +
+                    "was already added to the zaak with UUID '${zaak.uuid}'. Ignoring."
+            )
         }
         addRoleToZaak(
             roleType = roleType,

--- a/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/ZaakService.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.instrumentation.annotations.SpanAttribute
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import jakarta.inject.Inject
 import net.atos.client.zgw.zrc.ZrcClientService
+import net.atos.client.zgw.zrc.exception.ZrcResponseExceptionMapper
 import net.atos.client.zgw.zrc.model.BetrokkeneType
 import net.atos.client.zgw.zrc.model.Medewerker
 import net.atos.client.zgw.zrc.model.NatuurlijkPersoon
@@ -29,8 +30,9 @@ import net.atos.zac.event.EventingService
 import net.atos.zac.identity.model.Group
 import net.atos.zac.identity.model.User
 import net.atos.zac.websocket.event.ScreenEventType
-import net.atos.zac.zaak.Betrokkenen.BETROKKENEN_ENUMSET
+import net.atos.zac.zaak.model.Betrokkenen.BETROKKENEN_ENUMSET
 import nl.lifely.zac.util.AllOpen
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
 import java.util.Locale
 import java.util.UUID
 import java.util.logging.Logger

--- a/src/main/kotlin/net/atos/zac/zaak/exception/BetrokkeneIsAlreadyAddedToZaakException.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/exception/BetrokkeneIsAlreadyAddedToZaakException.kt
@@ -1,0 +1,3 @@
+package net.atos.zac.zaak.exception
+
+class BetrokkeneIsAlreadyAddedToZaakException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/net/atos/zac/zaak/model/Betrokkenen.kt
+++ b/src/main/kotlin/net/atos/zac/zaak/model/Betrokkenen.kt
@@ -1,4 +1,8 @@
-package net.atos.zac.zaak
+/*
+* SPDX-FileCopyrightText: 2024 Lifely
+* SPDX-License-Identifier: EUPL-1.2+
+*/
+package net.atos.zac.zaak.model
 
 import net.atos.client.zgw.ztc.model.generated.OmschrijvingGeneriekEnum
 import java.util.EnumSet

--- a/src/test/kotlin/net/atos/zac/zaak/ZaakServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/zaak/ZaakServiceTest.kt
@@ -28,6 +28,7 @@ import net.atos.zac.identity.model.createGroup
 import net.atos.zac.identity.model.createUser
 import net.atos.zac.websocket.event.ScreenEvent
 import net.atos.zac.websocket.event.ScreenEventType
+import net.atos.zac.zaak.exception.BetrokkeneIsAlreadyAddedToZaakException
 import java.net.URI
 import java.util.UUID
 
@@ -382,15 +383,19 @@ class ZaakServiceTest : BehaviorSpec({
         every { zrcClientService.listRollen(zaak) } returns listOf(roleAdviseur)
 
         When("the same betrokkene is added again with the same role type") {
-            zaakService.addBetrokkeneToZaak(
-                roleTypeUUID = roleTypeUUID,
-                identificationType = IdentificatieType.BSN,
-                identification = identification,
-                zaak = zaak,
-                explanation = explanation
-            )
+            val exception = shouldThrow<BetrokkeneIsAlreadyAddedToZaakException> {
+                zaakService.addBetrokkeneToZaak(
+                    roleTypeUUID = roleTypeUUID,
+                    identificationType = IdentificatieType.BSN,
+                    identification = identification,
+                    zaak = zaak,
+                    explanation = explanation
+                )
+            }
 
-            Then("the betrokkene is not added to the zaak again") {
+            Then("an exception is thrown and the betrokkene is not added to the zaak again") {
+                exception.message shouldBe "Betrokkene with type 'BSN' and identification 'dummyBSN' " +
+                    "was already added to the zaak with UUID '${zaak.uuid}'. Ignoring."
                 verify(exactly = 0) {
                     zrcClientService.createRol(any(), any())
                 }


### PR DESCRIPTION
Use 409 HTTP response with translated error message when betrokkene is added to zaak but the betrokkene was already added to the zaak with this role type/

Solves PZ-4517