### PR TITLE
chore: added empty lines after SPDX headers in Helm Chart files to hopefully fix broken deployment script

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 apiVersion: v2
 name: zaakafhandelcomponent
 description: A Helm chart for installing Zaakafhandelcomponent

--- a/helm/templates/config.yaml
+++ b/helm/templates/config.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/templates/configmap-nginx.yaml
+++ b/helm/templates/configmap-nginx.yaml
@@ -1,7 +1,8 @@
 #
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-  # SPDX-License-Identifier: EUPL-1.2+
-  #
+# SPDX-License-Identifier: EUPL-1.2+
+#
+
 {{- if not .Values.nginx.existingConfigmap }}
 {{- if .Values.nginx.enabled }}
 apiVersion: v1

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/templates/extra-deploy.yaml
+++ b/helm/templates/extra-deploy.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 {{- range .Values.extraDeploy }}
 ---
 {{ include "common.tplvalues.render" (dict "value" . "context" $) }}

--- a/helm/templates/hpa.yaml
+++ b/helm/templates/hpa.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 {{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "zaakafhandelcomponent.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}

--- a/helm/templates/nginx-deployment.yaml
+++ b/helm/templates/nginx-deployment.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 {{- if .Values.nginx.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/templates/nginx-service.yaml
+++ b/helm/templates/nginx-service.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 {{- if .Values.nginx.enabled }}
 apiVersion: v1
 kind: Service

--- a/helm/templates/office-converter-deployment.yaml
+++ b/helm/templates/office-converter-deployment.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/templates/office-converter-service.yaml
+++ b/helm/templates/office-converter-service.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/templates/opa-deployment.yaml
+++ b/helm/templates/opa-deployment.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 {{- if .Values.opa.enabled }}
 {{- if not .Values.opa.sidecar }}
 apiVersion: apps/v1

--- a/helm/templates/opa-service.yaml
+++ b/helm/templates/opa-service.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 {{- if .Values.opa.enabled }}
 {{- if not .Values.opa.sidecar }}
 apiVersion: v1

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/templates/signaleren-cron-job.yaml
+++ b/helm/templates/signaleren-cron-job.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/helm/templates/signaleren-delete-cron-job.yaml
+++ b/helm/templates/signaleren-delete-cron-job.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
 apiVersion: batch/v1
 kind: CronJob
 metadata:


### PR DESCRIPTION
Added empty lines after SPDX headers in Helm Chart files to hopefully fix broken deployment script.

Solves PZ-4777