### PR TITLE
fix(app): beluiten list - prevent undefined error crashing app

### DIFF
--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -738,7 +738,7 @@
           class="besluiten"
           *ngIf="zaak.besluiten"
           [besluiten]="zaak.besluiten"
-          [result]="zaak.resultaat"
+          [result]="zaak?.resultaat"
           [readonly]="!zaak.isOpen || !zaak.rechten.behandelen"
           (besluitWijzigen)="besluitWijzigen($event)"
           (doIntrekking)="doIntrekking($event)"


### PR DESCRIPTION
prevent undefined error crashing app; components renders, but when zaak reopened the 'resultaat' has been reset. Because of that the FE threw error undefined of.

Solves PZ-5260