### PR TITLE
chore: reverted adding SPDX headers to Helm Chart files because that breaks our deployment script

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -20,6 +20,7 @@ header:
     - 'config'
     - 'docs'
     - 'gradle'
+    - 'helm'
     - 'scripts'
     - 'target'
     - 'wildfly-*'

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,9 +1,4 @@
 {{/*
- SPDX-FileCopyrightText: 2024 Lifely
- SPDX-License-Identifier: EUPL-1.2+
-*/}}
-
-{{/*
 Expand the name of the chart.
 */}}
 {{- define "zaakafhandelcomponent.name" -}}

--- a/helm/templates/config.yaml
+++ b/helm/templates/config.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/templates/configmap-nginx.yaml
+++ b/helm/templates/configmap-nginx.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 {{- if not .Values.nginx.existingConfigmap }}
 {{- if .Values.nginx.enabled }}
 apiVersion: v1

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/templates/extra-deploy.yaml
+++ b/helm/templates/extra-deploy.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 {{- range .Values.extraDeploy }}
 ---
 {{ include "common.tplvalues.render" (dict "value" . "context" $) }}

--- a/helm/templates/hpa.yaml
+++ b/helm/templates/hpa.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 {{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "zaakafhandelcomponent.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}

--- a/helm/templates/nginx-deployment.yaml
+++ b/helm/templates/nginx-deployment.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 {{- if .Values.nginx.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/templates/nginx-service.yaml
+++ b/helm/templates/nginx-service.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 {{- if .Values.nginx.enabled }}
 apiVersion: v1
 kind: Service

--- a/helm/templates/office-converter-deployment.yaml
+++ b/helm/templates/office-converter-deployment.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/templates/office-converter-service.yaml
+++ b/helm/templates/office-converter-service.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/templates/opa-deployment.yaml
+++ b/helm/templates/opa-deployment.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 {{- if .Values.opa.enabled }}
 {{- if not .Values.opa.sidecar }}
 apiVersion: apps/v1

--- a/helm/templates/opa-service.yaml
+++ b/helm/templates/opa-service.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 {{- if .Values.opa.enabled }}
 {{- if not .Values.opa.sidecar }}
 apiVersion: v1

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/templates/signaleren-cron-job.yaml
+++ b/helm/templates/signaleren-cron-job.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/helm/templates/signaleren-delete-cron-job.yaml
+++ b/helm/templates/signaleren-delete-cron-job.yaml
@@ -1,8 +1,3 @@
-#
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
-# SPDX-License-Identifier: EUPL-1.2+
-#
-
 apiVersion: batch/v1
 kind: CronJob
 metadata:


### PR DESCRIPTION
Reverted adding SPDX headers to Helm Chart files because that breaks our deployment script. The 'Bake deployment' provisioning step failed because it generates a corrupt Helm Chart file with SPDX headers:

```
# Source: zaakafhandelcomponent/templates/serviceaccount.yaml
#
# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
# SPDX-License-Identifier: EUPL-1.2+
#apiVersion: v1
kind: ServiceAccount
metadata:
  name: zac-dev-zaakafhandelcomponent
```

Solves PZ-4778