### PR TITLE
chore: added missing on: main triggger in CodeQL workflow to fix warnings in GitHub about this

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main]
   merge_group:
+  push:
+    branches:
+      - main
   schedule:
     - cron: "21 11 * * 0"
 


### PR DESCRIPTION
Added missing on: main triggger in CodeQL workflow to fix warnings in GitHub about this in our builds.

<img width="996" alt="Screenshot 2025-02-06 at 14 52 23" src="https://github.com/user-attachments/assets/0209d5ae-f734-46af-84bd-e034c3727015" />

Solves PZ-5419