### PR TITLE
chore: no longer show error detail in error detail screen when it is not explicitly sent by the backend

### DIFF
--- a/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
+++ b/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
@@ -144,7 +144,7 @@ export class FoutAfhandelingService {
     } else {
       // only show server error texts in case of a server error (500 family of errors)
       // or in case of a 403 Forbidden error
-      const showServerErrorTexts = err.status >= 500 ||  err.status === 403;
+      const showServerErrorTexts = err.status >= 500 || err.status === 403;
 
       // show error in context and do not redirect to error page
       return this.openFoutDetailedDialog(

--- a/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
+++ b/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
@@ -142,18 +142,16 @@ export class FoutAfhandelingService {
       this.bericht = "";
       this.router.navigate(["/fout-pagina"]);
     } else {
-      const errorDetail: string = err.error.exception || err.message;
-
       // only show server error texts in case of a server error (500 family of errors)
       // or in case of a 403 Forbidden error
-      const showServerErrorTexts = err.status >= 500 || err.status === 403;
+      const showServerErrorTexts = err.status >= 500 ||  err.status === 403;
 
       // show error in context and do not redirect to error page
       return this.openFoutDetailedDialog(
         this.translate.instant(
           err.error.message || err.message || "dialoog.body.error.technisch",
         ),
-        errorDetail,
+        err.error.exception,
         showServerErrorTexts,
       );
     }


### PR DESCRIPTION
No longer show error detail in error detail screen when it is not explicitly sent by the backend.

Solves PZ-5229