### PR TITLE
chore: fix error in logs on certain zaaktype changes

### DIFF
--- a/src/main/java/net/atos/zac/admin/ZaakafhandelParameterService.java
+++ b/src/main/java/net/atos/zac/admin/ZaakafhandelParameterService.java
@@ -31,7 +31,7 @@ public class ZaakafhandelParameterService implements Caching {
     private static final int EXPIRATION_TIME_HOURS = 1;
 
     @Inject
-    private ZaakafhandelParameterBeheerService beheerService;
+    private ZaakafhandelParameterBeheerService zaakafhandelParameterBeheerService;
 
     private static final Map<String, Cache<?, ?>> CACHES = new HashMap<>();
 
@@ -57,14 +57,14 @@ public class ZaakafhandelParameterService implements Caching {
     public ZaakafhandelParameters readZaakafhandelParameters(final UUID zaaktypeUUID) {
         return uuidToZaakafhandelParametersCache.get(
                 zaaktypeUUID,
-                uuid -> beheerService.readZaakafhandelParameters(zaaktypeUUID)
+                uuid -> zaakafhandelParameterBeheerService.readZaakafhandelParameters(zaaktypeUUID)
         );
     }
 
     public List<ZaakafhandelParameters> listZaakafhandelParameters() {
         return stringToZaakafhandelParametersListCache.get(
                 ZAC_ZAAKAFHANDELPARAMETERS,
-                s -> beheerService.listZaakafhandelParameters()
+                s -> zaakafhandelParameterBeheerService.listZaakafhandelParameters()
         );
     }
 

--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -202,7 +202,7 @@ public class NotificatieReceiver {
         try {
             if (notificatie.getResource() == ZAAKTYPE) {
                 if (notificatie.getAction() == CREATE || notificatie.getAction() == UPDATE) {
-                    zaakafhandelParameterBeheerService.zaaktypeAangepast(notificatie.getResourceUrl());
+                    zaakafhandelParameterBeheerService.createNewZaakafhandelParametersOnZaakTypeChange(notificatie.getResourceUrl());
                 }
             }
         } catch (RuntimeException ex) {

--- a/src/main/java/net/atos/zac/util/UriUtil.java
+++ b/src/main/java/net/atos/zac/util/UriUtil.java
@@ -11,9 +11,7 @@ import static org.apache.commons.lang3.StringUtils.substringAfterLast;
 import java.net.URI;
 import java.util.UUID;
 
-/**
- *
- */
+
 public final class UriUtil {
 
     private UriUtil() {

--- a/src/main/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerService.kt
+++ b/src/main/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerService.kt
@@ -40,7 +40,7 @@ class ZaakafhandelParameterBeheerService @Inject constructor(
     private val zaakafhandelParameterService: ZaakafhandelParameterService
 ) {
     /**
-     * Retrieves the zaakafhandelparameters for a given zaaktype UUID.
+     * Retrieves the most recent zaakafhandelparameters for a given zaaktype UUID.
      * Note that a zaaktype UUID uniquely identifies a _version_ of a zaaktype, and therefore also
      * a specific version of the corresponding zaakafhandelparameters.
      */
@@ -126,47 +126,50 @@ class ZaakafhandelParameterBeheerService @Inject constructor(
     }
 
     /**
-     * Zaaktype is aangepast, indien geen concept, dan de zaakafhandelparameters van de vorige versie zoveel mogelijk overnemen
+     * Zaaktype has been changed. If it is not a concept, and we do not already have zaakafhandelparameters for this
+     * exact zaaktype (identified by the uuid) then this indicates that a 'new version' of the zaaktype
+     * was created. Therefore, we create new zaakafhandelparameters with values which are copied from the previous
+     * zaakafhandelparameters 'version' for this zaaktype.
+     * Note that when a zaaktype is republished in the ZGW APIs technically a new zaaktype is created with its own
+     * unique zaaktype UUID. A new zaaktype relates to the previous 'version' of this zaaktype only by zaaktype description.
      *
-     * @param zaaktypeUri uri van het nieuwe zaaktype
+     * @param zaaktypeUri uri of the new zaaktype
      */
-    fun zaaktypeAangepast(zaaktypeUri: URI) {
-        zaakafhandelParameterService.clearListCache()
-        ztcClientService.clearZaaktypeCache()
-        val zaaktype = ztcClientService.readZaaktype(zaaktypeUri)
-        if (!zaaktype.concept) {
-            val omschrijving = zaaktype.omschrijving
-            val vorigeZaakafhandelparameters = readRecentsteZaakafhandelParameters(omschrijving)
-            val nieuweZaakafhandelParameters = ZaakafhandelParameters().apply {
+    fun createNewZaakafhandelParametersOnZaakTypeChange(zaaktypeUri: URI) {
+        ztcClientService.readZaaktype(zaaktypeUri).takeIf { !it.concept }?.let { zaaktype ->
+            zaakafhandelParameterService.clearListCache()
+            ztcClientService.clearZaaktypeCache()
+            val currentZaakafhandelParameters = readMostRecentZaakafhandelParametersForZaaktypeDescription(
+                zaaktype.omschrijving
+            )
+            val newZaakafhandelParameters = ZaakafhandelParameters().apply {
                 zaakTypeUUID = UriUtil.uuidFromURI(zaaktype.url)
                 zaaktypeOmschrijving = zaaktype.omschrijving
-                caseDefinitionID = vorigeZaakafhandelparameters.caseDefinitionID
-                groepID = vorigeZaakafhandelparameters.groepID
-                gebruikersnaamMedewerker = vorigeZaakafhandelparameters.gebruikersnaamMedewerker
-                einddatumGeplandWaarschuwing = zaaktype.servicenorm?.let {
-                    vorigeZaakafhandelparameters.einddatumGeplandWaarschuwing
-                }
-                uiterlijkeEinddatumAfdoeningWaarschuwing = vorigeZaakafhandelparameters.uiterlijkeEinddatumAfdoeningWaarschuwing
-                intakeMail = vorigeZaakafhandelparameters.intakeMail
-                afrondenMail = vorigeZaakafhandelparameters.afrondenMail
-                productaanvraagtype = vorigeZaakafhandelparameters.productaanvraagtype
-                domein = vorigeZaakafhandelparameters.domein
+                caseDefinitionID = currentZaakafhandelParameters.caseDefinitionID
+                groepID = currentZaakafhandelParameters.groepID
+                gebruikersnaamMedewerker = currentZaakafhandelParameters.gebruikersnaamMedewerker
+                einddatumGeplandWaarschuwing = zaaktype.servicenorm?.let { currentZaakafhandelParameters.einddatumGeplandWaarschuwing }
+                uiterlijkeEinddatumAfdoeningWaarschuwing = currentZaakafhandelParameters.uiterlijkeEinddatumAfdoeningWaarschuwing
+                intakeMail = currentZaakafhandelParameters.intakeMail
+                afrondenMail = currentZaakafhandelParameters.afrondenMail
+                productaanvraagtype = currentZaakafhandelParameters.productaanvraagtype
+                domein = currentZaakafhandelParameters.domein
             }
-            mapHumanTaskParameters(vorigeZaakafhandelparameters, nieuweZaakafhandelParameters)
-            mapUserEventListenerParameters(vorigeZaakafhandelparameters, nieuweZaakafhandelParameters)
-            mapZaakbeeindigGegevens(vorigeZaakafhandelparameters, nieuweZaakafhandelParameters, zaaktype)
-            mapMailtemplateKoppelingen(vorigeZaakafhandelparameters, nieuweZaakafhandelParameters)
-            createZaakafhandelParameters(nieuweZaakafhandelParameters)
+            mapHumanTaskParameters(currentZaakafhandelParameters, newZaakafhandelParameters)
+            mapUserEventListenerParameters(currentZaakafhandelParameters, newZaakafhandelParameters)
+            mapZaakbeeindigGegevens(currentZaakafhandelParameters, newZaakafhandelParameters, zaaktype)
+            mapMailtemplateKoppelingen(currentZaakafhandelParameters, newZaakafhandelParameters)
+            createZaakafhandelParameters(newZaakafhandelParameters)
         }
     }
 
-    private fun readRecentsteZaakafhandelParameters(zaaktypeOmschrijving: String): ZaakafhandelParameters {
+    private fun readMostRecentZaakafhandelParametersForZaaktypeDescription(zaaktypeDescription: String): ZaakafhandelParameters {
         val builder = entityManager.criteriaBuilder
         val query = builder.createQuery(ZaakafhandelParameters::class.java)
         val root = query.from(ZaakafhandelParameters::class.java)
         query.select(root)
-            .where(builder.equal(root.get<Any>(ZaakafhandelParameters.ZAAKTYPE_OMSCHRIJVING), zaaktypeOmschrijving))
-        query.orderBy(builder.desc(root.get<Any>(ZaakafhandelParameters.CREATIEDATUM)))
+            .where(builder.equal(root.get<Any>(ZAAKTYPE_OMSCHRIJVING), zaaktypeDescription))
+        query.orderBy(builder.desc(root.get<Any>(CREATIEDATUM)))
         val resultList = entityManager.createQuery(query).setMaxResults(1).resultList
         return if (resultList.isNotEmpty()) {
             resultList.first()

--- a/src/main/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestService.kt
@@ -99,9 +99,9 @@ class ZaakafhandelParametersRestService @Inject constructor(
     }
 
     /**
-     * Retrieve all ZAAKAFHANDELPARAMETERS for overview
+     * Retrieve all zaakafhandelparameters for all available zaaktypes in the zaakregister.
      *
-     * @return LIST of ZAAKAFHANDELPARAMETERS
+     * @return list of all zaakafhandelparameters
      */
     @GET
     fun listZaakafhandelParameters(): List<RestZaakafhandelParameters> {

--- a/src/test/kotlin/net/atos/client/zgw/ztc/model/ZtcFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/ztc/model/ZtcFixtures.kt
@@ -65,26 +65,29 @@ fun createRolType(
     this.omschrijvingGeneriek = omschrijvingGeneriek
 }
 
+@Suppress("LongParameterList")
 fun createZaakType(
     uri: URI = URI("https://example.com/zaaktypes/${UUID.randomUUID()}"),
     omschrijving: String = "dummyZaakTypeOmschrijving",
     informatieObjectTypen: List<URI>? = listOf(URI("dummyInformatieObjectType1"), URI("dummyInformatieObjectType2")),
-    identifactie: String = "dummyIdentificatie",
+    identification: String = "dummyIdentificatie",
     besluittypen: List<URI>? = null,
+    resultTypes: List<URI>? = listOf(URI("dummyResultaatType1"), URI("dummyResultaatType2")),
+    concept: Boolean = false
 ) = ZaakType(
     uri,
-    false,
+    concept,
     null,
     null,
     listOf(URI("dummyStatusType1"), URI("dummyStatusType2")),
-    listOf(URI("dummyResultaatType1"), URI("dummyResultaatType2")),
+    resultTypes,
     listOf(URI("dummyEigenschap1"), URI("dummyEigenschap2")), informatieObjectTypen,
     listOf(URI("dummyRolType1"), URI("dummyRolType2")),
     null
 ).apply {
     this.omschrijving = omschrijving
     this.besluittypen = besluittypen
-    this.identificatie = identifactie
+    this.identificatie = identification
 }
 
 fun createInformatieObjectType(

--- a/src/test/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
@@ -7,9 +7,11 @@ package net.atos.zac.admin
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContainOnly
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.checkUnnecessaryStub
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import jakarta.persistence.EntityManager
 import jakarta.persistence.TypedQuery
 import jakarta.persistence.criteria.CriteriaBuilder
@@ -21,10 +23,14 @@ import jakarta.persistence.criteria.Predicate
 import jakarta.persistence.criteria.Root
 import jakarta.persistence.criteria.Subquery
 import net.atos.client.zgw.ztc.ZtcClientService
+import net.atos.client.zgw.ztc.model.createResultaatType
+import net.atos.client.zgw.ztc.model.createZaakType
 import net.atos.zac.admin.model.ZaakafhandelParameters
 import net.atos.zac.admin.model.createZaakafhandelParameters
+import java.net.URI
 import java.time.ZonedDateTime
 import java.util.Date
+import java.util.UUID
 
 class ZaakafhandelParameterBeheerServiceTest : BehaviorSpec({
     val entityManager = mockk<EntityManager>()
@@ -169,6 +175,61 @@ class ZaakafhandelParameterBeheerServiceTest : BehaviorSpec({
             Then("two zaakafhandelparameters should be returned") {
                 returnedZaakafhandelParameters.size shouldBe 2
                 returnedZaakafhandelParameters.map { productaanvraagType } shouldContainOnly listOf(productaanvraagType)
+            }
+        }
+    }
+    Given("No existing zaakafhandelparameters for a given zaaktype UUID and the zaaktype is not a concept") {
+        val zaakTypeUUID = UUID.randomUUID()
+        val zaaktypeURI = URI("https://example.com/zaaktype/$zaakTypeUUID")
+        val resultaatType = createResultaatType()
+        val zaaktype = createZaakType(
+            uri = zaaktypeURI,
+            concept = false,
+            resultTypes = listOf(resultaatType.url)
+        )
+        val createdZaakafhandelparametersSlot = slot<ZaakafhandelParameters>()
+        every { entityManager.criteriaBuilder } returns criteriaBuilder
+        every { criteriaBuilder.createQuery(ZaakafhandelParameters::class.java) } returns zaakafhandelparametersCriteriaQuery
+        every {
+            zaakafhandelparametersCriteriaQuery.from(ZaakafhandelParameters::class.java)
+        } returns zaakafhandelparametersRoot
+        every {
+            zaakafhandelparametersCriteriaQuery.select(zaakafhandelparametersRoot)
+        } returns zaakafhandelparametersCriteriaQuery
+        every { zaakafhandelparametersRoot.get<Any>("zaakTypeUUID") } returns path
+        every { zaakafhandelparametersRoot.get<Any>("zaaktypeOmschrijving") } returns path
+        every { zaakafhandelparametersRoot.get<Any>("creatiedatum") } returns path
+        every { criteriaBuilder.equal(path, zaakTypeUUID) } returns predicate
+        every { criteriaBuilder.equal(path, zaaktype.omschrijving) } returns predicate
+        every { criteriaBuilder.desc(path) } returns order
+        every { zaakafhandelparametersCriteriaQuery.where(predicate) } returns zaakafhandelparametersCriteriaQuery
+        every { zaakafhandelparametersCriteriaQuery.orderBy(order) } returns zaakafhandelparametersCriteriaQuery
+        every {
+            entityManager.createQuery(zaakafhandelparametersCriteriaQuery).resultList
+        } returns emptyList()
+        every {
+            entityManager.createQuery(zaakafhandelparametersCriteriaQuery).setMaxResults(1)
+        } returns zaakafhandelparametersTypedQuery
+        every { entityManager.persist(capture(createdZaakafhandelparametersSlot)) } returns Unit
+        every { zaakafhandelparametersTypedQuery.resultList } returns emptyList()
+        every { ztcClientService.readZaaktype(zaaktypeURI) } returns zaaktype
+        every { zaakafhandelParameterService.clearListCache() } returns "dummyCacheString"
+        every { ztcClientService.clearZaaktypeCache() } returns "dummyCacheString"
+        every { ztcClientService.readResultaattype(resultaatType.url) } returns resultaatType
+
+        When("new zaakafhandelparameters are created for the given zaaktype URI") {
+            zaakafhandelParameterBeheerService.createNewZaakafhandelParametersOnZaakTypeChange(zaaktypeURI)
+
+            Then("new zaakafhandelparameters should be created") {
+                with(createdZaakafhandelparametersSlot.captured) {
+                    this.zaakTypeUUID shouldBe zaakTypeUUID
+                    zaaktypeOmschrijving shouldBe zaaktype.omschrijving
+                    creatiedatum shouldNotBe null
+                    // there was no current zaakafhandelparameters, so these values should be null
+                    caseDefinitionID shouldBe null
+                    groepID shouldBe null
+                    gebruikersnaamMedewerker shouldBe null
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed the error in the logs on certain zaaktype changes when we tried to insert a new record in the zaakafhandelparameters database table when we already had a zaakafhandelparameters for the given zaaktype UUID.

Solves PZ-4521