### PR TITLE
fix: revert changes that moved code to constructor instead of `ngOnInit`

### DIFF
--- a/src/main/app/src/app/zaken/besluit-edit/besluit-edit.component.ts
+++ b/src/main/app/src/app/zaken/besluit-edit/besluit-edit.component.ts
@@ -8,6 +8,7 @@ import {
   EventEmitter,
   Input,
   OnDestroy,
+  OnInit,
   Output,
 } from "@angular/core";
 import { FormGroup, Validators } from "@angular/forms";
@@ -39,7 +40,7 @@ import { ZakenService } from "../zaken.service";
   templateUrl: "./besluit-edit.component.html",
   styleUrls: ["./besluit-edit.component.less"],
 })
-export class BesluitEditComponent implements OnDestroy {
+export class BesluitEditComponent implements OnDestroy, OnInit {
   formConfig: FormConfig;
   @Input({ required: true }) besluit!: GeneratedType<"RestDecision">;
   @Input({ required: true }) zaak!: Zaak;
@@ -55,7 +56,9 @@ export class BesluitEditComponent implements OnDestroy {
     private informatieObjectenService: InformatieObjectenService,
     protected translate: TranslateService,
     public utilService: UtilService,
-  ) {
+  ) {}
+
+  ngOnInit(): void {
     this.formConfig = new FormConfigBuilder()
       .saveText("actie.wijzigen")
       .cancelText("actie.annuleren")

--- a/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
+++ b/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import { Component, Input, OnDestroy } from "@angular/core";
+import { Component, Input, OnDestroy, OnInit } from "@angular/core";
 import {
   AbstractControl,
   FormGroup,
@@ -40,7 +40,7 @@ import { ZakenService } from "../zaken.service";
   templateUrl: "./zaak-details-wijzigen.component.html",
   styleUrls: ["./zaak-details-wijzigen.component.less"],
 })
-export class CaseDetailsEditComponent implements OnDestroy {
+export class CaseDetailsEditComponent implements OnDestroy, OnInit {
   @Input({ required: true }) zaak!: Zaak; // GeneratedType<"RestZaak">;
   @Input({ required: true }) loggedInUser!: GeneratedType<"RestLoggedInUser">;
   @Input({ required: true }) sideNav!: MatDrawer;
@@ -65,7 +65,9 @@ export class CaseDetailsEditComponent implements OnDestroy {
     private zakenService: ZakenService,
     private referentieTabelService: ReferentieTabelService,
     private utilService: UtilService,
-  ) {
+  ) {}
+
+  ngOnInit() {
     this.formConfig = new FormConfigBuilder()
       .saveText("actie.opslaan")
       .cancelText("actie.annuleren")


### PR DESCRIPTION
Revert some changed from https://github.com/infonl/dimpact-zaakafhandelcomponent/pull/2781 that caused regression in two components due to moving logic from `ngOnInit` to the constructor

Solves [PZ-5710](https://dimpact.atlassian.net/browse/PZ-5710)