### PR TITLE
chore: make starting of Objecten optional in Docker Compose setup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -193,6 +193,7 @@ services:
     depends_on:
       objecten-api-database:
         condition: service_healthy
+    profiles: [ "objecten", "itest" ]
 
   objecten-api-database:
     image: docker.io/postgis/postgis:17-3.4@sha256:d0b5a6ecab18997637f55a83cb4a9467391de5645916cfa1b6f2a8d19eee7be5
@@ -209,6 +210,7 @@ services:
       - POSTGRES_USER=objects
       - POSTGRES_PASSWORD=objects
       - POSTGRES_DB=objects
+    profiles: [ "objecten", "itest" ]
 
   objecten-api-import:
     image: docker.io/maykinmedia/objects-api:2.4.4@sha256:2980ce1b62c4ae9575003a694c700e06d0ed77a55e8214a4984aded2d9e7d8c4
@@ -222,6 +224,7 @@ services:
     depends_on:
       objecten-api.local:
         condition: service_healthy
+    profiles: [ "objecten", "itest" ]
 
   solr:
     image: docker.io/solr:9.7.0-slim@sha256:5eb3e2e6791020c6d098514594bc6bd16f2a95a7df0f855801af6f5af98169f5

--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -11,7 +11,7 @@ help()
 {
    echo "Starts the ZAC Docker Compose environment using the 1Password CLI tools to retrieve secrets."
    echo
-   echo "Syntax: $0 [-d|h|z|b|l|m|t|o|a]"
+   echo "Syntax: $0 [-d|h|z|b|l|m|t|o|n|a]"
    echo
    echo "General:"
    echo "   -d     Delete local Docker volume data before starting Docker Compose."
@@ -25,7 +25,8 @@ help()
    echo "Additional components:"
    echo "   -m     Start the containers used for handling metrics and traces."
    echo "   -t     Start containers used for integration testing."
-   echo "   -o     Start OpenNotificaties."
+   echo "   -o     Start Objecten (required e.g. for the Dimpact productaanvraag flow)."
+   echo "   -n     Start OpenNotificaties."
    echo "   -a     Start OpenArchiefbeheer."
    echo
 }
@@ -75,6 +76,9 @@ while getopts ':dhzblmtoa' OPTION; do
       profiles+=("itest")
       ;;
     o)
+      profiles+=("objecten")
+      ;;
+    n)
       profiles+=("opennotificaties")
       export OPENZAAK_NOTIFICATIONS_DISABLED=false
       ;;


### PR DESCRIPTION
Make starting of Objecten optional in Docker Compose setup to save startup time and resources for local development.

Solves PZ-5805