### PR TITLE
fix(e2e): select correct for aanvullende informatie nodig voor zaak

### DIFF
--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -112,10 +112,8 @@ When(
     await this.page.getByRole("button", { name: "Start" }).first().click();
 
     await this.expect(
-      this.page.getByText(
-        `Aanvullende informatie nodig voor zaak ${zaakNumber}`,
-      ).first(),
-    ).toBeVisible({ timeout: FIFTEEN_SECONDS_IN_MS });
+      this.page.getByRole('cell', { name: 'Aanvullende informatie' })
+          .toBeVisible({ timeout: FIFTEEN_SECONDS_IN_MS });
     await checkZaakAssignment.call(this, zaakNumber, user2Profile);
   },
 );

--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -113,7 +113,8 @@ When(
 
     await this.expect(
       this.page.getByRole('cell', { name: 'Aanvullende informatie' })
-          .toBeVisible({ timeout: FIFTEEN_SECONDS_IN_MS });
+    )
+        .toBeVisible({ timeout: FIFTEEN_SECONDS_IN_MS });
     await checkZaakAssignment.call(this, zaakNumber, user2Profile);
   },
 );
@@ -217,7 +218,9 @@ Then(
     await this.page.goto(`${this.worldParameters.urls.zac}/taken/mijn`);
 
     await this.expect(
-      this.page.getByRole("cell", { name: caseNumber, exact: true }).first(),
+      this.page
+          .getByRole("cell", { name: caseNumber, exact: true })
+          .first(),
     ).toBeVisible({ timeout: FIFTEEN_SECONDS_IN_MS });
 
     await this.expect(

--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -112,9 +112,8 @@ When(
     await this.page.getByRole("button", { name: "Start" }).first().click();
 
     await this.expect(
-      this.page.getByRole('cell', { name: 'Aanvullende informatie' })
-    )
-        .toBeVisible({ timeout: FIFTEEN_SECONDS_IN_MS });
+      this.page.getByRole("cell", { name: "Aanvullende informatie" }),
+    ).toBeVisible({ timeout: FIFTEEN_SECONDS_IN_MS });
     await checkZaakAssignment.call(this, zaakNumber, user2Profile);
   },
 );
@@ -218,9 +217,7 @@ Then(
     await this.page.goto(`${this.worldParameters.urls.zac}/taken/mijn`);
 
     await this.expect(
-      this.page
-          .getByRole("cell", { name: caseNumber, exact: true })
-          .first(),
+      this.page.getByRole("cell", { name: caseNumber, exact: true }).first(),
     ).toBeVisible({ timeout: FIFTEEN_SECONDS_IN_MS });
 
     await this.expect(

--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -114,7 +114,7 @@ When(
     await this.expect(
       this.page.getByText(
         `Aanvullende informatie nodig voor zaak ${zaakNumber}`,
-      ),
+      ).first(),
     ).toBeVisible({ timeout: FIFTEEN_SECONDS_IN_MS });
     await checkZaakAssignment.call(this, zaakNumber, user2Profile);
   },


### PR DESCRIPTION
The selector to get "Aanvullende informatie nodig voor zaak" finds both the td cell and div tooltip. Now select specifically the first item from these 2, as that is the item to wait for to become visible.
