### PR TITLE
fix: only run the Trivvy code scanner on the main branch

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -327,6 +327,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
+        if: github.ref == 'refs/heads/main'
         uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
         with:
           image-ref: '${{ env.ZAC_DOCKER_IMAGE }}'
@@ -343,6 +344,7 @@ jobs:
           TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: Upload Trivy scan results to GitHub Security tab
+        if: github.ref == 'refs/heads/main'
         uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Only run the Trivvy code scanner on the main branch because it quite often fails in the GitHub merge queue and does not add a lot of value there. May be related to: https://github.com/github/codeql-action/issues/1537

Solves PZ-5362