### PR TITLE
fix: node version to 20 in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,9 @@
   "helm-values": {
     "fileMatch": "(^|/)ci/.+values\\.ya?ml$"
   },
+  "constraints": {
+    "node": "^20"
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Fix node version to 20 to prevent lock file format differences

Solves PZ-5497