### PR TITLE
chore: revert changes made in PZ-4521 in the ZaakafhandelParameterBeheerService.kt

### DIFF
--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -202,7 +202,7 @@ public class NotificatieReceiver {
         try {
             if (notificatie.getResource() == ZAAKTYPE) {
                 if (notificatie.getAction() == CREATE || notificatie.getAction() == UPDATE) {
-                    zaakafhandelParameterBeheerService.createNewZaakafhandelParametersOnZaakTypeChange(notificatie.getResourceUrl());
+                    zaakafhandelParameterBeheerService.zaaktypeAangepast(notificatie.getResourceUrl());
                 }
             }
         } catch (RuntimeException ex) {


### PR DESCRIPTION
Reverted changes made in PZ-4521 in the ZaakafhandelParameterBeheerService.kt to see if that solves an issue where new zaakafhandelparameters created from a new zaaktype are sometimes empty.

Solves PZ-4521