### PR TITLE
chore: no longer use deprecated indentWithSpaces Gradle setting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -283,7 +283,7 @@ configure<SpotlessExtension> {
         target(".gitattributes", ".gitignore", ".containerignore", ".dockerignore")
 
         trimTrailingWhitespace()
-        indentWithSpaces()
+        leadingTabsToSpaces()
         endWithNewline()
     }
     java {


### PR DESCRIPTION
No longer use deprecated indentWithSpaces Gradle setting.

Solves PZ-5117