### PR TITLE
chore: always log server errors in REST exception mapper

### DIFF
--- a/src/main/kotlin/net/atos/zac/app/exception/RestExceptionMapper.kt
+++ b/src/main/kotlin/net/atos/zac/app/exception/RestExceptionMapper.kt
@@ -36,7 +36,7 @@ import net.atos.zac.smartdocuments.exception.SmartDocumentsDisabledException
 import net.atos.zac.zaak.exception.BetrokkeneIsAlreadyAddedToZaakException
 import net.atos.zac.zaak.exception.CaseHasLockedInformationObjectsException
 import net.atos.zac.zaak.exception.CaseHasOpenSubcasesException
-import nl.info.zac.util.log
+import nl.info.zac.log.log
 import java.net.ConnectException
 import java.net.UnknownHostException
 import java.util.concurrent.ExecutionException

--- a/src/main/kotlin/net/atos/zac/app/exception/RestExceptionMapper.kt
+++ b/src/main/kotlin/net/atos/zac/app/exception/RestExceptionMapper.kt
@@ -36,6 +36,7 @@ import net.atos.zac.smartdocuments.exception.SmartDocumentsDisabledException
 import net.atos.zac.zaak.exception.BetrokkeneIsAlreadyAddedToZaakException
 import net.atos.zac.zaak.exception.CaseHasLockedInformationObjectsException
 import net.atos.zac.zaak.exception.CaseHasOpenSubcasesException
+import nl.info.zac.util.log
 import java.net.ConnectException
 import java.net.UnknownHostException
 import java.util.concurrent.ExecutionException
@@ -218,10 +219,11 @@ class RestExceptionMapper : ExceptionMapper<Exception> {
             )
         )
         .build().also {
-            LOG.log(
-                if (responseStatus == Response.Status.INTERNAL_SERVER_ERROR) Level.SEVERE else Level.FINE,
-                exception.message ?: "Exception was thrown. Returning response with error code $errorCode.",
-                exception
+            log(
+                logger = LOG,
+                level = if (responseStatus == Response.Status.INTERNAL_SERVER_ERROR) Level.SEVERE else Level.FINE,
+                message = exception.message ?: "Exception was thrown. Returning response with error code $errorCode.",
+                throwable = exception
             )
         }
 
@@ -231,7 +233,7 @@ class RestExceptionMapper : ExceptionMapper<Exception> {
             exceptionMessage?.let { errorJsonHashMap["exception"] = it }
             ObjectMapper().writeValueAsString(errorJsonHashMap)
         } catch (jsonProcessingException: JsonProcessingException) {
-            LOG.log(Level.SEVERE, JSON_CONVERSION_ERROR_MESSAGE, jsonProcessingException)
+            log(LOG, Level.SEVERE, JSON_CONVERSION_ERROR_MESSAGE, jsonProcessingException)
             JSON_CONVERSION_ERROR_MESSAGE
         }
 }

--- a/src/main/kotlin/net/atos/zac/app/exception/RestExceptionMapper.kt
+++ b/src/main/kotlin/net/atos/zac/app/exception/RestExceptionMapper.kt
@@ -219,7 +219,7 @@ class RestExceptionMapper : ExceptionMapper<Exception> {
         )
         .build().also {
             LOG.log(
-                Level.FINE,
+                if (responseStatus == Response.Status.INTERNAL_SERVER_ERROR) Level.SEVERE else Level.FINE,
                 exception.message ?: "Exception was thrown. Returning response with error code $errorCode.",
                 exception
             )

--- a/src/main/kotlin/nl/info/zac/log/LogUtils.kt
+++ b/src/main/kotlin/nl/info/zac/log/LogUtils.kt
@@ -11,6 +11,4 @@ import java.util.logging.Logger
 /**
  * Simple wapper function around [Logger.log] to make it easier to unit test classes that use logging.
  */
-fun log(logger: Logger, level: Level, message: String, throwable: Throwable) {
-    logger.log(level, message, throwable)
-}
+fun log(logger: Logger, level: Level, message: String, throwable: Throwable) = logger.log(level, message, throwable)

--- a/src/main/kotlin/nl/info/zac/log/LogUtils.kt
+++ b/src/main/kotlin/nl/info/zac/log/LogUtils.kt
@@ -9,7 +9,7 @@ import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
- * Simple wapper function around the Java Util Logger class to make it easier to unit test classes that use logging.
+ * Simple wapper function around [Logger.log] to make it easier to unit test classes that use logging.
  */
 fun log(logger: Logger, level: Level, message: String, throwable: Throwable) {
     logger.log(level, message, throwable)

--- a/src/main/kotlin/nl/info/zac/log/LogUtils.kt
+++ b/src/main/kotlin/nl/info/zac/log/LogUtils.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-package nl.info.zac.util
+package nl.info.zac.log
 
 import java.util.logging.Level
 import java.util.logging.Logger

--- a/src/main/kotlin/nl/info/zac/util/LoggerWrapper.kt
+++ b/src/main/kotlin/nl/info/zac/util/LoggerWrapper.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package nl.info.zac.util
 
 import java.util.logging.Level

--- a/src/main/kotlin/nl/info/zac/util/LoggerWrapper.kt
+++ b/src/main/kotlin/nl/info/zac/util/LoggerWrapper.kt
@@ -1,0 +1,11 @@
+package nl.info.zac.util
+
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * Simple wapper function around the Java Util Logger class to make it easier to unit test classes that use logging.
+ */
+fun log(logger: Logger, level: Level, message: String, throwable: Throwable) {
+    logger.log(level, message, throwable)
+}

--- a/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
@@ -260,7 +260,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the general server error error code with an exception message and log the exception") {
+            Then(
+                "it should return the general server error error code with an exception message and log the exception"
+            ) {
                 checkResponse(response, "msg.error.server.generic", exceptionMessage)
                 verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }

--- a/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
@@ -30,7 +30,7 @@ import net.atos.zac.app.decision.DecisionResponseDateMissingException
 import net.atos.zac.app.exception.RestExceptionMapper
 import net.atos.zac.smartdocuments.exception.SmartDocumentsConfigurationException
 import net.atos.zac.smartdocuments.exception.SmartDocumentsDisabledException
-import nl.info.zac.util.log
+import nl.info.zac.log.log
 import org.apache.http.HttpHost
 import org.apache.http.HttpStatus
 import org.apache.http.conn.HttpHostConnectException

--- a/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
@@ -7,6 +7,9 @@ package net.atos.zac.app.util.exception
 
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
 import jakarta.ws.rs.ProcessingException
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
@@ -27,15 +30,25 @@ import net.atos.zac.app.decision.DecisionResponseDateMissingException
 import net.atos.zac.app.exception.RestExceptionMapper
 import net.atos.zac.smartdocuments.exception.SmartDocumentsConfigurationException
 import net.atos.zac.smartdocuments.exception.SmartDocumentsDisabledException
+import nl.info.zac.util.log
 import org.apache.http.HttpHost
 import org.apache.http.HttpStatus
 import org.apache.http.conn.HttpHostConnectException
 import org.json.JSONObject
 import java.io.IOException
 import java.net.UnknownHostException
+import java.util.logging.Level
 
 class RestExceptionMapperTest : BehaviorSpec({
     val restExceptionMapper = RestExceptionMapper()
+
+    beforeSpec {
+        mockkStatic(::log)
+    }
+
+    afterSpec {
+        unmockkStatic(::log)
+    }
 
     Given("A runtime exception") {
         val exceptionMessage = "DummyRuntimeException"
@@ -44,8 +57,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the generic server error code and the exception message") {
+            Then("it should return the generic server error code and the exception message and log the exception") {
                 checkResponse(response, "msg.error.server.generic", exceptionMessage)
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -56,8 +70,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the ZTC server error code") {
+            Then("it should return the ZTC server error code and log the exception") {
                 checkResponse(response, "msg.error.brc.client.exception")
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -68,8 +83,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the DRC server error code") {
+            Then("it should return the DRC server error code and log the exception") {
                 checkResponse(response, "msg.error.drc.client.exception")
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -80,8 +96,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the ZRC server error code") {
+            Then("it should return the ZRC server error code and log the exception") {
                 checkResponse(response, "msg.error.zrc.client.exception")
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -92,8 +109,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the generic server error code and the exception message") {
+            Then("it should return the generic server error code and the exception message and log the exception") {
                 checkResponse(response, "msg.error.server.generic", exceptionMessage)
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -104,8 +122,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the ZTC server error code and the exception message") {
+            Then("it should return the ZTC server error code and the exception message and log the exception") {
                 checkResponse(response, "msg.error.ztc.client.exception")
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -127,8 +146,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the BAG server error code and no exception message") {
+            Then("it should return the BAG server error code and no exception message and log the exception") {
                 checkResponse(response, "msg.error.bag.client.exception")
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -150,8 +170,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the BRC server error code and no exception message") {
+            Then("it should return the BRC server error code and no exception message and log the exception") {
                 checkResponse(response, "msg.error.brc.client.exception")
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -173,8 +194,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the Klanten server error code and no exception message") {
+            Then("it should return the Klanten server error code and no exception message and log the exception") {
                 checkResponse(response, "msg.error.klanten.client.exception")
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -196,8 +218,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the Objecten server error code and no exception message") {
+            Then("it should return the Objecten server error code and no exception message and log the exception") {
                 checkResponse(response, "msg.error.objects.client.exception")
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -216,8 +239,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the ZTC server error code and no exception message") {
+            Then("it should return the ZTC server error code and no exception message and log the exception") {
                 checkResponse(response, "msg.error.ztc.client.exception")
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -236,8 +260,9 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the general server error error code with an exception message") {
+            Then("it should return the general server error error code with an exception message and log the exception") {
                 checkResponse(response, "msg.error.server.generic", exceptionMessage)
+                verify(exactly = 1) { log(any(), Level.SEVERE, exception.message!!, exception) }
             }
         }
     }
@@ -247,12 +272,13 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the proper error code and no exception message") {
+            Then("it should return the proper error code and no exception message and log the exception") {
                 checkResponse(
                     response = response,
                     errorMessage = "msg.error.smartdocuments.disabled",
                     expectedStatus = HttpStatus.SC_BAD_REQUEST
                 )
+                verify(exactly = 1) { log(any(), Level.FINE, exception.message!!, exception) }
             }
         }
     }
@@ -262,12 +288,13 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the proper error code and no exception message") {
+            Then("it should return the proper error code and no exception message and log the exception") {
                 checkResponse(
                     response = response,
                     errorMessage = "msg.error.smartdocuments.not.configured",
                     expectedStatus = HttpStatus.SC_BAD_REQUEST
                 )
+                verify(exactly = 1) { log(any(), Level.FINE, exception.message!!, exception) }
             }
         }
     }
@@ -277,12 +304,13 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the proper error code and no exception message") {
+            Then("it should return the proper error code and no exception message and log the exception") {
                 checkResponse(
                     response = response,
                     errorMessage = "msg.error.besluit.publication.disabled",
                     expectedStatus = HttpStatus.SC_BAD_REQUEST
                 )
+                verify(exactly = 1) { log(any(), Level.FINE, exception.message!!, exception) }
             }
         }
     }
@@ -292,12 +320,13 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the proper error code and no exception message") {
+            Then("it should return the proper error code and no exception message and log the exception") {
                 checkResponse(
                     response = response,
                     errorMessage = "msg.error.besluit.publication.date.missing",
                     expectedStatus = HttpStatus.SC_BAD_REQUEST
                 )
+                verify(exactly = 1) { log(any(), Level.FINE, exception.message!!, exception) }
             }
         }
     }
@@ -307,12 +336,13 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the proper error code and no exception message") {
+            Then("it should return the proper error code and no exception message and log the exception") {
                 checkResponse(
                     response = response,
                     errorMessage = "msg.error.besluit.response.date.missing",
                     expectedStatus = HttpStatus.SC_BAD_REQUEST
                 )
+                verify(exactly = 1) { log(any(), Level.FINE, exception.message!!, exception) }
             }
         }
     }
@@ -322,12 +352,13 @@ class RestExceptionMapperTest : BehaviorSpec({
         When("the exception is mapped to a response") {
             val response = restExceptionMapper.toResponse(exception)
 
-            Then("it should return the proper error code and no exception message") {
+            Then("it should return the proper error code and no exception message and log the exception") {
                 checkResponse(
                     response = response,
                     errorMessage = "msg.error.besluit.response.date.invalid",
                     expectedStatus = HttpStatus.SC_BAD_REQUEST
                 )
+                verify(exactly = 1) { log(any(), Level.FINE, exception.message!!, exception) }
             }
         }
     }


### PR DESCRIPTION
Always log server errors in REST exception mapper so that uncaught exceptions do not get lost.

Solves PZ-5165