### PR TITLE
chore: added a full stop characters to the automatically generated "Aangemaakt vanuit xxx met kenmerk 'yyy'" substring 

### DIFF
--- a/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/wsxmldeposit-wizard.json
+++ b/scripts/docker-compose/imports/smartdocuments-wiremock/mappings/wsxmldeposit-wizard.json
@@ -54,7 +54,7 @@
             "registratiedatum": "${json-unit.any-string}",
             "startdatum": "01-01-1970",
             "status": "Wacht op aanvullende informatie",
-            "toelichting": "Aangemaakt vanuit open-forms met kenmerk 'f8534f13-0669-4d4d-a364-6b6c4ad3d243' dummyZaakToelichting",
+            "toelichting": "Aangemaakt vanuit open-forms met kenmerk 'f8534f13-0669-4d4d-a364-6b6c4ad3d243'. dummyZaakToelichting",
             "uiterlijkeEinddatumAfdoening": "${json-unit.any-string}",
             "verlengingReden" : "dummyReason",
             "vertrouwelijkheidaanduiding": "openbaar",

--- a/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/NotificationsTest.kt
@@ -136,7 +136,7 @@ class NotificationsTest : BehaviorSpec({
                         getString("communicatiekanaal") shouldBe "E-formulier"
                         getString("omschrijving") shouldBe ZAAK_PRODUCTAANVRAAG_1_OMSCHRIJVING
                         getString("toelichting") shouldBe "Aangemaakt vanuit $OPEN_FORMULIEREN_FORMULIER_BRON_NAAM " +
-                            "met kenmerk '$OBJECT_PRODUCTAANVRAAG_1_BRON_KENMERK' $ZAAK_PRODUCTAANVRAAG_1_TOELICHTING"
+                            "met kenmerk '$OBJECT_PRODUCTAANVRAAG_1_BRON_KENMERK'. $ZAAK_PRODUCTAANVRAAG_1_TOELICHTING"
                         getString("uiterlijkeEinddatumAfdoening") shouldBe ZAAK_PRODUCTAANVRAAG_1_UITERLIJKE_EINDDATUM_AFDOENING
                         with(getJSONObject("zaakgeometrie").getJSONObject("point")) {
                             getBigDecimal("latitude") shouldBe PRODUCTAANVRAAG_ZAAKGEGEVENS_GEOMETRY_LATITUDE.toBigDecimal()
@@ -234,7 +234,7 @@ class NotificationsTest : BehaviorSpec({
                         getBoolean("isProcesGestuurd") shouldBe false
                         getString("communicatiekanaal") shouldBe "E-formulier"
                         getString("toelichting") shouldBe "Aangemaakt vanuit $OPEN_FORMULIEREN_FORMULIER_BRON_NAAM " +
-                            "met kenmerk '$OPEN_FORMULIEREN_PRODUCTAANVRAAG_FORMULIER_2_BRON_KENMERK'"
+                            "met kenmerk '$OPEN_FORMULIEREN_PRODUCTAANVRAAG_FORMULIER_2_BRON_KENMERK'."
                         getString("initiatorIdentificatie") shouldBe TEST_KVK_VESTIGINGSNUMMER_1
                         getString("initiatorIdentificatieType") shouldBe BETROKKENE_IDENTIFACTION_TYPE_VESTIGING
                         zaakProductaanvraag2Uuid = getString("uuid").let(UUID::fromString)

--- a/src/itest/kotlin/nl/lifely/zac/itest/ZaakRestServiceHistoryTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZaakRestServiceHistoryTest.kt
@@ -205,7 +205,7 @@ class ZaakRestServiceHistoryTest : BehaviorSpec({
                     "attribuutLabel": "zaak",
                     "door": "Functionele gebruiker",
                     "nieuweWaarde": "$ZAAK_PRODUCTAANVRAAG_1_IDENTIFICATION",
-                    "toelichting": "Aangemaakt vanuit $OPEN_FORMULIEREN_FORMULIER_BRON_NAAM met kenmerk '$OBJECT_PRODUCTAANVRAAG_1_BRON_KENMERK' $ZAAK_PRODUCTAANVRAAG_1_TOELICHTING"
+                    "toelichting": "Aangemaakt vanuit $OPEN_FORMULIEREN_FORMULIER_BRON_NAAM met kenmerk '$OBJECT_PRODUCTAANVRAAG_1_BRON_KENMERK'. $ZAAK_PRODUCTAANVRAAG_1_TOELICHTING"
                   }]
                 """.trimIndent()
 

--- a/src/itest/kotlin/nl/lifely/zac/itest/ZoekenRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/ZoekenRESTServiceTest.kt
@@ -464,7 +464,7 @@ class ZoekenRESTServiceTest : BehaviorSpec({
                                 "status": "NIET_TOEGEKEND",
                                 "zaakIdentificatie": "$ZAAK_PRODUCTAANVRAAG_1_IDENTIFICATION",
                                 "zaakOmschrijving": "$ZAAK_PRODUCTAANVRAAG_1_OMSCHRIJVING",
-                                "zaakToelichting": "Aangemaakt vanuit $OPEN_FORMULIEREN_FORMULIER_BRON_NAAM met kenmerk '$OBJECT_PRODUCTAANVRAAG_1_BRON_KENMERK' $ZAAK_PRODUCTAANVRAAG_1_TOELICHTING",
+                                "zaakToelichting": "Aangemaakt vanuit $OPEN_FORMULIEREN_FORMULIER_BRON_NAAM met kenmerk '$OBJECT_PRODUCTAANVRAAG_1_BRON_KENMERK'. $ZAAK_PRODUCTAANVRAAG_1_TOELICHTING",
                                 "zaaktypeOmschrijving": "$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION"
                             }
                         ],

--- a/src/main/kotlin/net/atos/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/net/atos/zac/productaanvraag/ProductaanvraagService.kt
@@ -501,7 +501,7 @@ class ProductaanvraagService @Inject constructor(
 
     private fun generateZaakExplanationFromProductaanvraag(productaanvraag: ProductaanvraagDimpact): String =
         (
-            "Aangemaakt vanuit ${productaanvraag.bron.naam} met kenmerk '${productaanvraag.bron.kenmerk}'" +
+            "Aangemaakt vanuit ${productaanvraag.bron.naam} met kenmerk '${productaanvraag.bron.kenmerk}'." +
                 (productaanvraag.zaakgegevens?.toelichting?.let { " $it" } ?: "")
             )
             // truncate to maximum length allowed by the ZGW APIs

--- a/src/test/kotlin/net/atos/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -286,7 +286,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                     // the provided zaak explanation should be appended to the default explanation but truncated
                     // to the maximum length allowed
                     toelichting.length shouldBe 1000
-                    toelichting shouldBe "Aangemaakt vanuit ${formulierBron.naam} met kenmerk '${formulierBron.kenmerk}' $zaakExplanation"
+                    toelichting shouldBe "Aangemaakt vanuit ${formulierBron.naam} met kenmerk '${formulierBron.kenmerk}'. $zaakExplanation"
                         .take(1000)
                     with(zaakgeometrie) {
                         type.toValue() shouldBe Geometry.Type.POINT.value()
@@ -381,7 +381,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                     communicatiekanaalNaam shouldBe "E-formulier"
                     bronorganisatie shouldBe "123443210"
                     omschrijving shouldBe null
-                    toelichting shouldBe "Aangemaakt vanuit ${formulierBron.naam} met kenmerk '${formulierBron.kenmerk}'"
+                    toelichting shouldBe "Aangemaakt vanuit ${formulierBron.naam} met kenmerk '${formulierBron.kenmerk}'."
                 }
                 with(roleToBeCreated.captured) {
                     betrokkeneType shouldBe BetrokkeneType.VESTIGING
@@ -465,7 +465,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                     communicatiekanaalNaam shouldBe "E-formulier"
                     bronorganisatie shouldBe "123443210"
                     omschrijving shouldBe null
-                    toelichting shouldBe "Aangemaakt vanuit ${formulierBron.naam} met kenmerk '${formulierBron.kenmerk}'"
+                    toelichting shouldBe "Aangemaakt vanuit ${formulierBron.naam} met kenmerk '${formulierBron.kenmerk}'."
                 }
             }
         }
@@ -534,7 +534,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                     communicatiekanaalNaam shouldBe "E-formulier"
                     bronorganisatie shouldBe "123443210"
                     omschrijving shouldBe null
-                    toelichting shouldBe "Aangemaakt vanuit ${formulierBron.naam} met kenmerk '${formulierBron.kenmerk}'"
+                    toelichting shouldBe "Aangemaakt vanuit ${formulierBron.naam} met kenmerk '${formulierBron.kenmerk}'."
                 }
             }
         }
@@ -695,7 +695,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                     communicatiekanaalNaam shouldBe "E-formulier"
                     bronorganisatie shouldBe "123443210"
                     omschrijving shouldBe null
-                    toelichting shouldBe "Aangemaakt vanuit ${formulierBron.naam} met kenmerk '${formulierBron.kenmerk}'"
+                    toelichting shouldBe "Aangemaakt vanuit ${formulierBron.naam} met kenmerk '${formulierBron.kenmerk}'."
                 }
                 rolesToBeCreated.forEach {
                     it.roltoelichting shouldBe "Overgenomen vanuit de product aanvraag"


### PR DESCRIPTION
Added a full stop characters to the automatically generated "Aangemaakt vanuit xxx met kenmerk 'yyy'" substring in the zaak explanation from a productaanvraag.

Solves PZ-4711