### PR TITLE
chore: add Dax to codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-*   @infonl/dimpact @hsiliev
+*   @infonl/dimpact @hsiliev @DaxRiool
 


### PR DESCRIPTION
Added Dax to codeowners file so that he is invited to review all pull requests. Also see: https://graphite.dev/guides/in-depth-guide-github-codeowners

Solves PZ-5803