### PR TITLE
fix: update `taak` after document created update from open forms

### DIFF
--- a/src/main/app/src/app/taken/taak-view/taak-view.component.ts
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.ts
@@ -498,7 +498,7 @@ export class TaakViewComponent
       this.taak.zaakUuid,
       () => {
         this.websocketService.removeListener(listener);
-        this.formulier.refreshTaakdocumentenEnBijlagen();
+        this.reloadTaak();
       },
     );
   }


### PR DESCRIPTION
We do not know the `informatieobject.uuid` from the update so we can not push it to list of documents. We have to reload the whole `Taak` to update the list.

Solves PZ-4412