### PR TITLE
fix: added missing `--addr` argument to ZAC Helm Chart when OPA is run as a side-car container

### DIFF
--- a/charts/zac/Chart.yaml
+++ b/charts/zac/Chart.yaml
@@ -6,7 +6,7 @@
 apiVersion: v2
 name: zaakafhandelcomponent
 description: A Helm chart for installing Zaakafhandelcomponent
-version: 1.0.16
+version: 1.0.17
 appVersion: '3.0'
 icon: https://raw.githubusercontent.com/infonl/dimpact-zaakafhandelcomponent/49f8dee60948282b546ebdfdc5cff6f8bbef0305/docs/manuals/ZAC-gebruikershandleiding/images/pic.svg
 dependencies:

--- a/charts/zac/README.md
+++ b/charts/zac/README.md
@@ -1,6 +1,6 @@
 # zaakafhandelcomponent
 
-![Version: 1.0.16](https://img.shields.io/badge/Version-1.0.16-informational?style=flat-square) ![AppVersion: 3.0](https://img.shields.io/badge/AppVersion-3.0-informational?style=flat-square)
+![Version: 1.0.17](https://img.shields.io/badge/Version-1.0.17-informational?style=flat-square) ![AppVersion: 3.0](https://img.shields.io/badge/AppVersion-3.0-informational?style=flat-square)
 
 A Helm chart for installing Zaakafhandelcomponent
 

--- a/charts/zac/templates/deployment.yaml
+++ b/charts/zac/templates/deployment.yaml
@@ -121,6 +121,7 @@ spec:
           args:
             - run
             - --server
+            - --addr=0.0.0.0:8181
             - --ignore=.*  # exclude hidden dirs created by Kubernetes
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Added missing `--addr` argument to ZAC Helm Chart when OPA is run as a side-car container.

Solves PZ-5833