### PR TITLE
chore: add integration test for destroying zaak

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/AanvullendeInformatieTaskCompleteTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/AanvullendeInformatieTaskCompleteTest.kt
@@ -12,7 +12,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.client.ZacClient
-import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_SEARCH
+import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_REINDEXING
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
 import org.json.JSONArray
@@ -20,7 +20,7 @@ import org.json.JSONArray
 /**
  * This test assumes a human task plan item (=task) has been started for a zaak in a previously run test.
  */
-@Order(TEST_SPEC_ORDER_AFTER_SEARCH)
+@Order(TEST_SPEC_ORDER_AFTER_REINDEXING)
 class AanvullendeInformatieTaskCompleteTest : BehaviorSpec({
     val logger = KotlinLogging.logger {}
     val itestHttpClient = ItestHttpClient()

--- a/src/itest/kotlin/nl/info/zac/itest/CsvRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/CsvRESTServiceTest.kt
@@ -19,7 +19,7 @@ import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import org.junit.jupiter.api.Order
 
 /**
- * Since we run this test after [IndexerenRESTServiceTest], we expect
+ * Since we run this test after [IndexingRestServiceTest], we expect
  * all created and still open zaken up to that point to be present in the search index
  * which is used to generate the CSV.
  * The number of CSV rows is expected to be equal to the number of open zaken + 1 for the header row.

--- a/src/itest/kotlin/nl/info/zac/itest/IndexingRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/IndexingRestServiceTest.kt
@@ -23,7 +23,7 @@ import kotlin.time.Duration.Companion.seconds
  * @see NotificationsTest
  */
 @Order(TEST_SPEC_ORDER_AFTER_ZAKEN_TAKEN_DOCUMENTEN_ADDED)
-class IndexerenRESTServiceTest : BehaviorSpec({
+class IndexingRestServiceTest : BehaviorSpec({
     val itestHttpClient = ItestHttpClient()
 
     Given("""Two zaken, a task and a document have been created""") {
@@ -50,7 +50,7 @@ class IndexerenRESTServiceTest : BehaviorSpec({
                             "zoeken": {},
                             "filters": {},
                             "datums": {},
-                            "rows": 10,
+                            "rows": 100,
                             "page": 0,
                             "type": "ZAAK"
                         }
@@ -83,7 +83,7 @@ class IndexerenRESTServiceTest : BehaviorSpec({
                             "zoeken":{},
                             "filters": {},
                             "datums": {},
-                            "rows": 10,
+                            "rows": 100,
                             "page": 0,
                             "type":"TAAK"
                         }
@@ -115,7 +115,7 @@ class IndexerenRESTServiceTest : BehaviorSpec({
                             "zoeken": {},
                             "filters": {},
                             "datums": {},
-                            "rows": 10,
+                            "rows": 100,
                             "page": 0,
                             "type":"DOCUMENT"
                         }

--- a/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDeleteTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDeleteTest.kt
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package nl.info.zac.itest
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.core.spec.Order
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import nl.info.zac.itest.client.ItestHttpClient
+import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
+import nl.info.zac.itest.config.ItestConfiguration.OPEN_NOTIFICATIONS_API_SECRET_KEY
+import nl.info.zac.itest.config.ItestConfiguration.OPEN_ZAAK_BASE_URI
+import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_REINDEXING
+import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
+import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
+import okhttp3.Headers
+import org.json.JSONObject
+
+/**
+ * This test creates a zaak and a document (the form data PDF) which we use in other tests, and therefore we run this test first.
+ */
+@Order(TEST_SPEC_ORDER_AFTER_REINDEXING)
+class NotificationsZaakDeleteTest : BehaviorSpec({
+    val logger = KotlinLogging.logger {}
+    val itestHttpClient = ItestHttpClient()
+
+    // TODO: ideally we want the situation where the zaak no longer exists in OpenZaak..
+    Given("Existing zaak process data and Solr index data for a specific zaak in ZAC") {
+        When("the notificaties endpoint is called with a 'zaak destroy' payload") {
+//            val response = itestHttpClient.performJSONPostRequest(
+//                url = "$ZAC_API_URI/notificaties",
+//                headers = Headers.headersOf(
+//                    "Content-Type",
+//                    "application/json",
+//                    // this test simulates that Open Notificaties sends the request to ZAC
+//                    // using the secret API key that is configured in ZAC
+//                    "Authorization",
+//                    OPEN_NOTIFICATIONS_API_SECRET_KEY
+//                ),
+//                requestBodyAsString = JSONObject(
+//                    mapOf(
+//                        "kanaal" to "zaken",
+//                        "resource" to "zaak",
+//                        "resourceUrl" to "$OPEN_ZAAK_BASE_URI/zaken/api/v1/zaken/$zaakProductaanvraag1Uuid",
+//                        "actie" to "destroy"
+//                    )
+//                ).toString(),
+//                addAuthorizationHeader = false
+ //           )
+            Then(
+                """the response should be 'no content', a zaak should be created in OpenZaak
+                        and a zaak productaanvraag proces of type 'Productaanvraag-Dimpact' should be started in ZAC"""
+            ) {
+                //response.code shouldBe HTTP_STATUS_NO_CONTENT
+            }
+        }
+    }
+})

--- a/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
@@ -7,9 +7,7 @@ package nl.info.zac.itest
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
 import nl.info.zac.itest.config.ItestConfiguration.OPEN_NOTIFICATIONS_API_SECRET_KEY
 import nl.info.zac.itest.config.ItestConfiguration.OPEN_ZAAK_BASE_URI
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_REINDEXING
@@ -22,12 +20,13 @@ import org.json.JSONObject
  * This test creates a zaak and a document (the form data PDF) which we use in other tests, and therefore we run this test first.
  */
 @Order(TEST_SPEC_ORDER_AFTER_REINDEXING)
-class NotificationsZaakDeleteTest : BehaviorSpec({
+class NotificationsZaakDestroyTest : BehaviorSpec({
     val logger = KotlinLogging.logger {}
     val itestHttpClient = ItestHttpClient()
 
     // TODO: ideally we want the situation where the zaak no longer exists in OpenZaak..
     Given("Existing zaak process data and Solr index data for a specific zaak in ZAC") {
+
         When("the notificaties endpoint is called with a 'zaak destroy' payload") {
 //            val response = itestHttpClient.performJSONPostRequest(
 //                url = "$ZAC_API_URI/notificaties",
@@ -48,7 +47,7 @@ class NotificationsZaakDeleteTest : BehaviorSpec({
 //                    )
 //                ).toString(),
 //                addAuthorizationHeader = false
- //           )
+//            )
             Then(
                 """the response should be 'no content', a zaak should be created in OpenZaak
                         and a zaak productaanvraag proces of type 'Productaanvraag-Dimpact' should be started in ZAC"""

--- a/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
@@ -5,54 +5,136 @@
 package nl.info.zac.itest
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.assertions.json.shouldContainJsonKeyValue
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
+import nl.info.zac.itest.client.ZacClient
+import nl.info.zac.itest.config.ItestConfiguration.DATE_TIME_2024_01_31
+import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
 import nl.info.zac.itest.config.ItestConfiguration.OPEN_NOTIFICATIONS_API_SECRET_KEY
 import nl.info.zac.itest.config.ItestConfiguration.OPEN_ZAAK_BASE_URI
-import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_REINDEXING
+import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
+import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_ID
+import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_SEARCH
+import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
-import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
 import okhttp3.Headers
 import org.json.JSONObject
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
 
 /**
- * This test creates a zaak and a document (the form data PDF) which we use in other tests, and therefore we run this test first.
+ * This test creates a zaak and because we do not want this test to impact [ZoekenRESTServiceTest]
+ * we run it afterward.
  */
-@Order(TEST_SPEC_ORDER_AFTER_REINDEXING)
+@Order(TEST_SPEC_ORDER_AFTER_SEARCH)
 class NotificationsZaakDestroyTest : BehaviorSpec({
     val logger = KotlinLogging.logger {}
     val itestHttpClient = ItestHttpClient()
+    val zacClient = ZacClient()
 
-    // TODO: ideally we want the situation where the zaak no longer exists in OpenZaak..
-    Given("Existing zaak process data and Solr index data for a specific zaak in ZAC") {
-
+    Given("Existing process data and Solr index data for a specific zaak in ZAC") {
+        lateinit var zaakUUID: UUID
+        lateinit var zaakIdentificatie: String
+        zacClient.createZaak(
+            zaakTypeUUID = ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID,
+            groupId = TEST_GROUP_A_ID,
+            groupName = TEST_GROUP_A_DESCRIPTION,
+            startDate = DATE_TIME_2024_01_31
+        ).run {
+            val responseBody = body!!.string()
+            logger.info { "Response: $responseBody" }
+            this.isSuccessful shouldBe true
+            JSONObject(responseBody).run {
+                zaakUUID = getString("uuid").run(UUID::fromString)
+                zaakIdentificatie = getString("identificatie")
+            }
+        }
+        // reindex so that the new zaak gets added to the Solr index
+        itestHttpClient.performGetRequest(
+            url = "$ZAC_API_URI/indexeren/herindexeren/ZAAK",
+            addAuthorizationHeader = false
+        ).run {
+            logger.info { "Response: ${body!!.string()}" }
+            this.isSuccessful shouldBe true
+        }
+        // wait for the indexing to complete
+        eventually(10.seconds) {
+            val searchResponseBody = itestHttpClient.performPutRequest(
+                url = "$ZAC_API_URI/zoeken/list",
+                requestBodyAsString = """
+                    {
+                        "filtersType": "ZoekParameters",
+                        "alleenMijnZaken": false,
+                        "alleenOpenstaandeZaken": true,
+                        "alleenAfgeslotenZaken": false,
+                        "alleenMijnTaken": false,
+                        "zoeken": { "ALLE": "$zaakIdentificatie" }, 
+                        "filters": {},                            
+                        "datums": {},
+                        "rows": 10,
+                        "page": 0                        
+                    }
+                """.trimIndent()
+            ).body!!.string()
+            JSONObject(searchResponseBody).getInt("totaal") shouldBe 1
+            with(JSONObject(searchResponseBody).getJSONArray("resultaten").getJSONObject(0).toString()) {
+                shouldContainJsonKeyValue("identificatie", zaakIdentificatie)
+            }
+        }
         When("the notificaties endpoint is called with a 'zaak destroy' payload") {
-//            val response = itestHttpClient.performJSONPostRequest(
-//                url = "$ZAC_API_URI/notificaties",
-//                headers = Headers.headersOf(
-//                    "Content-Type",
-//                    "application/json",
-//                    // this test simulates that Open Notificaties sends the request to ZAC
-//                    // using the secret API key that is configured in ZAC
-//                    "Authorization",
-//                    OPEN_NOTIFICATIONS_API_SECRET_KEY
-//                ),
-//                requestBodyAsString = JSONObject(
-//                    mapOf(
-//                        "kanaal" to "zaken",
-//                        "resource" to "zaak",
-//                        "resourceUrl" to "$OPEN_ZAAK_BASE_URI/zaken/api/v1/zaken/$zaakProductaanvraag1Uuid",
-//                        "actie" to "destroy"
-//                    )
-//                ).toString(),
-//                addAuthorizationHeader = false
-//            )
+            val response = itestHttpClient.performJSONPostRequest(
+                url = "$ZAC_API_URI/notificaties",
+                headers = Headers.headersOf(
+                    "Content-Type",
+                    "application/json",
+                    "Authorization",
+                    OPEN_NOTIFICATIONS_API_SECRET_KEY
+                ),
+                requestBodyAsString = JSONObject(
+                    mapOf(
+                        "kanaal" to "zaken",
+                        "resource" to "zaak",
+                        "hoofdObject" to "$OPEN_ZAAK_BASE_URI/zaken/api/v1/zaken/$zaakUUID",
+                        "resourceUrl" to "$OPEN_ZAAK_BASE_URI/zaken/api/v1/zaken/$zaakUUID",
+                        "actie" to "destroy",
+                        "aanmaakdatum" to ZonedDateTime.now(ZoneId.of("UTC")).toString()
+                    )
+                ).toString(),
+                addAuthorizationHeader = false
+            )
             Then(
-                """the response should be 'no content', a zaak should be created in OpenZaak
-                        and a zaak productaanvraag proces of type 'Productaanvraag-Dimpact' should be started in ZAC"""
+                """the response should be 'no content', and the zaak should be removed from the Solr index"""
             ) {
-                //response.code shouldBe HTTP_STATUS_NO_CONTENT
+                val responseBody = response.body!!.string()
+                logger.info { "Response: $responseBody" }
+                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                // wait for the zaak to be removed from the Solr index
+                eventually(10.seconds) {
+                    val searchResponseBody = itestHttpClient.performPutRequest(
+                        url = "$ZAC_API_URI/zoeken/list",
+                        requestBodyAsString = """
+                    {
+                        "filtersType": "ZoekParameters",
+                        "alleenMijnZaken": false,
+                        "alleenOpenstaandeZaken": true,
+                        "alleenAfgeslotenZaken": false,
+                        "alleenMijnTaken": false,
+                        "zoeken": { "ALLE": "$zaakIdentificatie" }, 
+                        "filters": {},                            
+                        "datums": {},
+                        "rows": 10,
+                        "page": 0                        
+                    }
+                        """.trimIndent()
+                    ).body!!.string()
+                    JSONObject(searchResponseBody).getInt("totaal") shouldBe 0
+                }
             }
         }
     }

--- a/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
@@ -83,9 +83,7 @@ class NotificationsZaakDestroyTest : BehaviorSpec({
                 """.trimIndent()
             ).body!!.string()
             JSONObject(searchResponseBody).getInt("totaal") shouldBe 1
-            with(JSONObject(searchResponseBody).getJSONArray("resultaten").getJSONObject(0).toString()) {
-                shouldContainJsonKeyValue("identificatie", zaakIdentificatie)
-            }
+            searchResponseBody.shouldContainJsonKeyValue("$.resultaten[0].identificatie", zaakIdentificatie)
         }
         When("the notificaties endpoint is called with a 'zaak destroy' payload") {
             val response = itestHttpClient.performJSONPostRequest(

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceHistoryTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceHistoryTest.kt
@@ -18,7 +18,7 @@ import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
 import nl.info.zac.itest.config.ItestConfiguration.TEST_PERSON_2_BSN
 import nl.info.zac.itest.config.ItestConfiguration.TEST_PERSON_3_BSN
 import nl.info.zac.itest.config.ItestConfiguration.TEST_PERSON_HENDRIKA_JANSE_BSN
-import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_LAST
+import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_ZAAK_UPDATED
 import nl.info.zac.itest.config.ItestConfiguration.TEST_USER_1_NAME
 import nl.info.zac.itest.config.ItestConfiguration.TEST_USER_2_NAME
 import nl.info.zac.itest.config.ItestConfiguration.ZAAK_PRODUCTAANVRAAG_1_IDENTIFICATION
@@ -27,7 +27,7 @@ import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
 import nl.info.zac.itest.util.shouldEqualJsonIgnoringExtraneousFields
 
-@Order(TEST_SPEC_ORDER_LAST)
+@Order(TEST_SPEC_ORDER_AFTER_ZAAK_UPDATED)
 class ZaakRestServiceHistoryTest : BehaviorSpec({
     val logger = KotlinLogging.logger {}
     val itestHttpClient = ItestHttpClient()
@@ -43,27 +43,7 @@ class ZaakRestServiceHistoryTest : BehaviorSpec({
                 logger.info { "Response: $responseBody" }
                 response.isSuccessful shouldBe true
 
-                val expectedResponse = """[{
-                    "actie": "GEWIJZIGD",
-                    "attribuutLabel": "status",
-                    "door": "$TEST_USER_1_NAME",
-                    "nieuweWaarde": "Intake",
-                    "toelichting": "Status gewijzigd"
-                  },
-                  {
-                    "actie": "GEKOPPELD",
-                    "attribuutLabel": "Behandelaar",
-                    "door": "$TEST_USER_1_NAME",
-                    "nieuweWaarde": "$TEST_USER_1_NAME",
-                    "toelichting": ""
-                  },
-                  {
-                    "actie": "GEKOPPELD",
-                    "attribuutLabel": "zaakinformatieobject",
-                    "door": "$TEST_USER_1_NAME",
-                    "nieuweWaarde": "subject",
-                    "toelichting": ""
-                  },
+                val expectedResponse = """[   
                   {
                     "actie": "GEKOPPELD",
                     "attribuutLabel": "zaakinformatieobject",

--- a/src/itest/kotlin/nl/info/zac/itest/ZoekenRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZoekenRESTServiceTest.kt
@@ -24,7 +24,6 @@ import nl.info.zac.itest.config.ItestConfiguration.OPEN_FORMULIEREN_FORMULIER_BR
 import nl.info.zac.itest.config.ItestConfiguration.TAAK_1_FATAL_DATE
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_REINDEXING
-import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_LAST
 import nl.info.zac.itest.config.ItestConfiguration.TEST_USER_1_NAME
 import nl.info.zac.itest.config.ItestConfiguration.TEST_USER_1_USERNAME
 import nl.info.zac.itest.config.ItestConfiguration.TOTAL_COUNT_DOCUMENTS

--- a/src/itest/kotlin/nl/info/zac/itest/ZoekenRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZoekenRESTServiceTest.kt
@@ -23,6 +23,7 @@ import nl.info.zac.itest.config.ItestConfiguration.OBJECT_PRODUCTAANVRAAG_1_BRON
 import nl.info.zac.itest.config.ItestConfiguration.OPEN_FORMULIEREN_FORMULIER_BRON_NAAM
 import nl.info.zac.itest.config.ItestConfiguration.TAAK_1_FATAL_DATE
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
+import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_REINDEXING
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_LAST
 import nl.info.zac.itest.config.ItestConfiguration.TEST_USER_1_NAME
 import nl.info.zac.itest.config.ItestConfiguration.TEST_USER_1_USERNAME
@@ -45,8 +46,8 @@ import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.util.shouldEqualJsonIgnoringOrderAndExtraneousFields
 import org.json.JSONObject
 
-// Run this test last so that all the required data is available in the Solr index
-@Order(TEST_SPEC_ORDER_LAST)
+// Run this test after reindexing so that all the required data is available in the Solr index
+@Order(TEST_SPEC_ORDER_AFTER_REINDEXING)
 @Suppress("LargeClass")
 class ZoekenRESTServiceTest : BehaviorSpec({
     val itestHttpClient = ItestHttpClient()

--- a/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
@@ -110,7 +110,7 @@ object ItestConfiguration {
     const val TEST_SPEC_ORDER_AFTER_TASK_COMPLETED = 5
     const val TEST_SPEC_ORDER_AFTER_ZAKEN_TAKEN_DOCUMENTEN_ADDED = 6
     const val TEST_SPEC_ORDER_AFTER_REINDEXING = 7
-    const val TEST_SPEC_ORDER_LAST = 100
+    const val TEST_SPEC_ORDER_AFTER_SEARCH = 8
 
     const val TOTAL_COUNT_ZAKEN = 10
     const val TOTAL_COUNT_ZAKEN_AFGEROND = 2
@@ -311,10 +311,6 @@ object ItestConfiguration {
         "Verzoek is bij verkeerde organisatie ingediend"
 
     @Suppress("MagicNumber")
-    val DATE_TIME_2000_01_01: ZonedDateTime = LocalDate.of(2000, Month.JANUARY, 1)
-        .atStartOfDay(TimeZone.getDefault().toZoneId())
-
-    @Suppress("MagicNumber")
     val DATE_2000_01_01: LocalDate = LocalDate.of(2000, Month.JANUARY, 1)
 
     @Suppress("MagicNumber")
@@ -335,8 +331,10 @@ object ItestConfiguration {
     @Suppress("MagicNumber")
     val DATE_2024_01_31: LocalDate = LocalDate.of(2024, Month.JANUARY, 31)
 
+    val DATE_TIME_2000_01_01: ZonedDateTime = DATE_2000_01_01.atStartOfDay(TimeZone.getDefault().toZoneId())
     val DATE_TIME_2020_01_01: ZonedDateTime = DATE_2020_01_01.atStartOfDay(TimeZone.getDefault().toZoneId())
     val DATE_TIME_2024_01_01: ZonedDateTime = DATE_2024_01_01.atStartOfDay(TimeZone.getDefault().toZoneId())
+    val DATE_TIME_2024_01_31: ZonedDateTime = DATE_2024_01_31.atStartOfDay(TimeZone.getDefault().toZoneId())
 
     val ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID: UUID = UUID.fromString("448356ff-dcfb-4504-9501-7fe929077c4f")
     val ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID: UUID =

--- a/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
@@ -110,7 +110,6 @@ object ItestConfiguration {
     const val TEST_SPEC_ORDER_AFTER_TASK_COMPLETED = 5
     const val TEST_SPEC_ORDER_AFTER_ZAKEN_TAKEN_DOCUMENTEN_ADDED = 6
     const val TEST_SPEC_ORDER_AFTER_REINDEXING = 7
-    const val TEST_SPEC_ORDER_AFTER_SEARCH = 8
     const val TEST_SPEC_ORDER_LAST = 100
 
     const val TOTAL_COUNT_ZAKEN = 10


### PR DESCRIPTION
Add integration test for destroying zaak. For now only checks if the zaak gets correctly removed from the Solr index. To be extended later. Also refactored the order of the integration tests a bit so that we have somewhat less interdependencies between individual integration tests.

Solves PZ-3850