### PR TITLE
fix: fix creation date not set when creating document

### DIFF
--- a/src/itest/kotlin/nl/lifely/zac/itest/DocumentCreationRestServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/DocumentCreationRestServiceTest.kt
@@ -52,7 +52,9 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
                         "zaakUuid" to zaakProductaanvraag1Uuid,
                         "smartDocumentsTemplateGroupId" to SMART_DOCUMENTS_ROOT_GROUP_ID,
                         "smartDocumentsTemplateId" to SMART_DOCUMENTS_ROOT_TEMPLATE_1_ID,
-                        "title" to SMART_DOCUMENTS_FILE_TITLE
+                        "title" to SMART_DOCUMENTS_FILE_TITLE,
+                        "creationDate" to ZonedDateTime.now(),
+                        "author" to TEST_USER_1_NAME
                     )
                 ).toString()
             )

--- a/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
@@ -128,7 +128,7 @@ export class InformatieObjectCreateAttendedComponent
       .build();
 
     const beginRegistratie = new DateFormFieldBuilder(moment())
-      .id("creatiedatum")
+      .id("creationDate")
       .label("creatiedatum")
       .validators(Validators.required)
       .build();

--- a/src/main/app/src/app/informatie-objecten/model/document-creation-data.ts
+++ b/src/main/app/src/app/informatie-objecten/model/document-creation-data.ts
@@ -10,6 +10,6 @@ export class DocumentCreationData {
   public smartDocumentsTemplateId: string;
   public title: string;
   public description?: string;
-  public author?: string;
-  public creationDate?: string;
+  public author: string;
+  public creationDate: string;
 }

--- a/src/main/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestService.kt
@@ -71,7 +71,7 @@ class DocumentCreationRestService @Inject constructor(
                 title = restDocumentCreationAttendedData.title,
                 description = restDocumentCreationAttendedData.description,
                 author = restDocumentCreationAttendedData.author,
-                creationDate = restDocumentCreationAttendedData.creationDate ?: ZonedDateTime.now()
+                creationDate = restDocumentCreationAttendedData.creationDate
             )
                 .let(documentCreationService::createDocumentAttended)
                 .let { response -> RestDocumentCreationAttendedResponse(response.redirectUrl, response.message) }

--- a/src/main/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestService.kt
@@ -19,8 +19,8 @@ import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import net.atos.client.zgw.zrc.ZrcClientService
-import net.atos.zac.app.documentcreation.rest.RestDocumentCreationAttendedData
-import net.atos.zac.app.documentcreation.rest.RestDocumentCreationAttendedResponse
+import net.atos.zac.app.documentcreation.model.RestDocumentCreationAttendedData
+import net.atos.zac.app.documentcreation.model.RestDocumentCreationAttendedResponse
 import net.atos.zac.configuratie.ConfiguratieService
 import net.atos.zac.documentcreation.DocumentCreationService
 import net.atos.zac.documentcreation.model.DocumentCreationDataAttended

--- a/src/main/kotlin/net/atos/zac/app/documentcreation/model/RestDocumentCreationAttendedData.kt
+++ b/src/main/kotlin/net/atos/zac/app/documentcreation/model/RestDocumentCreationAttendedData.kt
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-package net.atos.zac.app.documentcreation.rest
+package net.atos.zac.app.documentcreation.model
 
 import jakarta.validation.constraints.NotNull
 import nl.lifely.zac.util.NoArgConstructor

--- a/src/main/kotlin/net/atos/zac/app/documentcreation/model/RestDocumentCreationAttendedResponse.kt
+++ b/src/main/kotlin/net/atos/zac/app/documentcreation/model/RestDocumentCreationAttendedResponse.kt
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-package net.atos.zac.app.documentcreation.rest
+package net.atos.zac.app.documentcreation.model
 
 import nl.lifely.zac.util.NoArgConstructor
 import java.net.URI

--- a/src/main/kotlin/net/atos/zac/app/documentcreation/rest/RestDocumentCreationAttendedData.kt
+++ b/src/main/kotlin/net/atos/zac/app/documentcreation/rest/RestDocumentCreationAttendedData.kt
@@ -21,9 +21,11 @@ data class RestDocumentCreationAttendedData(
 
     var description: String? = null,
 
-    var author: String? = null,
+    @field:NotNull
+    var author: String,
 
-    var creationDate: ZonedDateTime? = null,
+    @field:NotNull
+    var creationDate: ZonedDateTime,
 
     @field:NotNull
     var smartDocumentsTemplateGroupId: String,

--- a/src/test/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestServiceTest.kt
@@ -16,7 +16,7 @@ import net.atos.client.zgw.zrc.ZrcClientService
 import net.atos.client.zgw.zrc.model.createZaak
 import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.client.zgw.ztc.model.createInformatieObjectType
-import net.atos.zac.app.documentcreation.rest.RestDocumentCreationAttendedData
+import net.atos.zac.app.documentcreation.model.createRestDocumentCreationAttendedData
 import net.atos.zac.configuratie.ConfiguratieService
 import net.atos.zac.documentcreation.DocumentCreationService
 import net.atos.zac.documentcreation.model.DocumentCreationDataAttended
@@ -42,7 +42,7 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
 
     Given("document creation data is provided and zaaktype can use the 'bijlage' informatieobjecttype") {
         val zaak = createZaak()
-        val restDocumentCreationAttendedData = RestDocumentCreationAttendedData(
+        val restDocumentCreationAttendedData = createRestDocumentCreationAttendedData(
             zaakUuid = zaak.uuid,
             taskId = "dummyTaskId",
             smartDocumentsTemplateGroupId = "groupId",

--- a/src/test/kotlin/net/atos/zac/app/documentcreation/model/DocumentCreationFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/documentcreation/model/DocumentCreationFixtures.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.zac.app.documentcreation.model
 
 import java.time.ZonedDateTime

--- a/src/test/kotlin/net/atos/zac/app/documentcreation/model/DocumentCreationFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/documentcreation/model/DocumentCreationFixtures.kt
@@ -1,0 +1,23 @@
+package net.atos.zac.app.documentcreation.model
+
+import java.time.ZonedDateTime
+import java.util.UUID
+
+@Suppress("LongParameterList")
+fun createRestDocumentCreationAttendedData(
+    zaakUuid: UUID = UUID.randomUUID(),
+    taskId: String? = null,
+    smartDocumentsTemplateGroupId: String = "dummyGroupId",
+    smartDocumentsTemplateId: String = "dummyTtemplateId",
+    title: String = "dummyTitle",
+    author: String = "dummyAuthor",
+    creationDate: ZonedDateTime = ZonedDateTime.now()
+) = RestDocumentCreationAttendedData(
+    zaakUuid = zaakUuid,
+    taskId = taskId,
+    smartDocumentsTemplateGroupId = smartDocumentsTemplateGroupId,
+    smartDocumentsTemplateId = smartDocumentsTemplateId,
+    title = title,
+    author = author,
+    creationDate = creationDate
+)


### PR DESCRIPTION
Fixed creation date not set when creating document by using correct field id in frontend. Made author and creation dates mandatory in backend when creating a SmartDocuments document.

Solves PZ-4676