### PR TITLE
feat:  FE -  Besluit edit form -  Publication Date fields incorrectly prefilled

### DIFF
--- a/src/main/app/src/app/zaken/besluit-edit/besluit-edit.component.ts
+++ b/src/main/app/src/app/zaken/besluit-edit/besluit-edit.component.ts
@@ -137,14 +137,14 @@ export class BesluitEditComponent implements OnInit, OnDestroy {
       .build();
 
     const publicationDateField = new DateFormFieldBuilder(
-      this.besluit.vervaldatum || null,
+      this.besluit.publicationDate || null,
     )
       .id("publicationDate")
       .label("publicatiedatum")
       .build();
 
     const lastResponseDateField = new DateFormFieldBuilder(
-      this.besluit.vervaldatum || null,
+      this.besluit.lastResponseDate || null,
     )
       .id("lastResponseDate")
       .label("uiterlijkereactiedatum")


### PR DESCRIPTION
FE -  Besluit edit form -  Publication Date fields were incorrectly prefilled with a testing value. In this PR it is reading the by the backend newly provided fields.

Solves: PZ-4829