### PR TITLE
fix: revert otel 0.110 helm chart change

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.110.7
+  version: 0.108.1
 - name: solr
   repository: https://charts.bitnami.com/bitnami
   version: 9.1.6
-digest: sha256:d59b09b8009445999761fcc4fa37bd9a09d44960581361a048e6bd41b256986a
-generated: "2025-01-09T15:23:15.933404634Z"
+digest: sha256:61112b8cde3d8668bb9de1f6896dff5ce0b7e51c68f34718fc9c6abeb2150a84
+generated: "2025-01-09T14:10:20.69446609Z"

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.108.1
+  version: 0.104.0
 - name: solr
   repository: https://charts.bitnami.com/bitnami
   version: 9.1.6
-digest: sha256:61112b8cde3d8668bb9de1f6896dff5ce0b7e51c68f34718fc9c6abeb2150a84
-generated: "2025-01-09T14:10:20.69446609Z"
+digest: sha256:3a74d1361dc1aa2faee585df3efd5af95f27a5f1d175e1f970ad51375f049fc9
+generated: "2025-01-09T12:10:34.161897863Z"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
   - name: opentelemetry-collector
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector.enabled
-    version: 0.108.1
+    version: 0.104.0
   - name: solr
     version: 9.1.6
     repository: https://charts.bitnami.com/bitnami

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
   - name: opentelemetry-collector
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector.enabled
-    version: 0.110.7
+    version: 0.108.1
   - name: solr
     version: 9.1.6
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Revert otel to previous version as 0.111 requires changes in helm chart values/overrides

Solves: PZ-4845