### PR TITLE
chore: skip building the Docker image and running the integration tests in the merge queue

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -233,7 +233,9 @@ jobs:
 
   build-docker-image-and-run-itests:
     needs: [build, paths-ignore, next-version]
-    if: ${{ needs.paths-ignore.outputs.skip != 'true' || github.ref == 'refs/heads/main'}}
+    # Do not run in the merge queue and do not run if the paths-ignore step defines it to skip
+    # but always run for the main branch
+    if: ${{ (github.event_name != 'merge_group' && needs.paths-ignore.outputs.skip != 'true') || github.ref == 'refs/heads/main'}}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:


### PR DESCRIPTION
Skip building the Docker image and running the integration tests in the merge queue in order to improve overall performance of our build pipeline. This slightly increases the risk of breaking the main branch but we think this is acceptable.

Solves PZ-5417