### PR TITLE
fix: add write permissions to run-e2e workflow

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
 
 jobs:


### PR DESCRIPTION
Add write permissions to e2e workflow to fix 403 on git push

Solves PZ-5425