### PR TITLE
chore: make dependency scripts executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ src/main/app/.nvmrc
 scripts/python/.venv
 scripts/python/.venv/*
 
+### Python cache ###
+**/__pycache__/
+
 ### INTELLIJ ###
 *.iml
 .idea

--- a/scripts/python/.envrc
+++ b/scripts/python/.envrc
@@ -1,0 +1,1 @@
+source init-pyenv.sh

--- a/scripts/python/README.md
+++ b/scripts/python/README.md
@@ -4,6 +4,8 @@ This folder contains some python scripts that might be useful. Further details o
 is described below.
 
 ## Setup Python virtual environment
+
+### Manually
 There's a simple shell [init script](./init-pyenv.sh) that can be used to create the virtual environment. It will use command 
 `python3 -m venv .venv` and therefore requires a python 3 version to be available, and will then install this in folder 
 `.venv`, with the required [requirements](./requirements.txt) applied. Once the python environment is available, the scripts from the 
@@ -13,7 +15,13 @@ The init script will have to be run from the context of the current session (in 
 immediately make use of the installed environment and installed libraries. 
 Use the following command:
 ```shell
-source init-pyenv.sh
+   source init-pyenv.sh
+```
+
+### direnv
+Allow sourcing of Python init script with:
+```shell
+   direnv allow
 ```
 
 ## Dependencies scripts
@@ -23,7 +31,7 @@ a defined list of dependencies of components that ZAC integrates with.
 
 To run the script use the following command (in `scripts/python`):
 ```shell
-python ./dependencies/versions-of-components.py
+   ./dependencies/versions.py
 ```
 
 ## PodiumD scripts
@@ -34,14 +42,14 @@ and Version files from [GitHub PodiumD Helm Charts](https://github.com/Dimpact-S
 
 To run the script use the following command:
 ```shell
-python ./podiumd/podiumd_versions.py -o 3.2.0
+   ./podiumd/versions.py -o 3.2.0
 ```
 
 ### PodiumD versions script options
 The script has a number of parameters to be able to compare specific versions, this from the help:
 
 ```
-usage: podiumd_versions.py [-h] -o OLD_VERSION [-n NEW_VERSION] [-b NEW_VERSION_BRANCH]
+usage: versions.py [-h] -o OLD_VERSION [-n NEW_VERSION] [-b NEW_VERSION_BRANCH]
 
 Script for comparing PodiumD version details between specific versions
 

--- a/scripts/python/dependencies/versions.py
+++ b/scripts/python/dependencies/versions.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 #  SPDX-FileCopyrightText: 2024 Lifely
 #  SPDX-License-Identifier: EUPL-1.2+
 

--- a/scripts/python/podiumd/versions.py
+++ b/scripts/python/podiumd/versions.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 #  SPDX-FileCopyrightText: 2024 Lifely
 #  SPDX-License-Identifier: EUPL-1.2+
 
@@ -45,7 +47,7 @@ def __main():
 
     # Add arguments
     parser.add_argument('-o', '--old_version', type=str, help='Version to base comparison on', required=True)
-    parser.add_argument('-n', '--new_version', type=str, help='Version to comparison with. Defaults to the latest on main.', required=False)
+    parser.add_argument('-n', '--new_version', type=str, help='Version to compare with. Defaults to the latest on main.', required=False)
     parser.add_argument('-b', '--new_version_branch', type=str, help='Branch to comparison on. Defaults to the main branch.', required=False)
 
     # Parse the arguments


### PR DESCRIPTION
Rename scripts to `versions` as the directories already mention the type of components 
Add direnv config to save from venv manual setup
Make scripts executable
Adapt readme

Solves PZ-5391
