### PR TITLE
feat: FE - Taak detail - Show Document Create button only when SmartDocuments is enabled

### DIFF
--- a/src/main/app/src/app/taken/taak-view/taak-view.component.ts
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.ts
@@ -141,7 +141,6 @@ export class TaakViewComponent
   }
 
   private initTaakGegevens(taak: Taak): void {
-    this.menu = [];
     this.taak = taak;
     this.loadHistorie();
     this.setEditableFormFields();
@@ -154,6 +153,7 @@ export class TaakViewComponent
       this.zakenService.readZaak(this.taak.zaakUuid).subscribe((zaak) => {
         this.zaak = zaak;
         this.initialized = true;
+        this.setupMenu();
         this.createTaakForm(taak, zaak);
       });
     } else {
@@ -324,19 +324,28 @@ export class TaakViewComponent
   }
 
   private setupMenu(): void {
+    this.menu = [];
     this.menu.push(new HeaderMenuItem("taak"));
 
     if (this.taak.rechten.toevoegenDocument) {
-      this.menu.push(
-        new ButtonMenuItem(
-          "actie.document.maken",
-          () => {
-            this.actionsSidenav.open();
-            this.action = SideNavAction.DOCUMENT_MAKEN;
-          },
-          "note_add",
-        ),
-      );
+      if (
+        this.zaak.zaaktype.zaakafhandelparameters?.smartDocuments
+          .enabledGlobally &&
+        this.zaak.zaaktype?.zaakafhandelparameters.smartDocuments
+          .enabledForZaaktype
+      ) {
+        this.menu.push(
+          new ButtonMenuItem(
+            "actie.document.maken",
+            () => {
+              this.actionsSidenav.open();
+              this.action = SideNavAction.DOCUMENT_MAKEN;
+            },
+            "note_add",
+          ),
+        );
+      }
+
       this.menu.push(
         new ButtonMenuItem(
           "actie.document.toevoegen",

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.ts
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.ts
@@ -328,6 +328,17 @@ export class TaakViewComponent
     this.menu.push(new HeaderMenuItem("taak"));
 
     if (this.taak.rechten.toevoegenDocument) {
+      this.menu.push(
+        new ButtonMenuItem(
+          "actie.document.toevoegen",
+          () => {
+            this.actionsSidenav.open();
+            this.action = SideNavAction.DOCUMENT_TOEVOEGEN;
+          },
+          "upload_file",
+        ),
+      );
+
       if (
         this.zaak.zaaktype.zaakafhandelparameters?.smartDocuments
           .enabledGlobally &&
@@ -345,17 +356,6 @@ export class TaakViewComponent
           ),
         );
       }
-
-      this.menu.push(
-        new ButtonMenuItem(
-          "actie.document.toevoegen",
-          () => {
-            this.actionsSidenav.open();
-            this.action = SideNavAction.DOCUMENT_TOEVOEGEN;
-          },
-          "upload_file",
-        ),
-      );
     }
   }
 

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -254,6 +254,8 @@ export class ZaakViewComponent
     };
 
     this.toonAfgerondeTaken = SessionStorageUtil.getItem("toonAfgerondeTaken");
+
+    console.log("zaak", this.zaak);
   }
 
   init(zaak: Zaak): void {
@@ -571,16 +573,23 @@ export class ZaakViewComponent
     }
 
     if (this.zaak.rechten.creeerenDocument) {
-      this.menu.push(
-        new ButtonMenuItem(
-          "actie.document.maken",
-          () => {
-            this.actionsSidenav.open();
-            this.action = SideNavAction.DOCUMENT_MAKEN;
-          },
-          "note_add",
-        ),
-      );
+      if (
+        this.zaak.zaaktype.zaakafhandelparameters.smartDocuments
+          .enabledGlobally &&
+        this.zaak.zaaktype.zaakafhandelparameters.smartDocuments
+          .enabledForZaaktype
+      ) {
+        this.menu.push(
+          new ButtonMenuItem(
+            "actie.document.maken",
+            () => {
+              this.actionsSidenav.open();
+              this.action = SideNavAction.DOCUMENT_MAKEN;
+            },
+            "note_add",
+          ),
+        );
+      }
 
       this.menu.push(
         new ButtonMenuItem(

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -254,8 +254,6 @@ export class ZaakViewComponent
     };
 
     this.toonAfgerondeTaken = SessionStorageUtil.getItem("toonAfgerondeTaken");
-
-    console.log("zaak", this.zaak);
   }
 
   init(zaak: Zaak): void {


### PR DESCRIPTION
FE - Taak detail - Show Document Create button only when SmartDocuments is enabled

The Zaak data is loaded after Taak data is loaded; so that is why there is a menu update needed. Discussed with Karin about order of buttons; Create should be the bottom one.

Solves PZ-3406