### PR TITLE
fix: revert force push when updating publiccode.yaml

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -453,7 +453,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add publiccode.yaml
           git commit -m "${{ github.workflow }}" || echo "No changes to commit"
-          git push --force    
+          git push    
 
   trigger-provision:
     needs: [next-version, push-docker-image]


### PR DESCRIPTION
revert force push when updating publiccode.yaml because that can override PR commits altogether

Solves PZ-5081