### PR TITLE
fix: failure copying zaakafhandelparameters

### DIFF
--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -199,14 +199,13 @@ public class NotificatieReceiver {
     }
 
     private void handleZaaktype(final Notificatie notificatie) {
-        try {
-            if (notificatie.getResource() != ZAAKTYPE) {
-                return;
-            }
+        if (notificatie.getResource() != ZAAKTYPE)
+            return;
 
+        try {
             switch (notificatie.getAction()) {
                 case CREATE, UPDATE:
-                    zaakafhandelParameterBeheerService.upsertZaaktype(notificatie.getResourceUrl());
+                    zaakafhandelParameterBeheerService.upsertZaakafhandelParameters(notificatie.getResourceUrl());
                     break;
             }
         } catch (RuntimeException ex) {

--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -201,7 +201,10 @@ public class NotificatieReceiver {
     private void handleZaaktype(final Notificatie notificatie) {
         try {
             if (notificatie.getResource() == ZAAKTYPE) {
-                if (notificatie.getAction() == CREATE || notificatie.getAction() == UPDATE) {
+                if (notificatie.getAction() == CREATE) {
+                    zaakafhandelParameterBeheerService.zaaktypeAangemaakt(notificatie.getResourceUrl());
+                }
+                if (notificatie.getAction() == UPDATE) {
                     zaakafhandelParameterBeheerService.zaaktypeAangepast(notificatie.getResourceUrl());
                 }
             }

--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -200,13 +200,16 @@ public class NotificatieReceiver {
 
     private void handleZaaktype(final Notificatie notificatie) {
         try {
-            if (notificatie.getResource() == ZAAKTYPE) {
-                if (notificatie.getAction() == CREATE) {
-                    zaakafhandelParameterBeheerService.zaaktypeAangemaakt(notificatie.getResourceUrl());
-                }
-                if (notificatie.getAction() == UPDATE) {
-                    zaakafhandelParameterBeheerService.zaaktypeAangepast(notificatie.getResourceUrl());
-                }
+            if(notificatie.getResource() != ZAAKTYPE) return;
+
+            switch (notificatie.getAction()) {
+                case CREATE, UPDATE:
+                    zaakafhandelParameterBeheerService.upsertZaaktype(notificatie.getResourceUrl());
+                    break;
+                case DELETE:
+                    // TODO: we are not receiving this notificatie
+                    zaakafhandelParameterBeheerService.deleteZaaktype(notificatie.getResourceUrl());
+                    break;
             }
         } catch (RuntimeException ex) {
             warning("Zaaktype", notificatie, ex);

--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -208,10 +208,6 @@ public class NotificatieReceiver {
                 case CREATE, UPDATE:
                     zaakafhandelParameterBeheerService.upsertZaaktype(notificatie.getResourceUrl());
                     break;
-                case DELETE:
-                    // TODO: we are not receiving this notificatie
-                    zaakafhandelParameterBeheerService.deleteZaaktype(notificatie.getResourceUrl());
-                    break;
             }
         } catch (RuntimeException ex) {
             warning("Zaaktype", notificatie, ex);

--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -200,7 +200,9 @@ public class NotificatieReceiver {
 
     private void handleZaaktype(final Notificatie notificatie) {
         try {
-            if(notificatie.getResource() != ZAAKTYPE) return;
+            if (notificatie.getResource() != ZAAKTYPE) {
+                return;
+            }
 
             switch (notificatie.getAction()) {
                 case CREATE, UPDATE:

--- a/src/main/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerService.kt
+++ b/src/main/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerService.kt
@@ -73,15 +73,13 @@ class ZaakafhandelParameterBeheerService @Inject constructor(
             humanTaskParametersCollection.forEach { ValidationUtil.valideerObject(it) }
             userEventListenerParametersCollection.forEach { ValidationUtil.valideerObject(it) }
             mailtemplateKoppelingen.forEach { ValidationUtil.valideerObject(it) }
-            creatiedatum = zaakafhandelParameters.creatiedatum ?: ZonedDateTime.now()
         }
 
         return if (zaakafhandelParameters.id == null) {
             entityManager.persist(zaakafhandelParameters)
             zaakafhandelParameters
         } else {
-            entityManager.merge(zaakafhandelParameters)
-            zaakafhandelParameters
+            return entityManager.merge(zaakafhandelParameters)
         }
     }
 
@@ -122,7 +120,8 @@ class ZaakafhandelParameterBeheerService @Inject constructor(
         return entityManager.createQuery(query).resultList
     }
 
-    fun upsertZaaktype(zaaktypeUri: URI) {
+    @SuppressWarnings("ReturnCount")
+    fun upsertZaakafhandelParameters(zaaktypeUri: URI) {
         zaakafhandelParameterService.clearListCache()
         ztcClientService.clearZaaktypeCache()
         val zaaktype = ztcClientService.readZaaktype(zaaktypeUri)
@@ -170,6 +169,7 @@ class ZaakafhandelParameterBeheerService @Inject constructor(
             productaanvraagtype = previousZaakafhandelparameters.productaanvraagtype
             domein = previousZaakafhandelparameters.domein
             isSmartDocumentsIngeschakeld = previousZaakafhandelparameters.isSmartDocumentsIngeschakeld
+            creatiedatum = ZonedDateTime.now()
         }
 
         mapHumanTaskParameters(previousZaakafhandelparameters, zaakafhandelParameters)

--- a/src/main/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerService.kt
+++ b/src/main/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerService.kt
@@ -73,6 +73,7 @@ class ZaakafhandelParameterBeheerService @Inject constructor(
             humanTaskParametersCollection.forEach { ValidationUtil.valideerObject(it) }
             userEventListenerParametersCollection.forEach { ValidationUtil.valideerObject(it) }
             mailtemplateKoppelingen.forEach { ValidationUtil.valideerObject(it) }
+            creatiedatum = zaakafhandelParameters.creatiedatum ?: ZonedDateTime.now()
         }
 
         return if (zaakafhandelParameters.id == null) {

--- a/src/main/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerService.kt
+++ b/src/main/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerService.kt
@@ -53,7 +53,6 @@ class ZaakafhandelParameterBeheerService @Inject constructor(
         val query = builder.createQuery(ZaakafhandelParameters::class.java)
         val root = query.from(ZaakafhandelParameters::class.java)
         query.select(root).where(builder.equal(root.get<Any>(ZaakafhandelParameters.ZAAKTYPE_UUID), zaaktypeUUID))
-        // IT FAILS HERE (persistent instance references an unsaved transient instance of 'net.atos.zac.admin.model.HumanTaskParameters')
         val resultList = entityManager.createQuery(query).setMaxResults(1).resultList
         return resultList.firstOrNull() ?: ZaakafhandelParameters().apply {
             zaakTypeUUID = zaaktypeUUID
@@ -123,13 +122,6 @@ class ZaakafhandelParameterBeheerService @Inject constructor(
         return entityManager.createQuery(query).resultList
     }
 
-    fun deleteZaaktype(zaaktypeUri: URI) {
-        zaakafhandelParameterService.clearListCache()
-        ztcClientService.clearZaaktypeCache()
-
-        // TODO: what to do when a case type has been removed
-    }
-
     fun upsertZaaktype(zaaktypeUri: URI) {
         zaakafhandelParameterService.clearListCache()
         ztcClientService.clearZaaktypeCache()
@@ -186,7 +178,8 @@ class ZaakafhandelParameterBeheerService @Inject constructor(
         mapMailtemplateKoppelingen(previousZaakafhandelparameters, zaakafhandelParameters)
 
         // We need to store the zaakafhandel parameters before mapping smart documents
-        // as we are reliant on fetching data which is mapped in the methods above
+        // as we are reliant on fetching data which is mapped in the methods above and should be stored
+        // to prevent issues with the entityManager
         storeZaakafhandelParameters(zaakafhandelParameters)
 
         mapSmartDocuments(previousZaakafhandelparameters.zaakTypeUUID, zaakafhandelParameters.zaakTypeUUID)

--- a/src/main/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestService.kt
@@ -146,7 +146,7 @@ class ZaakafhandelParametersRestService @Inject constructor(
             restZaakafhandelParameters
         ).let { zaakafhandelParameters ->
             val updatedZaakafhandelParameters = zaakafhandelParameters.id?.let {
-                zaakafhandelParameterBeheerService.updateZaakafhandelParameters(zaakafhandelParameters).also {
+                zaakafhandelParameterBeheerService.storeZaakafhandelParameters(zaakafhandelParameters).also {
                     zaakafhandelParameterService.cacheRemoveZaakafhandelParameters(zaakafhandelParameters.zaakTypeUUID)
                     zaakafhandelParameterService.clearListCache()
                 }

--- a/src/main/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestService.kt
@@ -150,7 +150,7 @@ class ZaakafhandelParametersRestService @Inject constructor(
                     zaakafhandelParameterService.cacheRemoveZaakafhandelParameters(zaakafhandelParameters.zaakTypeUUID)
                     zaakafhandelParameterService.clearListCache()
                 }
-            } ?: zaakafhandelParameterBeheerService.createZaakafhandelParameters(zaakafhandelParameters)
+            } ?: zaakafhandelParameterBeheerService.storeZaakafhandelParameters(zaakafhandelParameters)
             zaakafhandelParametersConverter.toRestZaakafhandelParameters(
                 updatedZaakafhandelParameters,
                 true

--- a/src/test/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
@@ -219,7 +219,7 @@ class ZaakafhandelParameterBeheerServiceTest : BehaviorSpec({
 
             every { entityManager.merge(capture(slotPersistZaakafhandelParameters)) } answers { ZaakafhandelParameters() }
 
-            zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri)
+            zaakafhandelParameterBeheerService.upsertZaakafhandelParameters(zaaktypeUri)
 
             Then("The related zaakafhandelparameters is stored through the entity manager") {
                 slotPersistZaakafhandelParameters.isCaptured shouldBe true
@@ -260,7 +260,7 @@ class ZaakafhandelParameterBeheerServiceTest : BehaviorSpec({
                 smartDocumentsTemplatesService.storeTemplatesMapping(any<Set<RestMappedSmartDocumentsTemplateGroup>>(), any<UUID>())
             } returns mockk {}
 
-            zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri)
+            zaakafhandelParameterBeheerService.upsertZaakafhandelParameters(zaaktypeUri)
 
             Then("The zaaktype simple values have been copied from the original") {
                 with(slotPersistZaakafhandelParameters.captured) {

--- a/src/test/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
@@ -260,7 +260,12 @@ class ZaakafhandelParameterBeheerServiceTest : BehaviorSpec({
             every { resultList } returns listOf(originalZaakafhandelParameters)
         }
         every { smartDocumentsTemplatesService.getTemplatesMapping(any<UUID>()) } returns emptySet()
-        every { smartDocumentsTemplatesService.storeTemplatesMapping(any<Set<RestMappedSmartDocumentsTemplateGroup>>(), any<UUID>()) } just runs
+        every {
+            smartDocumentsTemplatesService.storeTemplatesMapping(
+                any<Set<RestMappedSmartDocumentsTemplateGroup>>(),
+                any<UUID>()
+            )
+        } just runs
 
         val slotPersistZaakafhandelParameters = slot<ZaakafhandelParameters>()
         every { entityManager.persist(capture(slotPersistZaakafhandelParameters)) } answers { }

--- a/src/test/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
@@ -11,9 +11,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.checkUnnecessaryStub
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import jakarta.persistence.EntityManager
@@ -246,6 +244,23 @@ class ZaakafhandelParameterBeheerServiceTest : BehaviorSpec({
                 every { setMaxResults(1) } returns this
                 every { resultList } returns emptyList() andThen listOf(originalZaakafhandelParameters)
             }
+
+            val template = RestMappedSmartDocumentsTemplateGroup(
+                id = "test",
+                name = "test",
+                groups = null,
+                templates = null
+            )
+
+            every { smartDocumentsTemplatesService.getTemplatesMapping(any<UUID>()) } answers {
+                setOf(template)
+            }
+
+            every {
+                smartDocumentsTemplatesService.storeTemplatesMapping(any<Set<RestMappedSmartDocumentsTemplateGroup>>(), any<UUID>())
+            } returns mockk {}
+
+            zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri)
 
             Then("The zaaktype simple values have been copied from the original") {
                 with(slotPersistZaakafhandelParameters.captured) {

--- a/src/test/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
@@ -218,7 +218,7 @@ class ZaakafhandelParameterBeheerServiceTest : BehaviorSpec({
         every { entityManager.merge(capture(slotPersistZaakafhandelParameters)) } answers { ZaakafhandelParameters() }
 
         When("Processing the updated zaaktype") {
-            zaakafhandelParameterBeheerService.zaaktypeAangepast(zaaktypeUri)
+            zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri)
 
             Then("The related zaakafhandelparameters is stored through the entity manager") {
                 slotPersistZaakafhandelParameters.isCaptured shouldBe true

--- a/src/test/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
@@ -83,7 +83,7 @@ class ZaakafhandelParametersRestServiceTest : BehaviorSpec({
         every {
             zaakafhandelParametersConverter.toZaakafhandelParameters(restZaakafhandelParameters)
         } returns zaakafhandelParameters
-        every { zaakafhandelParameterBeheerService.updateZaakafhandelParameters(zaakafhandelParameters) } returns
+        every { zaakafhandelParameterBeheerService.storeZaakafhandelParameters(zaakafhandelParameters) } returns
             updatedZaakafhandelParameters
         every {
             zaakafhandelParameterService.cacheRemoveZaakafhandelParameters(zaakafhandelParameters.zaakTypeUUID)
@@ -107,7 +107,7 @@ class ZaakafhandelParametersRestServiceTest : BehaviorSpec({
             ) {
                 returnedRestZaakafhandelParameters shouldBe updatedRestZaakafhandelParameters
                 verify(exactly = 1) {
-                    zaakafhandelParameterBeheerService.updateZaakafhandelParameters(zaakafhandelParameters)
+                    zaakafhandelParameterBeheerService.storeZaakafhandelParameters(zaakafhandelParameters)
                     zaakafhandelParameterService.cacheRemoveZaakafhandelParameters(zaakafhandelParameters.zaakTypeUUID)
                     zaakafhandelParameterService.clearListCache()
                 }

--- a/src/test/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
@@ -146,7 +146,7 @@ class ZaakafhandelParametersRestServiceTest : BehaviorSpec({
         } returns
             emptyList()
         every {
-            zaakafhandelParameterBeheerService.createZaakafhandelParameters(zaakafhandelParameters)
+            zaakafhandelParameterBeheerService.storeZaakafhandelParameters(zaakafhandelParameters)
         } returns createdZaakafhandelParameters
         every {
             zaakafhandelParametersConverter.toRestZaakafhandelParameters(createdZaakafhandelParameters, true)
@@ -165,7 +165,7 @@ class ZaakafhandelParametersRestServiceTest : BehaviorSpec({
             ) {
                 returnedRestZaakafhandelParameters shouldBe updatedRestZaakafhandelParameters
                 verify(exactly = 1) {
-                    zaakafhandelParameterBeheerService.createZaakafhandelParameters(zaakafhandelParameters)
+                    zaakafhandelParameterBeheerService.storeZaakafhandelParameters(zaakafhandelParameters)
                 }
             }
         }
@@ -212,7 +212,7 @@ class ZaakafhandelParametersRestServiceTest : BehaviorSpec({
             ) {
                 exception.message shouldBe "msg.error.productaanvraagtype.already.in.use"
                 verify(exactly = 0) {
-                    zaakafhandelParameterBeheerService.createZaakafhandelParameters(zaakafhandelParameters)
+                    zaakafhandelParameterBeheerService.storeZaakafhandelParameters(zaakafhandelParameters)
                 }
             }
         }

--- a/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
+++ b/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
@@ -125,7 +125,7 @@ class NotificatieReceiverTest : BehaviorSpec({
             resourceUrl = zaaktypeUri,
             action = Action.UPDATE
         )
-        every { zaakafhandelParameterBeheerService.zaaktypeAangepast(zaaktypeUri) } just runs
+        every { zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri) } just runs
 
         When("notificatieReceive is called with the zaaktype create notificatie") {
             val response = notificatieReceiver.notificatieReceive(httpHeaders, notificatie)
@@ -135,7 +135,7 @@ class NotificatieReceiverTest : BehaviorSpec({
             ) {
                 response.status shouldBe 204
                 verify(exactly = 1) {
-                    zaakafhandelParameterBeheerService.zaaktypeAangepast(zaaktypeUri)
+                    zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri)
                 }
             }
         }

--- a/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
+++ b/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
@@ -97,7 +97,7 @@ class NotificatieReceiverTest : BehaviorSpec({
             resource = Resource.ZAAKTYPE,
             resourceUrl = zaaktypeUri
         )
-        every { zaakafhandelParameterBeheerService.zaaktypeAangemaakt(zaaktypeUri) } just runs
+        every { zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri) } just runs
 
         When("notificatieReceive is called with the zaaktype create notificatie") {
             val response = notificatieReceiver.notificatieReceive(httpHeaders, notificatie)
@@ -107,7 +107,7 @@ class NotificatieReceiverTest : BehaviorSpec({
             ) {
                 response.status shouldBe 204
                 verify(exactly = 1) {
-                    zaakafhandelParameterBeheerService.zaaktypeAangemaakt(zaaktypeUri)
+                    zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri)
                 }
             }
         }

--- a/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
+++ b/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
@@ -97,7 +97,7 @@ class NotificatieReceiverTest : BehaviorSpec({
             resource = Resource.ZAAKTYPE,
             resourceUrl = zaaktypeUri
         )
-        every { zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri) } just runs
+        every { zaakafhandelParameterBeheerService.upsertZaakafhandelParameters(zaaktypeUri) } just runs
 
         When("notificatieReceive is called with the zaaktype create notificatie") {
             val response = notificatieReceiver.notificatieReceive(httpHeaders, notificatie)
@@ -107,7 +107,7 @@ class NotificatieReceiverTest : BehaviorSpec({
             ) {
                 response.status shouldBe 204
                 verify(exactly = 1) {
-                    zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri)
+                    zaakafhandelParameterBeheerService.upsertZaakafhandelParameters(zaaktypeUri)
                 }
             }
         }
@@ -125,7 +125,7 @@ class NotificatieReceiverTest : BehaviorSpec({
             resourceUrl = zaaktypeUri,
             action = Action.UPDATE
         )
-        every { zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri) } just runs
+        every { zaakafhandelParameterBeheerService.upsertZaakafhandelParameters(zaaktypeUri) } just runs
 
         When("notificatieReceive is called with the zaaktype create notificatie") {
             val response = notificatieReceiver.notificatieReceive(httpHeaders, notificatie)
@@ -135,7 +135,7 @@ class NotificatieReceiverTest : BehaviorSpec({
             ) {
                 response.status shouldBe 204
                 verify(exactly = 1) {
-                    zaakafhandelParameterBeheerService.upsertZaaktype(zaaktypeUri)
+                    zaakafhandelParameterBeheerService.upsertZaakafhandelParameters(zaaktypeUri)
                 }
             }
         }

--- a/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
+++ b/src/test/kotlin/net/atos/zac/notificaties/NotificatieReceiverTest.kt
@@ -35,6 +35,9 @@ class NotificatieReceiverTest : BehaviorSpec({
     val inboxDocumentenService = mockk<InboxDocumentenService>()
     val zaakafhandelParameterBeheerService = mockk<ZaakafhandelParameterBeheerService>()
     val objecttypesClientService = mockk<ObjecttypesClientService>()
+
+    val httpHeaders = mockk<HttpHeaders>()
+    val httpSession = mockk<HttpSession>(relaxed = true)
     val httpSessionInstance = mockk<Instance<HttpSession>>()
 
     val notificatieReceiver = NotificatieReceiver(
@@ -48,36 +51,91 @@ class NotificatieReceiverTest : BehaviorSpec({
         httpSessionInstance
     )
 
+    // HTTP session mock
+
     Given(
-        "a request containing a authorization header, a productaanvraag notificatie with a object type UUID " +
-            "for the productaanvraag object type"
+        """
+            a request containing a authorization header and
+            a productaanvraag notificatie with a object type UUID for the productaanvraag object type
+            """
     ) {
+        val productaanvraagObjectUUID = UUID.randomUUID()
+        val productTypeUUID = UUID.randomUUID()
+        val objectType = createObjecttype(name = "Productaanvraag-Dimpact")
+        every { objecttypesClientService.readObjecttype(productTypeUUID) } returns objectType
+        every { httpHeaders.getHeaderString(eq(HttpHeaders.AUTHORIZATION)) } returns SECRET
+        every { httpSessionInstance.get() } returns httpSession
+        val notificatie = createNotificatie(
+            resourceUrl = URI("http://example.com/dummyproductaanvraag/$productaanvraagObjectUUID"),
+            properties = mapOf("objectType" to "http://example.com/dummyproducttype/$productTypeUUID")
+        )
+        every { productaanvraagService.handleProductaanvraag(productaanvraagObjectUUID) } just runs
+
         When("notificatieReceive is called") {
+            val response = notificatieReceiver.notificatieReceive(httpHeaders, notificatie)
+
             Then(
                 "the 'functional user' is added to the HTTP sessionm the productaanvraag service is invoked " +
                     "and a 'no content' response is returned"
             ) {
-                val secret = "dummySecret"
-                val productaanvraagObjectUUID = UUID.randomUUID()
-                val productTypeUUID = UUID.randomUUID()
-                val httpHeaders = mockk<HttpHeaders>()
-                val httpSession = mockk<HttpSession>()
-                val notifcatie = createNotificatie(
-                    resourceUrl = URI("http://example.com/dummyproductaanvraag/$productaanvraagObjectUUID"),
-                    properties = mapOf("objectType" to "http://example.com/dummyproducttype/$productTypeUUID")
-                )
-                val objectType = createObjecttype(name = "Productaanvraag-Dimpact")
-                every { httpHeaders.getHeaderString("Authorization") } returns secret
-                every { httpSessionInstance.get() } returns httpSession
-                every { httpSession.setAttribute("logged-in-user", any()) } just runs
-                every { objecttypesClientService.readObjecttype(productTypeUUID) } returns objectType
-                every { productaanvraagService.handleProductaanvraag(productaanvraagObjectUUID) } just runs
-
-                val response = notificatieReceiver.notificatieReceive(httpHeaders, notifcatie)
-
                 response.status shouldBe 204
                 verify(exactly = 1) {
                     productaanvraagService.handleProductaanvraag(productaanvraagObjectUUID)
+                }
+            }
+        }
+    }
+
+    Given(
+        "a request containing a authorization header and a zaaktype create notificatie"
+    ) {
+        every { httpHeaders.getHeaderString(eq(HttpHeaders.AUTHORIZATION)) } returns SECRET
+        every { httpSessionInstance.get() } returns httpSession
+        val zaaktypeUUID = UUID.randomUUID()
+        val zaaktypeUri = URI("http://example.com/dummyzaaktype/$zaaktypeUUID")
+        val notificatie = createNotificatie(
+            resource = Resource.ZAAKTYPE,
+            resourceUrl = zaaktypeUri
+        )
+        every { zaakafhandelParameterBeheerService.zaaktypeAangemaakt(zaaktypeUri) } just runs
+
+        When("notificatieReceive is called with the zaaktype create notificatie") {
+            val response = notificatieReceiver.notificatieReceive(httpHeaders, notificatie)
+
+            Then(
+                "the zaaktype aanvraag service is invoked and a 'no content' response is returned"
+            ) {
+                response.status shouldBe 204
+                verify(exactly = 1) {
+                    zaakafhandelParameterBeheerService.zaaktypeAangemaakt(zaaktypeUri)
+                }
+            }
+        }
+    }
+
+    Given(
+        "a request containing a authorization header and a zaaktype update notificatie"
+    ) {
+        every { httpHeaders.getHeaderString(eq(HttpHeaders.AUTHORIZATION)) } returns SECRET
+        every { httpSessionInstance.get() } returns httpSession
+        val zaaktypeUUID = UUID.randomUUID()
+        val zaaktypeUri = URI("http://example.com/dummyzaaktype/$zaaktypeUUID")
+        val notificatie = createNotificatie(
+            resource = Resource.ZAAKTYPE,
+            resourceUrl = zaaktypeUri,
+            action = Action.UPDATE
+        )
+        every { zaakafhandelParameterBeheerService.zaaktypeAangepast(zaaktypeUri) } just runs
+
+        When("notificatieReceive is called with the zaaktype create notificatie") {
+            val response = notificatieReceiver.notificatieReceive(httpHeaders, notificatie)
+
+            Then(
+                "the zaaktype aanvraag service is invoked and a 'no content' response is returned"
+            ) {
+                response.status shouldBe 204
+                verify(exactly = 1) {
+                    zaakafhandelParameterBeheerService.zaaktypeAangepast(zaaktypeUri)
                 }
             }
         }


### PR DESCRIPTION
Makes a difference between receiving an "update" from open-zaak on `zaaktypes` which we already know within `ZAC` and newly published `zaaktypen`

Solves [PZ-5014](https://dimpact.atlassian.net/browse/PZ-5014) and [PZ-4990](https://dimpact.atlassian.net/browse/PZ-4990)