### PR TITLE
chore: set missing platform for OAB Docker images in Docker Compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -557,6 +557,7 @@ services:
 
   openarchiefbeheer-web:
     image: maykinmedia/open-archiefbeheer:0.1.0-beta.39@sha256:79f3c59248c6e7143606a096b0885e2acc2b1545a4ec1fb004c2d31bc6b61ca4
+    platform: linux/amd64
     environment: &web_env
       - ALLOWED_HOSTS="*"
       # We should be able to switch off 2FA with:
@@ -606,6 +607,7 @@ services:
 
   openarchiefbeheer-web-init:
     image: maykinmedia/open-archiefbeheer:0.1.0-beta.39@sha256:79f3c59248c6e7143606a096b0885e2acc2b1545a4ec1fb004c2d31bc6b61ca4
+    platform: linux/amd64
     environment: *web_env
     command: /setup_configuration.sh
     volumes:
@@ -619,6 +621,7 @@ services:
 
   openarchiefbeheer-celery:
     image: maykinmedia/open-archiefbeheer:0.1.0-beta.39@sha256:79f3c59248c6e7143606a096b0885e2acc2b1545a4ec1fb004c2d31bc6b61ca4
+    platform: linux/amd64
     command: /celery_worker.sh
     environment: *web_env
     healthcheck:
@@ -634,6 +637,7 @@ services:
 
   openarchiefbeheer-celery-beat:
     image: maykinmedia/open-archiefbeheer:0.1.0-beta.39@sha256:79f3c59248c6e7143606a096b0885e2acc2b1545a4ec1fb004c2d31bc6b61ca4
+    platform: linux/amd64
     command: /celery_beat.sh
     environment: *web_env
     depends_on:


### PR DESCRIPTION
Set missing platform for OAB Docker images in Docker Compose to fix 'The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested' warnings.

Solves PZ-5704