### PR TITLE
fix(zaak-create.component): initialize `medewerkers` and `groepen`

### DIFF
--- a/src/main/app/src/app/zaken/zaak-create/zaak-create.component.ts
+++ b/src/main/app/src/app/zaken/zaak-create/zaak-create.component.ts
@@ -81,8 +81,8 @@ export class ZaakCreateComponent implements OnInit, OnDestroy {
   private readonly inboxProductaanvraag: InboxProductaanvraag;
   private communicatiekanalen: Observable<string[]>;
   private communicatiekanaalField: SelectFormField;
-  private medewerkers: GeneratedType<"RestUser">[];
-  private groepen: GeneratedType<"RestGroup">[];
+  private medewerkers: GeneratedType<"RestUser">[] = [];
+  private groepen: GeneratedType<"RestGroup">[] = [];
 
   constructor(
     private zakenService: ZakenService,


### PR DESCRIPTION
Fixes accessing arrays when not initialised yet

```
ERROR TypeError: Cannot read properties of undefined (reading 'find')
    at n.getMedewerkerGroupFormField (main.0557c498deab72c3.js:1:3132266)
    at n.ngOnInit (main.0557c498deab72c3.js:1:3129427)
    at nD (main.0557c498deab72c3.js:1:253754)
    at jC (main.0557c498deab72c3.js:1:253901)
    at tg (main.0557c498deab72c3.js:1:253659)
    at Mv (main.0557c498deab72c3.js:1:253383)
    at pce (main.0557c498deab72c3.js:1:287099)
    at BL (main.0557c498deab72c3.js:1:288354)
    at gB (main.0557c498deab72c3.js:1:288184)
    at pB (main.0557c498deab72c3.js:1:288115)
```

Solves [PZ-5059](https://dimpact.atlassian.net/browse/PZ-5059)