### PR TITLE
fix: force rebuild docker image for integration tests

### DIFF
--- a/start-it-with-local-env.sh
+++ b/start-it-with-local-env.sh
@@ -65,8 +65,9 @@ while getopts ':bdvurh' OPTION; do
 done
 
 if [ $build = "true" ]; then
-  echo "Building ZAC Docker Image ..."
-  ./gradlew buildDockerImage
+  echo "Building fresh ZAC Docker Image ..."
+  # shellcheck disable=SC2086
+  ./gradlew $args clean buildDockerImage
 fi
 
 export ZAC_DOCKER_IMAGE=ghcr.io/infonl/zaakafhandelcomponent:dev


### PR DESCRIPTION
Gradle caches results and changes in code does not end in docker image
Add `clean` task if Docker image rebuild was requested

Solves  PZ-5234