### PR TITLE
fix: do not hide abort zaak button if no managed reasons exist

### DIFF
--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -731,9 +731,7 @@ export class ZaakViewComponent
     if (
       this.zaak.isOpen &&
       !this.zaak.isHeropend &&
-      this.zaak.rechten.afbreken &&
-      this.zaak.zaaktype.zaakafhandelparameters.zaakbeeindigParameters.length >
-        0
+      this.zaak.rechten.afbreken
     ) {
       actionMenuItems.push(
         new ButtonMenuItem(


### PR DESCRIPTION
We always have the hardcoded and unmanaged "Zaak is niet ontvankelijk" reason

Solves PZ-5434