### PR TITLE
fix: do not check for task document creation policy

### DIFF
--- a/src/main/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestService.kt
@@ -71,7 +71,7 @@ class DocumentCreationRestService @Inject constructor(
             restDocumentCreationAttendedData.taskId?.let {
                 val task = flowableTaskService.findOpenTask(it)
                     ?: throw TaskNotFoundException("No open task found with task id: '$it'")
-                assertPolicy(policyService.readTaakRechten(task).toevoegenDocument)
+                assertPolicy(policyService.readTaakRechten(task).creeerenDocument)
             }
             assertPolicy(zaakafhandelParameterService.isSmartDocumentsEnabled(uuidFromURI(it.zaaktype)))
         }.let {

--- a/src/main/kotlin/net/atos/zac/documentcreation/DocumentCreationService.kt
+++ b/src/main/kotlin/net/atos/zac/documentcreation/DocumentCreationService.kt
@@ -124,6 +124,7 @@ class DocumentCreationService @Inject constructor(
                     zaak = zaak,
                     enkelvoudigInformatieObjectCreateLockRequest = it,
                     taskId = taskId,
+                    skipPolicyCheck = true
                 )
             }
         }

--- a/src/main/kotlin/net/atos/zac/documentcreation/DocumentCreationService.kt
+++ b/src/main/kotlin/net/atos/zac/documentcreation/DocumentCreationService.kt
@@ -124,6 +124,10 @@ class DocumentCreationService @Inject constructor(
                     zaak = zaak,
                     enkelvoudigInformatieObjectCreateLockRequest = it,
                     taskId = taskId,
+                    // We open SmartDocuments in a new tab. This means that authorization token we have from Keycloak
+                    // will expire in some time (60-90 seconds usually). After this time no policy checks can be done,
+                    // as we no longer have a valid token. All policy checks need to be performed on document creation
+                    // request time.
                     skipPolicyCheck = true
                 )
             }

--- a/src/test/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestServiceTest.kt
@@ -80,7 +80,7 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
                 creeerenDocument = true
             )
             every { flowableTaskService.findOpenTask(taskId) } returns task
-            every { policyService.readTaakRechten(task).toevoegenDocument } returns true
+            every { policyService.readTaakRechten(task).creeerenDocument } returns true
             every { zaakafhandelParameterService.isSmartDocumentsEnabled(zaakTypeUUID) } returns true
 
             val restDocumentCreationResponse = documentCreationRestService.createDocumentAttended(
@@ -104,7 +104,7 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
                 creeerenDocument = true
             )
             every { flowableTaskService.findOpenTask(taskId) } returns task
-            every { policyService.readTaakRechten(task).toevoegenDocument } returns false
+            every { policyService.readTaakRechten(task).creeerenDocument } returns false
 
             val exception = shouldThrow<PolicyException> {
                 documentCreationRestService.createDocumentAttended(restDocumentCreationAttendedData)
@@ -147,7 +147,7 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
                 creeerenDocument = true
             )
             every { flowableTaskService.findOpenTask(taskId) } returns task
-            every { policyService.readTaakRechten(task).toevoegenDocument } returns true
+            every { policyService.readTaakRechten(task).creeerenDocument } returns true
             every { zaakafhandelParameterService.isSmartDocumentsEnabled(zaakTypeUUID) } returns false
 
             val exception = shouldThrow<PolicyException> {

--- a/src/test/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/documentcreation/DocumentCreationRestServiceTest.kt
@@ -22,6 +22,9 @@ import net.atos.zac.configuratie.ConfiguratieService
 import net.atos.zac.documentcreation.DocumentCreationService
 import net.atos.zac.documentcreation.model.DocumentCreationDataAttended
 import net.atos.zac.documentcreation.model.createDocumentCreationAttendedResponse
+import net.atos.zac.flowable.createTestTask
+import net.atos.zac.flowable.task.FlowableTaskService
+import net.atos.zac.flowable.task.exception.TaskNotFoundException
 import net.atos.zac.policy.PolicyService
 import net.atos.zac.policy.exception.PolicyException
 import net.atos.zac.policy.output.createZaakRechtenAllDeny
@@ -35,12 +38,14 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
     val ztcClientService = mockk<ZtcClientService>()
     val configurationService = mockk<ConfiguratieService>()
     val zaakafhandelParameterService = mockk<ZaakafhandelParameterService>()
+    val flowableTaskService = mockk<FlowableTaskService>()
     val documentCreationRestService = DocumentCreationRestService(
         policyService = policyService,
         documentCreationService = documentCreationService,
         zrcClientService = zrcClientService,
         configurationService = configurationService,
-        zaakafhandelParameterService = zaakafhandelParameterService
+        zaakafhandelParameterService = zaakafhandelParameterService,
+        flowableTaskService = flowableTaskService
     )
 
     isolationMode = IsolationMode.InstancePerTest
@@ -50,9 +55,11 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
         val zaak = createZaak(
             zaakTypeURI = URI("https://example.com/$zaakTypeUUID"),
         )
+        val taskId = "dummyTaskId"
+        val task = createTestTask()
         val restDocumentCreationAttendedData = createRestDocumentCreationAttendedData(
             zaakUuid = zaak.uuid,
-            taskId = "dummyTaskId",
+            taskId = taskId,
             smartDocumentsTemplateGroupId = "groupId",
             smartDocumentsTemplateId = "templateId",
             title = "Title",
@@ -72,6 +79,8 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
             every { policyService.readZaakRechten(zaak) } returns createZaakRechtenAllDeny(
                 creeerenDocument = true
             )
+            every { flowableTaskService.findOpenTask(taskId) } returns task
+            every { policyService.readTaakRechten(task).toevoegenDocument } returns true
             every { zaakafhandelParameterService.isSmartDocumentsEnabled(zaakTypeUUID) } returns true
 
             val restDocumentCreationResponse = documentCreationRestService.createDocumentAttended(
@@ -87,6 +96,37 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
                     templateId shouldBe restDocumentCreationAttendedData.smartDocumentsTemplateId
                     templateGroupId shouldBe restDocumentCreationAttendedData.smartDocumentsTemplateGroupId
                 }
+            }
+        }
+
+        When("createDocument is called by a role that is not allowed to create documents for tasks") {
+            every { policyService.readZaakRechten(zaak) } returns createZaakRechtenAllDeny(
+                creeerenDocument = true
+            )
+            every { flowableTaskService.findOpenTask(taskId) } returns task
+            every { policyService.readTaakRechten(task).toevoegenDocument } returns false
+
+            val exception = shouldThrow<PolicyException> {
+                documentCreationRestService.createDocumentAttended(restDocumentCreationAttendedData)
+            }
+
+            Then("it throws exception with no message") {
+                exception.message shouldBe null
+            }
+        }
+
+        When("createDocument is called for a task that is not opened") {
+            every { policyService.readZaakRechten(zaak) } returns createZaakRechtenAllDeny(
+                creeerenDocument = true
+            )
+            every { flowableTaskService.findOpenTask(taskId) } returns null
+
+            val exception = shouldThrow<TaskNotFoundException> {
+                documentCreationRestService.createDocumentAttended(restDocumentCreationAttendedData)
+            }
+
+            Then("it throws exception with message that mentions the task id") {
+                exception.message shouldBe "No open task found with task id: 'dummyTaskId'"
             }
         }
 
@@ -106,6 +146,8 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
             every { policyService.readZaakRechten(zaak) } returns createZaakRechtenAllDeny(
                 creeerenDocument = true
             )
+            every { flowableTaskService.findOpenTask(taskId) } returns task
+            every { policyService.readTaakRechten(task).toevoegenDocument } returns true
             every { zaakafhandelParameterService.isSmartDocumentsEnabled(zaakTypeUUID) } returns false
 
             val exception = shouldThrow<PolicyException> {

--- a/src/test/kotlin/net/atos/zac/documentcreation/DocumentCreationServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/documentcreation/DocumentCreationServiceTest.kt
@@ -140,9 +140,10 @@ class DocumentCreationServiceTest : BehaviorSpec({
         } returns enkelvoudigInformatieObjectLockRequest
         every {
             enkelvoudigInformatieObjectUpdateService.createZaakInformatieobjectForZaak(
-                zaak,
-                enkelvoudigInformatieObjectLockRequest,
-                taakId
+                zaak = zaak,
+                enkelvoudigInformatieObjectCreateLockRequest = enkelvoudigInformatieObjectLockRequest,
+                taskId = taakId,
+                skipPolicyCheck = true
             )
         } returns zaakInformatieobject
 
@@ -164,9 +165,10 @@ class DocumentCreationServiceTest : BehaviorSpec({
 
                 verify(exactly = 1) {
                     enkelvoudigInformatieObjectUpdateService.createZaakInformatieobjectForZaak(
-                        zaak,
-                        enkelvoudigInformatieObjectLockRequest,
-                        taakId
+                        zaak = zaak,
+                        enkelvoudigInformatieObjectCreateLockRequest = enkelvoudigInformatieObjectLockRequest,
+                        taskId = taakId,
+                        skipPolicyCheck = true
                     )
                 }
             }


### PR DESCRIPTION
When SmartDocuments callback is invoked we might not have logged in user
Keycloak token expires usually 60-90 seconds after SmartDocuments dialog is opened

Solves: PZ-3731