### PR TITLE
fix: undo moving of classes used in our CMMN model

### DIFF
--- a/src/main/java/net/atos/zac/app/admin/converter/RESTCaseDefinitionConverter.java
+++ b/src/main/java/net/atos/zac/app/admin/converter/RESTCaseDefinitionConverter.java
@@ -16,7 +16,7 @@ import org.flowable.cmmn.model.UserEventListener;
 
 import net.atos.zac.app.admin.model.RESTCaseDefinition;
 import net.atos.zac.app.admin.model.RESTPlanItemDefinition;
-import nl.info.zac.flowable.cmmn.CMMNService;
+import net.atos.zac.flowable.cmmn.CMMNService;
 
 public class RESTCaseDefinitionConverter {
 

--- a/src/main/java/net/atos/zac/flowable/processengine/ProcessEngineLookupImpl.java
+++ b/src/main/java/net/atos/zac/flowable/processengine/ProcessEngineLookupImpl.java
@@ -22,10 +22,10 @@ import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.impl.cfg.StandaloneProcessEngineConfiguration;
 
+import net.atos.zac.flowable.cmmn.CompleteTaskInterceptor;
+import net.atos.zac.flowable.cmmn.EndCaseLifecycleListener;
+import net.atos.zac.flowable.cmmn.ZacCreateHumanTaskInterceptor;
 import net.atos.zac.flowable.task.CreateUserTaskInterceptor;
-import nl.info.zac.flowable.cmmn.CompleteTaskInterceptor;
-import nl.info.zac.flowable.cmmn.EndCaseLifecycleListener;
-import nl.info.zac.flowable.cmmn.ZacCreateHumanTaskInterceptor;
 
 /**
  * Looks up the ZAC Flowable process engine.

--- a/src/main/java/net/atos/zac/flowable/task/CreateUserTaskInterceptor.java
+++ b/src/main/java/net/atos/zac/flowable/task/CreateUserTaskInterceptor.java
@@ -6,7 +6,7 @@
 package net.atos.zac.flowable.task;
 
 import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAK_UUID;
-import static nl.info.zac.flowable.cmmn.ZacCreateHumanTaskInterceptor.SECONDS_TO_DELAY;
+import static net.atos.zac.flowable.cmmn.ZacCreateHumanTaskInterceptor.SECONDS_TO_DELAY;
 
 import java.util.UUID;
 

--- a/src/main/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestService.kt
@@ -36,6 +36,7 @@ import net.atos.zac.app.admin.model.RestZaakafhandelParameters
 import net.atos.zac.app.zaak.converter.RestResultaattypeConverter
 import net.atos.zac.app.zaak.model.RestResultaattype
 import net.atos.zac.configuratie.ConfiguratieService
+import net.atos.zac.flowable.cmmn.CMMNService
 import net.atos.zac.policy.PolicyService
 import net.atos.zac.policy.PolicyService.assertPolicy
 import net.atos.zac.smartdocuments.SmartDocumentsTemplatesService
@@ -44,7 +45,6 @@ import net.atos.zac.smartdocuments.rest.RestSmartDocumentsTemplateGroup
 import net.atos.zac.smartdocuments.rest.isSubsetOf
 import nl.info.zac.exception.ErrorCode.ERROR_CODE_PRODUCTAANVRAAGTYPE_ALREADY_IN_USE
 import nl.info.zac.exception.InputValidationFailedException
-import nl.info.zac.flowable.cmmn.CMMNService
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
 import java.util.UUID

--- a/src/main/kotlin/net/atos/zac/app/planitems/PlanItemsRESTService.kt
+++ b/src/main/kotlin/net/atos/zac/app/planitems/PlanItemsRESTService.kt
@@ -32,6 +32,7 @@ import net.atos.zac.app.planitems.model.RESTUserEventListenerData
 import net.atos.zac.app.planitems.model.UserEventListenerActie
 import net.atos.zac.configuratie.ConfiguratieService
 import net.atos.zac.flowable.ZaakVariabelenService
+import net.atos.zac.flowable.cmmn.CMMNService
 import net.atos.zac.flowable.task.TaakVariabelenService
 import net.atos.zac.mail.MailService
 import net.atos.zac.mail.model.MailAdres
@@ -45,7 +46,6 @@ import net.atos.zac.util.time.DateTimeConverterUtil
 import net.atos.zac.zaak.ZaakService
 import net.atos.zac.zoeken.IndexingService
 import nl.info.zac.exception.InputValidationFailedException
-import nl.info.zac.flowable.cmmn.CMMNService
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
 import org.flowable.cmmn.api.runtime.PlanItemInstance

--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -97,6 +97,7 @@ import net.atos.zac.documenten.OntkoppeldeDocumentenService
 import net.atos.zac.event.EventingService
 import net.atos.zac.flowable.ZaakVariabelenService
 import net.atos.zac.flowable.bpmn.BPMNService
+import net.atos.zac.flowable.cmmn.CMMNService
 import net.atos.zac.flowable.task.FlowableTaskService
 import net.atos.zac.healthcheck.HealthCheckService
 import net.atos.zac.history.ZaakHistoryService
@@ -117,7 +118,6 @@ import net.atos.zac.websocket.event.ScreenEventType
 import net.atos.zac.zaak.ZaakService
 import net.atos.zac.zoeken.IndexingService
 import net.atos.zac.zoeken.model.zoekobject.ZoekObjectType
-import nl.info.zac.flowable.cmmn.CMMNService
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
 import org.apache.commons.collections4.CollectionUtils

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/AanvullendeInformatieTaskListener.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/AanvullendeInformatieTaskListener.kt
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-package nl.info.zac.flowable.cmmn
+package net.atos.zac.flowable.cmmn
 
 import net.atos.client.zgw.zrc.model.Zaak
 import net.atos.zac.configuratie.ConfiguratieService

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/CMMNService.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/CMMNService.kt
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-package nl.info.zac.flowable.cmmn
+package net.atos.zac.flowable.cmmn
 
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Instance
@@ -14,9 +14,9 @@ import net.atos.client.zgw.ztc.model.generated.ZaakType
 import net.atos.zac.admin.model.ZaakafhandelParameters
 import net.atos.zac.authentication.LoggedInUser
 import net.atos.zac.flowable.ZaakVariabelenService
+import net.atos.zac.flowable.cmmn.exception.CaseDefinitionNotFoundException
+import net.atos.zac.flowable.cmmn.exception.OpenTaskItemNotFoundException
 import net.atos.zac.flowable.task.CreateUserTaskInterceptor
-import nl.info.zac.flowable.cmmn.exception.CaseDefinitionNotFoundException
-import nl.info.zac.flowable.cmmn.exception.OpenTaskItemNotFoundException
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
 import org.flowable.cmmn.api.CmmnRepositoryService

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/CmmnEngineLookupImpl.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/CmmnEngineLookupImpl.kt
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-package nl.info.zac.flowable.cmmn
+package net.atos.zac.flowable.cmmn
 
 import net.atos.zac.flowable.processengine.ProcessEngineLookupImpl
 import org.flowable.cdi.spi.CmmnEngineLookup

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/CompleteTaskInterceptor.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/CompleteTaskInterceptor.kt
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-package nl.info.zac.flowable.cmmn
+package net.atos.zac.flowable.cmmn
 
 import net.atos.zac.flowable.FlowableHelper
 import org.flowable.cmmn.engine.CmmnEngineConfiguration

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/EndCaseLifecycleListener.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/EndCaseLifecycleListener.kt
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-package nl.info.zac.flowable.cmmn
+package net.atos.zac.flowable.cmmn
 
 import net.atos.zac.flowable.FlowableHelper
 import org.flowable.cmmn.api.listener.CaseInstanceLifecycleListener

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/UpdateZaakLifecycleListener.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/UpdateZaakLifecycleListener.kt
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-package nl.info.zac.flowable.cmmn
+package net.atos.zac.flowable.cmmn
 
 import net.atos.zac.flowable.FlowableHelper
 import nl.info.zac.util.NoArgConstructor

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/ZacCreateHumanTaskInterceptor.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/ZacCreateHumanTaskInterceptor.kt
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-package nl.info.zac.flowable.cmmn
+package net.atos.zac.flowable.cmmn
 
 import net.atos.zac.flowable.FlowableHelper
 import net.atos.zac.signalering.event.SignaleringEventUtil

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/exception/CmmnExceptions.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/exception/CmmnExceptions.kt
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-package nl.info.zac.flowable.cmmn.exception
+package net.atos.zac.flowable.cmmn.exception
 
 class OpenTaskItemNotFoundException(override val message: String) : RuntimeException(message)
 

--- a/src/main/kotlin/net/atos/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/net/atos/zac/productaanvraag/ProductaanvraagService.kt
@@ -36,6 +36,7 @@ import net.atos.zac.admin.model.ZaakafhandelParameters
 import net.atos.zac.configuratie.ConfiguratieService
 import net.atos.zac.documenten.InboxDocumentenService
 import net.atos.zac.flowable.bpmn.BPMNService
+import net.atos.zac.flowable.cmmn.CMMNService
 import net.atos.zac.identity.IdentityService
 import net.atos.zac.productaanvraag.model.InboxProductaanvraag
 import net.atos.zac.productaanvraag.model.generated.Betrokkene
@@ -47,7 +48,6 @@ import net.atos.zac.productaanvraag.util.IndicatieMachtigingEnumJsonAdapter
 import net.atos.zac.productaanvraag.util.RolOmschrijvingGeneriekEnumJsonAdapter
 import net.atos.zac.productaanvraag.util.convertToZgwPoint
 import net.atos.zac.util.JsonbUtil
-import nl.info.zac.flowable.cmmn.CMMNService
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
 import java.net.URI

--- a/src/main/resources/META-INF/services/org.flowable.cdi.spi.CmmnEngineLookup
+++ b/src/main/resources/META-INF/services/org.flowable.cdi.spi.CmmnEngineLookup
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: EUPL-1.2+
 #
 
-nl.info.zac.flowable.cmmn.CmmnEngineLookupImpl
+net.atos.zac.flowable.cmmn.CmmnEngineLookupImpl

--- a/src/main/resources/cmmn/Generiek_zaakafhandelmodel.cmmn.xml
+++ b/src/main/resources/cmmn/Generiek_zaakafhandelmodel.cmmn.xml
@@ -29,7 +29,7 @@
             <stage id="INTAKE" name="Intake" autoComplete="true" flowable:displayOrder="1">
                 <extensionElements>
                     <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
-                    <flowable:planItemLifecycleListener sourceState="available" targetState="active" class="nl.info.zac.flowable.cmmn.UpdateZaakLifecycleListener">
+                    <flowable:planItemLifecycleListener sourceState="available" targetState="active" class="net.atos.zac.flowable.cmmn.UpdateZaakLifecycleListener">
                         <flowable:field name="status">
                             <flowable:string><![CDATA[Intake]]></flowable:string>
                         </flowable:field>
@@ -74,8 +74,8 @@
                         <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
                         <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
                         <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
-                        <flowable:taskListener event="create" class="nl.info.zac.flowable.cmmn.AanvullendeInformatieTaskListener"></flowable:taskListener>
-                        <flowable:taskListener event="complete" class="nl.info.zac.flowable.cmmn.AanvullendeInformatieTaskListener"></flowable:taskListener>
+                        <flowable:taskListener event="create" class="net.atos.zac.flowable.cmmn.AanvullendeInformatieTaskListener"></flowable:taskListener>
+                        <flowable:taskListener event="complete" class="net.atos.zac.flowable.cmmn.AanvullendeInformatieTaskListener"></flowable:taskListener>
                     </extensionElements>
                 </humanTask>
                 <milestone id="INTAKE_GEREED" name="Intake Gereed" flowable:milestoneVariable="Intake Gereed">
@@ -94,7 +94,7 @@
             <stage id="IN_BEHANDELING" name="In behandeling" autoComplete="true" flowable:displayOrder="2">
                 <extensionElements>
                     <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
-                    <flowable:planItemLifecycleListener sourceState="available" targetState="active" class="nl.info.zac.flowable.cmmn.UpdateZaakLifecycleListener">
+                    <flowable:planItemLifecycleListener sourceState="available" targetState="active" class="net.atos.zac.flowable.cmmn.UpdateZaakLifecycleListener">
                         <flowable:field name="status">
                             <flowable:string><![CDATA[In behandeling]]></flowable:string>
                         </flowable:field>

--- a/src/test/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
@@ -23,12 +23,12 @@ import net.atos.zac.app.admin.converter.RESTCaseDefinitionConverter
 import net.atos.zac.app.admin.converter.RestZaakafhandelParametersConverter
 import net.atos.zac.app.zaak.converter.RestResultaattypeConverter
 import net.atos.zac.configuratie.ConfiguratieService
+import net.atos.zac.flowable.cmmn.CMMNService
 import net.atos.zac.policy.PolicyService
 import net.atos.zac.smartdocuments.SmartDocumentsTemplatesService
 import net.atos.zac.smartdocuments.exception.SmartDocumentsConfigurationException
 import nl.info.zac.exception.ErrorCode.ERROR_CODE_PRODUCTAANVRAAGTYPE_ALREADY_IN_USE
 import nl.info.zac.exception.InputValidationFailedException
-import nl.info.zac.flowable.cmmn.CMMNService
 import java.util.UUID
 
 class ZaakafhandelParametersRestServiceTest : BehaviorSpec({

--- a/src/test/kotlin/net/atos/zac/app/planitems/PlanItemsRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/planitems/PlanItemsRESTServiceTest.kt
@@ -34,6 +34,7 @@ import net.atos.zac.app.planitems.model.createRESTHumanTaskData
 import net.atos.zac.app.planitems.model.createRESTUserEventListenerData
 import net.atos.zac.configuratie.ConfiguratieService
 import net.atos.zac.flowable.ZaakVariabelenService
+import net.atos.zac.flowable.cmmn.CMMNService
 import net.atos.zac.mail.MailService
 import net.atos.zac.mail.model.Bronnen
 import net.atos.zac.mailtemplates.MailTemplateService
@@ -46,7 +47,6 @@ import net.atos.zac.util.time.DateTimeConverterUtil
 import net.atos.zac.zaak.ZaakService
 import net.atos.zac.zoeken.IndexingService
 import nl.info.zac.exception.InputValidationFailedException
-import nl.info.zac.flowable.cmmn.CMMNService
 import org.flowable.cmmn.api.runtime.PlanItemInstance
 import java.net.URI
 import java.time.LocalDate

--- a/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
@@ -7,7 +7,6 @@ package net.atos.zac.app.zaak
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.doubles.exactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.checkUnnecessaryStub
@@ -84,6 +83,7 @@ import net.atos.zac.documenten.OntkoppeldeDocumentenService
 import net.atos.zac.event.EventingService
 import net.atos.zac.flowable.ZaakVariabelenService
 import net.atos.zac.flowable.bpmn.BPMNService
+import net.atos.zac.flowable.cmmn.CMMNService
 import net.atos.zac.flowable.task.FlowableTaskService
 import net.atos.zac.healthcheck.HealthCheckService
 import net.atos.zac.healthcheck.createZaaktypeInrichtingscheck
@@ -107,7 +107,6 @@ import net.atos.zac.websocket.event.ScreenEvent
 import net.atos.zac.zaak.ZaakService
 import net.atos.zac.zoeken.IndexingService
 import net.atos.zac.zoeken.model.zoekobject.ZoekObjectType
-import nl.info.zac.flowable.cmmn.CMMNService
 import nl.info.zac.test.date.toDate
 import org.flowable.task.api.Task
 import java.net.URI

--- a/src/test/kotlin/net/atos/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -39,10 +39,10 @@ import net.atos.zac.admin.model.createZaakafhandelParameters
 import net.atos.zac.configuratie.ConfiguratieService
 import net.atos.zac.documenten.InboxDocumentenService
 import net.atos.zac.flowable.bpmn.BPMNService
+import net.atos.zac.flowable.cmmn.CMMNService
 import net.atos.zac.identity.IdentityService
 import net.atos.zac.productaanvraag.model.InboxProductaanvraag
 import net.atos.zac.productaanvraag.model.generated.Geometry
-import nl.info.zac.flowable.cmmn.CMMNService
 import nl.info.zac.test.util.createRandomStringWithAlphanumericCharacters
 import java.net.URI
 import java.util.UUID

--- a/src/test/kotlin/nl/info/zac/flowable/cmmn/CMMNServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/flowable/cmmn/CMMNServiceTest.kt
@@ -17,6 +17,7 @@ import net.atos.client.zgw.ztc.model.createZaakType
 import net.atos.zac.admin.model.createZaakafhandelParameters
 import net.atos.zac.authentication.LoggedInUser
 import net.atos.zac.flowable.ZaakVariabelenService
+import net.atos.zac.flowable.cmmn.CMMNService
 import org.flowable.cmmn.api.CmmnRepositoryService
 import org.flowable.cmmn.api.CmmnRuntimeService
 import org.flowable.cmmn.api.runtime.CaseInstance

--- a/src/test/kotlin/nl/info/zac/flowable/cmmn/UpdateZaakLifecycleListenerTest.kt
+++ b/src/test/kotlin/nl/info/zac/flowable/cmmn/UpdateZaakLifecycleListenerTest.kt
@@ -15,6 +15,7 @@ import net.atos.client.zgw.zrc.model.createZaak
 import net.atos.client.zgw.zrc.model.createZaakStatus
 import net.atos.zac.flowable.FlowableHelper
 import net.atos.zac.flowable.ZaakVariabelenService
+import net.atos.zac.flowable.cmmn.UpdateZaakLifecycleListener
 import org.flowable.cmmn.api.delegate.DelegatePlanItemInstance
 import org.flowable.common.engine.api.delegate.Expression
 


### PR DESCRIPTION
Undo moving of classes used in our CMMN model because this breaks all zaken and tasks that were created by earlier versions of the CMMN model! Do note that this change will again break those zaken and tasks that were created by the previous version of the CMMN model (luckily that only applies to the INFO test environment).

Solves PZ-5466