### PR TITLE
fix: add null handling to kvk vestigingsprofiel conversion

### DIFF
--- a/docs/manuals/ZAC-gebruikershandleiding/ZAC-gebruikershandleiding.md
+++ b/docs/manuals/ZAC-gebruikershandleiding/ZAC-gebruikershandleiding.md
@@ -613,7 +613,7 @@ Deze actie maakt het mogelijk om een document met sjablonen in een documentcreat
 
 2 Kies de sjabloongroep en daarvan het sjabloon van het te maken document en vul de titel in en als gewenst een beschrijving
 
-3 Pas als gewenst de creartiedatum en behandelaar aan
+3 Pas als gewenst de creatiedatum en behandelaar aan
 
 4 Klik op de Toevoegen knop om de documentcreatieapplicatie te starten. Deze opent in een nieuw tabblad
 
@@ -711,7 +711,7 @@ De initiator bij een zaak is bovenaan het zaakgegevensscherm te vinden. Als er g
 Als een zaak wel een initiator heeft toegekend dan kan deze gewijzigd worden met het ‘Initiator wijzigen’ icoon, deze is dan beschikbaar in plaats van het ‘initiator toekennen’ icoon.
 ![Initiator wijzigen](./images/initiator-wijzigen.png)
 
-Als relevant voor de toegekende initiator zal er een inidicatie zichtbaar worden in de vorm van een icoon. De volgende indicatoren zijn er mogelijk:
+Als relevant voor de toegekende initiator zal er een indicatie zichtbaar worden in de vorm van een icoon. De volgende indicatoren zijn er mogelijk:
  - In onderzoek
  - Geheimhouding op persoonsgegevens
  - Overleden

--- a/src/main/kotlin/net/atos/zac/app/klant/model/bedrijven/RestKlantenAdres.kt
+++ b/src/main/kotlin/net/atos/zac/app/klant/model/bedrijven/RestKlantenAdres.kt
@@ -4,6 +4,9 @@
  */
 package net.atos.zac.app.klant.model.bedrijven
 
+import net.atos.client.kvk.vestigingsprofiel.model.generated.Adres
+import java.util.Locale
+
 data class RestKlantenAdres(
     /**
      * Correspondentieadres en/of bezoekadres
@@ -12,3 +15,16 @@ data class RestKlantenAdres(
     var afgeschermd: Boolean,
     var volledigAdres: String
 )
+
+fun Adres.toRestKlantenAdres() = RestKlantenAdres(
+    this.type,
+    this.indAfgeschermd?.isIndicatie() == true,
+    this.volledigAdres
+)
+
+fun String.isIndicatie(): Boolean =
+    when (this.lowercase(Locale.getDefault())) {
+        "ja" -> true
+        "nee" -> false
+        else -> error("Unexpected value: $this")
+    }

--- a/src/main/kotlin/net/atos/zac/app/klant/model/bedrijven/RestVestigingsprofiel.kt
+++ b/src/main/kotlin/net/atos/zac/app/klant/model/bedrijven/RestVestigingsprofiel.kt
@@ -17,16 +17,16 @@ private const val VESTIGINGTYPE_NEVENVESTIGING = "NEVENVESTIGING"
 data class RestVestigingsprofiel(
     var adressen: List<RestKlantenAdres>? = null,
     var commercieleVestiging: Boolean = false,
-    var deeltijdWerkzamePersonen: Int = 0,
+    var deeltijdWerkzamePersonen: Int? = null,
     var eersteHandelsnaam: String? = null,
     var kvkNummer: String? = null,
     var rsin: String? = null,
     var sbiActiviteiten: List<String>? = null,
     var sbiHoofdActiviteit: String? = null,
     var type: String? = null,
-    var totaalWerkzamePersonen: Int = 0,
+    var totaalWerkzamePersonen: Int? = null,
     var vestigingsnummer: String? = null,
-    var voltijdWerkzamePersonen: Int = 0,
+    var voltijdWerkzamePersonen: Int? = null,
     var website: String? = null
 )
 
@@ -40,22 +40,19 @@ fun Vestiging.toRestVestigingsProfiel() = RestVestigingsprofiel(
     voltijdWerkzamePersonen = this.voltijdWerkzamePersonen,
     commercieleVestiging = this.indCommercieleVestiging?.isIndicatie() ?: false,
     type = if (this.indHoofdvestiging?.isIndicatie() == true) VESTIGINGTYPE_HOOFDVESTIGING else VESTIGINGTYPE_NEVENVESTIGING,
-    sbiHoofdActiviteit = this.sbiActiviteiten
-        .filter { it.indHoofdactiviteit?.isIndicatie() == true }
-        .map { it.sbiOmschrijving }
-        .firstOrNull(),
-    sbiActiviteiten = this.sbiActiviteiten
-        .filter { it.indHoofdactiviteit?.isIndicatie() == false }
-        .map { it.sbiOmschrijving },
-    adressen = this.adressen
-        .map {
-            RestKlantenAdres(
-                it.type,
-                it.indAfgeschermd?.isIndicatie() ?: false,
-                it.volledigAdres
-            )
-        }
-        .toList(),
+    sbiHoofdActiviteit = this.sbiActiviteiten?.firstOrNull {
+        it?.indHoofdactiviteit?.isIndicatie() == true
+    }?.sbiOmschrijving,
+    sbiActiviteiten = this.sbiActiviteiten?.filter {
+        it.indHoofdactiviteit?.isIndicatie() == false
+    }?.map { it.sbiOmschrijving },
+    adressen = this.adressen?.map {
+        RestKlantenAdres(
+            it.type,
+            it.indAfgeschermd?.isIndicatie() == true,
+            it.volledigAdres
+        )
+    },
     website = this.websites?.first()
 )
 

--- a/src/main/kotlin/net/atos/zac/app/klant/model/bedrijven/RestVestigingsprofiel.kt
+++ b/src/main/kotlin/net/atos/zac/app/klant/model/bedrijven/RestVestigingsprofiel.kt
@@ -7,7 +7,6 @@ package net.atos.zac.app.klant.model.bedrijven
 import net.atos.client.kvk.vestigingsprofiel.model.generated.Vestiging
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
-import java.util.Locale
 
 private const val VESTIGINGTYPE_HOOFDVESTIGING = "HOOFDVESTIGING"
 private const val VESTIGINGTYPE_NEVENVESTIGING = "NEVENVESTIGING"
@@ -46,19 +45,6 @@ fun Vestiging.toRestVestigingsProfiel() = RestVestigingsprofiel(
     sbiActiviteiten = this.sbiActiviteiten?.filter {
         it.indHoofdactiviteit?.isIndicatie() == false
     }?.map { it.sbiOmschrijving },
-    adressen = this.adressen?.map {
-        RestKlantenAdres(
-            it.type,
-            it.indAfgeschermd?.isIndicatie() == true,
-            it.volledigAdres
-        )
-    },
+    adressen = this.adressen?.map { it.toRestKlantenAdres() },
     website = this.websites?.first()
 )
-
-private fun String.isIndicatie(): Boolean =
-    when (this.lowercase(Locale.getDefault())) {
-        "ja" -> true
-        "nee" -> false
-        else -> error("Unexpected value: $this")
-    }

--- a/src/test/kotlin/net/atos/client/kvk/zoeken/model/KvkZoekenFixtures.kt
+++ b/src/test/kotlin/net/atos/client/kvk/zoeken/model/KvkZoekenFixtures.kt
@@ -77,6 +77,7 @@ fun createVestiging(
             indHoofdactiviteit = "nee"
         )
     ),
+    adressen: List<net.atos.client.kvk.vestigingsprofiel.model.generated.Adres>? = listOf(createVestigingsAdres())
 ) = Vestiging().apply {
     this.vestigingsnummer = vestigingsnummer
     this.kvkNummer = kvkNumber
@@ -85,4 +86,15 @@ fun createVestiging(
     this.deeltijdWerkzamePersonen = deeltijdWerkzamePersonen
     this.totaalWerkzamePersonen = totaalWerkzamePersonen
     this.sbiActiviteiten = sbiActiviteiten
+    this.adressen = adressen
+}
+
+fun createVestigingsAdres(
+    type: String = "dummyType",
+    indAfgeschermd: String = "nee",
+    volledigAdres: String = "dummyVolledigAdres"
+) = net.atos.client.kvk.vestigingsprofiel.model.generated.Adres().apply {
+    this.type = type
+    this.indAfgeschermd = indAfgeschermd
+    this.volledigAdres = volledigAdres
 }

--- a/src/test/kotlin/net/atos/client/kvk/zoeken/model/KvkZoekenFixtures.kt
+++ b/src/test/kotlin/net/atos/client/kvk/zoeken/model/KvkZoekenFixtures.kt
@@ -5,6 +5,8 @@
 
 package net.atos.client.kvk.zoeken.model
 
+import net.atos.client.kvk.vestigingsprofiel.model.generated.SBIActiviteit
+import net.atos.client.kvk.vestigingsprofiel.model.generated.Vestiging
 import net.atos.client.kvk.zoeken.model.generated.Adres
 import net.atos.client.kvk.zoeken.model.generated.AdresType
 import net.atos.client.kvk.zoeken.model.generated.BinnenlandsAdres
@@ -43,4 +45,44 @@ fun createResultaatItem(
     this.type = type
     this.kvkNummer = kvkNummer
     this.vestigingsnummer = vestingsnummer
+}
+
+fun createSBIActiviteit(
+    sbiCode: String = "dummySbiCode",
+    sbiOmschrijving: String = "dummySbiOmschrijving",
+    indHoofdactiviteit: String = "ja",
+) = SBIActiviteit().apply {
+    this.sbiCode = sbiCode
+    this.sbiOmschrijving = sbiOmschrijving
+    this.indHoofdactiviteit = indHoofdactiviteit
+}
+
+@Suppress("LongParameterList")
+fun createVestiging(
+    vestigingsnummer: String = "dummyVestigingsnummer",
+    kvkNumber: String = "dummyKvkNummer",
+    eersteHandelsNaam: String = "dummyEersteHandelsNaam",
+    voltijdWerkzamePersonen: Int? = 10,
+    deeltijdWerkzamePersonen: Int? = 5,
+    totaalWerkzamePersonen: Int? = 15,
+    sbiActiviteiten: List<SBIActiviteit>? = listOf(
+        createSBIActiviteit(
+            sbiCode = "dummySbiCode1",
+            sbiOmschrijving = "dummySbiOmschrijving1",
+            indHoofdactiviteit = "ja"
+        ),
+        createSBIActiviteit(
+            sbiCode = "dummySbiCode2",
+            sbiOmschrijving = "dummySbiOmschrijving2",
+            indHoofdactiviteit = "nee"
+        )
+    ),
+) = Vestiging().apply {
+    this.vestigingsnummer = vestigingsnummer
+    this.kvkNummer = kvkNumber
+    this.eersteHandelsnaam = eersteHandelsNaam
+    this.voltijdWerkzamePersonen = voltijdWerkzamePersonen
+    this.deeltijdWerkzamePersonen = deeltijdWerkzamePersonen
+    this.totaalWerkzamePersonen = totaalWerkzamePersonen
+    this.sbiActiviteiten = sbiActiviteiten
 }

--- a/src/test/kotlin/net/atos/zac/app/klant/KlantRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/klant/KlantRestServiceTest.kt
@@ -20,6 +20,7 @@ import net.atos.client.kvk.zoeken.model.createAdresWithBinnenlandsAdres
 import net.atos.client.kvk.zoeken.model.createResultaatItem
 import net.atos.client.kvk.zoeken.model.createSBIActiviteit
 import net.atos.client.kvk.zoeken.model.createVestiging
+import net.atos.client.kvk.zoeken.model.createVestigingsAdres
 import net.atos.client.zgw.ztc.ZtcClientService
 import net.atos.zac.app.klant.exception.VestigingNotFoundException
 import java.util.Optional
@@ -208,7 +209,7 @@ class KlantRestServiceTest : BehaviorSpec({
             }
         }
     }
-    Given("A KVK vestigingsprofiel including werkzame personen and activiteiten") {
+    Given("A KVK vestigingsprofiel including werkzame personen, activiteiten and adressen") {
         val vestiging = createVestiging(
             sbiActiviteiten = listOf(
                 createSBIActiviteit(
@@ -225,6 +226,18 @@ class KlantRestServiceTest : BehaviorSpec({
                     sbiCode = "dummySbiCode3",
                     sbiOmschrijving = "dummySbiOmschrijving3",
                     indHoofdactiviteit = "nee"
+                )
+            ),
+            adressen = listOf(
+                createVestigingsAdres(
+                    type = "dummyType1",
+                    indAfgeschermd = "nee",
+                    volledigAdres = "dummyVolledigAdres1"
+                ),
+                createVestigingsAdres(
+                    type = "dummyType2",
+                    indAfgeschermd = "ja",
+                    volledigAdres = "dummyVolledigAdres2"
                 )
             )
         )
@@ -245,6 +258,19 @@ class KlantRestServiceTest : BehaviorSpec({
                     // the SBI activiteiten list is the list of descriptions of the non-hoofd activiteiten
                     this.sbiActiviteiten shouldBe listOf("dummySbiOmschrijving1", "dummySbiOmschrijving3")
                     this.sbiHoofdActiviteit shouldBe "dummySbiOmschrijving2"
+                    with(this.adressen!!) {
+                        size shouldBe 2
+                        with(this[0]) {
+                            type shouldBe "dummyType1"
+                            afgeschermd shouldBe false
+                            volledigAdres shouldBe "dummyVolledigAdres1"
+                        }
+                        with(this[1]) {
+                            type shouldBe "dummyType2"
+                            afgeschermd shouldBe true
+                            volledigAdres shouldBe "dummyVolledigAdres2"
+                        }
+                    }
                 }
             }
         }
@@ -254,7 +280,8 @@ class KlantRestServiceTest : BehaviorSpec({
             voltijdWerkzamePersonen = null,
             deeltijdWerkzamePersonen = null,
             totaalWerkzamePersonen = null,
-            sbiActiviteiten = null
+            sbiActiviteiten = null,
+            adressen = null
         )
         every { kvkClientService.findVestigingsprofiel(vestiging.vestigingsnummer) } returns Optional.of(vestiging)
 
@@ -272,6 +299,7 @@ class KlantRestServiceTest : BehaviorSpec({
                     this.voltijdWerkzamePersonen shouldBe vestiging.voltijdWerkzamePersonen
                     this.sbiActiviteiten shouldBe null
                     this.sbiHoofdActiviteit shouldBe null
+                    this.adressen shouldBe null
                 }
             }
         }


### PR DESCRIPTION
Added null handling to all fields in KVK vestigingsprofiel conversion. Added unit tests. Fixed some typos in the ZAC user manual while at it.

Solves PZ-5045