### PR TITLE
chore(build): pin workflow runner to ubuntu 24.04 instead of latest. 

### DIFF
--- a/.github/workflows/check-for-conventional-commits.yml
+++ b/.github/workflows/check-for-conventional-commits.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-for-conventional-commits:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: check-for-cc
         id: check-for-cc

--- a/.github/workflows/clean-up-cache-on-pr-close.yml
+++ b/.github/workflows/clean-up-cache-on-pr-close.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   cleanup-branch-cache:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: snnaplab/delete-branch-cache-action@20f7992a7b8b51aa719420d11b32c9d34a5eb362 # v1.0.0
         with:

--- a/.github/workflows/clean-up-old-zac-docker-images.yml
+++ b/.github/workflows/clean-up-old-zac-docker-images.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   clean:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Delete ZAC Docker Images older than 8 weeks
     steps:
       - uses: snok/container-retention-policy@4f22ef80902ad409ed55a99dc5133cc1250a0d03 # v3.0.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   paths-ignore:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       skip: ${{ steps.paths-ignore.outputs.skip }}
     steps:
@@ -30,7 +30,7 @@ jobs:
 
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: paths-ignore
     if: ${{ needs.paths-ignore.outputs.skip != 'true' }}
     permissions:
@@ -74,7 +74,7 @@ jobs:
     needs:
       - analyze
       - paths-ignore
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       checks: read

--- a/.github/workflows/remove-stale-branches.yml
+++ b/.github/workflows/remove-stale-branches.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   remove_stale_branches:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: remove stale branches
     steps:
       - name: remove stale branches

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   playwright:
     name: "Playwright Tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: azure-dimpact-dta
     steps:
       - name: Get current date


### PR DESCRIPTION
pin workflow runner to ubuntu 24.04 instead of latest. Will be kept up-to-date using renovate

Solves PZ-5021