### PR TITLE
chore: rollback keycloak version to be in line with the PodiumD 2.0.0 pinned limits

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@
 #
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:25.0.6@sha256:82c5b7a110456dbd42b86ea572e728878549954cc8bd03cd65410d75328095d2
+    image: quay.io/keycloak/keycloak:24.0.5@sha256:c916c668a5cd589948c3310ab31ffcfc5da55f0e546028f2f606419ce17c6ad8
     depends_on:
       keycloak-database:
         condition: service_healthy


### PR DESCRIPTION
The keycloak image in docker-compose is more recent than the version specified in the PodiumD 2.0.0 release. Rollback and pin to the defined version.

solves PZ-4639