### PR TITLE
fix: do a git force push when updating the publiccode.yaml in our GitHub workflow

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -450,7 +450,7 @@ jobs:
       - name: Commit changes
         run: |
           git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"        
+          git config --local user.name "GitHub Action"
           git add publiccode.yaml
           git commit -m "${{ github.workflow }}" || echo "No changes to commit"
           git push --force    

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -454,7 +454,7 @@ jobs:
           git pull      
           git add publiccode.yaml
           git commit -m "${{ github.workflow }}" || echo "No changes to commit"
-          git push    
+          git push --force    
 
   trigger-provision:
     needs: [push-docker-image]

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -451,7 +451,6 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"        
-          git pull      
           git add publiccode.yaml
           git commit -m "${{ github.workflow }}" || echo "No changes to commit"
           git push --force    

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -450,7 +450,8 @@ jobs:
       - name: Commit changes
         run: |
           git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.name "GitHub Action"        
+          git pull      
           git add publiccode.yaml
           git commit -m "${{ github.workflow }}" || echo "No changes to commit"
           git push    


### PR DESCRIPTION
Do a git force push when updating the publiccode.yaml in our GitHub workflow to avoid most git push errors "error: failed to push some refs to 'github.com:infonl/dimpact-zaakafhandelcomponent.git'"

Solves PZ-5009