### PR TITLE
fix: fixed failing deployment on existing environments by reverting adding SPDX copyright headers to Flyway database migration scripts

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -42,4 +42,10 @@ header:
     - 'src/main/resources/cmmn/**'
     - 'src/main/resources/openapi-generator-templates/**'
     - 'src/main/resources/policies/policies'
+    # ignore Flyway DB migration files without SPDX headers
+    # adding SPDX headers to these files would break the migration on existing databases
+    - 'src/main/resources/db/migration/V34__*.sql'
+    - 'src/main/resources/db/migration/V38__*.sql'
+    - 'src/main/resources/db/migration/V39__*.sql'
+    - 'src/main/resources/db/migration/V40__*.sql'
   comment: on-failure

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -44,8 +44,8 @@ header:
     - 'src/main/resources/policies/policies'
     # ignore Flyway DB migration files without SPDX headers
     # adding SPDX headers to these files would break the migration on existing databases
-    - 'src/main/resources/db/migration/V34__*.sql'
-    - 'src/main/resources/db/migration/V38__*.sql'
-    - 'src/main/resources/db/migration/V39__*.sql'
-    - 'src/main/resources/db/migration/V40__*.sql'
+    - 'src/main/resources/schemas/V34__*.sql'
+    - 'src/main/resources/schemas/V38__*.sql'
+    - 'src/main/resources/schemas/V39__*.sql'
+    - 'src/main/resources/schemas/V40__*.sql'
   comment: on-failure

--- a/src/main/resources/schemas/V34__mail_template_defaults.sql
+++ b/src/main/resources/schemas/V34__mail_template_defaults.sql
@@ -1,8 +1,3 @@
-/*
- * SPDX-FileCopyrightText: 2022 Atos
- * SPDX-License-Identifier: EUPL-1.2+
- */
-
 INSERT INTO ${schema}.mail_template(id_mail_template, mail_template_naam, onderwerp, body, mail_template_enum)
 VALUES (nextval('${schema}.sq_mail_template'), 'Zaak ontvankelijk', 'Wij hebben uw verzoek in behandeling genomen (zaaknummer: {zaaknummer})',
         '<p>Beste klant,</p><p></p><p>Uw verzoek over {zaaktypenaam} met zaaknummer {zaaknummer} is in behandeling genomen. Voor meer informatie gaat u naar Mijn Loket.</p><p></p><p>Met vriendelijke groet,</p><p>Gemeente</p>',

--- a/src/main/resources/schemas/V38__mail_template_defaults_revisited.sql
+++ b/src/main/resources/schemas/V38__mail_template_defaults_revisited.sql
@@ -1,8 +1,3 @@
-/*
- * SPDX-FileCopyrightText: 2022 Atos
- * SPDX-License-Identifier: EUPL-1.2+
- */
-
 UPDATE ${schema}.mail_template
 SET body=REPLACE(body, 'Klik om de zaak te bekijken {ZAAKURL}', '{DOCUMENTLINK}');
 UPDATE ${schema}.mail_template

--- a/src/main/resources/schemas/V39__mail_template_defaults_revisited2.sql
+++ b/src/main/resources/schemas/V39__mail_template_defaults_revisited2.sql
@@ -1,8 +1,3 @@
-/*
- * SPDX-FileCopyrightText: 2022 Atos
- * SPDX-License-Identifier: EUPL-1.2+
- */
-
 UPDATE ${schema}.mail_template
 SET onderwerp=REPLACE(onderwerp, '{REGISTRATIEDATUM}', '{ZAAKREGISTRATIEDATUM}');
 UPDATE ${schema}.mail_template

--- a/src/main/resources/schemas/V40__taken_streef_naar_fataal.sql
+++ b/src/main/resources/schemas/V40__taken_streef_naar_fataal.sql
@@ -1,8 +1,3 @@
-/*
- * SPDX-FileCopyrightText: 2022 Atos
- * SPDX-License-Identifier: EUPL-1.2+
- */
-
 UPDATE ${schema}.mail_template
 SET body=REPLACE(body, 'uiterlijke datum', 'fatale datum')
 WHERE mail_template_naam = 'SIGNALERING_TAAK_VERLOPEN';


### PR DESCRIPTION
Fixed failing deployment on existing environments by reverting adding SPDX copyright headers to Flyway database migration scripts.

Solves 4692