### PR TITLE
fix(zaak-details-wijzigen): enable reason field after location change

### DIFF
--- a/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
+++ b/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
@@ -346,6 +346,7 @@ export class CaseDetailsEditComponent implements OnDestroy, OnInit {
 
   locationChanged(update?: Geometry) {
     this.zaak.zaakgeometrie = update;
+    this.reasonField.formControl.enable();
   }
 
   private createZaakPatch(update: Record<string, any>) {

--- a/src/main/app/src/app/zaken/zoek/locatie-zoek/locatie-zoek.component.ts
+++ b/src/main/app/src/app/zaken/zoek/locatie-zoek/locatie-zoek.component.ts
@@ -224,13 +224,11 @@ export class LocatieZoekComponent implements OnInit, AfterViewInit, OnDestroy {
           LocationUtil.wktToPoint(this.nearestAddress.centroide_ll),
           true,
         );
-        this.reasonControl.enable();
       });
   }
 
   clearLocation() {
     this.setLocation();
-    this.reasonControl.enable();
   }
 
   private setLocation(geometry?: Geometry, fromSearch = true) {
@@ -256,6 +254,9 @@ export class LocatieZoekComponent implements OnInit, AfterViewInit, OnDestroy {
         }
     }
 
+    if(JSON.stringify(geometry) === JSON.stringify(this.initialLocation)) {
+      return
+    }
     this.locationChanged.emit(geometry);
   }
 
@@ -294,6 +295,7 @@ export class LocatieZoekComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   save(): void {
+    this.initialLocation = this.currentLocation;
     this.locatie.next(
       new GeometryGegevens(this.markerLocatie, this.reasonControl.value),
     );


### PR DESCRIPTION
Unlock the reason field for all three interactions for location change:
- unlink location
- set location via search dropdown
- set location via map click

Solves https://dimpact.atlassian.net/browse/PZ-5770