### PR TITLE
chore: skip PR and merge queue builds on certain file and file type changes

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -38,15 +38,16 @@ permissions:
   # Required for uploading SARIF reports
   security-events: write
 
-# Only allow a single concurrent run per branch. Cancel in-progress runs on multiple pushes when not on main branch.  
+
+# Only allow a single concurrent run per branch. Cancel in-progress runs on multiple pushes when not on main branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'main')}}
 
+jobs:
   build:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: paths-ignore
     if: ${{ github.ref == 'refs/heads/main'}}
     outputs:
       branch_name: ${{ steps.gen_branch_name.outputs.BRANCH_NAME }}
@@ -117,7 +118,7 @@ concurrency:
           key: zac-jar-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   run-unit-tests:
-    needs: [build, paths-ignore]
+    needs: build
     if: ${{ github.ref == 'refs/heads/main'}}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -235,7 +236,7 @@ concurrency:
           echo "Next version tag: ${{ github.ref == 'refs/heads/main' && steps.get-tag-main.outputs.new_tag || steps.get-tag-non-main.outputs.new_tag }}"
 
   build-docker-image-and-run-itests:
-    needs: [build, paths-ignore, next-version]
+    needs: [build, next-version]
     # Do not run in the merge queue and do not run if the paths-ignore step defines it to skip
     # but always run for the main branch
     if: ${{ github.event_name != 'merge_group' || github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -237,8 +237,7 @@ jobs:
 
   build-docker-image-and-run-itests:
     needs: [build, next-version]
-    # Do not run in the merge queue and do not run if the paths-ignore step defines it to skip
-    # but always run for the main branch
+    # Do not run in the merge queue but always run for the main branch
     if: ${{ github.event_name != 'merge_group' || github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -6,7 +6,17 @@ name: Build, test & deploy
 
 on:
   pull_request:
+    paths-ignore:
+      # skip on changes to files which do not require a PR build
+      - '**.md'
+      - 'helm/**'
+      - 'renovate.json'
   merge_group:
+    paths-ignore:
+      # skip on changes to files which do not require a build in the merge queue
+      - '**.md'
+      - 'helm/**'
+      - 'renovate.json'
   workflow_dispatch:
   push:
     branches:
@@ -33,25 +43,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'main')}}
 
-jobs:
-  paths-ignore:
-    runs-on: ubuntu-24.04
-    outputs:
-      skip: ${{ steps.paths-ignore.outputs.skip }}
-    steps:
-      - name: Skip job when only Markdown files are changed
-        uses: kunitsucom/github-actions-paths-ignore-alternative@d1b27090d1a610f8cdde46d8d937a4a9c9127619 # v1.0.1
-        id: paths-ignore
-        with:
-          paths-ignore: |-
-            ^.*\.md$
-            ^helm/
-
   build:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: paths-ignore
-    if: ${{ needs.paths-ignore.outputs.skip != 'true' || github.ref == 'refs/heads/main'}}
+    if: ${{ github.ref == 'refs/heads/main'}}
     outputs:
       branch_name: ${{ steps.gen_branch_name.outputs.BRANCH_NAME }}
       build_number: ${{ steps.gen_build_number.outputs.BUILD_NUMBER }}
@@ -122,7 +118,7 @@ jobs:
 
   run-unit-tests:
     needs: [build, paths-ignore]
-    if: ${{ needs.paths-ignore.outputs.skip != 'true' || github.ref == 'refs/heads/main'}}
+    if: ${{ github.ref == 'refs/heads/main'}}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -242,7 +238,7 @@ jobs:
     needs: [build, paths-ignore, next-version]
     # Do not run in the merge queue and do not run if the paths-ignore step defines it to skip
     # but always run for the main branch
-    if: ${{ (github.event_name != 'merge_group' && needs.paths-ignore.outputs.skip != 'true') || github.ref == 'refs/heads/main'}}
+    if: ${{ github.event_name != 'merge_group' || github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -38,7 +38,6 @@ permissions:
   # Required for uploading SARIF reports
   security-events: write
 
-
 # Only allow a single concurrent run per branch. Cancel in-progress runs on multiple pushes when not on main branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -48,7 +47,6 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    if: ${{ github.ref == 'refs/heads/main'}}
     outputs:
       branch_name: ${{ steps.gen_branch_name.outputs.BRANCH_NAME }}
       build_number: ${{ steps.gen_build_number.outputs.BUILD_NUMBER }}
@@ -119,7 +117,6 @@ jobs:
 
   run-unit-tests:
     needs: build
-    if: ${{ github.ref == 'refs/heads/main'}}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,8 +6,17 @@ name: "CodeQL"
 
 on:
   pull_request:
-    branches: [main]
+    paths-ignore:
+      # skip on changes to files which do not require a PR build
+      - '**.md'
+      - 'helm/**'
+      - 'renovate.json'
   merge_group:
+    paths-ignore:
+      # skip on changes to files which do not require a PR build
+      - '**.md'
+      - 'helm/**'
+      - 'renovate.json'
   push:
     branches:
       - main
@@ -26,23 +35,9 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'main')}}
 
 jobs:
-  paths-ignore:
-    runs-on: ubuntu-24.04
-    outputs:
-      skip: ${{ steps.paths-ignore.outputs.skip }}
-    steps:
-      - name: Skip job when only Markdown files are changed
-        uses: kunitsucom/github-actions-paths-ignore-alternative@d1b27090d1a610f8cdde46d8d937a4a9c9127619 # v1.0.1
-        id: paths-ignore
-        with:
-          paths-ignore: |-
-            ^.*\.md$
-            ^helm/
-
   analyze:
     name: Analyze
     runs-on: ubuntu-24.04
-    needs: paths-ignore
     if: ${{ needs.paths-ignore.outputs.skip != 'true' }}
     permissions:
       actions: read
@@ -82,9 +77,7 @@ jobs:
 
   check_codeql_status:
     name: Check CodeQL Status
-    needs:
-      - analyze
-      - paths-ignore
+    needs: analyze
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,6 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-24.04
-    if: ${{ needs.paths-ignore.outputs.skip != 'true' }}
     permissions:
       actions: read
       contents: read
@@ -83,7 +82,7 @@ jobs:
       contents: read
       checks: read
       pull-requests: read
-    if: ${{ needs.paths-ignore.outputs.skip != 'true' && github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Check CodeQL Status
         uses: eldrick19/code-scanning-status-checker@868f78ef588214f12e365604583b7673d18941ce # v2.0.1

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 [![Codecov](https://codecov.io/gh/infonl/dimpact-zaakafhandelcomponent/branch/main/graph/badge.svg)](https://app.codecov.io/gh/infonl/dimpact-zaakafhandelcomponent/)
 [![License](https://img.shields.io/badge/License-EUPL_1.2-blue.svg)](https://opensource.org/licenses/https://opensource.org/license/eupl-1-2/)
 
-This repository contains the source code of the "zaakafhandelcomponent" (ZAC) developed for [Dimpact](https://www.dimpact.nl/).
+This repository contains the source code of the "zaakafhandelcomponent" (ZAC) developed mainly 
+for [Dimpact](https://www.dimpact.nl/), a cooperation of Dutch municipalities.
 The zaakafhandelcomponent is an open-source, generic, workflow-based component for managing 'zaken'
 in the context of [zaakgericht werken](https://www.noraonline.nl/wiki/Zaakgericht_Werken), a Dutch approach to case management.
-It is developed for Dimpact and used by Dutch municipalities.
 
 ZAC was initially [developed by Atos](https://github.com/NL-AMS-LOCGOV/zaakafhandelcomponent).
-Starting July 2023 the development of ZAC was taken over by Lifely and INFO, where INFO is a partner of Lifely.
+Starting July 2023 the development of ZAC was taken over by INFO, where INFO is a partner of Lifely.
 
 ## Contributing
 


### PR DESCRIPTION
Skip PR and merge queue builds on certain file and file type changes.

DRAFT PR only. Does not work at all I think. See e..g https://github.com/actions/runner/issues/2324 and https://stackoverflow.com/questions/71070064/github-workflow-excluding-paths-does-not-work

Solves PZ-5583