### PR TITLE
chore: added automated check for SPDX copyright headers for Java main source files

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -13,7 +13,7 @@ header:
        SPDX-FileCopyrightText: .*
        SPDX-License-Identifier: EUPL-1\.2\+
   paths:
-    # for now check Kotlin src/main files only; later on expand
+    # for now check specific folders/file types only; later on expand
     - 'src/main/kotlin/**'
     - 'src/main/java/**'
   paths-ignore:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -15,6 +15,7 @@ header:
   paths:
     # for now check Kotlin src/main files only; later on expand
     - 'src/main/kotlin/**'
+    - 'src/main/java/**'
   paths-ignore:
     - 'build'
     - 'certificates'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,15 @@ on the top of the file by adding a `, <YYYY> Lifely` to the `SPDX-FileCopyrightT
 Note that each contributor should only be mentioned once in an SPDX header, where we use the convention that the year 
 indicates the _initial_ year when a contribution was made by that contributor.
 
+### Checking for SPDX license identifiers and (optionally) adding them in bulk
+
+We automatically check for SPDX license identifiers in our source code with a GitHub workflow that uses the
+[Skywalking Eyes](https://github.com/apache/skywalking-eyes) GitHub Action.
+
+Using the Skywalking Eyes configuration file in our codebase you can also run this check locally, and optionally
+add SPDX license identifiers to files that are missing them.
+Please see https://github.com/apache/skywalking-eyes for instructions.
+
 ## Conventional Commits
 
 We use [Conventional Commits](https://www.conventionalcommits.org) for our commit messages.

--- a/src/main/java/net/atos/client/bag/BagClientService.java
+++ b/src/main/java/net/atos/client/bag/BagClientService.java
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: 2022 Atos
  * SPDX-License-Identifier: EUPL-1.2+
  */
-
 package net.atos.client.bag;
 
 import static net.atos.client.bag.util.BagClientHeadersFactory.API_KEY;

--- a/src/main/java/net/atos/client/klant/model/Actor.java
+++ b/src/main/java/net/atos/client/klant/model/Actor.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/ActorForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/ActorForeignKey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/ActorKlantcontact.java
+++ b/src/main/java/net/atos/client/klant/model/ActorKlantcontact.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Actoridentificator.java
+++ b/src/main/java/net/atos/client/klant/model/Actoridentificator.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Betrokkene.java
+++ b/src/main/java/net/atos/client/klant/model/Betrokkene.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/BetrokkeneCorrespondentieadres.java
+++ b/src/main/java/net/atos/client/klant/model/BetrokkeneCorrespondentieadres.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/BetrokkeneForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/BetrokkeneForeignKey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Bezoekadres.java
+++ b/src/main/java/net/atos/client/klant/model/Bezoekadres.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Bijlage.java
+++ b/src/main/java/net/atos/client/klant/model/Bijlage.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/BijlageForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/BijlageForeignKey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/BijlageIdentificator.java
+++ b/src/main/java/net/atos/client/klant/model/BijlageIdentificator.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Categorie.java
+++ b/src/main/java/net/atos/client/klant/model/Categorie.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/CategorieForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/CategorieForeignKey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/CategorieRelatie.java
+++ b/src/main/java/net/atos/client/klant/model/CategorieRelatie.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/CategorieRelatieForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/CategorieRelatieForeignKey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Contactnaam.java
+++ b/src/main/java/net/atos/client/klant/model/Contactnaam.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/DigitaalAdres.java
+++ b/src/main/java/net/atos/client/klant/model/DigitaalAdres.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/DigitaalAdresForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/DigitaalAdresForeignKey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/ExpandBetrokkene.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandBetrokkene.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/ExpandBetrokkeneAllOfExpand.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandBetrokkeneAllOfExpand.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.client.klant.model;
 
 import jakarta.json.bind.annotation.JsonbProperty;

--- a/src/main/java/net/atos/client/klant/model/ExpandKlantcontact.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandKlantcontact.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/ExpandKlantcontactAllOfExpand.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandKlantcontactAllOfExpand.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/ExpandPartij.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandPartij.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/ExpandPartijAllOfExpand.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandPartijAllOfExpand.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/InterneTaak.java
+++ b/src/main/java/net/atos/client/klant/model/InterneTaak.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/InterneTaakForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/InterneTaakForeignKey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Klantcontact.java
+++ b/src/main/java/net/atos/client/klant/model/Klantcontact.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/KlantcontactForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/KlantcontactForeignKey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Onderwerpobject.java
+++ b/src/main/java/net/atos/client/klant/model/Onderwerpobject.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/OnderwerpobjectForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/OnderwerpobjectForeignKey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Onderwerpobjectidentificator.java
+++ b/src/main/java/net/atos/client/klant/model/Onderwerpobjectidentificator.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedActorKlantcontactList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedActorKlantcontactList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedActorList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedActorList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedBetrokkeneList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedBetrokkeneList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedBijlageList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedBijlageList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedCategorieList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedCategorieList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedCategorieRelatieList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedCategorieRelatieList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedDigitaalAdresList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedDigitaalAdresList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedExpandKlantcontactList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedExpandKlantcontactList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedExpandPartijList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedExpandPartijList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedInterneTaakList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedInterneTaakList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedKlantcontactList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedKlantcontactList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedOnderwerpobjectList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedOnderwerpobjectList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedPartijIdentificatorList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedPartijIdentificatorList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedPartijList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedPartijList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedRekeningnummerList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedRekeningnummerList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PaginatedVertegenwoordigdenList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedVertegenwoordigdenList.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Partij.java
+++ b/src/main/java/net/atos/client/klant/model/Partij.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PartijBezoekadres.java
+++ b/src/main/java/net/atos/client/klant/model/PartijBezoekadres.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PartijCorrespondentieadres.java
+++ b/src/main/java/net/atos/client/klant/model/PartijCorrespondentieadres.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PartijForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/PartijForeignKey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PartijForeignkeyBase.java
+++ b/src/main/java/net/atos/client/klant/model/PartijForeignkeyBase.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PartijIdentificator.java
+++ b/src/main/java/net/atos/client/klant/model/PartijIdentificator.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PartijIdentificatorForeignkey.java
+++ b/src/main/java/net/atos/client/klant/model/PartijIdentificatorForeignkey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/PartijIdentificatorGroepType.java
+++ b/src/main/java/net/atos/client/klant/model/PartijIdentificatorGroepType.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Rekeningnummer.java
+++ b/src/main/java/net/atos/client/klant/model/Rekeningnummer.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/RekeningnummerForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/RekeningnummerForeignKey.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/RolEnum.java
+++ b/src/main/java/net/atos/client/klant/model/RolEnum.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/SoortActorEnum.java
+++ b/src/main/java/net/atos/client/klant/model/SoortActorEnum.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/SoortPartijEnum.java
+++ b/src/main/java/net/atos/client/klant/model/SoortPartijEnum.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/StatusEnum.java
+++ b/src/main/java/net/atos/client/klant/model/StatusEnum.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/klant/model/Vertegenwoordigden.java
+++ b/src/main/java/net/atos/client/klant/model/Vertegenwoordigden.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 /**
  * klantinteracties
  * Description WIP.

--- a/src/main/java/net/atos/client/zgw/zrc/model/HoofdzaakZaakPatch.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/HoofdzaakZaakPatch.java
@@ -1,12 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.client.zgw.zrc.model;
 
 import java.net.URI;
 
+import jakarta.json.bind.annotation.JsonbNillable;
 import jakarta.json.bind.annotation.JsonbProperty;
 
 public class HoofdzaakZaakPatch extends Zaak {
 
-    @JsonbProperty(nillable = true)
+    @JsonbProperty
+    @JsonbNillable
     private final URI hoofdzaak;
 
     public HoofdzaakZaakPatch(final URI hoofdzaak) {

--- a/src/main/java/net/atos/client/zgw/zrc/model/zaakobjecten/ObjectOverige.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/zaakobjecten/ObjectOverige.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Atos
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.client.zgw.zrc.model.zaakobjecten;
 
 public class ObjectOverige<OVERIGE> {

--- a/src/main/java/net/atos/client/zgw/zrc/util/StatusTypeUtil.java
+++ b/src/main/java/net/atos/client/zgw/zrc/util/StatusTypeUtil.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.client.zgw.zrc.util;
 
 import static net.atos.zac.configuratie.ConfiguratieService.STATUSTYPE_OMSCHRIJVING_HEROPEND;

--- a/src/main/java/net/atos/client/zgw/zrc/util/ZaakUtil.java
+++ b/src/main/java/net/atos/client/zgw/zrc/util/ZaakUtil.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.client.zgw.zrc.util;
 
 import net.atos.client.zgw.zrc.model.generated.Zaak;

--- a/src/main/java/net/atos/zac/admin/model/UserEventListenerParameters.java
+++ b/src/main/java/net/atos/zac/admin/model/UserEventListenerParameters.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.admin.model;
 
 import static net.atos.zac.util.FlywayIntegrator.SCHEMA;

--- a/src/main/java/net/atos/zac/app/admin/model/RESTTaakFormulierDefinitie.java
+++ b/src/main/java/net/atos/zac/app/admin/model/RESTTaakFormulierDefinitie.java
@@ -1,9 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.app.admin.model;
 
 import java.util.List;
 
-public record RESTTaakFormulierDefinitie(
-                                         String id,
-                                         List<RESTTaakFormulierVeldDefinitie> veldDefinities
-) {
+public record RESTTaakFormulierDefinitie(String id, List<RESTTaakFormulierVeldDefinitie> veldDefinities) {
 }

--- a/src/main/java/net/atos/zac/app/admin/model/RESTTaakFormulierVeldDefinitie.java
+++ b/src/main/java/net/atos/zac/app/admin/model/RESTTaakFormulierVeldDefinitie.java
@@ -1,7 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.app.admin.model;
 
-public record RESTTaakFormulierVeldDefinitie(
-                                             String naam,
-                                             String waarde
-) {
+public record RESTTaakFormulierVeldDefinitie(String naam, String waarde) {
 }

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/RestEnkelvoudigInformatieFileUpload.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/RestEnkelvoudigInformatieFileUpload.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.app.informatieobjecten.model;
 
 import jakarta.ws.rs.FormParam;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadForm.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadForm.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.app.informatieobjecten.model.validation;
 
 import static java.lang.annotation.ElementType.TYPE;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadFormValidator.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadFormValidator.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.app.informatieobjecten.model.validation;
 
 import jakarta.validation.ConstraintValidator;

--- a/src/main/java/net/atos/zac/app/mail/converter/RESTMailGegevensConverter.java
+++ b/src/main/java/net/atos/zac/app/mail/converter/RESTMailGegevensConverter.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.app.mail.converter;
 
 import jakarta.inject.Inject;

--- a/src/main/java/net/atos/zac/app/mail/model/RESTMailGegevens.java
+++ b/src/main/java/net/atos/zac/app/mail/model/RESTMailGegevens.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.app.mail.model;
 
 /**

--- a/src/main/java/net/atos/zac/app/mailtemplate/MailtemplateRESTService.java
+++ b/src/main/java/net/atos/zac/app/mailtemplate/MailtemplateRESTService.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.app.mailtemplate;
 
 import java.util.UUID;

--- a/src/main/java/net/atos/zac/app/util/EnkelvoudigInformatieObjectStatusEnumReader.java
+++ b/src/main/java/net/atos/zac/app/util/EnkelvoudigInformatieObjectStatusEnumReader.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.app.util;
 
 import java.io.IOException;

--- a/src/main/java/net/atos/zac/app/util/RESTTaalReader.java
+++ b/src/main/java/net/atos/zac/app/util/RESTTaalReader.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.app.util;
 
 import java.io.IOException;

--- a/src/main/java/net/atos/zac/app/util/UUIDReader.java
+++ b/src/main/java/net/atos/zac/app/util/UUIDReader.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.app.util;
 
 import java.io.IOException;

--- a/src/main/java/net/atos/zac/flowable/ZaakVariabelenService.java
+++ b/src/main/java/net/atos/zac/flowable/ZaakVariabelenService.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.flowable;
 
 import java.time.ZonedDateTime;

--- a/src/main/java/net/atos/zac/flowable/delegate/UpdateZaakJavaDelegate.java
+++ b/src/main/java/net/atos/zac/flowable/delegate/UpdateZaakJavaDelegate.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.flowable.delegate;
 
 import java.util.logging.Logger;

--- a/src/main/java/net/atos/zac/flowable/util/TaskUtil.java
+++ b/src/main/java/net/atos/zac/flowable/util/TaskUtil.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.flowable.util;
 
 import static net.atos.zac.app.task.model.TaakStatus.AFGEROND;

--- a/src/main/java/net/atos/zac/formulieren/FormulierRuntimeService.java
+++ b/src/main/java/net/atos/zac/formulieren/FormulierRuntimeService.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.formulieren;
 
 import static jakarta.json.JsonValue.ValueType.STRING;

--- a/src/main/java/net/atos/zac/formulieren/ResolveDefaultValueContext.java
+++ b/src/main/java/net/atos/zac/formulieren/ResolveDefaultValueContext.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.formulieren;
 
 import java.util.Map;

--- a/src/main/java/net/atos/zac/healthcheck/model/ZaaktypeInrichtingscheck.java
+++ b/src/main/java/net/atos/zac/healthcheck/model/ZaaktypeInrichtingscheck.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.healthcheck.model;
 
 import java.util.ArrayList;
@@ -13,35 +17,20 @@ import net.atos.client.zgw.ztc.model.generated.ZaakType;
  * indien zaak besluit heeft, Besluittype
  */
 public class ZaaktypeInrichtingscheck {
-
     private final ZaakType zaaktype;
-
     private boolean statustypeIntakeAanwezig;
-
     private boolean statustypeInBehandelingAanwezig;
-
     private boolean statustypeHeropendAanwezig;
-
     private boolean statustypeAanvullendeInformatieVereist;
-
     private boolean statustypeAfgerondAanwezig;
-
     private boolean statustypeAfgerondLaatsteVolgnummer;
-
     private boolean resultaattypeAanwezig;
-
     private boolean rolInitiatorAanwezig;
-
     private boolean rolBehandelaarAanwezig;
-
     private boolean rolOverigeAanwezig;
-
     private boolean informatieobjecttypeEmailAanwezig;
-
     private boolean besluittypeAanwezig;
-
     private final List<String> resultaattypesMetVerplichtBesluit = new ArrayList<>();
-
     private boolean zaakafhandelParametersValide;
 
     public ZaaktypeInrichtingscheck(final ZaakType zaaktype) {

--- a/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
+++ b/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.mailtemplates;
 
 import static net.atos.client.zgw.shared.util.URIUtil.parseUUIDFromResourceURI;
@@ -105,7 +109,6 @@ public class MailTemplateHelper {
         this.zgwApiService = zgwApiService;
         this.zrcClientService = zrcClientService;
         this.ztcClientService = ztcClientService;
-
     }
 
     /**

--- a/src/main/java/net/atos/zac/mailtemplates/model/MailLink.java
+++ b/src/main/java/net/atos/zac/mailtemplates/model/MailLink.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.mailtemplates.model;
 
 import java.net.URI;

--- a/src/main/java/net/atos/zac/productaanvraag/util/BetalingStatusEnumJsonAdapter.java
+++ b/src/main/java/net/atos/zac/productaanvraag/util/BetalingStatusEnumJsonAdapter.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.productaanvraag.util;
 
 import jakarta.json.bind.adapter.JsonbAdapter;

--- a/src/main/java/net/atos/zac/productaanvraag/util/GeometryTypeEnumJsonAdapter.java
+++ b/src/main/java/net/atos/zac/productaanvraag/util/GeometryTypeEnumJsonAdapter.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.productaanvraag.util;
 
 import jakarta.json.bind.adapter.JsonbAdapter;

--- a/src/main/java/net/atos/zac/productaanvraag/util/IndicatieMachtigingEnumJsonAdapter.java
+++ b/src/main/java/net/atos/zac/productaanvraag/util/IndicatieMachtigingEnumJsonAdapter.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.productaanvraag.util;
 
 import jakarta.json.bind.adapter.JsonbAdapter;

--- a/src/main/java/net/atos/zac/productaanvraag/util/RolOmschrijvingGeneriekEnumJsonAdapter.java
+++ b/src/main/java/net/atos/zac/productaanvraag/util/RolOmschrijvingGeneriekEnumJsonAdapter.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.productaanvraag.util;
 
 import jakarta.json.bind.adapter.JsonbAdapter;

--- a/src/main/java/net/atos/zac/util/time/LocalDateReader.java
+++ b/src/main/java/net/atos/zac/util/time/LocalDateReader.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.util.time;
 
 import java.io.IOException;

--- a/src/main/java/net/atos/zac/util/time/ZonedDateTimeParamConverter.java
+++ b/src/main/java/net/atos/zac/util/time/ZonedDateTimeParamConverter.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.util.time;
 
 import java.time.ZonedDateTime;

--- a/src/main/java/net/atos/zac/util/time/ZonedDateTimeParamConverterProvider.java
+++ b/src/main/java/net/atos/zac/util/time/ZonedDateTimeParamConverterProvider.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.util.time;
 
 import java.lang.annotation.Annotation;

--- a/src/main/java/net/atos/zac/util/time/ZonedDateTimeReader.java
+++ b/src/main/java/net/atos/zac/util/time/ZonedDateTimeReader.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.util.time;
 
 import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;

--- a/src/main/java/net/atos/zac/webdav/WebdavHelper.java
+++ b/src/main/java/net/atos/zac/webdav/WebdavHelper.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.webdav;
 
 import static java.lang.String.format;
@@ -24,18 +28,14 @@ import net.atos.zac.util.MediaTypes;
 @Singleton
 public class WebdavHelper {
     public static final String FOLDER = "folder";
-
-    private static final String WEBDAV_CONTEXT_PATH = "/webdav";
     private static final Set<String> WEBDAV_WORD = Set.of(
             MediaTypes.Application.MS_WORD.getMediaType(),
             MediaTypes.Application.MS_WORD_OPEN_XML.getMediaType()
     );
-
     private static final Set<String> WEBDAV_POWERPOINT = Set.of(
             MediaTypes.Application.MS_POWER_POINT.getMediaType(),
             MediaTypes.Application.MS_POWER_POINT_OPEN_XML.getMediaType()
     );
-
     private static final Set<String> WEBDAV_EXCEL = Set.of(
             MediaTypes.Application.MS_EXCEL.getMediaType(),
             MediaTypes.Application.MS_EXCEL_OPEN_XML.getMediaType()

--- a/src/main/java/net/atos/zac/webdav/WebdavStore.java
+++ b/src/main/java/net/atos/zac/webdav/WebdavStore.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.webdav;
 
 import static net.atos.zac.authentication.SecurityUtilKt.setLoggedInUser;

--- a/src/main/java/net/atos/zac/websocket/WebsocketHandshakeInterceptor.java
+++ b/src/main/java/net/atos/zac/websocket/WebsocketHandshakeInterceptor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
 package net.atos.zac.websocket;
 
 import jakarta.servlet.http.HttpSession;
@@ -5,7 +9,7 @@ import jakarta.websocket.HandshakeResponse;
 import jakarta.websocket.server.HandshakeRequest;
 import jakarta.websocket.server.ServerEndpointConfig;
 
-/*
+/**
  * This interceptor is only needed to access the httpSession when opening a websocket.
  */
 public class WebsocketHandshakeInterceptor extends ServerEndpointConfig.Configurator {


### PR DESCRIPTION
Added automated check for SPDX copyright headers for Java main source files using https://github.com/apache/skywalking-eyes and fixed missing headers.

Solves PZ-4626