### PR TITLE
fix(app): Zaakafhandel-parameters - date fields number inputs - prevent characters

### DIFF
--- a/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.html
+++ b/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.html
@@ -123,6 +123,7 @@
               <input
                 matInput
                 type="number"
+                [attr.inputmode]="'numeric'"
                 min="0"
                 max="31"
                 formControlName="einddatumGeplandWaarschuwing"
@@ -272,9 +273,10 @@
                     <input
                       matInput
                       type="number"
-                      formControlName="doorlooptijd"
+                      [attr.inputmode]="'numeric'"
                       min="0"
                       max="2147483647"
+                      formControlName="doorlooptijd"
                     />
                     <span matSuffix>{{ "kalenderdagen" | translate }}</span>
                   </mat-form-field>

--- a/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.less
+++ b/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.less
@@ -12,6 +12,12 @@ mat-expansion-panel-header {
   }
 }
 
+::ng-deep.mat-mdc-form-field-icon-suffix {
+  color: var(--mdc-filled-text-field-label-text-color);
+  align-self: inherit;
+  padding: 0 20px 0 10px;
+}
+
 .button-group {
   padding: 10px;
 }


### PR DESCRIPTION
FE - Zaakafhandel-parameters - date fields number inputs - prevent characters

- scientific 'e' and '-' ignored
- some improved styling
- touching tab Gegevens + (not in Bug description) Tab the Human tasks field doorlooptijden

Solves PZ-5053