### PR TITLE
fix: Don't explicitly version chart-releaser

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -39,6 +39,5 @@ jobs:
         uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         with:
           skip_existing: true
-          version: 1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Looks like the GitHub action cannot fetch chart-releaser 1.7.0. So don't explicitly set a version to download. 

Solves PZ-5105