### PR TITLE
fix: do a Git force push when adding the generated publiccode.yaml file to allow bypassing our main branch protection

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -459,7 +459,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add publiccode.yaml
           git commit -m "${{ github.workflow }}" || echo "No changes to commit"
-          git push        
+          git push --force      
 
   trigger-provision:
     needs: [push-docker-image]


### PR DESCRIPTION
Do a Git force push when adding the generated publiccode.yaml file to allow bypassing our main branch protection.

Solves PZ-4644