### PR TITLE
fix(deps): renovate open-notificaties config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -81,6 +81,16 @@
     },
     {
       "matchPackageNames": [
+        "docker.io/openzaak/open-notificaties"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "allowedVersions": "<= 1.7.1",
+      "description": "We currently focus on Dimpact PodiumD release 2.0 which pins this package to this version"
+    },
+    {
+      "matchPackageNames": [
         "ghcr.io/infonl/zaakafhandelcomponent"
       ],
       "matchDatasources": [


### PR DESCRIPTION
Renovate has to follow the component versions per PodiumD releases, including for open-notificaties. This has been configured to follow only updates up-to the current PodiumD version.

Solves PZ-4823