### PR TITLE
fix: fixed broken zaken werkvoorraad due to betrokkenen being null

### DIFF
--- a/src/main/java/net/atos/zac/app/zoeken/converter/RESTZaakZoekObjectConverter.java
+++ b/src/main/java/net/atos/zac/app/zoeken/converter/RESTZaakZoekObjectConverter.java
@@ -59,12 +59,14 @@ public class RESTZaakZoekObjectConverter {
         restZoekItem.indicaties = zoekItem.getZaakIndicaties();
         restZoekItem.rechten = RestRechtenConverter.convert(policyService.readZaakRechten(zoekItem));
         restZoekItem.betrokkenen = new HashMap<>();
-        zoekItem.getBetrokkenen().forEach((betrokkenheid, ids) -> {
-            restZoekItem.betrokkenen.put(
-                    betrokkenheid.replace(ZaakZoekObject.ZAAK_BETROKKENE_PREFIX, ""),
-                    ids
-            );
-        });
+        if (zoekItem.getBetrokkenen() != null) {
+            zoekItem.getBetrokkenen().forEach((betrokkenheid, ids) -> {
+                restZoekItem.betrokkenen.put(
+                        betrokkenheid.replace(ZaakZoekObject.ZAAK_BETROKKENE_PREFIX, ""),
+                        ids
+                );
+            });
+        }
         return restZoekItem;
     }
 }

--- a/src/main/kotlin/net/atos/zac/zoeken/ZoekenService.kt
+++ b/src/main/kotlin/net/atos/zac/zoeken/ZoekenService.kt
@@ -67,12 +67,12 @@ class ZoekenService @Inject constructor(
         }
         zoekParameters.getFilterQueries()
             .forEach { (veld: String, waarde: String) -> query.addFilterQuery("$veld:${quoted(waarde)}") }
-        query.setFacetMinCount(1)
+        query.facetMinCount = 1
         query.setFacetMissing(!zoekParameters.isGlobaalZoeken())
         query.setFacet(true)
         query.setParam("q.op", SimpleParams.AND_OPERATOR)
-        query.setRows(zoekParameters.rows)
-        query.setStart(zoekParameters.start)
+        query.rows = zoekParameters.rows
+        query.start = zoekParameters.start
         query.addSort(
             zoekParameters.sortering.sorteerVeld.veld,
             if (zoekParameters.sortering.richting == SorteerRichting.DESCENDING) SolrQuery.ORDER.desc else SolrQuery.ORDER.asc

--- a/src/main/kotlin/net/atos/zac/zoeken/model/zoekobject/ZaakZoekObject.kt
+++ b/src/main/kotlin/net/atos/zac/zoeken/model/zoekobject/ZaakZoekObject.kt
@@ -136,7 +136,7 @@ data class ZaakZoekObject(
     private var indicatiesVolgorde: Long = 0,
 
     @Field("zaak_betrokkene_*")
-    var betrokkenen: MutableMap<String, MutableList<String>> = mutableMapOf(),
+    var betrokkenen: MutableMap<String, MutableList<String>>? = null,
 
     @Field("zaak_bagObjecten")
     var bagObjectIDs: List<String>? = null
@@ -186,7 +186,8 @@ data class ZaakZoekObject(
 
     fun addBetrokkene(rol: String, identificatie: String) {
         val key = "$ZAAK_BETROKKENE_PREFIX$rol"
-        betrokkenen.getOrPut(key) { mutableListOf() }.add(identificatie)
+        betrokkenen = betrokkenen ?: mutableMapOf()
+        betrokkenen!!.getOrPut(key) { mutableListOf() }.add(identificatie)
     }
 
     private fun updateIndicaties(indicatie: ZaakIndicatie, value: Boolean) {

--- a/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/zoeken/converter/ZaakZoekObjectConverterTest.kt
@@ -120,15 +120,17 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
                     initiatorIdentificatie shouldBe rolInitiator.identificatienummer
                     // locatie conversion is not implemented yet
                     locatie shouldBe null
-                    betrokkenen.size shouldBe rollenZaak.size
-                    betrokkenen shouldContain Pair(
-                        "zaak_betrokkene_${rolAdviseur.omschrijving}",
-                        listOf(rolAdviseur.identificatienummer)
-                    )
-                    betrokkenen shouldContain Pair(
-                        "zaak_betrokkene_${rolBelanghebbende.omschrijving}",
-                        listOf(rolBelanghebbende.identificatienummer)
-                    )
+                    with(betrokkenen!!) {
+                        size shouldBe rollenZaak.size
+                        this shouldContain Pair(
+                            "zaak_betrokkene_${rolAdviseur.omschrijving}",
+                            listOf(rolAdviseur.identificatienummer)
+                        )
+                        this shouldContain Pair(
+                            "zaak_betrokkene_${rolBelanghebbende.omschrijving}",
+                            listOf(rolBelanghebbende.identificatienummer)
+                        )
+                    }
                     getZaakIndicaties() shouldNotContain ZaakIndicatie.HEROPEND
                     resultaattypeOmschrijving shouldBe resultaatType.omschrijving
                 }
@@ -198,15 +200,17 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
                     // locatie conversion is not implemented (yet?)
                     locatie shouldBe null
 
-                    betrokkenen.size shouldBe rollenZaak.size
-                    betrokkenen shouldContain Pair(
-                        "zaak_betrokkene_${rolAdviseur.omschrijving}",
-                        listOf(rolAdviseur.identificatienummer)
-                    )
-                    betrokkenen shouldContain Pair(
-                        "zaak_betrokkene_${rolBelanghebbende.omschrijving}",
-                        listOf(rolBelanghebbende.identificatienummer)
-                    )
+                    with(betrokkenen!!) {
+                        size shouldBe rollenZaak.size
+                        this shouldContain Pair(
+                            "zaak_betrokkene_${rolAdviseur.omschrijving}",
+                            listOf(rolAdviseur.identificatienummer)
+                        )
+                        this shouldContain Pair(
+                            "zaak_betrokkene_${rolBelanghebbende.omschrijving}",
+                            listOf(rolBelanghebbende.identificatienummer)
+                        )
+                    }
                     getZaakIndicaties() shouldContain ZaakIndicatie.HEROPEND
                 }
             }


### PR DESCRIPTION
Fixed broken zaken werkvoorraad due to betrokkenen being null in zaakzoekobject. Perhaps caused by a recent upgrade to Solr.

Solves PZ-5065