### PR TITLE
chore: fixed deprecation warnings for our use of the shouldEqualJson function

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/util/JsonHelpers.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/util/JsonHelpers.kt
@@ -7,27 +7,23 @@ package nl.info.zac.itest.util
 
 import io.kotest.assertions.json.ArrayOrder
 import io.kotest.assertions.json.FieldComparison
-import io.kotest.assertions.json.compareJsonOptions
 import io.kotest.assertions.json.shouldEqualJson
 
-infix fun String.shouldEqualJsonIgnoringOrder(other: String) = shouldEqualJson(
-    other,
-    compareJsonOptions {
+infix fun String.shouldEqualJsonIgnoringOrder(other: String) =
+    this shouldEqualJson {
         arrayOrder = ArrayOrder.Lenient
+        other
     }
-)
 
-infix fun String.shouldEqualJsonIgnoringExtraneousFields(other: String) = shouldEqualJson(
-    other,
-    compareJsonOptions {
+infix fun String.shouldEqualJsonIgnoringExtraneousFields(other: String) =
+    this shouldEqualJson {
         fieldComparison = FieldComparison.Lenient
+        other
     }
-)
 
-infix fun String.shouldEqualJsonIgnoringOrderAndExtraneousFields(other: String) = shouldEqualJson(
-    other,
-    compareJsonOptions {
+infix fun String.shouldEqualJsonIgnoringOrderAndExtraneousFields(other: String) =
+    this shouldEqualJson {
         arrayOrder = ArrayOrder.Lenient
         fieldComparison = FieldComparison.Lenient
+        other
     }
-)


### PR DESCRIPTION
Fixed deprecation warnings for our use of the shouldEqualJson function. Solution taken from: https://github.com/kotest/kotest/issues/3543

Solves PZ-5171