### PR TITLE
chore: use Kotlin coroutines test dispatcher in unit test to hopefully fix flaky tests on GitHub

### DIFF
--- a/src/main/kotlin/net/atos/zac/app/task/TaskRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/task/TaskRestService.kt
@@ -21,8 +21,8 @@ import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.atos.client.zgw.drc.DrcClientService
 import net.atos.client.zgw.drc.model.generated.SoortEnum
@@ -106,7 +106,13 @@ class TaskRestService @Inject constructor(
     private val enkelvoudigInformatieObjectUpdateService: EnkelvoudigInformatieObjectUpdateService,
     private val opschortenZaakHelper: SuspensionZaakHelper,
     private val formulierRuntimeService: FormulierRuntimeService,
-    private val zaakVariabelenService: ZaakVariabelenService
+    private val zaakVariabelenService: ZaakVariabelenService,
+
+    /**
+     * Declare a Kotlin coroutine dispatcher here so that it can be overridden in unit tests with a test dispatcher
+     * while in normal operation it will be injected using [nl.info.zac.util.CoroutineDispatcherProducer].
+     */
+    private val dispatcher: CoroutineDispatcher
 ) {
     @GET
     @Path("zaak/{zaakUUID}")
@@ -177,7 +183,7 @@ class TaskRestService @Inject constructor(
     fun distributeFromList(@Valid restTaskDistributeData: RestTaskDistributeData) {
         assertPolicy(policyService.readWerklijstRechten().zakenTakenVerdelen)
         // this can be a long-running operation so run it asynchronously
-        CoroutineScope(Dispatchers.IO).launch {
+        CoroutineScope(dispatcher).launch {
             taskService.assignTasks(
                 restTaskDistributeData = restTaskDistributeData,
                 loggedInUser = loggedInUserInstance.get(),
@@ -191,7 +197,7 @@ class TaskRestService @Inject constructor(
     fun releaseFromList(@Valid restTaskReleaseData: RestTaskReleaseData) {
         assertPolicy(policyService.readWerklijstRechten().zakenTakenVerdelen)
         // this can be a long-running operation so run it asynchronously
-        CoroutineScope(Dispatchers.IO).launch {
+        CoroutineScope(dispatcher).launch {
             taskService.releaseTasks(
                 restTaskReleaseData = restTaskReleaseData,
                 loggedInUser = loggedInUserInstance.get(),

--- a/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/zaak/ZaakRestService.kt
@@ -20,8 +20,8 @@ import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.atos.client.or.`object`.ObjectsClientService
 import net.atos.client.zgw.brc.BrcClientService
@@ -165,7 +165,13 @@ class ZaakRestService @Inject constructor(
     private val healthCheckService: HealthCheckService,
     private val opschortenZaakHelper: SuspensionZaakHelper,
     private val zaakService: ZaakService,
-    private val zaakHistoryService: ZaakHistoryService
+    private val zaakHistoryService: ZaakHistoryService,
+
+    /**
+     * Declare a Kotlin coroutine dispatcher here so that it can be overridden in unit tests with a test dispatcher
+     * while in normal operation it will be injected using [nl.info.zac.util.CoroutineDispatcherProducer].
+     */
+    private val dispatcher: CoroutineDispatcher
 ) {
     companion object {
         private const val ROL_VERWIJDER_REDEN = "Verwijderd door de medewerker tijdens het behandelen van de zaak"
@@ -568,7 +574,7 @@ class ZaakRestService @Inject constructor(
     fun assignFromList(@Valid restZakenVerdeelGegevens: RESTZakenVerdeelGegevens) {
         assertPolicy(policyService.readWerklijstRechten().zakenTakenVerdelen)
         // this can be a long-running operation so run it asynchronously
-        CoroutineScope(Dispatchers.IO).launch {
+        CoroutineScope(dispatcher).launch {
             zaakService.assignZaken(
                 zaakUUIDs = restZakenVerdeelGegevens.uuids,
                 explanation = restZakenVerdeelGegevens.reden,
@@ -594,7 +600,7 @@ class ZaakRestService @Inject constructor(
     fun releaseFromList(@Valid restZakenVrijgevenGegevens: RESTZakenVrijgevenGegevens) {
         assertPolicy(policyService.readWerklijstRechten().zakenTakenVerdelen)
         // this can be a long-running operation so run it asynchronously
-        CoroutineScope(Dispatchers.IO).launch {
+        CoroutineScope(dispatcher).launch {
             zaakService.releaseZaken(
                 zaakUUIDs = restZakenVrijgevenGegevens.uuids,
                 explanation = restZakenVrijgevenGegevens.reden,

--- a/src/main/kotlin/nl/info/zac/util/CoroutineDispatcherProducer.kt
+++ b/src/main/kotlin/nl/info/zac/util/CoroutineDispatcherProducer.kt
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package nl.info.zac.util
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Produces a CoroutineDispatcher which can be injected in classes that need to run coroutines.
+ * Injecting this dispatcher in classes makes it possible to switch it to a test dispatcher in unit tests.
+ */
+@AllOpen
+@ApplicationScoped
+class CoroutineDispatcherProducer {
+
+    @Produces
+    fun provideDispatcher(): CoroutineDispatcher = Dispatchers.IO
+}

--- a/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/zaak/ZaakRestServiceTest.kt
@@ -17,6 +17,7 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import jakarta.enterprise.inject.Instance
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import net.atos.client.or.`object`.ObjectsClientService
 import net.atos.client.or.`object`.model.createORObject
@@ -150,7 +151,7 @@ class ZaakRestServiceTest : BehaviorSpec({
     val zrcClientService = mockk<ZrcClientService>()
     val ztcClientService = mockk<ZtcClientService>()
     val zaakHistoryService = mockk<ZaakHistoryService>()
-
+    val testDispatcher = StandardTestDispatcher()
     val zaakRestService = ZaakRestService(
         decisionService = decisionService,
         cmmnService = cmmnService,
@@ -182,7 +183,8 @@ class ZaakRestServiceTest : BehaviorSpec({
         flowableTaskService = flowableTaskService,
         restZaaktypeConverter = restZaaktypeConverter,
         zaakHistoryService = zaakHistoryService,
-        zgwApiService = zgwApiService
+        zgwApiService = zgwApiService,
+        dispatcher = testDispatcher
     )
 
     beforeEach {
@@ -434,9 +436,8 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { identityService.readUser(restZakenVerdeelGegevens.behandelaarGebruikersnaam!!) } returns user
 
         When("the assign zaken from a list function is called") {
-            runTest {
+            runTest(testDispatcher) {
                 zaakRestService.assignFromList(restZakenVerdeelGegevens)
-                testScheduler.advanceUntilIdle()
             }
 
             Then("the zaken are assigned to the group and user") {


### PR DESCRIPTION
Use Kotlin coroutines test dispatcher in unit test to hopefully fix flaky tests on GitHub.

Solves PZ-5570