### PR TITLE
chore: skip build docker image and itest on pr workflow

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -186,6 +186,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   next-version:
+    # Do not run this job for pull requests
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.get-version.outputs.replaced }}
@@ -220,7 +222,9 @@ jobs:
 
   build-docker-image-and-run-itests:
     needs: [build, paths-ignore, next-version]
-    if: ${{ needs.paths-ignore.outputs.skip != 'true' || github.ref == 'refs/heads/main'}}
+    # Do not run this job for pull requests and do not run if the paths-ignore step defines it to skip
+    # but always run for the main branch
+    if: ${{ (github.event_name != 'pull_request' && needs.paths-ignore.outputs.skip != 'true') || github.ref == 'refs/heads/main'}}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -360,27 +364,11 @@ jobs:
           path: docker-image.tar
           key: docker-image-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
-  dependabot-auto-merge:
-    needs: [run-unit-tests, build-docker-image-and-run-itests]
-    runs-on: ubuntu-24.04
-    if: github.actor == 'dependabot[bot]'
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - uses: fastify/github-action-merge-dependabot@c3bde0759d4f24db16f7b250b2122bc2df57e817 # v3.11.0
-        with:
-          # Our Dependabot PRs are not merged automatically because an automatically merged PR
-          # does not trigger our push workflow (and so no release would be made).
-          # see: https://github.com/fastify/github-action-merge-dependabot/issues/134
-          approve-only: true
-          target: minor
-
   push-docker-image:
     needs: [build, run-unit-tests, build-docker-image-and-run-itests, next-version]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    # Avoid infinite build loop on renovate updates
+    # Only run on the main branch and avoid infinite build loop on Renovate updates
     if: ${{ github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'update ghcr.io/infonl/zaakafhandelcomponent docker tag') && !contains(github.event.head_commit.message, 'update dependency infonl/dimpact-zaakafhandelcomponent to') }}
     env:
       ZAC_DOCKER_IMAGE: ${{ needs.build.outputs.zac_docker_image }}
@@ -414,6 +402,7 @@ jobs:
 
   create-release:
     needs: [next-version, push-docker-image]
+    # Only run on the main branch
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     env:
@@ -445,6 +434,7 @@ jobs:
       NEXT_VERSION: ${{ needs.next-version.outputs.version }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    # Only run on the main branch
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -331,6 +331,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
+        # Only run on the main branch
         if: github.ref == 'refs/heads/main'
         uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -170,15 +170,20 @@ jobs:
 
       - name: Upload unit test results to CodeCov
         uses: codecov/test-results-action@44ecb3a270cd942bdf0fa8f2ce14cb32493e810a # v1.0.3
-        if: ${{ !cancelled() }}
+        # Do not run in the merge queue and do not run if the job got cancelled
+        if: ${{ github.event_name != 'merge_group' && !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
 
       - name: Generate unit test code coverage report
+        # Do not run in the merge queue
+        if: ${{ github.event_name != 'merge_group' }}
         run: ./gradlew -x compileJava -x processResources -x compileKotlin -x classes -x test -x itest -x npmRunBuild npmRunTestCoverage jacocoTestReport --info
 
       - name: Upload unit test coverage report to Codecov
+        # Do not run in the merge queue
+        if: ${{ github.event_name != 'merge_group' }}
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
         with:
           flags: unittests
@@ -186,7 +191,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   next-version:
-    # Do not run this job for pull requests
+    # Do not run for pull requests
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     outputs:
@@ -222,7 +227,7 @@ jobs:
 
   build-docker-image-and-run-itests:
     needs: [build, paths-ignore, next-version]
-    # Do not run this job for pull requests and do not run if the paths-ignore step defines it to skip
+    # Do not run for pull requests and do not run if the paths-ignore step defines it to skip
     # but always run for the main branch
     if: ${{ (github.event_name != 'pull_request' && needs.paths-ignore.outputs.skip != 'true') || github.ref == 'refs/heads/main'}}
     runs-on: ubuntu-24.04
@@ -298,7 +303,8 @@ jobs:
 
       - name: Upload integration test results to CodeCov
         uses: codecov/test-results-action@44ecb3a270cd942bdf0fa8f2ce14cb32493e810a # v1.0.3
-        if: ${{ !cancelled() }}
+        # Do not run in the merge queue and do not run if the job got cancelled
+        if: ${{ github.event_name != 'merge_group' && !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integrationtests
@@ -321,9 +327,13 @@ jobs:
           key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
       - name: Generate JaCoCo integration test code coverage report
+        # Do not run in the merge queue
+        if: ${{ github.event_name != 'merge_group' }}
         run: ./gradlew jacocoIntegrationTestReport -x itest --info
 
       - name: Upload integration test coverage report to Codecov
+        # Do not run in the merge queue
+        if: ${{ github.event_name != 'merge_group' }}
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
         with:
           flags: integrationtests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main]
   merge_group:
+  push:
+    branches:
+      - main
   schedule:
     - cron: "21 11 * * 0"
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,9 +3,4 @@
 # SPDX-License-Identifier: EUPL-1.2+
 #
 codecov:
-  notify:
-    # only notify Codecov after two builds because we want to make sure
-    # that the reported coverage from our GitHub workflow includes both
-    # our unit test and integration test coverage
-    after_n_builds: 2
   max_report_age: off

--- a/src/itest/kotlin/nl/info/zac/itest/BagRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/BagRestServiceTest.kt
@@ -16,7 +16,7 @@ import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.util.shouldEqualJsonIgnoringExtraneousFields
 
 @Order(TEST_SPEC_ORDER_AFTER_ZAAK_CREATED)
-class BAGRESTServiceTest : BehaviorSpec({
+class BagRestServiceTest : BehaviorSpec({
     val itestHttpClient = ItestHttpClient()
     val logger = KotlinLogging.logger {}
 

--- a/src/main/java/net/atos/zac/app/bag/BagRestService.java
+++ b/src/main/java/net/atos/zac/app/bag/BagRestService.java
@@ -51,7 +51,7 @@ import net.atos.zac.policy.PolicyService;
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 @Singleton
-public class BAGRESTService {
+public class BagRestService {
     private BagClientService bagClientService;
     private ZrcClientService zrcClientService;
     private RESTBAGConverter restbagConverter;
@@ -65,11 +65,11 @@ public class BAGRESTService {
     /**
      * Default no-arg constructor, required by Weld.
      */
-    public BAGRESTService() {
+    public BagRestService() {
     }
 
     @Inject
-    public BAGRESTService(
+    public BagRestService(
             BagClientService bagClientService,
             ZrcClientService zrcClientService,
             RESTBAGConverter restbagConverter,

--- a/src/main/kotlin/nl/info/client/keycloak/KeycloakEmployeesAdminClientConfiguration.kt
+++ b/src/main/kotlin/nl/info/client/keycloak/KeycloakEmployeesAdminClientConfiguration.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-package net.atos.client.keycloak
+package nl.info.client.keycloak
 
 import jakarta.enterprise.inject.Produces
 import jakarta.inject.Inject

--- a/src/test/kotlin/net/atos/client/bag/model/BagFixtures.kt
+++ b/src/test/kotlin/net/atos/client/bag/model/BagFixtures.kt
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package net.atos.client.bag.model
+
+import net.atos.client.bag.model.generated.AdresIOHal
+
+fun createAdresIOHal(
+    huisnummer: Int = 123,
+    huisletter: String = "dummyHuisletter",
+    huisnummertoevoeging: String = "dummyHuisnummertoevoeging",
+    postcode: String = "dummyPostcode",
+    woonplaatsNaam: String = "dummyWoonplaatsNaam",
+) = AdresIOHal().apply {
+    this.huisnummer = huisnummer
+    this.huisletter = huisletter
+    this.huisnummertoevoeging = huisnummertoevoeging
+    this.postcode = postcode
+    this.woonplaatsNaam = woonplaatsNaam
+}

--- a/src/test/kotlin/net/atos/zac/app/bag/BagFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/bag/BagFixtures.kt
@@ -17,6 +17,8 @@ import net.atos.client.bag.model.generated.StatusVerblijfsobject
 import net.atos.client.bag.model.generated.Surface
 import net.atos.client.bag.model.generated.Verblijfsobject
 import net.atos.client.bag.model.generated.VerblijfsobjectIOHal
+import net.atos.zac.app.bag.model.RESTBAGAdres
+import net.atos.zac.app.bag.model.RESTWoonplaats
 import java.math.BigDecimal
 
 fun createLigplaatsAdresseerbaarObject(status: StatusPlaats) =
@@ -28,6 +30,16 @@ fun createLigplaatsAdresseerbaarObject(status: StatusPlaats) =
             }
         }
     }
+
+fun createRESTBAGAdres() = RESTBAGAdres().apply {
+    huisnummer = 1
+    postcode = "1234AB"
+    woonplaats = createRESTWoonplaats()
+}
+
+fun createRESTWoonplaats() = RESTWoonplaats().apply {
+    naam = "Amsterdam"
+}
 
 fun createStandplaatsAdresseerbaarObject(status: StatusPlaats) =
     AdresseerbaarObjectIOHal().apply {

--- a/src/test/kotlin/net/atos/zac/app/bag/BagRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/bag/BagRestServiceTest.kt
@@ -54,7 +54,7 @@ class BagRestServiceTest : BehaviorSpec({
             val bagObject = bagRestService.read(BAGObjectType.ADRES, bagObjectId)
 
             Then(
-                "the response should be a 200 HTTP response with the expected BAG object"
+                "the expected BAG object should be returned"
             ) {
                 verify(exactly = 1) {
                     bagClientService.readAdres(bagObjectId)

--- a/src/test/kotlin/net/atos/zac/app/bag/BagRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/bag/BagRestServiceTest.kt
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package net.atos.zac.app.bag
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.atos.client.bag.BagClientService
+import net.atos.client.bag.model.createAdresIOHal
+import net.atos.client.zgw.zrc.ZrcClientService
+import net.atos.zac.app.bag.converter.RESTAdresConverter
+import net.atos.zac.app.bag.converter.RESTBAGConverter
+import net.atos.zac.app.bag.converter.RESTNummeraanduidingConverter
+import net.atos.zac.app.bag.converter.RESTOpenbareRuimteConverter
+import net.atos.zac.app.bag.converter.RESTPandConverter
+import net.atos.zac.app.bag.converter.RESTWoonplaatsConverter
+import net.atos.zac.app.bag.model.BAGObjectType
+import net.atos.zac.policy.PolicyService
+
+class BagRestServiceTest : BehaviorSpec({
+    val bagClientService = mockk<BagClientService>()
+    var zrcClientService = mockk<ZrcClientService>()
+    var restbagConverter = mockk<RESTBAGConverter>()
+    var restAdresConverter = mockk<RESTAdresConverter>()
+    var restNummeraanduidingConverter = mockk<RESTNummeraanduidingConverter>()
+    var restOpenbareRuimteConverter = mockk<RESTOpenbareRuimteConverter>()
+    var restPandConverter = mockk<RESTPandConverter>()
+    var restWoonplaatsConverter = mockk<RESTWoonplaatsConverter>()
+    var policyService = mockk<PolicyService>()
+    val bagRestService = BagRestService(
+        bagClientService,
+        zrcClientService,
+        restbagConverter,
+        restAdresConverter,
+        restNummeraanduidingConverter,
+        restOpenbareRuimteConverter,
+        restPandConverter,
+        restWoonplaatsConverter,
+        policyService
+    )
+
+    Given("A BAG object of type address ") {
+        val bagObjectId = "dummyBagObjectId"
+        val bagAddress = createAdresIOHal()
+        val restBAGAddress = createRESTBAGAdres()
+        every { bagClientService.readAdres(bagObjectId) } returns bagAddress
+        every { restAdresConverter.convertToREST(bagAddress) } returns restBAGAddress
+
+        When("the BAG object is read") {
+            val bagObject = bagRestService.read(BAGObjectType.ADRES, bagObjectId)
+
+            Then(
+                "the response should be a 200 HTTP response with the expected BAG object"
+            ) {
+                verify(exactly = 1) {
+                    bagClientService.readAdres(bagObjectId)
+                    restAdresConverter.convertToREST(bagAddress)
+                }
+                bagObject shouldBe restBAGAddress
+            }
+        }
+    }
+})


### PR DESCRIPTION
Skip build docker image and itest on pr workflow.
- build Docker image and run integration tests is now only done in the merge queue and no longer on a pull request
- I made some code changes and added a unit test just to check how the code coverage now works
- code cov is a bit messy. the PR workflow now only has the unit test coverage so every PR will have much less code coverage compared to the main branch where the integration test coverage is also taken into account. needs some more tweaking in the `codecov.yml` maybe related to the `unittest` vs `integrationtest` flags. not super critical since the codecov status check is not a blocking status check but still..

Took inspiration from: https://medium.com/@kojoru/how-to-set-up-merge-queues-in-github-actions-59381e5f435a

Solves PZ-5417