### PR TITLE
fix: use 'INFO push to protected branch' GitHub App to be able to push the generated `publiccode.yaml` file to our protected main branch

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -430,8 +430,18 @@ jobs:
     env:
       NEXT_VERSION: ${{ needs.next-version.outputs.version }}
     steps:
+      # create GitHub App token so that we can later on push to the protected 'main branch
+      # see: https://github.com/orgs/community/discussions/25305#discussioncomment-8256560
+      - name: Create 'INFO push to protected branch' GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PUSH_TO_PROTECTED_BRANCH_APP_ID }}
+          private-key: ${{ secrets.PUSH_TO_PROTECTED_BRANCH_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -433,7 +433,7 @@ jobs:
       # create GitHub App token so that we can later on push to the protected 'main branch
       # see: https://github.com/orgs/community/discussions/25305#discussioncomment-8256560
       - name: Create 'INFO push to protected branch' GitHub App token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         id: app-token
         with:
           app-id: ${{ vars.PUSH_TO_PROTECTED_BRANCH_APP_ID }}


### PR DESCRIPTION
Use 'INFO push to protected branch' GitHub App in our GitHub workflow to be able to push the generated `publiccode.yaml` file to our protected main branch. See https://github.com/orgs/community/discussions/25305#discussioncomment-8256560 for details.

Solves PZ-4631