### PR TITLE
fix(app): Search form - persons tab - fix too narrow gemeente code field

### DIFF
--- a/src/main/app/src/app/klanten/zoek/personen/persoon-zoek.component.html
+++ b/src/main/app/src/app/klanten/zoek/personen/persoon-zoek.component.html
@@ -33,10 +33,7 @@
     ></mfb-form-field>
   </div>
   <div class="flex-row flex-col-md gap-10 flex-fill">
-    <mfb-form-field
-      class="flex-1 w66"
-      [field]="straatFormField"
-    ></mfb-form-field>
+    <mfb-form-field class="flex-1" [field]="straatFormField"></mfb-form-field>
     <mfb-form-field
       class="flex-1"
       [field]="gemeenteVanInschrijvingFormField"


### PR DESCRIPTION
Search form - persons tab - fix too narrow gemeente code field; the clear cross and gemeente code icons were wrapping to the next line; 

New layout:

![image](https://github.com/user-attachments/assets/b7d1aad7-b658-4672-aac8-4e9cfff28484)

Solves PZ-5153