### PR TITLE
fix: use the correct Keycloak API method to retrieve a user

### DIFF
--- a/src/main/kotlin/net/atos/zac/identity/IdentityService.kt
+++ b/src/main/kotlin/net/atos/zac/identity/IdentityService.kt
@@ -36,7 +36,8 @@ class IdentityService @Inject constructor(
         .sortedBy { it.name }
 
     fun readUser(userId: String): User = keycloakZacRealmResource.users()
-        .search(userId).map { it.toUser() }.firstOrNull()
+        .searchByUsername(userId, true)
+        .map { it.toUser() }.firstOrNull()
         // is this fallback really needed? better to return null or throw a custom exception
         ?: User(userId)
 

--- a/src/test/kotlin/net/atos/zac/identity/IdentityServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/identity/IdentityServiceTest.kt
@@ -55,18 +55,44 @@ class IdentityServiceTest : BehaviorSpec({
                     firstName shouldBe "dummyFirstName1"
                     lastName shouldBe "dummyLastName1"
                     fullName shouldBe "dummyFirstName1 dummyLastName1"
+                    email shouldBe "test1@example.com"
                 }
                 with(users[1]) {
                     id shouldBe "dummyUsername2"
                     firstName shouldBe "dummyFirstName2"
                     lastName shouldBe "dummyLastName2"
                     fullName shouldBe "dummyFirstName2 dummyLastName2"
+                    email shouldBe "test2@example.com"
                 }
                 with(users[2]) {
                     id shouldBe "dummyUsername3"
                     firstName shouldBe "dummyFirstName3"
                     lastName shouldBe "dummyLastName3"
                     fullName shouldBe "dummyFirstName3 dummyLastName3"
+                    email shouldBe "test3@example.com"
+                }
+            }
+        }
+    }
+    Given("A user in the Keycloak realm") {
+        val userRepresentation = createUserRepresentation(
+            username = "dummyUsername",
+            firstName = "dummyFirstName",
+            lastName = "dummyLastName",
+            email = "test@example.com"
+        )
+        every { realmResource.users().searchByUsername(userRepresentation.username, true) } returns listOf(userRepresentation)
+
+        When("the user is retrieved") {
+            val user = identityService.readUser(userRepresentation.username)
+
+            Then("the user is retrieved from Keycloak") {
+                with(user) {
+                    id shouldBe "dummyUsername"
+                    firstName shouldBe "dummyFirstName"
+                    lastName shouldBe "dummyLastName"
+                    fullName shouldBe "dummyFirstName dummyLastName"
+                    email shouldBe "test@example.com"
                 }
             }
         }


### PR DESCRIPTION
Use the correct Keycloak API method to retrieve a user so that we do not accidentally retrieve the wrong user.

Solves PZ-4988