### PR TITLE
feat(app): add missing icon in error dialogs

### DIFF
--- a/src/main/app/src/app/fout-afhandeling/dialog/fout-detailed-dialog.component.html
+++ b/src/main/app/src/app/fout-afhandeling/dialog/fout-detailed-dialog.component.html
@@ -4,7 +4,10 @@
   -->
 
 <div mat-dialog-title>
-  <h3>{{"dialoog.titel.fout" | translate}}</h3>
+  <h3>
+    <mat-icon>error</mat-icon>
+    {{"dialoog.titel.fout" | translate}}
+  </h3>
   <button mat-icon-button (click)="close()">
     <mat-icon>close</mat-icon>
   </button>

--- a/src/main/app/src/app/fout-afhandeling/dialog/fout-dialog.component.html
+++ b/src/main/app/src/app/fout-afhandeling/dialog/fout-dialog.component.html
@@ -4,7 +4,10 @@
   -->
 
 <div mat-dialog-title>
-  <h3>{{"dialoog.titel.fout" | translate}}</h3>
+  <h3>
+      <mat-icon>error</mat-icon>
+      {{"dialoog.titel.fout" | translate}}
+  </h3>
   <button mat-icon-button (click)="close()">
     <mat-icon>close</mat-icon>
   </button>

--- a/src/main/app/src/app/fout-afhandeling/dialog/fout-dialog.component.html
+++ b/src/main/app/src/app/fout-afhandeling/dialog/fout-dialog.component.html
@@ -5,8 +5,8 @@
 
 <div mat-dialog-title>
   <h3>
-      <mat-icon>error</mat-icon>
-      {{"dialoog.titel.fout" | translate}}
+    <mat-icon>error</mat-icon>
+    {{"dialoog.titel.fout" | translate}}
   </h3>
   <button mat-icon-button (click)="close()">
     <mat-icon>close</mat-icon>


### PR DESCRIPTION
FE - add missing icon in error dialogs

When implementing new Opschorten and Vwerlenger dialogs, also the Error dialogs were aligned with the new styling. But there were no icons in the nav header added; so after remark and suggestion of Camiel added it thorough this PR

Solves PZ-5060