### PR TITLE
feat: add actions to codeql workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["java-kotlin", "javascript-typescript"]
+        language: ["java-kotlin", "javascript-typescript", "actions"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
With codeql [gaining support](https://github.blog/security/application-security/how-to-secure-your-github-actions-workflows-with-codeql/
) for GitHub Actions, let's enable this 

Solves PZ-5005