### PR TITLE
fix: ignore medewerker rol without medewerker

### DIFF
--- a/src/main/java/net/atos/client/zgw/zrc/ZrcClientService.java
+++ b/src/main/java/net/atos/client/zgw/zrc/ZrcClientService.java
@@ -231,11 +231,8 @@ public class ZrcClientService {
 
     public void deleteRol(final Zaak zaak, final BetrokkeneType betrokkeneType, final String toelichting) {
         final List<Rol<?>> rollen = listRollen(zaak);
-
         final Optional<Rol<?>> rolMedewerker = rollen.stream().filter(rol -> rol.getBetrokkeneType() == betrokkeneType).findFirst();
-
         rolMedewerker.ifPresent(betrokkene -> rollen.removeIf(rol -> rol.equalBetrokkeneRol(betrokkene)));
-
         updateRollen(zaak, rollen, toelichting);
     }
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/Rol.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Rol.java
@@ -12,6 +12,8 @@ import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
 import jakarta.json.bind.annotation.JsonbDateFormat;
 import jakarta.json.bind.annotation.JsonbTypeDeserializer;
 
@@ -172,6 +174,12 @@ public abstract class Rol<T> {
         this.indicatieMachtiging = indicatieMachtiging;
     }
 
+    /**
+     * Can be null according to the ZGW API and this does occur in practice in certain circumstances.
+     *
+     * @return the betrokkene identificatie; or null if there is none
+     */
+    @Nullable
     public T getBetrokkeneIdentificatie() {
         return betrokkeneIdentificatie;
     }
@@ -185,6 +193,9 @@ public abstract class Rol<T> {
             return false;
         }
         Rol<T> rol = (Rol<T>) o;
+        if (rol.getBetrokkeneIdentificatie() == null) {
+            return false;
+        }
         return equalBetrokkeneRol(rol) && equalBetrokkeneIdentificatie(rol.getBetrokkeneIdentificatie());
     }
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/Rol.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Rol.java
@@ -193,9 +193,6 @@ public abstract class Rol<T> {
             return false;
         }
         Rol<T> rol = (Rol<T>) o;
-        if (rol.getBetrokkeneIdentificatie() == null) {
-            return false;
-        }
         return equalBetrokkeneRol(rol) && equalBetrokkeneIdentificatie(rol.getBetrokkeneIdentificatie());
     }
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/RolMedewerker.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/RolMedewerker.java
@@ -10,11 +10,11 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.net.URI;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 
 import net.atos.client.zgw.ztc.model.generated.RolType;
-
-import javax.annotation.Nullable;
 
 public class RolMedewerker extends Rol<Medewerker> {
 
@@ -27,8 +27,7 @@ public class RolMedewerker extends Rol<Medewerker> {
             final String roltoelichting,
             // it is possible in the ZGW API to have a RolMedewerker without a Medewerker
             // and this does occur in practice in certain circumstances
-            @Nullable
-            final Medewerker betrokkeneIdentificatie
+            @Nullable final Medewerker betrokkeneIdentificatie
     ) {
         super(zaak, roltype, BetrokkeneType.MEDEWERKER, betrokkeneIdentificatie, roltoelichting);
     }

--- a/src/main/java/net/atos/client/zgw/zrc/model/RolMedewerker.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/RolMedewerker.java
@@ -14,6 +14,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import net.atos.client.zgw.ztc.model.generated.RolType;
 
+import javax.annotation.Nullable;
+
 public class RolMedewerker extends Rol<Medewerker> {
 
     public RolMedewerker() {
@@ -23,6 +25,9 @@ public class RolMedewerker extends Rol<Medewerker> {
             final URI zaak,
             final RolType roltype,
             final String roltoelichting,
+            // it is possible in the ZGW API to have a RolMedewerker without a Medewerker
+            // and this does occur in practice in certain circumstances
+            @Nullable
             final Medewerker betrokkeneIdentificatie
     ) {
         super(zaak, roltype, BetrokkeneType.MEDEWERKER, betrokkeneIdentificatie, roltoelichting);
@@ -72,6 +77,9 @@ public class RolMedewerker extends Rol<Medewerker> {
 
     @Override
     protected int hashCodeBetrokkeneIdentificatie() {
+        if (getBetrokkeneIdentificatie() == null) {
+            return -1;
+        }
         return Objects.hash(getBetrokkeneIdentificatie().getIdentificatie());
     }
 }

--- a/src/main/java/net/atos/zac/formulieren/FormulierRuntimeService.java
+++ b/src/main/java/net/atos/zac/formulieren/FormulierRuntimeService.java
@@ -16,6 +16,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -201,13 +202,13 @@ public class FormulierRuntimeService {
     }
 
     private String getGroepForZaakDefaultValue(final Zaak zaak) {
-        return zgwApiService.findGroepForZaak(zaak)
+        return Optional.ofNullable(zgwApiService.findGroepForZaak(zaak))
                 .map(groep -> identityService.readGroup(groep.getBetrokkeneIdentificatie().getIdentificatie()).getName())
                 .orElse(null);
     }
 
     private String getBehandelaarForZaakDefaultValue(final Zaak zaak) {
-        return zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
+        return Optional.ofNullable(zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak))
                 .map(behandelaar -> identityService.readUser(behandelaar.getIdentificatienummer()).getFullName())
                 .orElse(null);
     }

--- a/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
+++ b/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
@@ -165,7 +165,7 @@ public class MailTemplateHelper {
                 resolvedTekst.contains(ZAAK_INITIATOR_ADRES.getVariabele())) {
                 resolvedTekst = replaceInitiatorVariabelen(
                         resolvedTekst,
-                        zgwApiService.findInitiatorRoleForZaak(zaak)
+                        Optional.ofNullable(zgwApiService.findInitiatorRoleForZaak(zaak))
                 );
             }
 

--- a/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
+++ b/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
@@ -145,7 +145,9 @@ public class MailTemplateHelper {
                     zaak.getUiterlijkeEinddatumAfdoening().format(DATE_FORMATTER));
 
             if (resolvedTekst.contains(ZAAK_STATUS.getVariabele())) {
-                resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_STATUS,
+                resolvedTekst = replaceVariabele(
+                        resolvedTekst,
+                        ZAAK_STATUS,
                         Optional.of(zaak.getStatus())
                                 .map(zrcClientService::readStatus)
                                 .map(Status::getStatustype)
@@ -244,9 +246,12 @@ public class MailTemplateHelper {
 
     private MailLink createMailLinkFromZaak(final Zaak zaak) {
         final ZaakType zaaktype = ztcClientService.readZaaktype(zaak.getZaaktype());
-        return new MailLink(zaak.getIdentificatie(),
+        return new MailLink(
+                zaak.getIdentificatie(),
                 configuratieService.zaakTonenUrl(zaak.getIdentificatie()),
-                "de zaak", "(%s)".formatted(zaaktype.getOmschrijving()));
+                "de zaak",
+                "(%s)".formatted(zaaktype.getOmschrijving())
+        );
     }
 
     private MailLink createMailLinkFromTask(final TaskInfo taskInfo) {

--- a/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
+++ b/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
@@ -163,20 +163,24 @@ public class MailTemplateHelper {
 
             if (resolvedTekst.contains(ZAAK_INITIATOR.getVariabele()) ||
                 resolvedTekst.contains(ZAAK_INITIATOR_ADRES.getVariabele())) {
-                resolvedTekst = replaceInitiatorVariabelen(resolvedTekst,
-                        zgwApiService.findInitiatorRoleForZaak(zaak));
+                resolvedTekst = replaceInitiatorVariabelen(
+                        resolvedTekst,
+                        zgwApiService.findInitiatorRoleForZaak(zaak)
+                );
             }
 
             if (resolvedTekst.contains(ZAAK_BEHANDELAAR_GROEP.getVariabele())) {
-                resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_BEHANDELAAR_GROEP,
-                        zgwApiService.findGroepForZaak(zaak)
-                                .map(RolOrganisatorischeEenheid::getNaam));
+                String groupName = Optional.ofNullable(zgwApiService.findGroepForZaak(zaak))
+                        .map(RolOrganisatorischeEenheid::getNaam)
+                        .orElse(null);
+                resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_BEHANDELAAR_GROEP, groupName);
             }
 
             if (resolvedTekst.contains(ZAAK_BEHANDELAAR_MEDEWERKER.getVariabele())) {
-                resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_BEHANDELAAR_MEDEWERKER,
-                        zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
-                                .map(RolMedewerker::getNaam));
+                String medewerkerName = Optional.ofNullable(zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak))
+                        .map(RolMedewerker::getNaam)
+                        .orElse(null);
+                resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_BEHANDELAAR_MEDEWERKER, medewerkerName);
             }
         }
         return resolvedTekst;

--- a/src/main/kotlin/net/atos/client/zgw/shared/ZGWApiService.kt
+++ b/src/main/kotlin/net/atos/client/zgw/shared/ZGWApiService.kt
@@ -38,6 +38,7 @@ import java.time.Period
 import java.time.ZonedDateTime
 import java.util.UUID
 import java.util.logging.Logger
+import kotlin.jvm.optionals.getOrNull
 
 /**
  * Service class for ZGW API's.
@@ -56,6 +57,7 @@ class ZGWApiService @Inject constructor(
 
         // Page numbering in ZGW APIs starts with 1
         const val FIRST_PAGE_NUMBER_ZGW_APIS: Int = 1
+        const val ZAAK_OBJECT_DELETION_PREFIX = "Verwijderd"
     }
 
     /**
@@ -235,7 +237,7 @@ class ZGWApiService @Inject constructor(
         // delete the relationship of the EnkelvoudigInformatieobject with the zaak.
         zaakInformatieobjecten
             .filter { it.zaakUUID == zaakUUID }
-            .forEach { zrcClientService.deleteZaakInformatieobject(it.uuid, toelichting, "Verwijderd") }
+            .forEach { zrcClientService.deleteZaakInformatieobject(it.uuid, toelichting, ZAAK_OBJECT_DELETION_PREFIX) }
 
         // if the EnkelvoudigInformatieobject has no relationship(s) with other zaken it can be deleted.
         if (zaakInformatieobjecten.all { it.zaakUUID == zaakUUID }) {
@@ -270,8 +272,7 @@ class ZGWApiService @Inject constructor(
             // there should be only one initiator role type,
             // but in case there are multiple, we take the first one
             .firstOrNull()?.let {
-                zrcClientService.listRollen(RolListParameters(zaak.url, it.url))
-                    .getSingleResult().takeIf { it.isPresent }?.get()
+                zrcClientService.listRollen(RolListParameters(zaak.url, it.url)).getSingleResult().getOrNull()
             }
 
     private fun findBehandelaarRoleForZaak(
@@ -281,8 +282,7 @@ class ZGWApiService @Inject constructor(
         // there should be one and only one 'behandelaar' role type
         // but in case there are multiple, we take the first one
         .firstOrNull()?.let {
-            zrcClientService.listRollen(RolListParameters(zaak.url, it.url, betrokkeneType))
-                .singleResult.takeIf { it.isPresent }?.get()
+            zrcClientService.listRollen(RolListParameters(zaak.url, it.url, betrokkeneType)).singleResult.getOrNull()
         }
 
     private fun createStatusForZaak(zaakURI: URI, statustypeURI: URI, toelichting: String?): Status {

--- a/src/main/kotlin/net/atos/client/zgw/shared/ZGWApiService.kt
+++ b/src/main/kotlin/net/atos/client/zgw/shared/ZGWApiService.kt
@@ -36,7 +36,6 @@ import java.net.URI
 import java.time.LocalDate
 import java.time.Period
 import java.time.ZonedDateTime
-import java.util.Optional
 import java.util.UUID
 import java.util.logging.Logger
 
@@ -266,12 +265,14 @@ class ZGWApiService @Inject constructor(
             RolMedewerker::class.java.cast(it)
         }
 
-    fun findInitiatorRoleForZaak(zaak: Zaak): Optional<Rol<*>> =
+    fun findInitiatorRoleForZaak(zaak: Zaak): Rol<*>? =
         ztcClientService.findRoltypen(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR)
-            // there should be only one initiator role type but in case there are multiple, we take the first one
+            // there should be only one initiator role type,
+            // but in case there are multiple, we take the first one
             .firstOrNull()?.let {
-                zrcClientService.listRollen(RolListParameters(zaak.url, it.url)).getSingleResult()
-            } ?: Optional.empty()
+                zrcClientService.listRollen(RolListParameters(zaak.url, it.url))
+                    .getSingleResult().takeIf { it.isPresent }?.get()
+            }
 
     private fun findBehandelaarRoleForZaak(
         zaak: Zaak,

--- a/src/main/kotlin/net/atos/client/zgw/shared/ZGWApiService.kt
+++ b/src/main/kotlin/net/atos/client/zgw/shared/ZGWApiService.kt
@@ -282,7 +282,7 @@ class ZGWApiService @Inject constructor(
         // but in case there are multiple, we take the first one
         .firstOrNull()?.let {
             zrcClientService.listRollen(RolListParameters(zaak.url, it.url, betrokkeneType))
-                .getSingleResult().takeIf { it.isPresent }?.get()
+                .singleResult.takeIf { it.isPresent }?.get()
         }
 
     private fun createStatusForZaak(zaakURI: URI, statustypeURI: URI, toelichting: String?): Status {

--- a/src/main/kotlin/net/atos/client/zgw/shared/ZGWApiService.kt
+++ b/src/main/kotlin/net/atos/client/zgw/shared/ZGWApiService.kt
@@ -253,7 +253,7 @@ class ZGWApiService @Inject constructor(
      */
     fun findGroepForZaak(zaak: Zaak): RolOrganisatorischeEenheid? =
         findBehandelaarRoleForZaak(zaak, BetrokkeneType.ORGANISATORISCHE_EENHEID)?.let {
-            RolOrganisatorischeEenheid::class.java.cast(it)
+            it as RolOrganisatorischeEenheid
         }
 
     /**
@@ -264,7 +264,7 @@ class ZGWApiService @Inject constructor(
      */
     fun findBehandelaarMedewerkerRoleForZaak(zaak: Zaak): RolMedewerker? =
         findBehandelaarRoleForZaak(zaak, BetrokkeneType.MEDEWERKER)?.let {
-            RolMedewerker::class.java.cast(it)
+            it as RolMedewerker
         }
 
     fun findInitiatorRoleForZaak(zaak: Zaak): Rol<*>? =

--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -519,9 +519,8 @@ class ZaakRestService @Inject constructor(
         val zaak = zrcClientService.readZaak(toekennenGegevens.zaakUUID).also {
             assertPolicy(policyService.readZaakRechten(it).toekennen)
         }
-        val behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(
-            zaak
-        )?.betrokkeneIdentificatie?.identificatie
+        val behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
+            ?.betrokkeneIdentificatie?.identificatie
         val isUpdated = AtomicBoolean(false)
         if (behandelaar != toekennenGegevens.assigneeUserName) {
             toekennenGegevens.assigneeUserName?.takeIf { it.isNotEmpty() }?.let {
@@ -532,13 +531,15 @@ class ZaakRestService @Inject constructor(
                 ?: zrcClientService.deleteRol(zaak, BetrokkeneType.MEDEWERKER, toekennenGegevens.reason)
             isUpdated.set(true)
         }
-        zgwApiService.findGroepForZaak(zaak)?.let {
+        zgwApiService.findGroepForZaak(zaak)?.let { rolOrganisatorischeEenheid ->
             val groupId = toekennenGegevens.groupId
-            if (it.betrokkeneIdentificatie.identificatie != groupId) {
-                val group = identityService.readGroup(groupId)
-                val role = zaakService.bepaalRolGroep(group, zaak)
-                zrcClientService.updateRol(zaak, role, toekennenGegevens.reason)
-                isUpdated.set(true)
+            rolOrganisatorischeEenheid.betrokkeneIdentificatie?.let {
+                if (it.identificatie != groupId) {
+                    val group = identityService.readGroup(groupId)
+                    val role = zaakService.bepaalRolGroep(group, zaak)
+                    zrcClientService.updateRol(zaak, role, toekennenGegevens.reason)
+                    isUpdated.set(true)
+                }
             }
         }
         if (isUpdated.get()) {

--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -203,7 +203,7 @@ class ZaakRestService @Inject constructor(
     @Path("initiator")
     fun updateInitiator(gegevens: RESTZaakBetrokkeneGegevens): RestZaak {
         val zaak = zrcClientService.readZaak(gegevens.zaakUUID)
-        zgwApiService.findInitiatorRoleForZaak(zaak)?.let {
+        zgwApiService.findInitiatorRoleForZaak(zaak)?.also {
             removeInitiator(zaak, it, ROL_VERWIJDER_REDEN)
         }
         addInitiator(gegevens.betrokkeneIdentificatieType, gegevens.betrokkeneIdentificatie, zaak)
@@ -214,7 +214,9 @@ class ZaakRestService @Inject constructor(
     @Path("{uuid}/initiator")
     fun deleteInitiator(@PathParam("uuid") zaakUUID: UUID, reden: RESTReden): RestZaak {
         val zaak = zrcClientService.readZaak(zaakUUID)
-        zgwApiService.findInitiatorRoleForZaak(zaak)?.let { removeInitiator(zaak, it, reden.reden) }
+        zgwApiService.findInitiatorRoleForZaak(zaak)?.also {
+            removeInitiator(zaak, it, reden.reden)
+        }
         return restZaakConverter.toRestZaak(zaak)
     }
 

--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -203,8 +203,9 @@ class ZaakRestService @Inject constructor(
     @Path("initiator")
     fun updateInitiator(gegevens: RESTZaakBetrokkeneGegevens): RestZaak {
         val zaak = zrcClientService.readZaak(gegevens.zaakUUID)
-        zgwApiService.findInitiatorRoleForZaak(zaak)
-            .ifPresent { removeInitiator(zaak, it, ROL_VERWIJDER_REDEN) }
+        zgwApiService.findInitiatorRoleForZaak(zaak)?.let {
+            removeInitiator(zaak, it, ROL_VERWIJDER_REDEN)
+        }
         addInitiator(gegevens.betrokkeneIdentificatieType, gegevens.betrokkeneIdentificatie, zaak)
         return restZaakConverter.toRestZaak(zaak)
     }
@@ -213,8 +214,7 @@ class ZaakRestService @Inject constructor(
     @Path("{uuid}/initiator")
     fun deleteInitiator(@PathParam("uuid") zaakUUID: UUID, reden: RESTReden): RestZaak {
         val zaak = zrcClientService.readZaak(zaakUUID)
-        zgwApiService.findInitiatorRoleForZaak(zaak)
-            .ifPresent { removeInitiator(zaak, it, reden.reden) }
+        zgwApiService.findInitiatorRoleForZaak(zaak)?.let { removeInitiator(zaak, it, reden.reden) }
         return restZaakConverter.toRestZaak(zaak)
     }
 

--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -519,9 +519,9 @@ class ZaakRestService @Inject constructor(
         val zaak = zrcClientService.readZaak(toekennenGegevens.zaakUUID).also {
             assertPolicy(policyService.readZaakRechten(it).toekennen)
         }
-        val behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
-            .map { it.betrokkeneIdentificatie.identificatie }
-            .orElse(null)
+        val behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(
+            zaak
+        )?.betrokkeneIdentificatie?.identificatie
         val isUpdated = AtomicBoolean(false)
         if (behandelaar != toekennenGegevens.assigneeUserName) {
             toekennenGegevens.assigneeUserName?.takeIf { it.isNotEmpty() }?.let {
@@ -532,7 +532,7 @@ class ZaakRestService @Inject constructor(
                 ?: zrcClientService.deleteRol(zaak, BetrokkeneType.MEDEWERKER, toekennenGegevens.reason)
             isUpdated.set(true)
         }
-        zgwApiService.findGroepForZaak(zaak).ifPresent {
+        zgwApiService.findGroepForZaak(zaak)?.let {
             val groupId = toekennenGegevens.groupId
             if (it.betrokkeneIdentificatie.identificatie != groupId) {
                 val group = identityService.readGroup(groupId)

--- a/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverter.kt
@@ -77,9 +77,9 @@ class RestZaakConverter @Inject constructor(
         }
         val besluiten = brcClientService.listBesluiten(zaak)
             .map { restDecisionConverter.convertToRestDecision(it) }
-        val behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let { rolMedewerker ->
-            rolMedewerker.betrokkeneIdentificatie?.let { restUserConverter.convertUserId(it.identificatie) }
-        }
+        val behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
+            ?.betrokkeneIdentificatie
+            ?.let { restUserConverter.convertUserId(it.identificatie) }
         val initiator = zgwApiService.findInitiatorRoleForZaak(zaak)
         return RestZaak(
             identificatie = zaak.identificatie,

--- a/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverter.kt
@@ -40,7 +40,6 @@ import java.time.Period
 import java.util.EnumSet
 import java.util.UUID
 import java.util.logging.Logger
-import kotlin.jvm.optionals.getOrNull
 
 @Suppress("LongParameterList")
 class RestZaakConverter @Inject constructor(
@@ -112,8 +111,8 @@ class RestZaakConverter @Inject constructor(
             vertrouwelijkheidaanduiding = zaak.vertrouwelijkheidaanduiding.name,
             groep = groep,
             behandelaar = behandelaar,
-            initiatorIdentificatie = initiator.getOrNull()?.identificatienummer,
-            initiatorIdentificatieType = when (val betrokkeneType = initiator.getOrNull()?.betrokkeneType) {
+            initiatorIdentificatie = initiator?.identificatienummer,
+            initiatorIdentificatieType = when (val betrokkeneType = initiator?.betrokkeneType) {
                 BetrokkeneType.NATUURLIJK_PERSOON -> IdentificatieType.BSN
                 BetrokkeneType.VESTIGING -> IdentificatieType.VN
                 BetrokkeneType.NIET_NATUURLIJK_PERSOON -> IdentificatieType.RSIN

--- a/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverter.kt
@@ -71,14 +71,14 @@ class RestZaakConverter @Inject constructor(
     @Suppress("LongMethod", "CyclomaticComplexMethod")
     fun toRestZaak(zaak: Zaak, status: Status?, statustype: StatusType?): RestZaak {
         val zaaktype = ztcClientService.readZaaktype(zaak.zaaktype)
-        val groep = zgwApiService.findGroepForZaak(zaak)
-            .map { restGroupConverter.convertGroupId(it.betrokkeneIdentificatie.identificatie) }
-            .orElse(null)
+        val groep = zgwApiService.findGroepForZaak(zaak)?.let {
+            restGroupConverter.convertGroupId(it.betrokkeneIdentificatie.identificatie)
+        }
         val besluiten = brcClientService.listBesluiten(zaak)
             .map { restDecisionConverter.convertToRestDecision(it) }
-        val behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
-            .map { restUserConverter.convertUserId(it.betrokkeneIdentificatie.identificatie) }
-            .orElse(null)
+        val behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let {
+            restUserConverter.convertUserId(it.betrokkeneIdentificatie.identificatie)
+        }
         val initiator = zgwApiService.findInitiatorRoleForZaak(zaak)
         return RestZaak(
             identificatie = zaak.identificatie,

--- a/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverter.kt
@@ -70,13 +70,15 @@ class RestZaakConverter @Inject constructor(
     @Suppress("LongMethod", "CyclomaticComplexMethod")
     fun toRestZaak(zaak: Zaak, status: Status?, statustype: StatusType?): RestZaak {
         val zaaktype = ztcClientService.readZaaktype(zaak.zaaktype)
-        val groep = zgwApiService.findGroepForZaak(zaak)?.let {
-            restGroupConverter.convertGroupId(it.betrokkeneIdentificatie.identificatie)
+        val groep = zgwApiService.findGroepForZaak(zaak)?.let { rolOrganisatorischeEenheid ->
+            rolOrganisatorischeEenheid.betrokkeneIdentificatie?.let {
+                restGroupConverter.convertGroupId(it.identificatie)
+            }
         }
         val besluiten = brcClientService.listBesluiten(zaak)
             .map { restDecisionConverter.convertToRestDecision(it) }
-        val behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let {
-            restUserConverter.convertUserId(it.betrokkeneIdentificatie.identificatie)
+        val behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let { rolMedewerker ->
+            rolMedewerker.betrokkeneIdentificatie?.let { restUserConverter.convertUserId(it.identificatie) }
         }
         val initiator = zgwApiService.findInitiatorRoleForZaak(zaak)
         return RestZaak(

--- a/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakOverzichtConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakOverzichtConverter.kt
@@ -26,7 +26,7 @@ class RestZaakOverzichtConverter @Inject constructor(
     private val policyService: PolicyService,
     private val zrcClientService: ZrcClientService,
 ) {
-
+    @Suppress("CyclomaticComplexMethod")
     fun convert(zaak: Zaak): RestZaakOverzicht {
         val zaaktype = ztcClientService.readZaaktype(zaak.zaaktype)
         val zaakrechten = policyService.readZaakRechten(zaak, zaaktype)
@@ -55,14 +55,14 @@ class RestZaakOverzichtConverter @Inject constructor(
                 }
             },
             behandelaar = takeIf { zaakrechten.lezen }?.let {
-                zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
-                    .map { userConverter.convertUserId(it.betrokkeneIdentificatie.identificatie) }
-                    .orElse(null)
+                zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let {
+                    userConverter.convertUserId(it.betrokkeneIdentificatie.identificatie)
+                }
             },
             groep = takeIf { zaakrechten.lezen }?.let {
-                zgwApiService.findGroepForZaak(zaak)
-                    .map { groupConverter.convertGroupId(it.betrokkeneIdentificatie.identificatie) }
-                    .orElse(null)
+                zgwApiService.findGroepForZaak(zaak)?.let {
+                    groupConverter.convertGroupId(it.betrokkeneIdentificatie.identificatie)
+                }
             }
         )
     }

--- a/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakOverzichtConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakOverzichtConverter.kt
@@ -55,13 +55,17 @@ class RestZaakOverzichtConverter @Inject constructor(
                 }
             },
             behandelaar = takeIf { zaakrechten.lezen }?.let {
-                zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let {
-                    userConverter.convertUserId(it.betrokkeneIdentificatie.identificatie)
+                zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let { rolMedewerker ->
+                    rolMedewerker.betrokkeneIdentificatie?.let {
+                        userConverter.convertUserId(it.identificatie)
+                    }
                 }
             },
             groep = takeIf { zaakrechten.lezen }?.let {
-                zgwApiService.findGroepForZaak(zaak)?.let {
-                    groupConverter.convertGroupId(it.betrokkeneIdentificatie.identificatie)
+                zgwApiService.findGroepForZaak(zaak)?.let { rolOrganisatorischeEenheid ->
+                    rolOrganisatorischeEenheid.betrokkeneIdentificatie?.let {
+                        groupConverter.convertGroupId(it.identificatie)
+                    }
                 }
             }
         )

--- a/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakOverzichtConverter.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/converter/RestZaakOverzichtConverter.kt
@@ -11,6 +11,8 @@ import net.atos.client.zgw.zrc.model.Zaak
 import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.zac.app.identity.converter.RestGroupConverter
 import net.atos.zac.app.identity.converter.RestUserConverter
+import net.atos.zac.app.identity.model.RestGroup
+import net.atos.zac.app.identity.model.RestUser
 import net.atos.zac.app.policy.converter.RestRechtenConverter
 import net.atos.zac.app.zaak.model.RestZaakOverzicht
 import net.atos.zac.policy.PolicyService
@@ -26,7 +28,6 @@ class RestZaakOverzichtConverter @Inject constructor(
     private val policyService: PolicyService,
     private val zrcClientService: ZrcClientService,
 ) {
-    @Suppress("CyclomaticComplexMethod")
     fun convert(zaak: Zaak): RestZaakOverzicht {
         val zaaktype = ztcClientService.readZaaktype(zaak.zaaktype)
         val zaakrechten = policyService.readZaakRechten(zaak, zaaktype)
@@ -34,40 +35,20 @@ class RestZaakOverzichtConverter @Inject constructor(
             uuid = zaak.uuid,
             identificatie = zaak.identificatie,
             rechten = RestRechtenConverter.convert(zaakrechten),
-            startdatum = takeIf { zaakrechten.lezen }?.let { zaak.startdatum },
-            einddatum = takeIf { zaakrechten.lezen }?.let { zaak.einddatum },
-            einddatumGepland = takeIf { zaakrechten.lezen }?.let { zaak.einddatumGepland },
-            uiterlijkeEinddatumAfdoening = takeIf { zaakrechten.lezen }?.let { zaak.uiterlijkeEinddatumAfdoening },
-            toelichting = takeIf { zaakrechten.lezen }?.let { zaak.toelichting },
-            omschrijving = takeIf { zaakrechten.lezen }?.let { zaak.omschrijving },
-            zaaktype = takeIf { zaakrechten.lezen }?.let { zaaktype.omschrijving },
+            startdatum = zaakrechten.lezen.takeIf { it }?.let { zaak.startdatum },
+            einddatum = zaakrechten.lezen.takeIf { it }?.let { zaak.einddatum },
+            einddatumGepland = zaakrechten.lezen.takeIf { it }?.let { zaak.einddatumGepland },
+            uiterlijkeEinddatumAfdoening = zaakrechten.lezen.takeIf { it }?.let { zaak.uiterlijkeEinddatumAfdoening },
+            toelichting = zaakrechten.lezen.takeIf { it }?.let { zaak.toelichting },
+            omschrijving = zaakrechten.lezen.takeIf { it }?.let { zaak.omschrijving },
+            zaaktype = zaakrechten.lezen.takeIf { it }?.let { zaaktype.omschrijving },
             openstaandeTaken = openstaandeTakenConverter.convert(zaak.uuid),
-            resultaat = takeIf { zaakrechten.lezen }?.let {
-                zaak.resultaat?.let {
-                    zaakResultaatConverter.convert(
-                        it
-                    )
-                }
-            },
-            status = takeIf { zaakrechten.lezen }?.let {
-                zaak.status?.let {
-                    ztcClientService.readStatustype(zrcClientService.readStatus(it).statustype).omschrijving
-                }
-            },
-            behandelaar = takeIf { zaakrechten.lezen }?.let {
-                zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let { rolMedewerker ->
-                    rolMedewerker.betrokkeneIdentificatie?.let {
-                        userConverter.convertUserId(it.identificatie)
-                    }
-                }
-            },
-            groep = takeIf { zaakrechten.lezen }?.let {
-                zgwApiService.findGroepForZaak(zaak)?.let { rolOrganisatorischeEenheid ->
-                    rolOrganisatorischeEenheid.betrokkeneIdentificatie?.let {
-                        groupConverter.convertGroupId(it.identificatie)
-                    }
-                }
-            }
+            resultaat = zaakrechten.lezen.takeIf { it }?.let { zaak.resultaat?.let(zaakResultaatConverter::convert) },
+            status = zaakrechten.lezen.takeIf { it }?.let { zaak.status }
+                ?.let { zrcClientService.readStatus(it).statustype }
+                ?.let { ztcClientService.readStatustype(it).omschrijving },
+            behandelaar = zaakrechten.lezen.takeIf { it }?.let { getBehandelaarForZaak(zaak) },
+            groep = zaakrechten.lezen.takeIf { it }?.let { getGroupForZaak(zaak) }
         )
     }
 
@@ -84,4 +65,16 @@ class RestZaakOverzichtConverter @Inject constructor(
             }
         }
     }
+
+    private fun getBehandelaarForZaak(
+        zaak: Zaak
+    ): RestUser? = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
+        ?.betrokkeneIdentificatie
+        ?.let { userConverter.convertUserId(it.identificatie) }
+
+    private fun getGroupForZaak(
+        zaak: Zaak
+    ): RestGroup? = zgwApiService.findGroepForZaak(zaak)
+        ?.betrokkeneIdentificatie
+        ?.let { groupConverter.convertGroupId(it.identificatie) }
 }

--- a/src/main/kotlin/net/atos/zac/app/zaak/model/RestZaakBetrokkene.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/model/RestZaakBetrokkene.kt
@@ -25,7 +25,7 @@ data class RestZaakBetrokkene(
 
     var type: String,
 
-    var identificatie: String
+    var identificatie: String?
 )
 
 @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
@@ -35,11 +35,11 @@ fun Rol<*>.toRestZaakBetrokkene() = RestZaakBetrokkene(
     roltoelichting = this.roltoelichting,
     type = this.betrokkeneType.name,
     identificatie = when (this.betrokkeneType) {
-        BetrokkeneType.NATUURLIJK_PERSOON -> (this as RolNatuurlijkPersoon).betrokkeneIdentificatie.inpBsn
-        BetrokkeneType.NIET_NATUURLIJK_PERSOON -> (this as RolNietNatuurlijkPersoon).betrokkeneIdentificatie.innNnpId
-        BetrokkeneType.VESTIGING -> (this as RolVestiging).betrokkeneIdentificatie.vestigingsNummer
-        BetrokkeneType.ORGANISATORISCHE_EENHEID -> (this as RolOrganisatorischeEenheid).betrokkeneIdentificatie.naam
-        BetrokkeneType.MEDEWERKER -> (this as RolMedewerker).betrokkeneIdentificatie.identificatie
+        BetrokkeneType.NATUURLIJK_PERSOON -> (this as RolNatuurlijkPersoon).betrokkeneIdentificatie?.inpBsn
+        BetrokkeneType.NIET_NATUURLIJK_PERSOON -> (this as RolNietNatuurlijkPersoon).betrokkeneIdentificatie?.innNnpId
+        BetrokkeneType.VESTIGING -> (this as RolVestiging).betrokkeneIdentificatie?.vestigingsNummer
+        BetrokkeneType.ORGANISATORISCHE_EENHEID -> (this as RolOrganisatorischeEenheid).betrokkeneIdentificatie?.naam
+        BetrokkeneType.MEDEWERKER -> (this as RolMedewerker).betrokkeneIdentificatie?.identificatie
     }
 )
 

--- a/src/main/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverter.kt
+++ b/src/main/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverter.kt
@@ -110,9 +110,7 @@ class DocumentCreationDataConverter @Inject constructor(
         )
 
     private fun createAanvragerData(zaak: Zaak): AanvragerData? =
-        zgwApiService.findInitiatorRoleForZaak(zaak)
-            .map { convertToAanvragerData(it) }
-            .orElse(null)
+        zgwApiService.findInitiatorRoleForZaak(zaak)?.let(::convertToAanvragerData)
 
     private fun convertToAanvragerData(initiator: Rol<*>): AanvragerData? =
         when (initiator.betrokkeneType) {

--- a/src/main/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverter.kt
+++ b/src/main/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverter.kt
@@ -82,15 +82,11 @@ class DocumentCreationDataConverter @Inject constructor(
 
     private fun createZaakData(zaak: Zaak) =
         ZaakData(
-            behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
-                .map { it.naam }
-                .orElse(null),
+            behandelaar = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.naam,
             communicatiekanaal = zaak.communicatiekanaalNaam,
             einddatum = zaak.einddatum,
             einddatumGepland = zaak.einddatumGepland,
-            groep = zgwApiService.findGroepForZaak(zaak)
-                .map { it.naam }
-                .orElse(null),
+            groep = zgwApiService.findGroepForZaak(zaak)?.naam,
             identificatie = zaak.identificatie,
             omschrijving = zaak.omschrijving,
             opschortingReden = if (zaak.isOpgeschort) { zaak.opschorting.reden } else null,

--- a/src/main/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.kt
+++ b/src/main/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.kt
@@ -116,14 +116,14 @@ class ZaakZoekObjectConverter @Inject constructor(
     }
 
     private fun findBehandelaar(zaak: Zaak): User? =
-        zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
-            .map { identityService.readUser(it.betrokkeneIdentificatie.identificatie) }
-            .orElse(null)
+        zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let {
+            identityService.readUser(it.betrokkeneIdentificatie.identificatie)
+        }
 
     private fun findGroup(zaak: Zaak): Group? =
-        zgwApiService.findGroepForZaak(zaak)
-            .map { identityService.readGroup(it.betrokkeneIdentificatie.identificatie) }
-            .orElse(null)
+        zgwApiService.findGroepForZaak(zaak)?.let {
+            identityService.readGroup(it.betrokkeneIdentificatie.identificatie)
+        }
 
     private fun getBagObjectIDs(zaak: Zaak): List<String> {
         val zaakobjectListParameters = ZaakobjectListParameters().apply { this.zaak = zaak.url }

--- a/src/main/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.kt
+++ b/src/main/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.kt
@@ -55,7 +55,7 @@ class ZaakZoekObjectConverter @Inject constructor(
             // we use the name of this enum in the search index
             vertrouwelijkheidaanduiding = zaak.vertrouwelijkheidaanduiding.name
             isAfgehandeld = !zaak.isOpen
-            zgwApiService.findInitiatorRoleForZaak(zaak)?.let(::setInitiator)
+            zgwApiService.findInitiatorRoleForZaak(zaak)?.also(::setInitiator)
             // locatie is not yet supported
             locatie = null
             communicatiekanaal = zaak.communicatiekanaalNaam
@@ -99,10 +99,11 @@ class ZaakZoekObjectConverter @Inject constructor(
         }
         zaakZoekObject.aantalOpenstaandeTaken = flowableTaskService.countOpenTasksForZaak(zaak.uuid)
         zaak.resultaat?.let { zaakResultaat ->
-            zrcClientService.readResultaat(zaakResultaat)?.let {
-                val resultaattype = ztcClientService.readResultaattype(it.resultaattype)
-                zaakZoekObject.resultaattypeOmschrijving = resultaattype.omschrijving
-                zaakZoekObject.resultaatToelichting = it.toelichting
+            zrcClientService.readResultaat(zaakResultaat)?.let { resultaat ->
+                ztcClientService.readResultaattype(resultaat.resultaattype).let { resultaattype ->
+                    zaakZoekObject.resultaattypeOmschrijving = resultaattype.omschrijving
+                    zaakZoekObject.resultaatToelichting = resultaat.toelichting
+                }
             }
         }
         zaakZoekObject.bagObjectIDs = getBagObjectIDs(zaak)
@@ -116,25 +117,23 @@ class ZaakZoekObjectConverter @Inject constructor(
     }
 
     private fun findBehandelaar(zaak: Zaak): User? =
-        zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let { rolMedewerker ->
-            rolMedewerker.betrokkeneIdentificatie?.let {
-                identityService.readUser(it.identificatie)
-            }
-        }
+        zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
+            ?.betrokkeneIdentificatie
+            ?.identificatie
+            ?.let(identityService::readUser)
 
     private fun findGroup(zaak: Zaak): Group? =
-        zgwApiService.findGroepForZaak(zaak)?.let { rolOrganisatorischeEenheid ->
-            rolOrganisatorischeEenheid.betrokkeneIdentificatie?.let {
-                identityService.readGroup(it.identificatie)
-            }
-        }
+        zgwApiService.findGroepForZaak(zaak)
+            ?.betrokkeneIdentificatie
+            ?.identificatie
+            ?.let(identityService::readGroup)
 
     private fun getBagObjectIDs(zaak: Zaak): List<String> {
         val zaakobjectListParameters = ZaakobjectListParameters().apply { this.zaak = zaak.url }
-        val zaakobjecten = zrcClientService.listZaakobjecten(zaakobjectListParameters)
-        return zaakobjecten.results
+        return zrcClientService.listZaakobjecten(zaakobjectListParameters)
+            .results
             .filter { it.isBagObject }
             .map { it.waarde }
-            .takeIf { it.isNotEmpty() } ?: emptyList()
+            .let { if (it.isNotEmpty()) it else emptyList() }
     }
 }

--- a/src/main/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.kt
+++ b/src/main/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.kt
@@ -55,7 +55,7 @@ class ZaakZoekObjectConverter @Inject constructor(
             // we use the name of this enum in the search index
             vertrouwelijkheidaanduiding = zaak.vertrouwelijkheidaanduiding.name
             isAfgehandeld = !zaak.isOpen
-            zgwApiService.findInitiatorRoleForZaak(zaak).ifPresent { setInitiator(it) }
+            zgwApiService.findInitiatorRoleForZaak(zaak)?.let(::setInitiator)
             // locatie is not yet supported
             locatie = null
             communicatiekanaal = zaak.communicatiekanaalNaam

--- a/src/main/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.kt
+++ b/src/main/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverter.kt
@@ -116,13 +116,17 @@ class ZaakZoekObjectConverter @Inject constructor(
     }
 
     private fun findBehandelaar(zaak: Zaak): User? =
-        zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let {
-            identityService.readUser(it.betrokkeneIdentificatie.identificatie)
+        zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)?.let { rolMedewerker ->
+            rolMedewerker.betrokkeneIdentificatie?.let {
+                identityService.readUser(it.identificatie)
+            }
         }
 
     private fun findGroup(zaak: Zaak): Group? =
-        zgwApiService.findGroepForZaak(zaak)?.let {
-            identityService.readGroup(it.betrokkeneIdentificatie.identificatie)
+        zgwApiService.findGroepForZaak(zaak)?.let { rolOrganisatorischeEenheid ->
+            rolOrganisatorischeEenheid.betrokkeneIdentificatie?.let {
+                identityService.readGroup(it.identificatie)
+            }
         }
 
     private fun getBagObjectIDs(zaak: Zaak): List<String> {

--- a/src/test/kotlin/net/atos/client/zgw/shared/ZGWApiServiceTest.kt
+++ b/src/test/kotlin/net/atos/client/zgw/shared/ZGWApiServiceTest.kt
@@ -189,11 +189,11 @@ class ZGWApiServiceTest : BehaviorSpec({
             val rolMedewerker = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
 
             Then("the behandelaar medewerker role should be returned") {
-                rolMedewerker.get() shouldNotBe null
-                with(rolMedewerker.get()) {
+                rolMedewerker shouldNotBe null
+                with(rolMedewerker!!) {
                     this.zaak shouldBe zaak.url
-                    this.identificatienummer shouldBe rolMedewerker.get().identificatienummer
-                    this.naam shouldBe rolMedewerker.get().naam
+                    this.identificatienummer shouldBe rolMedewerker.identificatienummer
+                    this.naam shouldBe rolMedewerker.naam
                 }
             }
         }
@@ -210,8 +210,8 @@ class ZGWApiServiceTest : BehaviorSpec({
             val group = zgwApiService.findGroepForZaak(zaak)
 
             Then("the group should be returned") {
-                group.isPresent shouldBe true
-                with(group.get()) {
+                group shouldNotBe null
+                with(group!!) {
                     this.zaak shouldBe zaak.url
                     this.identificatienummer shouldBe rolOrganisatorischeEenheid.identificatienummer
                     this.naam shouldBe rolOrganisatorischeEenheid.naam
@@ -229,7 +229,7 @@ class ZGWApiServiceTest : BehaviorSpec({
             val group = zgwApiService.findGroepForZaak(zaak)
 
             Then("no group should be returned") {
-                group.isEmpty shouldBe true
+                group shouldBe null
             }
         }
     }

--- a/src/test/kotlin/net/atos/client/zgw/shared/ZGWApiServiceTest.kt
+++ b/src/test/kotlin/net/atos/client/zgw/shared/ZGWApiServiceTest.kt
@@ -192,7 +192,35 @@ class ZGWApiServiceTest : BehaviorSpec({
                 rolMedewerker shouldNotBe null
                 with(rolMedewerker!!) {
                     this.zaak shouldBe zaak.url
+                    this.betrokkeneIdentificatie shouldBe rolMedewerker.betrokkeneIdentificatie
                     this.identificatienummer shouldBe rolMedewerker.identificatienummer
+                    this.naam shouldBe rolMedewerker.naam
+                }
+            }
+        }
+    }
+        Given("A zaak with a behandelaar medewerker role without a betrokkene identificatie") {
+        val zaak = createZaak()
+        val rolMedewerker = createRolMedewerker(
+            zaak = zaak.url,
+            // in the ZGW API it is possible (strangely enough) to have a rol-medewerker object
+            // without a medewerker and this also happens in practise in some circumstances
+            betrokkeneIdentificatie = null
+        )
+        every {
+            ztcClientService.findRoltypen(zaak.zaaktype, OmschrijvingGeneriekEnum.BEHANDELAAR)
+        } returns listOf(createRolType(omschrijvingGeneriek = OmschrijvingGeneriekEnum.BEHANDELAAR))
+        every { zrcClientService.listRollen(any<RolListParameters>()) } returns Results(listOf(rolMedewerker), 1)
+
+        When("the behandelaar medewerker rol is requested") {
+            val rolMedewerker = zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak)
+
+            Then("a behandelaar medewerker role without a betrokkene identificatie should be returned") {
+                rolMedewerker shouldNotBe null
+                with(rolMedewerker!!) {
+                    this.zaak shouldBe zaak.url
+                    this.betrokkeneIdentificatie shouldBe null
+                    this.identificatienummer shouldBe null
                     this.naam shouldBe rolMedewerker.naam
                 }
             }

--- a/src/test/kotlin/net/atos/client/zgw/shared/ZGWApiServiceTest.kt
+++ b/src/test/kotlin/net/atos/client/zgw/shared/ZGWApiServiceTest.kt
@@ -199,7 +199,7 @@ class ZGWApiServiceTest : BehaviorSpec({
             }
         }
     }
-        Given("A zaak with a behandelaar medewerker role without a betrokkene identificatie") {
+    Given("A zaak with a behandelaar medewerker role without a betrokkene identificatie") {
         val zaak = createZaak()
         val rolMedewerker = createRolMedewerker(
             zaak = zaak.url,

--- a/src/test/kotlin/net/atos/client/zgw/shared/ZGWApiServiceTest.kt
+++ b/src/test/kotlin/net/atos/client/zgw/shared/ZGWApiServiceTest.kt
@@ -219,7 +219,7 @@ class ZGWApiServiceTest : BehaviorSpec({
             }
         }
     }
-    Given("A zaak without a group") {
+    Given("A zaaktype without a behandelaar role type") {
         val zaak = createZaak()
         every {
             ztcClientService.findRoltypen(zaak.zaaktype, OmschrijvingGeneriekEnum.BEHANDELAAR)
@@ -230,6 +230,57 @@ class ZGWApiServiceTest : BehaviorSpec({
 
             Then("no group should be returned") {
                 group shouldBe null
+            }
+        }
+    }
+    Given("A zaak without a group") {
+        val zaak = createZaak()
+        every {
+            ztcClientService.findRoltypen(zaak.zaaktype, OmschrijvingGeneriekEnum.BEHANDELAAR)
+        } returns listOf(createRolType(omschrijvingGeneriek = OmschrijvingGeneriekEnum.BEHANDELAAR))
+        every { zrcClientService.listRollen(any<RolListParameters>()) } returns Results(emptyList(), 0)
+
+        When("the group is requested") {
+            val group = zgwApiService.findGroepForZaak(zaak)
+
+            Then("no group should be returned") {
+                group shouldBe null
+            }
+        }
+    }
+    Given("A zaak with an initiator") {
+        val zaak = createZaak()
+        val rolMedewerker = createRolMedewerker(zaak = zaak.url)
+        every {
+            ztcClientService.findRoltypen(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR)
+        } returns listOf(createRolType(omschrijvingGeneriek = OmschrijvingGeneriekEnum.INITIATOR))
+        every { zrcClientService.listRollen(any<RolListParameters>()) } returns Results(listOf(rolMedewerker), 1)
+
+        When("the initiator is requested") {
+            val initiator = zgwApiService.findInitiatorRoleForZaak(zaak)
+
+            Then("the initiator should be returned") {
+                initiator shouldNotBe null
+                with(initiator!!) {
+                    this.zaak shouldBe zaak.url
+                    this.identificatienummer shouldBe rolMedewerker.identificatienummer
+                    this.naam shouldBe rolMedewerker.naam
+                }
+            }
+        }
+    }
+    Given("A zaak without an initiator") {
+        val zaak = createZaak()
+        every {
+            ztcClientService.findRoltypen(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR)
+        } returns listOf(createRolType(omschrijvingGeneriek = OmschrijvingGeneriekEnum.INITIATOR))
+        every { zrcClientService.listRollen(any<RolListParameters>()) } returns Results(emptyList(), 0)
+
+        When("the initiator is requested") {
+            val initiator = zgwApiService.findInitiatorRoleForZaak(zaak)
+
+            Then("the initiator should be returned") {
+                initiator shouldBe null
             }
         }
     }

--- a/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
+++ b/src/test/kotlin/net/atos/client/zgw/zrc/model/ZrcFixtures.kt
@@ -78,7 +78,7 @@ fun createRolMedewerker(
     zaak: URI = URI("https://example.com/${UUID.randomUUID()}"),
     rolType: RolType = createRolType(),
     roltoelichting: String = "dummyToelichting",
-    betrokkeneIdentificatie: Medewerker = createMedewerker()
+    betrokkeneIdentificatie: Medewerker? = createMedewerker()
 ) = RolMedewerker(
     zaak,
     rolType,

--- a/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
@@ -321,7 +321,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                 with(rolSlot.captured) {
                     betrokkeneType shouldBe BetrokkeneType.MEDEWERKER
                     with(betrokkeneIdentificatie as Medewerker) {
-                        identificatie shouldBe rolMedewerker.betrokkeneIdentificatie.identificatie
+                        identificatie shouldBe rolMedewerker.betrokkeneIdentificatie!!.identificatie
                     }
                     this.zaak shouldBe rolMedewerker.zaak
                     omschrijving shouldBe rolType.omschrijving

--- a/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
@@ -95,7 +95,6 @@ import org.flowable.task.api.Task
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.Date
-import java.util.Optional
 import java.util.UUID
 
 @Suppress("LongParameterList")
@@ -301,9 +300,9 @@ class ZaakRestServiceTest : BehaviorSpec({
 
         every { zrcClientService.readZaak(restZaakToekennenGegevens.zaakUUID) } returns zaak
         every { zrcClientService.updateRol(zaak, capture(rolSlot), restZaakToekennenGegevens.reason) } just runs
-        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns Optional.empty()
+        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns null
         every { identityService.readUser(restZaakToekennenGegevens.assigneeUserName!!) } returns user
-        every { zgwApiService.findGroepForZaak(zaak) } returns Optional.empty()
+        every { zgwApiService.findGroepForZaak(zaak) } returns null
         every { restZaakConverter.toRestZaak(zaak) } returns restZaak
         every { indexingService.indexeerDirect(zaak.uuid.toString(), ZoekObjectType.ZAAK, false) } just runs
         every { zaakService.bepaalRolMedewerker(user, zaak) } returns rolMedewerker

--- a/src/test/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverterTest.kt
@@ -88,7 +88,7 @@ class RestZaakConverterTest : BehaviorSpec({
         with(zgwApiService) {
             every { findGroepForZaak(zaak) } returns rolOrganistorischeEenheid
             every { findBehandelaarMedewerkerRoleForZaak(zaak) } returns rolMedewerker
-            every { findInitiatorRoleForZaak(zaak) } returns Optional.of(rol)
+            every { findInitiatorRoleForZaak(zaak) } returns rol
         }
         with(zaakVariabelenService) {
             every { findOntvangstbevestigingVerstuurd(zaak.uuid) } returns Optional.of(false)

--- a/src/test/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/converter/RestZaakConverterTest.kt
@@ -69,7 +69,7 @@ class RestZaakConverterTest : BehaviorSpec({
         val status = createZaakStatus()
         val statusType = createStatusType()
         val zaakType = createZaakType()
-        val rolOrganistorischeEenheid = Optional.of(createRolOrganisatorischeEenheid())
+        val rolOrganistorischeEenheid = createRolOrganisatorischeEenheid()
         val restGroup = createRestGroup()
         val besluit = createBesluit()
         val restBesluit = createRestDecision()
@@ -87,14 +87,14 @@ class RestZaakConverterTest : BehaviorSpec({
         }
         with(zgwApiService) {
             every { findGroepForZaak(zaak) } returns rolOrganistorischeEenheid
-            every { findBehandelaarMedewerkerRoleForZaak(zaak) } returns Optional.of(rolMedewerker)
+            every { findBehandelaarMedewerkerRoleForZaak(zaak) } returns rolMedewerker
             every { findInitiatorRoleForZaak(zaak) } returns Optional.of(rol)
         }
         with(zaakVariabelenService) {
             every { findOntvangstbevestigingVerstuurd(zaak.uuid) } returns Optional.of(false)
             every { readZaakdata(zaak.uuid) } returns zaakdata
         }
-        every { restGroupConverter.convertGroupId(rolOrganistorischeEenheid.get().identificatienummer) } returns restGroup
+        every { restGroupConverter.convertGroupId(rolOrganistorischeEenheid.identificatienummer) } returns restGroup
         every { brcClientService.listBesluiten(zaak) } returns listOf(besluit)
         every { restDecisionConverter.convertToRestDecision(besluit) } returns restBesluit
         every { restUserConverter.convertUserId(rolMedewerker.identificatienummer) } returns restUser

--- a/src/test/kotlin/net/atos/zac/app/zaak/model/RestZakenFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/model/RestZakenFixtures.kt
@@ -193,6 +193,20 @@ fun createRESTZaakAanmaakGegevens(
     bagObjecten = bagObjecten
 )
 
+fun createRESTZaakBetrokkeneGegevens(
+    zaakUUID: UUID = UUID.randomUUID(),
+    roltypeUUID: UUID = UUID.randomUUID(),
+    roltoelichting: String = "dummyRoltoelichting",
+    betrokkeneIdentificatieType: IdentificatieType = IdentificatieType.BSN,
+    betrokkeneIdentificatie: String = "dummyBetrokkeneIdentificatie"
+) = RESTZaakBetrokkeneGegevens(
+    zaakUUID = zaakUUID,
+    roltypeUUID = roltypeUUID,
+    roltoelichting = roltoelichting,
+    betrokkeneIdentificatieType = betrokkeneIdentificatieType,
+    betrokkeneIdentificatie = betrokkeneIdentificatie
+)
+
 fun createRESTZaakKenmerk() = RESTZaakKenmerk("Sample kenmerk", "Sample bron")
 
 fun createRESTZaakToekennenGegevens(

--- a/src/test/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
@@ -75,8 +75,8 @@ class DocumentCreationDataConverterTest : BehaviorSpec({
         every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns Optional.of(rolNatuurlijkPersoon)
         every { brpClientService.retrievePersoon(rolNatuurlijkPersoon.identificatienummer) } returns persoon
         every { zrcClientService.listZaakobjecten(any()) } returns Results(emptyList(), 0)
-        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns Optional.of(rolMedewerker)
-        every { zgwApiService.findGroepForZaak(zaak) } returns Optional.of(rolOrganisatorischeEenheid)
+        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns rolMedewerker
+        every { zgwApiService.findGroepForZaak(zaak) } returns rolOrganisatorischeEenheid
         every { ztcClientService.readZaaktype(zaak.zaaktype) } returns zaakType
 
         When("SmartDocuments data is created") {

--- a/src/test/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
@@ -32,7 +32,6 @@ import net.atos.zac.flowable.task.FlowableTaskService
 import net.atos.zac.identity.IdentityService
 import net.atos.zac.productaanvraag.ProductaanvraagService
 import net.atos.zac.smartdocuments.SmartDocumentsTemplatesService
-import java.util.Optional
 
 class DocumentCreationDataConverterTest : BehaviorSpec({
     val zgwApiService = mockk<ZGWApiService>()
@@ -72,7 +71,7 @@ class DocumentCreationDataConverterTest : BehaviorSpec({
         val rolMedewerker = createRolMedewerker()
         val rolOrganisatorischeEenheid = createRolOrganisatorischeEenheid()
 
-        every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns Optional.of(rolNatuurlijkPersoon)
+        every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns rolNatuurlijkPersoon
         every { brpClientService.retrievePersoon(rolNatuurlijkPersoon.identificatienummer) } returns persoon
         every { zrcClientService.listZaakobjecten(any()) } returns Results(emptyList(), 0)
         every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns rolMedewerker

--- a/src/test/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
@@ -99,8 +99,8 @@ class DocumentCreationDataConverterTest : BehaviorSpec({
                     }
                     with(zaakData) {
                         zaaktype shouldBe zaakType.omschrijving
-                        behandelaar shouldBe "${rolMedewerker.betrokkeneIdentificatie.voorletters} " +
-                            "${rolMedewerker.betrokkeneIdentificatie.achternaam}"
+                        behandelaar shouldBe "${rolMedewerker.betrokkeneIdentificatie!!.voorletters} " +
+                            "${rolMedewerker.betrokkeneIdentificatie!!.achternaam}"
                         groep shouldBe rolOrganisatorischeEenheid.naam
                     }
                     startformulierData shouldBe null

--- a/src/test/kotlin/net/atos/zac/mailtemplates/MailTemplateHelperTest.kt
+++ b/src/test/kotlin/net/atos/zac/mailtemplates/MailTemplateHelperTest.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package net.atos.zac.mailtemplates
 
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/net/atos/zac/mailtemplates/MailTemplateHelperTest.kt
+++ b/src/test/kotlin/net/atos/zac/mailtemplates/MailTemplateHelperTest.kt
@@ -1,0 +1,66 @@
+package net.atos.zac.mailtemplates
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import net.atos.client.brp.BrpClientService
+import net.atos.client.kvk.KvkClientService
+import net.atos.client.zgw.shared.ZGWApiService
+import net.atos.client.zgw.zrc.ZrcClientService
+import net.atos.client.zgw.zrc.model.createZaak
+import net.atos.client.zgw.zrc.model.createZaakStatus
+import net.atos.client.zgw.ztc.ZtcClientService
+import net.atos.client.zgw.ztc.model.createStatusType
+import net.atos.client.zgw.ztc.model.createZaakType
+import net.atos.zac.configuratie.ConfiguratieService
+import net.atos.zac.identity.IdentityService
+import java.net.URI
+import java.time.LocalDate
+
+class MailTemplateHelperTest : BehaviorSpec({
+    val brpClientService = mockk<BrpClientService>()
+    val configuratieService = mockk<ConfiguratieService>()
+    val identityService = mockk<IdentityService>()
+    val kvkClientService = mockk<KvkClientService>()
+    val zgwApiService = mockk<ZGWApiService>()
+    val zrcClientService = mockk<ZrcClientService>()
+    val ztcClientService = mockk<ZtcClientService>()
+    val mailTemplateHelper = MailTemplateHelper(
+        brpClientService,
+        configuratieService,
+        identityService,
+        kvkClientService,
+        zgwApiService,
+        zrcClientService,
+        ztcClientService
+    )
+
+    Given("A zaak") {
+        val zaakType = createZaakType()
+        val zaak = createZaak(
+            zaakTypeURI = zaakType.url,
+            status = URI("https://example.com/dummyStatus"),
+            startDate = LocalDate.of(2021, 10, 12)
+        )
+        val zaakStatus = createZaakStatus()
+        val statusType = createStatusType(omschrijving = "dummyStatusTypeDescription")
+        val zaakTonenURL = URI("https://example.com/dummyURL")
+        every { ztcClientService.readZaaktype(zaak.zaaktype) } returns createZaakType()
+        every { configuratieService.zaakTonenUrl(zaak.identificatie) } returns zaakTonenURL
+        every { zrcClientService.readStatus(zaak.status) } returns zaakStatus
+        every { ztcClientService.readStatustype(zaakStatus.statustype) } returns statusType
+
+        When("I call the getMailTemplate method") {
+            val resolvedText = mailTemplateHelper.resolveVariabelen(
+                "dummyText, {ZAAK_NUMMER}, {ZAAK_URL}, {ZAAK_TYPE}, {ZAAK_STATUS}, {ZAAK_STARTDATUM}",
+                zaak
+            )
+
+            Then("I should get the correct mail template") {
+                resolvedText shouldBe "dummyText, ${zaak.identificatie}, $zaakTonenURL, ${zaakType.omschrijving}, " +
+                    "${statusType.omschrijving}, 12-10-2021"
+            }
+        }
+    }
+})

--- a/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
@@ -37,7 +37,6 @@ import net.atos.zac.zoeken.model.zoekobject.ZoekObjectType
 import java.net.URI
 import java.time.ZoneId
 import java.util.Date
-import java.util.Optional
 
 class ZaakZoekObjectConverterTest : BehaviorSpec({
     val zrcClientService = mockk<ZrcClientService>()
@@ -95,7 +94,7 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
         )
         every { zrcClientService.readResultaat(zaak.resultaat) } returns resultaat
 
-        every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns Optional.of(rolInitiator)
+        every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns rolInitiator
         every { zgwApiService.findGroepForZaak(zaak) } returns null
         every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns rolMedewerkerBehandelaar
         every {
@@ -165,9 +164,8 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
         val zaakStatusType = createStatusType().apply {
             omschrijving = ConfiguratieService.STATUSTYPE_OMSCHRIJVING_HEROPEND
         }
-
         every { zrcClientService.readZaak(zaak.uuid) } returns zaak
-        every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns Optional.of(rolInitiator)
+        every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns rolInitiator
         every { zrcClientService.listRollen(zaak) } returns rollenZaak
         every { zgwApiService.findGroepForZaak(zaak) } returns null
         every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns rolMedewerkerBehandelaar

--- a/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
@@ -98,7 +98,7 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
         every { zgwApiService.findGroepForZaak(zaak) } returns null
         every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns rolMedewerkerBehandelaar
         every {
-            identityService.readUser(rolMedewerkerBehandelaar.betrokkeneIdentificatie.identificatie)
+            identityService.readUser(rolMedewerkerBehandelaar.betrokkeneIdentificatie!!.identificatie)
         } returns userBehandelaar
         every { ztcClientService.readZaaktype(zaak.zaaktype) } returns zaakType
         every { ztcClientService.readResultaattype(resultaat.resultaattype) } returns resultaatType
@@ -170,7 +170,7 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
         every { zgwApiService.findGroepForZaak(zaak) } returns null
         every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns rolMedewerkerBehandelaar
         every {
-            identityService.readUser(rolMedewerkerBehandelaar.betrokkeneIdentificatie.identificatie)
+            identityService.readUser(rolMedewerkerBehandelaar.betrokkeneIdentificatie!!.identificatie)
         } returns userBehandelaar
         every { ztcClientService.readZaaktype(zaak.zaaktype) } returns zaakType
         every { zrcClientService.readStatus(zaak.status) } returns zaakStatus

--- a/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
@@ -96,8 +96,8 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
         every { zrcClientService.readResultaat(zaak.resultaat) } returns resultaat
 
         every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns Optional.of(rolInitiator)
-        every { zgwApiService.findGroepForZaak(zaak) } returns Optional.empty()
-        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns Optional.of(rolMedewerkerBehandelaar)
+        every { zgwApiService.findGroepForZaak(zaak) } returns null
+        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns rolMedewerkerBehandelaar
         every {
             identityService.readUser(rolMedewerkerBehandelaar.betrokkeneIdentificatie.identificatie)
         } returns userBehandelaar
@@ -169,8 +169,8 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
         every { zrcClientService.readZaak(zaak.uuid) } returns zaak
         every { zgwApiService.findInitiatorRoleForZaak(zaak) } returns Optional.of(rolInitiator)
         every { zrcClientService.listRollen(zaak) } returns rollenZaak
-        every { zgwApiService.findGroepForZaak(zaak) } returns Optional.empty()
-        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns Optional.of(rolMedewerkerBehandelaar)
+        every { zgwApiService.findGroepForZaak(zaak) } returns null
+        every { zgwApiService.findBehandelaarMedewerkerRoleForZaak(zaak) } returns rolMedewerkerBehandelaar
         every {
             identityService.readUser(rolMedewerkerBehandelaar.betrokkeneIdentificatie.identificatie)
         } returns userBehandelaar


### PR DESCRIPTION
Ignore medewerker rol without medewerker because this is possible in the ZGW APIs and it does occur in certain scenarios.

Solves PZ-4904