### PR TITLE
feat: removed Flowable task data from SmartDocuments mapping when cre…

### DIFF
--- a/src/main/kotlin/net/atos/client/smartdocuments/model/document/SmartDocumentsDocumentRequestDeclarations.kt
+++ b/src/main/kotlin/net/atos/client/smartdocuments/model/document/SmartDocumentsDocumentRequestDeclarations.kt
@@ -28,7 +28,7 @@ data class Data(
     val startformulierData: StartformulierData? = null,
 
     @field:JsonbProperty("taak")
-    val taakData: TaakData? = null,
+    val taskData: TaskData? = null,
 
     @field:JsonbProperty("zaak")
     val zaakData: ZaakData
@@ -77,10 +77,9 @@ data class StartformulierData(
     val data: Map<String, Any>
 )
 
-data class TaakData(
+data class TaskData(
     val naam: String,
-    var behandelaar: String? = null,
-    val data: Map<String, Any>
+    var behandelaar: String? = null
 )
 
 data class Variables(

--- a/src/main/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverter.kt
+++ b/src/main/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverter.kt
@@ -17,7 +17,7 @@ import net.atos.client.smartdocuments.model.document.Data
 import net.atos.client.smartdocuments.model.document.File
 import net.atos.client.smartdocuments.model.document.GebruikerData
 import net.atos.client.smartdocuments.model.document.StartformulierData
-import net.atos.client.smartdocuments.model.document.TaakData
+import net.atos.client.smartdocuments.model.document.TaskData
 import net.atos.client.smartdocuments.model.document.ZaakData
 import net.atos.client.zgw.drc.model.generated.EnkelvoudigInformatieObjectCreateLockRequest
 import net.atos.client.zgw.drc.model.generated.StatusEnum
@@ -36,7 +36,6 @@ import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.zac.authentication.LoggedInUser
 import net.atos.zac.configuratie.ConfiguratieService
 import net.atos.zac.flowable.task.FlowableTaskService
-import net.atos.zac.flowable.task.TaakVariabelenService
 import net.atos.zac.identity.IdentityService
 import net.atos.zac.identity.model.getFullName
 import net.atos.zac.productaanvraag.ProductaanvraagService
@@ -71,7 +70,7 @@ class DocumentCreationDataConverter @Inject constructor(
             aanvragerData = createAanvragerData(zaak),
             gebruikerData = createGebruikerData(loggedInUser),
             startformulierData = createStartformulierData(zaak.url),
-            taakData = taskId?.let { createTaakData(it) },
+            taskData = taskId?.let { createTaskData(it) },
             zaakData = createZaakData(zaak)
         )
 
@@ -196,12 +195,11 @@ class DocumentCreationDataConverter @Inject constructor(
             )
         }
 
-    private fun createTaakData(taskId: String): TaakData =
+    private fun createTaskData(taskId: String): TaskData =
         flowableTaskService.readTask(taskId).let { taskInfo ->
-            TaakData(
+            TaskData(
                 naam = taskInfo.name,
-                behandelaar = taskInfo.assignee?.let { identityService.readUser(it).getFullName() },
-                data = TaakVariabelenService.readTaskData(taskInfo)
+                behandelaar = taskInfo.assignee?.let { identityService.readUser(it).getFullName() }
             )
         }
 

--- a/src/test/kotlin/net/atos/client/brp/model/BrpFixtures.kt
+++ b/src/test/kotlin/net/atos/client/brp/model/BrpFixtures.kt
@@ -5,6 +5,8 @@
 
 package net.atos.client.brp.model
 
+import net.atos.client.brp.model.generated.AbstractVerblijfplaats
+import net.atos.client.brp.model.generated.Adres
 import net.atos.client.brp.model.generated.Adressering
 import net.atos.client.brp.model.generated.AdresseringBeperkt
 import net.atos.client.brp.model.generated.OpschortingBijhouding
@@ -14,6 +16,26 @@ import net.atos.client.brp.model.generated.PersoonInOnderzoek
 import net.atos.client.brp.model.generated.PersoonInOnderzoekBeperkt
 import net.atos.client.brp.model.generated.RaadpleegMetBurgerservicenummerResponse
 import net.atos.client.brp.model.generated.RniDeelnemer
+import net.atos.client.brp.model.generated.VerblijfadresBinnenland
+import net.atos.client.brp.model.generated.Waardetabel
+
+fun createAdres(
+    verblijfAdresBinnenland: VerblijfadresBinnenland = createVerblijfadresBinnenland()
+) = Adres().apply {
+    verblijfadres = verblijfAdresBinnenland
+}
+
+fun createAdressering(
+    adresRegel1: String = "adresRegel1",
+    adresRegel2: String = "adresRegel2",
+    adresRegel3: String = "adresRegel3",
+    land: Waardetabel = createWaardeTabel()
+) = Adressering().apply {
+    adresregel1 = adresRegel1
+    adresregel2 = adresRegel2
+    adresregel3 = adresRegel3
+    this.land = land
+}
 
 @Suppress("LongParameterList")
 fun createPersoon(
@@ -24,7 +46,8 @@ fun createPersoon(
     suspensionMaintenance: OpschortingBijhouding? = null,
     indicationCuratoriesRegister: Boolean? = false,
     rniDeelnemerList: List<RniDeelnemer>? = null,
-    address: Adressering? = null
+    address: Adressering? = null,
+    verblijfplaats: AbstractVerblijfplaats? = null
 ) =
     Persoon().apply {
         burgerservicenummer = bsn
@@ -35,6 +58,7 @@ fun createPersoon(
         indicatieCurateleRegister = indicationCuratoriesRegister
         rni = rniDeelnemerList
         adressering = address
+        this.verblijfplaats = verblijfplaats
     }
 
 @Suppress("LongParameterList")
@@ -61,4 +85,24 @@ fun createRaadpleegMetBurgerservicenummerResponse(
     persons: List<Persoon> = listOf(createPersoon())
 ) = RaadpleegMetBurgerservicenummerResponse().apply {
     personen = persons
+}
+
+fun createVerblijfadresBinnenland(
+    officieleStraatnaam: String = "officieleStraatnaam",
+    huisnummer: Int = 123,
+    postcode: String = "postcode",
+    woonplaats: String = "woonplaats"
+) = VerblijfadresBinnenland().apply {
+    this.officieleStraatnaam = officieleStraatnaam
+    this.huisnummer = huisnummer
+    this.postcode = postcode
+    this.woonplaats = woonplaats
+}
+
+fun createWaardeTabel(
+    code: String = "dummyCode",
+    omschrijving: String = "dummyOmschrijving"
+) = Waardetabel().apply {
+    this.code = code
+    this.omschrijving = omschrijving
 }

--- a/src/test/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
@@ -1,0 +1,108 @@
+package net.atos.zac.documentcreation.converter
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import net.atos.client.brp.BrpClientService
+import net.atos.client.brp.model.createAdres
+import net.atos.client.brp.model.createAdressering
+import net.atos.client.brp.model.createPersoon
+import net.atos.client.brp.model.generated.Adres
+import net.atos.client.kvk.KvkClientService
+import net.atos.client.or.`object`.ObjectsClientService
+import net.atos.client.zgw.shared.ZGWApiService
+import net.atos.client.zgw.shared.model.Results
+import net.atos.client.zgw.zrc.ZrcClientService
+import net.atos.client.zgw.zrc.model.createRolMedewerker
+import net.atos.client.zgw.zrc.model.createRolNatuurlijkPersoon
+import net.atos.client.zgw.zrc.model.createRolOrganisatorischeEenheid
+import net.atos.client.zgw.zrc.model.createZaak
+import net.atos.client.zgw.ztc.ZtcClientService
+import net.atos.client.zgw.ztc.model.createRolType
+import net.atos.client.zgw.ztc.model.createZaakType
+import net.atos.client.zgw.ztc.model.generated.OmschrijvingGeneriekEnum
+import net.atos.zac.authentication.createLoggedInUser
+import net.atos.zac.flowable.task.FlowableTaskService
+import net.atos.zac.identity.IdentityService
+import net.atos.zac.productaanvraag.ProductaanvraagService
+import net.atos.zac.smartdocuments.SmartDocumentsTemplatesService
+import java.util.Optional
+
+class DocumentCreationDataConverterTest : BehaviorSpec({
+    val zgwApiService = mockk<ZGWApiService>()
+    val zrcClientService = mockk<ZrcClientService>()
+    val ztcClientService = mockk<ZtcClientService>()
+    val brpClientService = mockk<BrpClientService>()
+    val kvkClientService = mockk<KvkClientService>()
+    val objectsClientService = mockk<ObjectsClientService>()
+    val flowableTaskService = mockk<FlowableTaskService>()
+    val identityService = mockk<IdentityService>()
+    val productaanvraagService = mockk<ProductaanvraagService>()
+    val smartDocumentsTemplatesService = mockk<SmartDocumentsTemplatesService>()
+    val documentCreationDataConverter = DocumentCreationDataConverter(
+        zgwApiService = zgwApiService,
+        zrcClientService = zrcClientService,
+        ztcClientService = ztcClientService,
+        brpClientService = brpClientService,
+        kvkClientService = kvkClientService,
+        objectsClientService = objectsClientService,
+        flowableTaskService = flowableTaskService,
+        identityService = identityService,
+        productaanvraagService = productaanvraagService,
+        smartDocumentsTemplatesService = smartDocumentsTemplatesService
+    )
+    Given("A logged in user and a zaak with a behandelaar") {
+        val loggedInUser = createLoggedInUser()
+        val rolNatuurlijkPersoon =
+            createRolNatuurlijkPersoon(
+                rolType = createRolType(omschrijvingGeneriek = OmschrijvingGeneriekEnum.INITIATOR)
+            )
+        val persoon = createPersoon(
+            address = createAdressering(),
+            verblijfplaats = createAdres()
+        )
+        val zaakType = createZaakType()
+        val zaak = createZaak(zaakTypeURI = zaakType.url)
+        val rolMedewerker = createRolMedewerker()
+        val rolOrganisatorischeEenheid = createRolOrganisatorischeEenheid()
+
+        every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns Optional.of(rolNatuurlijkPersoon)
+        every { brpClientService.retrievePersoon(rolNatuurlijkPersoon.identificatienummer) } returns persoon
+        every { zrcClientService.listZaakobjecten(any()) } returns Results(emptyList(), 0)
+        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns Optional.of(rolMedewerker)
+        every { zgwApiService.findGroepForZaak(zaak) } returns Optional.of(rolOrganisatorischeEenheid)
+        every { ztcClientService.readZaaktype(zaak.zaaktype) } returns zaakType
+
+        When("SmartDocuments data is created") {
+            val data = documentCreationDataConverter.createData(
+                loggedInUser = loggedInUser,
+                zaak = zaak
+            )
+
+            Then("the data is created correctly") {
+                with(data) {
+                    with(aanvragerData!!) {
+                        naam shouldBe persoon.naam
+                        straat shouldBe (persoon.verblijfplaats as Adres).verblijfadres.officieleStraatnaam
+                        huisnummer shouldBe (persoon.verblijfplaats as Adres).verblijfadres.huisnummer.toString()
+                        postcode shouldBe (persoon.verblijfplaats as Adres).verblijfadres.postcode
+                        woonplaats shouldBe (persoon.verblijfplaats as Adres).verblijfadres.woonplaats
+                    }
+                    with(gebruikerData) {
+                        id shouldBe loggedInUser.id
+                        naam shouldBe loggedInUser.fullName
+                    }
+                    with(zaakData) {
+                        zaaktype shouldBe zaakType.omschrijving
+                        behandelaar shouldBe "${rolMedewerker.betrokkeneIdentificatie.voorletters} " +
+                            "${rolMedewerker.betrokkeneIdentificatie.achternaam}"
+                        groep shouldBe rolOrganisatorischeEenheid.naam
+                    }
+                    startformulierData shouldBe null
+                    taskData shouldBe null
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.zac.documentcreation.converter
 
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/net/atos/zac/documentcreation/model/DocumentCreationFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/documentcreation/model/DocumentCreationFixtures.kt
@@ -33,13 +33,13 @@ fun createAanvragerData(
 fun createData(
     startformulier: StartformulierData = createStartformulierData(),
     zaakData: ZaakData = createZaakData(),
-    taakData: TaskData = createTaakData(),
+    taskData: TaskData = createTaskData(),
     gebruikerData: GebruikerData = createGebruikerData(),
     aanvragerData: AanvragerData = createAanvragerData(),
 ) = Data(
     startformulierData = startformulier,
     zaakData = zaakData,
-    taskData = taakData,
+    taskData = taskData,
     gebruikerData = gebruikerData,
     aanvragerData = aanvragerData
 )
@@ -85,7 +85,7 @@ fun createStartformulierData(
     data = data
 )
 
-fun createTaakData(
+fun createTaskData(
     naam: String = "dummyNaam",
     behandelaar: String = "dummyBehandelaar"
 ) = TaskData(

--- a/src/test/kotlin/net/atos/zac/documentcreation/model/DocumentCreationFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/documentcreation/model/DocumentCreationFixtures.kt
@@ -9,7 +9,7 @@ import net.atos.client.smartdocuments.model.document.AanvragerData
 import net.atos.client.smartdocuments.model.document.Data
 import net.atos.client.smartdocuments.model.document.GebruikerData
 import net.atos.client.smartdocuments.model.document.StartformulierData
-import net.atos.client.smartdocuments.model.document.TaakData
+import net.atos.client.smartdocuments.model.document.TaskData
 import net.atos.client.smartdocuments.model.document.ZaakData
 import net.atos.client.zgw.zrc.model.Zaak
 import net.atos.client.zgw.zrc.model.createZaak
@@ -33,13 +33,13 @@ fun createAanvragerData(
 fun createData(
     startformulier: StartformulierData = createStartformulierData(),
     zaakData: ZaakData = createZaakData(),
-    taakData: TaakData = createTaakData(),
+    taakData: TaskData = createTaakData(),
     gebruikerData: GebruikerData = createGebruikerData(),
     aanvragerData: AanvragerData = createAanvragerData(),
 ) = Data(
     startformulierData = startformulier,
     zaakData = zaakData,
-    taakData = taakData,
+    taskData = taakData,
     gebruikerData = gebruikerData,
     aanvragerData = aanvragerData
 )
@@ -87,12 +87,10 @@ fun createStartformulierData(
 
 fun createTaakData(
     naam: String = "dummyNaam",
-    behandelaar: String = "dummyBehandelaar",
-    data: Map<String, String> = mapOf("dummyKey" to "dummyValue")
-) = TaakData(
+    behandelaar: String = "dummyBehandelaar"
+) = TaskData(
     naam = naam,
-    behandelaar = behandelaar,
-    data = data
+    behandelaar = behandelaar
 )
 
 fun createZaakData(


### PR DESCRIPTION
Removed Flowable task data from SmartDocuments mapping when creating a document because this is internal ZAC data which we do not want to expose in SmartDocuments.

Solves PZ-4809