### PR TITLE
feat: delete CMMN Flowable case related data on zaak destroy notification

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
@@ -24,8 +24,6 @@ import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_ID
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_SEARCH
 import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
-import nl.info.zac.itest.config.ItestConfiguration.task1ID
-import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
 import nl.info.zac.itest.util.sleep
 import okhttp3.Headers
 import org.json.JSONArray

--- a/src/itest/kotlin/nl/info/zac/itest/SignaleringAdminRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/SignaleringAdminRestServiceTest.kt
@@ -85,16 +85,8 @@ class SignaleringAdminRestServiceTest : BehaviorSpec({
         getHumanTaskPlanItemsResponse.isSuccessful shouldBe true
         getHumanTaskPlanItemsResponseBody.shouldBeJsonArray()
         val humanTaskItemId = JSONArray(getHumanTaskPlanItemsResponseBody).getJSONObject(0).getString("id")
-
-        // Wait before starting an Additional Info task, because that sets the status of the zaak to "Additional info"
-        // and OpenZaak does not allow setting multiple statuses for one zaak within the same timeframe of one second.
-        // If we do not wait in these cases we get a 400 response from OpenZaak with:
-        // "rest_framework.exceptions.ValidationError: {'non_field_errors':
-        // [ErrorDetail(string='De velden zaak, datum_status_gezet moeten een unieke set zijn.', code='unique')]}"
-        //
-        // Related OpenZaak issue: https://github.com/open-zaak/open-zaak/issues/1639
+        // wait for OpenZaak to accept this request
         sleep(1)
-
         val fataleDatum = DATE_2024_01_01.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
         val doHumanTaskPlanItemResponse = itestHttpClient.performJSONPostRequest(
             url = "$ZAC_API_URI/planitems/doHumanTaskPlanItem",

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceBesluitTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceBesluitTest.kt
@@ -65,14 +65,7 @@ class ZaakRestServiceBesluitTest : BehaviorSpec({
                 intakeId = getString("id").toInt()
             }
         }
-        // Wait before setting the status of a zaak (implicitly)
-        // because OpenZaak does not allow setting multiple statuses for one zaak
-        // within the same timeframe of one second.
-        // If we do not wait in these cases we get a 400 response from OpenZaak with:
-        // "rest_framework.exceptions.ValidationError: {'non_field_errors':
-        // [ErrorDetail(string='De velden zaak, datum_status_gezet moeten een unieke set zijn.', code='unique')]}"
-        //
-        // Related OpenZaak issue: https://github.com/open-zaak/open-zaak/issues/1639
+        // wait for OpenZaak to accept this request
         sleep(1)
         itestHttpClient.performJSONPostRequest(
             "$ZAC_API_URI/planitems/doUserEventListenerPlanItem",

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceCompleteTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceCompleteTest.kt
@@ -68,14 +68,7 @@ class ZaakRestServiceCompleteTest : BehaviorSpec({
                 intakeId = getString("id").toInt()
             }
         }
-        // Wait before setting the status of a zaak (implicitly)
-        // because OpenZaak does not allow setting multiple statuses for one zaak
-        // within the same timeframe of one second.
-        // If we do not wait in these cases we get a 400 response from OpenZaak with:
-        // "rest_framework.exceptions.ValidationError: {'non_field_errors':
-        // [ErrorDetail(string='De velden zaak, datum_status_gezet moeten een unieke set zijn.', code='unique')]}"
-        //
-        // Related OpenZaak issue: https://github.com/open-zaak/open-zaak/issues/1639
+        // wait for OpenZaak to accept this request
         sleep(1)
         itestHttpClient.performJSONPostRequest(
             "$ZAC_API_URI/planitems/doUserEventListenerPlanItem",
@@ -112,6 +105,7 @@ class ZaakRestServiceCompleteTest : BehaviorSpec({
                     afhandelenId = getString("id").toInt()
                 }
             }
+            // wait for OpenZaak to accept this request
             sleep(1)
             itestHttpClient.performJSONPostRequest(
                 "$ZAC_API_URI/planitems/doUserEventListenerPlanItem",
@@ -141,6 +135,7 @@ class ZaakRestServiceCompleteTest : BehaviorSpec({
         }
 
         When("the closed zaak is re-opened") {
+            // wait for OpenZaak to accept this request
             sleep(1)
             itestHttpClient.performPatchRequest(
                 "$ZAC_API_URI/zaken/zaak/$zaakUUID/heropenen",
@@ -165,6 +160,7 @@ class ZaakRestServiceCompleteTest : BehaviorSpec({
         }
 
         When("the re-opened zaak is completed again") {
+            // wait for OpenZaak to accept this request
             sleep(1)
             // Completing a re-opened zaak is done using the 'afsluiten' endpoint
             // instead of the 'doUserEventListenerPlanItem' endpoint.
@@ -238,15 +234,7 @@ class ZaakRestServiceCompleteTest : BehaviorSpec({
             val receiverMail = "receiverZaakComplete@example.com"
             val senderMail = "sender@example.com"
             val mailBody = "<p><b>bold</b>paragraph<i>italic</i></p>"
-
-            // Wait before setting the status of a zaak (implicitly)
-            // because OpenZaak does not allow setting multiple statuses for one zaak
-            // within the same timeframe of one second.
-            // If we do not wait in these cases we get a 400 response from OpenZaak with:
-            // "rest_framework.exceptions.ValidationError: {'non_field_errors':
-            // [ErrorDetail(string='De velden zaak, datum_status_gezet moeten een unieke set zijn.', code='unique')]}"
-            //
-            // Related OpenZaak issue: https://github.com/open-zaak/open-zaak/issues/1639
+            // wait for OpenZaak to accept this request
             sleep(1)
             itestHttpClient.performJSONPostRequest(
                 "$ZAC_API_URI/planitems/doUserEventListenerPlanItem",

--- a/src/itest/kotlin/nl/info/zac/itest/client/URLHelper.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/client/URLHelper.kt
@@ -7,4 +7,4 @@ package nl.info.zac.itest.client
 
 import java.net.URLEncoder
 
-fun String.urlEncode() = URLEncoder.encode(this, Charsets.UTF_8.name())
+fun String.urlEncode(): String = URLEncoder.encode(this, Charsets.UTF_8.name())

--- a/src/itest/kotlin/nl/info/zac/itest/util/SleepHelpers.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/util/SleepHelpers.kt
@@ -9,6 +9,7 @@ const val ONE_SECOND_IN_MILLIS = 1000L
 
 /**
  * Simple sleep function for integration tests that need to wait for an external service to finish processing.
+ *
  * For example, when we need to wait for a status to be set in OpenZaak before we can continue with some tests
  * because OpenZaak does not allow setting multiple statuses for one zaak
  * within the same timeframe of one second.

--- a/src/itest/kotlin/nl/info/zac/itest/util/SleepHelpers.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/util/SleepHelpers.kt
@@ -7,6 +7,17 @@ package nl.info.zac.itest.util
 
 const val ONE_SECOND_IN_MILLIS = 1000L
 
+/**
+ * Simple sleep function for integration tests that need to wait for an external service to finish processing.
+ * For example, when we need to wait for a status to be set in OpenZaak before we can continue with some tests
+ * because OpenZaak does not allow setting multiple statuses for one zaak
+ * within the same timeframe of one second.
+ * If we do not wait in these cases we get a 400 response from OpenZaak with:
+ * "rest_framework.exceptions.ValidationError: {'non_field_errors':
+ * [ErrorDetail(string='De velden zaak, datum_status_gezet moeten een unieke set zijn.', code='unique')]}"
+ *
+ * Related OpenZaak issue: (https://github.com/open-zaak/open-zaak/issues/1639)
+ */
 fun sleep(seconds: Long) {
     Thread.sleep(seconds * ONE_SECOND_IN_MILLIS)
 }

--- a/src/main/java/net/atos/zac/flowable/ZaakVariabelenService.java
+++ b/src/main/java/net/atos/zac/flowable/ZaakVariabelenService.java
@@ -32,14 +32,11 @@ public class ZaakVariabelenService {
     public static final String VAR_ZAAK_IDENTIFICATIE = "zaakIdentificatie";
     public static final String VAR_ZAAKTYPE_UUUID = "zaaktypeUUID";
     public static final String VAR_ZAAKTYPE_OMSCHRIJVING = "zaaktypeOmschrijving";
-
-    private static final String VAR_ONTVANGSTBEVESTIGING_VERSTUURD = "ontvangstbevestigingVerstuurd";
-    private static final String VAR_DATUMTIJD_OPGESCHORT = "datumTijdOpgeschort";
-    private static final String VAR_VERWACHTE_DAGEN_OPGESCHORT = "verwachteDagenOpgeschort";
-
-    // Wordt gebruikt binnen het CMMN model
+    public static final String VAR_ONTVANGSTBEVESTIGING_VERSTUURD = "ontvangstbevestigingVerstuurd";
+    public static final String VAR_DATUMTIJD_OPGESCHORT = "datumTijdOpgeschort";
+    public static final String VAR_VERWACHTE_DAGEN_OPGESCHORT = "verwachteDagenOpgeschort";
+    // as used in the ZAC CMMN model
     private static final String VAR_ONTVANKELIJK = "ontvankelijk";
-
     public static final List<String> VARS = List.of(
             VAR_ZAAK_UUID,
             VAR_ZAAK_IDENTIFICATIE,
@@ -51,17 +48,29 @@ public class ZaakVariabelenService {
             VAR_ONTVANKELIJK
     );
 
-    @Inject
     private CmmnRuntimeService cmmnRuntimeService;
-
-    @Inject
     private CmmnHistoryService cmmnHistoryService;
-
-    @Inject
     private RuntimeService bpmnRuntimeService;
+    private HistoryService bpmnHistoryService;
+
+    /**
+     * Default no-arg constructor, required by Weld.
+     */
+    public ZaakVariabelenService() {
+    }
 
     @Inject
-    private HistoryService bpmnHistoryService;
+    public ZaakVariabelenService(
+             CmmnRuntimeService cmmnRuntimeService,
+             CmmnHistoryService cmmnHistoryService,
+             RuntimeService bpmnRuntimeService,
+             HistoryService bpmnHistoryService
+    ) {
+        this.cmmnRuntimeService = cmmnRuntimeService;
+        this.cmmnHistoryService = cmmnHistoryService;
+        this.bpmnRuntimeService = bpmnRuntimeService;
+        this.bpmnHistoryService = bpmnHistoryService;
+    }
 
     public UUID readZaakUUID(final PlanItemInstance planItemInstance) {
         return (UUID) readCaseVariable(planItemInstance, VAR_ZAAK_UUID);
@@ -138,7 +147,6 @@ public class ZaakVariabelenService {
         if (caseInstance != null) {
             return caseInstance.getCaseVariables().get(variableName);
         }
-
         final HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .caseInstanceId(planItemInstance.getCaseInstanceId())
                 .includeCaseVariables()
@@ -146,7 +154,6 @@ public class ZaakVariabelenService {
         if (historicCaseInstance != null) {
             return historicCaseInstance.getCaseVariables().get(variableName);
         }
-
         throw new RuntimeException(
                 String.format("No variable found with name '%s' for case instance id '%s'", variableName,
                         planItemInstance.getCaseInstanceId()));

--- a/src/main/java/net/atos/zac/flowable/ZaakVariabelenService.java
+++ b/src/main/java/net/atos/zac/flowable/ZaakVariabelenService.java
@@ -61,15 +61,31 @@ public class ZaakVariabelenService {
 
     @Inject
     public ZaakVariabelenService(
-             CmmnRuntimeService cmmnRuntimeService,
-             CmmnHistoryService cmmnHistoryService,
-             RuntimeService bpmnRuntimeService,
-             HistoryService bpmnHistoryService
+            CmmnRuntimeService cmmnRuntimeService,
+            CmmnHistoryService cmmnHistoryService,
+            RuntimeService bpmnRuntimeService,
+            HistoryService bpmnHistoryService
     ) {
         this.cmmnRuntimeService = cmmnRuntimeService;
         this.cmmnHistoryService = cmmnHistoryService;
         this.bpmnRuntimeService = bpmnRuntimeService;
         this.bpmnHistoryService = bpmnHistoryService;
+    }
+
+    /**
+     * Deletes all CMMN case variables for the given zaakUUID.
+     * Does not need to be called before deleting the CMMN case itself.
+     * Also deletes historical variables.
+     *
+     * @param zaakUUID the zaak UUID
+     */
+    public void deleteAllCaseVariables(final UUID zaakUUID) {
+        final CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceQuery()
+                .variableValueEquals(VAR_ZAAK_UUID, zaakUUID)
+                .singleResult();
+        if (caseInstance != null) {
+            cmmnRuntimeService.removeVariables(caseInstance.getId(), VARS);
+        }
     }
 
     public UUID readZaakUUID(final PlanItemInstance planItemInstance) {

--- a/src/main/kotlin/net/atos/zac/configuratie/ConfiguratieService.kt
+++ b/src/main/kotlin/net/atos/zac/configuratie/ConfiguratieService.kt
@@ -85,7 +85,6 @@ class ConfiguratieService @Inject constructor(
 
         const val INFORMATIEOBJECTTYPE_OMSCHRIJVING_EMAIL = "e-mail"
 
-        // ~TODO
         const val ENV_VAR_ZGW_API_CLIENT_MP_REST_URL = "ZGW_API_CLIENT_MP_REST_URL"
 
         /**

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/CMMNService.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/CMMNService.kt
@@ -45,6 +45,13 @@ class CMMNService @Inject constructor(
         private val LOG = Logger.getLogger(CMMNService::class.java.getName())
     }
 
+    fun deleteCase(zaakUUID: UUID) =
+        cmmnRuntimeService.createCaseInstanceQuery()
+            .variableValueEquals(ZaakVariabelenService.VAR_ZAAK_UUID, zaakUUID)
+            .singleResult()?.let {
+                cmmnRuntimeService.deleteCaseInstance(it.id)
+            }
+
     fun listHumanTaskPlanItems(zaakUUID: UUID): MutableList<PlanItemInstance> =
         cmmnRuntimeService.createPlanItemInstanceQuery()
             .caseVariableValueEquals(ZaakVariabelenService.VAR_ZAAK_UUID, zaakUUID)

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/CMMNService.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/CMMNService.kt
@@ -19,6 +19,7 @@ import net.atos.zac.flowable.cmmn.exception.OpenTaskItemNotFoundException
 import net.atos.zac.flowable.task.CreateUserTaskInterceptor
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
+import org.flowable.cmmn.api.CmmnHistoryService
 import org.flowable.cmmn.api.CmmnRepositoryService
 import org.flowable.cmmn.api.CmmnRuntimeService
 import org.flowable.cmmn.api.repository.CaseDefinition
@@ -38,6 +39,7 @@ import java.util.logging.Logger
 @Suppress("TooManyFunctions")
 class CMMNService @Inject constructor(
     private val cmmnRuntimeService: CmmnRuntimeService,
+    private val cmmnHistoryService: CmmnHistoryService,
     private val cmmnRepositoryService: CmmnRepositoryService,
     private val loggedInUserInstance: Instance<LoggedInUser>
 ) {
@@ -49,7 +51,10 @@ class CMMNService @Inject constructor(
         cmmnRuntimeService.createCaseInstanceQuery()
             .variableValueEquals(ZaakVariabelenService.VAR_ZAAK_UUID, zaakUUID)
             .singleResult()?.let {
+                // delete the case instance
                 cmmnRuntimeService.deleteCaseInstance(it.id)
+                // delete any historic case instances
+                cmmnHistoryService.deleteHistoricCaseInstance(it.id)
             }
 
     fun listHumanTaskPlanItems(zaakUUID: UUID): MutableList<PlanItemInstance> =

--- a/src/test/kotlin/net/atos/zac/flowable/FlowableFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/FlowableFixtures.kt
@@ -271,7 +271,6 @@ data class TestPlanItemInstance(
     override fun getTenantId() = tenantId
     override fun getPlanItemInstanceLocalVariables() = planItemInstanceLocalVariables
     override fun setLocalizedName(localizedName: String) {
-         this.localizedName = localizedName
+        this.localizedName = localizedName
     }
 }
-

--- a/src/test/kotlin/net/atos/zac/flowable/FlowableFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/FlowableFixtures.kt
@@ -2,13 +2,40 @@
  * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-
 package net.atos.zac.flowable
 
+import org.flowable.cmmn.api.runtime.PlanItemInstance
 import org.flowable.identitylink.api.IdentityLinkInfo
 import org.flowable.task.api.DelegationState
 import org.flowable.task.api.Task
 import java.util.Date
+
+@Suppress("LongParameterList")
+fun createTestPlanItemInstance(
+    id: String = "dummyId",
+    name: String = "dummyName",
+    state: String = "dummyState",
+    caseDefinitionId: String = "dummyCaseDefinitionId",
+    derivedCaseDefinitionId: String = "dummyDerivedCaseDefinitionId",
+    caseInstanceId: String = "dummyCaseInstanceId",
+    stageInstanceId: String = "dummyStageInstanceId",
+    isStage: Boolean = false,
+    elementId: String = "dummyElementId",
+    planItemDefinitionId: String = "dummyPlanItemDefinitionId",
+    planItemDefinitionType: String = "dummyPlanItemDefinitionType",
+) = TestPlanItemInstance(
+    id,
+    name,
+    state,
+    caseDefinitionId,
+    derivedCaseDefinitionId,
+    caseInstanceId,
+    stageInstanceId,
+    isStage,
+    elementId,
+    planItemDefinitionId,
+    planItemDefinitionType
+)
 
 @Suppress("LongParameterList")
 fun createTestTask(
@@ -173,3 +200,78 @@ data class TestTask(
     override fun setFormKey(formKey: String) { this.formKey = formKey }
     override fun isSuspended() = suspended
 }
+
+data class TestPlanItemInstance(
+    private val id: String,
+    private val name: String,
+    private val state: String,
+    private val caseDefinitionId: String,
+    private val derivedCaseDefinitionId: String,
+    private val caseInstanceId: String,
+    private val stageInstanceId: String,
+    private val isStage: Boolean,
+    private val elementId: String,
+    private val planItemDefinitionId: String,
+    private val planItemDefinitionType: String,
+    private val createTime: Date? = null,
+    private val lastAvailableTime: Date? = null,
+    private val lastUnavailableTime: Date? = null,
+    private val lastEnabledTime: Date? = null,
+    private val lastDisabledTime: Date? = null,
+    private val lastStartedTime: Date? = null,
+    private val lastSuspendedTime: Date? = null,
+    private val completedTime: Date? = null,
+    private val occurredTime: Date? = null,
+    private val terminatedTime: Date? = null,
+    private val exitTime: Date? = null,
+    private val endedTime: Date? = null,
+    private val startUserId: String? = null,
+    private val referenceId: String? = null,
+    private val referenceType: String? = null,
+    private val completable: Boolean = false,
+    private val entryCriterionId: String? = null,
+    private val exitCriterionId: String? = null,
+    private val formKey: String? = null,
+    private val extraValue: String? = null,
+    private val tenantId: String? = null,
+    private val planItemInstanceLocalVariables: Map<String, Any>? = null,
+    private var localizedName: String? = null
+) : PlanItemInstance {
+    override fun getId() = id
+    override fun getName() = name
+    override fun getState() = state
+    override fun getCaseDefinitionId() = caseDefinitionId
+    override fun getDerivedCaseDefinitionId() = derivedCaseDefinitionId
+    override fun getCaseInstanceId() = caseInstanceId
+    override fun getStageInstanceId() = stageInstanceId
+    override fun isStage() = isStage
+    override fun getElementId() = elementId
+    override fun getPlanItemDefinitionId() = planItemDefinitionId
+    override fun getPlanItemDefinitionType() = planItemDefinitionType
+    override fun getCreateTime() = createTime
+    override fun getLastAvailableTime() = lastAvailableTime
+    override fun getLastUnavailableTime() = lastUnavailableTime
+    override fun getLastEnabledTime() = lastEnabledTime
+    override fun getLastDisabledTime() = lastDisabledTime
+    override fun getLastStartedTime() = lastStartedTime
+    override fun getLastSuspendedTime() = lastSuspendedTime
+    override fun getCompletedTime() = completedTime
+    override fun getOccurredTime() = occurredTime
+    override fun getTerminatedTime() = terminatedTime
+    override fun getExitTime() = exitTime
+    override fun getEndedTime() = endedTime
+    override fun getStartUserId() = startUserId
+    override fun getReferenceId() = referenceId
+    override fun getReferenceType() = referenceType
+    override fun isCompletable() = completable
+    override fun getEntryCriterionId() = entryCriterionId
+    override fun getExitCriterionId() = exitCriterionId
+    override fun getFormKey() = formKey
+    override fun getExtraValue() = extraValue
+    override fun getTenantId() = tenantId
+    override fun getPlanItemInstanceLocalVariables() = planItemInstanceLocalVariables
+    override fun setLocalizedName(localizedName: String) {
+         this.localizedName = localizedName
+    }
+}
+

--- a/src/test/kotlin/net/atos/zac/flowable/ZaakVariabelenServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/ZaakVariabelenServiceTest.kt
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package net.atos.zac.flowable
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.checkUnnecessaryStub
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.flowable.cmmn.api.CmmnHistoryService
+import org.flowable.cmmn.api.CmmnRuntimeService
+import org.flowable.cmmn.api.runtime.CaseInstance
+import org.flowable.engine.HistoryService
+import org.flowable.engine.RuntimeService
+import java.util.UUID
+
+class ZaakVariabelenServiceTest : BehaviorSpec({
+    val cmmnRuntimeService = mockk<CmmnRuntimeService>()
+    val cmmnHistoryService = mockk<CmmnHistoryService>()
+    val bpmnRuntimeService = mockk<RuntimeService>()
+    val bpmnHistoryService = mockk<HistoryService>()
+    val zaaKVariabelenService = ZaakVariabelenService(
+        cmmnRuntimeService,
+        cmmnHistoryService,
+        bpmnRuntimeService,
+        bpmnHistoryService
+    )
+
+    beforeEach {
+        checkUnnecessaryStub()
+    }
+
+    Given("A case instance with a zaak UUID case variable") {
+        val zaakUUID = UUID.randomUUID()
+        val planItemInstance = createTestPlanItemInstance()
+        val caseInstance = mockk<CaseInstance>()
+        val caseVariables = mapOf("zaakUUID" to zaakUUID)
+        every {
+            cmmnRuntimeService.createCaseInstanceQuery()
+                .caseInstanceId(planItemInstance.getCaseInstanceId())
+                .includeCaseVariables()
+                .singleResult()
+        } returns caseInstance
+        every { caseInstance.caseVariables } returns caseVariables
+
+        When("the zaak UUID variable is read") {
+            val returnedZaakUUID = zaaKVariabelenService.readZaakUUID(planItemInstance)
+
+            Then("the zaak UUID is correctly returned") {
+                returnedZaakUUID shouldBe zaakUUID
+                verify(exactly = 1) {
+                    cmmnRuntimeService.createCaseInstanceQuery()
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/nl/info/zac/flowable/cmmn/CMMNServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/flowable/cmmn/CMMNServiceTest.kt
@@ -101,4 +101,26 @@ class CMMNServiceTest : BehaviorSpec({
             }
         }
     }
+    Given("A CMMN case for a certain zaak UUID") {
+        val zaakUUID = UUID.randomUUID()
+        val caseInstanceID = "dummyCaseInstanceID"
+        val caseInstance = mockk<CaseInstance>()
+        every {
+            cmmnRuntimeService.createCaseInstanceQuery()
+                .variableValueEquals(ZaakVariabelenService.VAR_ZAAK_UUID, zaakUUID)
+                .singleResult()
+        } returns caseInstance
+        every { caseInstance.id } returns caseInstanceID
+        every { cmmnRuntimeService.deleteCaseInstance(caseInstanceID) } just Runs
+
+        When("the case is requested to be deleted") {
+            cmmnService.deleteCase(zaakUUID)
+
+            Then("the case is successfully deleted") {
+                verify(exactly = 1) {
+                    cmmnRuntimeService.deleteCaseInstance(caseInstanceID)
+                }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/nl/info/zac/flowable/cmmn/CMMNServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/flowable/cmmn/CMMNServiceTest.kt
@@ -17,7 +17,7 @@ import net.atos.client.zgw.ztc.model.createZaakType
 import net.atos.zac.admin.model.createZaakafhandelParameters
 import net.atos.zac.authentication.LoggedInUser
 import net.atos.zac.flowable.ZaakVariabelenService
-import net.atos.zac.flowable.cmmn.CMMNService
+import org.flowable.cmmn.api.CmmnHistoryService
 import org.flowable.cmmn.api.CmmnRepositoryService
 import org.flowable.cmmn.api.CmmnRuntimeService
 import org.flowable.cmmn.api.runtime.CaseInstance
@@ -28,9 +28,11 @@ import java.util.UUID
 class CMMNServiceTest : BehaviorSpec({
     val cmmnRuntimeService = mockk<CmmnRuntimeService>()
     val cmmnRepositoryService = mockk<CmmnRepositoryService>()
+    val cmmnHistoryService = mockk<CmmnHistoryService>()
     val loggedInUserInstance = mockk<Instance<LoggedInUser>>()
     val cmmnService = CMMNService(
         cmmnRuntimeService,
+        cmmnHistoryService,
         cmmnRepositoryService,
         loggedInUserInstance
     )
@@ -112,6 +114,7 @@ class CMMNServiceTest : BehaviorSpec({
         } returns caseInstance
         every { caseInstance.id } returns caseInstanceID
         every { cmmnRuntimeService.deleteCaseInstance(caseInstanceID) } just Runs
+        every { cmmnHistoryService.deleteHistoricCaseInstance(caseInstanceID) } just Runs
 
         When("the case is requested to be deleted") {
             cmmnService.deleteCase(zaakUUID)
@@ -119,6 +122,7 @@ class CMMNServiceTest : BehaviorSpec({
             Then("the case is successfully deleted") {
                 verify(exactly = 1) {
                     cmmnRuntimeService.deleteCaseInstance(caseInstanceID)
+                    cmmnHistoryService.deleteHistoricCaseInstance(caseInstanceID)
                 }
             }
         }

--- a/src/test/kotlin/nl/info/zac/notification/NotificationReceiverTest.kt
+++ b/src/test/kotlin/nl/info/zac/notification/NotificationReceiverTest.kt
@@ -20,6 +20,7 @@ import jakarta.ws.rs.core.Response
 import net.atos.zac.admin.ZaakafhandelParameterBeheerService
 import net.atos.zac.documenten.InboxDocumentenService
 import net.atos.zac.event.EventingService
+import net.atos.zac.flowable.ZaakVariabelenService
 import net.atos.zac.productaanvraag.ProductaanvraagService
 import net.atos.zac.zoeken.IndexingService
 import nl.info.zac.flowable.cmmn.CMMNService
@@ -35,6 +36,7 @@ class NotificationReceiverTest : BehaviorSpec({
     val inboxDocumentenService = mockk<InboxDocumentenService>()
     val zaakafhandelParameterBeheerService = mockk<ZaakafhandelParameterBeheerService>()
     val cmmnService = mockk<CMMNService>()
+    val zaakVariabelenService = mockk<ZaakVariabelenService>()
     val httpHeaders = mockk<HttpHeaders>()
     val httpSession = mockk<HttpSession>(relaxed = true)
     val httpSessionInstance = mockk<Instance<HttpSession>>()
@@ -45,6 +47,7 @@ class NotificationReceiverTest : BehaviorSpec({
         inboxDocumentenService = inboxDocumentenService,
         zaakafhandelParameterBeheerService = zaakafhandelParameterBeheerService,
         cmmnService = cmmnService,
+        zaakVariabelenService = zaakVariabelenService,
         secret = SECRET,
         httpSession = httpSessionInstance
     )
@@ -175,6 +178,7 @@ class NotificationReceiverTest : BehaviorSpec({
         every { httpHeaders.getHeaderString(eq(HttpHeaders.AUTHORIZATION)) } returns SECRET
         every { httpSessionInstance.get() } returns httpSession
         every { cmmnService.deleteCase(zaakUUID) } returns Unit
+        every { zaakVariabelenService.deleteAllCaseVariables(zaakUUID) } just Runs
         every { indexingService.removeZaak(zaakUUID) } just Runs
 
         When("notificatieReceive is called with the zaak destroy notificatie") {
@@ -186,6 +190,7 @@ class NotificationReceiverTest : BehaviorSpec({
                 response.status shouldBe Response.Status.NO_CONTENT.statusCode
                 verify(exactly = 1) {
                     cmmnService.deleteCase(zaakUUID)
+                    zaakVariabelenService.deleteAllCaseVariables(zaakUUID)
                     indexingService.removeZaak(zaakUUID)
                 }
             }


### PR DESCRIPTION
Delete CMMN Flowable case related data on zaak destroy notification, including any Flowable tasks related to the case.. Not yet deleting any BPMN related data (future PR).

Solves PZ-3848