### PR TITLE
chore: switch to wildfly maven plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ ENV WILDFLY_OVERRIDING_ENV_VARS=1
 
 # Start zaakafhandelcomponent
 # make sure that the WildFly management port is accessible from outside the container
-ENTRYPOINT ["java", "-jar", "zaakafhandelcomponent.jar", "-Djboss.bind.address.management=0.0.0.0"]
+ENTRYPOINT ["java", "-Djboss.bind.address.management=0.0.0.0", "-jar", "zaakafhandelcomponent.jar"]
 EXPOSE 8080 9990
 
 ENV BRANCH_NAME=$branchName COMMIT_HASH=$commitHash VERSION_NUMBER=$versionNumber

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN date -Iseconds > /build_timestamp.txt
 ENV WILDFLY_OVERRIDING_ENV_VARS=1
 
 # Start zaakafhandelcomponent
-ENTRYPOINT ["java", "-jar", "zaakafhandelcomponent.jar"]
+# make sure that the WildFly management port is accessible from outside the container
+ENTRYPOINT ["java", "-jar", "zaakafhandelcomponent.jar", "-Djboss.bind.address.management=0.0.0.0"]
 EXPOSE 8080 9990
 
 ENV BRANCH_NAME=$branchName COMMIT_HASH=$commitHash VERSION_NUMBER=$versionNumber

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -709,7 +709,7 @@ tasks {
 
     register<Maven>("generateWildflyBootableJar") {
         dependsOn("war")
-        execGoal("wildfly-jar:package")
+        execGoal("wildfly:package")
 
         val wildflyResources = srcMainResources.dir("wildfly")
         inputs.files(wildflyResources.asFileTree)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -640,7 +640,7 @@ services:
       "sh",
       "-c",
       # entrypoint may be overridden by environment variable to pass on extra arguments
-      "${ZAC_DOCKER_ENTRYPOINT:-java -Xms1024m -Xmx1024m -Xlog:gc::time,uptime -jar zaakafhandelcomponent.jar}",
+      "${ZAC_DOCKER_ENTRYPOINT:-java -Djboss.bind.address.management=0.0.0.0 -Xms1024m -Xmx1024m -Xlog:gc::time,uptime -jar zaakafhandelcomponent.jar}"
     ]
     deploy:
       resources:

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- please follow the instructions in 'updatingDependencies.md' when upgrading WildFly -->
         <wildfly.version>34.0.1.Final</wildfly.version>
-        <wildfly-jar-maven-plugin.version>11.0.2.Final</wildfly-jar-maven-plugin.version>
+        <wildfly-maven-plugin.version>5.1.0.Final</wildfly-maven-plugin.version>
         <wildfly-datasources-galleon-pack.version>9.1.0.Final</wildfly-datasources-galleon-pack.version>
     </properties>
 
@@ -28,18 +28,22 @@
         <plugins>
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>${wildfly-jar-maven-plugin.version}</version>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${wildfly-maven-plugin.version}</version>
                 <configuration>
+                    <bootableJar>true</bootableJar>
+                    <skipDeployment>true</skipDeployment>
+                    <bootableJarName>${project.artifactId}.jar</bootableJarName>
                     <featurePacks>
                         <featurePack>
                             <location>wildfly@maven(org.jboss.universe:community-universe)#${wildfly.version}</location>
                         </featurePack>
                         <featurePack>
-                            <groupId>org.wildfly</groupId>
-                            <artifactId>wildfly-datasources-galleon-pack</artifactId>
-                            <version>${wildfly-datasources-galleon-pack.version}</version>
+                            <location>org.wildfly:wildfly-galleon-pack:${wildfly.version}</location>
                         </featurePack>
+                        <feature-pack>
+                            <location>org.wildfly:wildfly-datasources-galleon-pack:${wildfly-datasources-galleon-pack.version}</location>
+                        </feature-pack>
                     </featurePacks>
                     <layers>
                         <layer>elytron-oidc-client</layer>
@@ -55,25 +59,14 @@
                     <excludedLayers>
                         <layer>deployment-scanner</layer>
                     </excludedLayers>
-                    <cliSessions>
-                        <cliSession>
-                            <scriptFiles>
+                    <packaging-scripts>
+                        <packaging-script>
+                            <scripts>
                                 <script>src/main/resources/wildfly/configure-wildfly.cli</script>
                                 <script>src/main/resources/wildfly/deploy-zaakafhandelcomponent.cli</script>
-                            </scriptFiles>
-                            <resolveExpressions>false</resolveExpressions>
-                        </cliSession>
-                    </cliSessions>
-                    <cloud>
-                        <type>kubernetes</type>
-                    </cloud>
-                    <jvmArguments>
-                        <!-- uncomment the following line to enable remote debugging -->
-                        <!-- <argument>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8787</argument> -->
-                    </jvmArguments>
-                    <outputFileName>${project.artifactId}.jar</outputFileName>
-                    <jarFileName>${project.artifactId}.jar</jarFileName>
-                    <hollow-jar>true</hollow-jar>
+                            </scripts>
+                        </packaging-script>
+                    </packaging-scripts>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,12 @@
                         <featurePack>
                             <location>org.wildfly:wildfly-galleon-pack:${wildfly.version}</location>
                         </featurePack>
-                        <feature-pack>
+                        <featurePack>
                             <location>org.wildfly:wildfly-datasources-galleon-pack:${wildfly-datasources-galleon-pack.version}</location>
-                        </feature-pack>
-                        <feature-pack>
+                        </featurePack>
+                        <featurePack>
                             <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${wildfly-cloud-galleon-pack.version}</location>
-                        </feature-pack>
+                        </featurePack>
                     </featurePacks>
                     <layers>
                         <layer>elytron-oidc-client</layer>
@@ -64,14 +64,14 @@
                     <excludedLayers>
                         <layer>deployment-scanner</layer>
                     </excludedLayers>
-                    <packaging-scripts>
-                        <packaging-script>
+                    <packagingScripts>
+                        <packagingScript>
                             <scripts>
                                 <script>src/main/resources/wildfly/configure-wildfly.cli</script>
                                 <script>src/main/resources/wildfly/deploy-zaakafhandelcomponent.cli</script>
                             </scripts>
-                        </packaging-script>
-                    </packaging-scripts>
+                        </packagingScript>
+                    </packagingScripts>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <wildfly.version>34.0.1.Final</wildfly.version>
         <wildfly-maven-plugin.version>5.1.0.Final</wildfly-maven-plugin.version>
         <wildfly-datasources-galleon-pack.version>9.1.0.Final</wildfly-datasources-galleon-pack.version>
+        <wildfly-cloud-galleon-pack.version>7.0.2.Final</wildfly-cloud-galleon-pack.version>
     </properties>
 
     <build>
@@ -44,6 +45,9 @@
                         <feature-pack>
                             <location>org.wildfly:wildfly-datasources-galleon-pack:${wildfly-datasources-galleon-pack.version}</location>
                         </feature-pack>
+                        <feature-pack>
+                            <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${wildfly-cloud-galleon-pack.version}</location>
+                        </feature-pack>
                     </featurePacks>
                     <layers>
                         <layer>elytron-oidc-client</layer>
@@ -55,6 +59,7 @@
                         <layer>microprofile-rest-client</layer>
                         <layer>opentelemetry</layer>
                         <layer>postgresql-driver</layer>
+                        <layer>cloud-server</layer>
                     </layers>
                     <excludedLayers>
                         <layer>deployment-scanner</layer>

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
@@ -68,10 +68,10 @@ class ProjectConfig : AbstractProjectConfig() {
         "ZAC_DOCKER_ENTRYPOINT" to
             "java" +
             " -javaagent:/jacoco-agent/org.jacoco.agent-runtime.jar=destfile=/jacoco-report/jacoco-it.exec" +
-            " -Xms1024m" +
-            " -Xmx1024m" +
             // make sure that the WildFly management port is accessible from outside the container
             " -Djboss.bind.address.management=0.0.0.0" +
+            " -Xms1024m" +
+            " -Xmx1024m" +
             " -jar zaakafhandelcomponent.jar",
         "ZAC_DOCKER_IMAGE" to zacDockerImage
     )

--- a/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
+++ b/src/itest/kotlin/nl/lifely/zac/itest/config/ProjectConfig.kt
@@ -70,6 +70,8 @@ class ProjectConfig : AbstractProjectConfig() {
             " -javaagent:/jacoco-agent/org.jacoco.agent-runtime.jar=destfile=/jacoco-report/jacoco-it.exec" +
             " -Xms1024m" +
             " -Xmx1024m" +
+            // make sure that the WildFly management port is accessible from outside the container
+            " -Djboss.bind.address.management=0.0.0.0" +
             " -jar zaakafhandelcomponent.jar",
         "ZAC_DOCKER_IMAGE" to zacDockerImage
     )


### PR DESCRIPTION
Switch to new WildFly Maven Plugin because the old WildFly JAR Maven Plugin is old and deprecated.

Solves PZ-4902