### PR TITLE
feat(search): allow for empty sorting

### DIFF
--- a/src/main/app/src/app/taken/taken-mijn/taken-mijn.component.html
+++ b/src/main/app/src/app/taken/taken-mijn/taken-mijn.component.html
@@ -7,7 +7,6 @@
   <table
     mat-table
     matSort
-    matSortDisableClear
     [matSortDirection]="dataSource.zoekParameters.sorteerRichting"
     [matSortActive]="dataSource.zoekParameters.sorteerVeld"
     multiTemplateDataRows

--- a/src/main/app/src/app/taken/taken-werkvoorraad/taken-werkvoorraad.component.html
+++ b/src/main/app/src/app/taken/taken-werkvoorraad/taken-werkvoorraad.component.html
@@ -10,7 +10,6 @@
   <table
     mat-table
     matSort
-    matSortDisableClear
     [matSortDirection]="dataSource.zoekParameters.sorteerRichting"
     [matSortActive]="dataSource.zoekParameters.sorteerVeld"
     multiTemplateDataRows

--- a/src/main/app/src/app/zaken/zaken-afgehandeld/zaken-afgehandeld.component.html
+++ b/src/main/app/src/app/zaken/zaken-afgehandeld/zaken-afgehandeld.component.html
@@ -7,7 +7,6 @@
   <table
     mat-table
     matSort
-    matSortDisableClear
     [matSortDirection]="dataSource.zoekParameters.sorteerRichting"
     [matSortActive]="dataSource.zoekParameters.sorteerVeld"
     multiTemplateDataRows

--- a/src/main/app/src/app/zaken/zaken-mijn/zaken-mijn.component.html
+++ b/src/main/app/src/app/zaken/zaken-mijn/zaken-mijn.component.html
@@ -7,7 +7,6 @@
   <table
     mat-table
     matSort
-    matSortDisableClear
     [matSortDirection]="dataSource.zoekParameters.sorteerRichting"
     [matSortActive]="dataSource.zoekParameters.sorteerVeld"
     multiTemplateDataRows

--- a/src/main/app/src/app/zaken/zaken-werkvoorraad/zaken-werkvoorraad.component.html
+++ b/src/main/app/src/app/zaken/zaken-werkvoorraad/zaken-werkvoorraad.component.html
@@ -10,7 +10,6 @@
   <table
     mat-table
     matSort
-    matSortDisableClear
     [matSortDirection]="dataSource.zoekParameters.sorteerRichting"
     [matSortActive]="dataSource.zoekParameters.sorteerVeld"
     multiTemplateDataRows

--- a/src/main/kotlin/net/atos/zac/search/SearchService.kt
+++ b/src/main/kotlin/net/atos/zac/search/SearchService.kt
@@ -73,10 +73,13 @@ class SearchService @Inject constructor(
         query.setParam("q.op", SimpleParams.AND_OPERATOR)
         query.rows = zoekParameters.rows
         query.start = zoekParameters.start
-        query.addSort(
-            zoekParameters.sortering.sorteerVeld.veld,
-            if (zoekParameters.sortering.richting == SorteerRichting.DESCENDING) SolrQuery.ORDER.desc else SolrQuery.ORDER.asc
-        )
+        if (zoekParameters.sortering.richting != SorteerRichting.NONE) {
+            query.addSort(
+                zoekParameters.sortering.sorteerVeld.veld,
+                if (zoekParameters.sortering.richting == SorteerRichting.DESCENDING) SolrQuery.ORDER.desc else SolrQuery.ORDER.asc
+            )
+        }
+
         if (zoekParameters.sortering.sorteerVeld != SorteerVeld.CREATED) {
             query.addSort(SorteerVeld.CREATED.veld, SolrQuery.ORDER.desc)
         }

--- a/src/main/kotlin/net/atos/zac/search/SearchService.kt
+++ b/src/main/kotlin/net/atos/zac/search/SearchService.kt
@@ -53,6 +53,7 @@ class SearchService @Inject constructor(
         ).build()
     }
 
+    @Suppress("LongMethod")
     fun zoek(zoekParameters: ZoekParameters): ZoekResultaat<out ZoekObject> {
         val query = SolrQuery("*:*")
         applyAllowedZaaktypenPolicy(query)

--- a/src/main/kotlin/net/atos/zac/shared/model/SorteerRichting.kt
+++ b/src/main/kotlin/net/atos/zac/shared/model/SorteerRichting.kt
@@ -6,15 +6,18 @@ package net.atos.zac.shared.model
 
 import net.atos.zac.shared.model.SorteerRichting.ASCENDING
 import net.atos.zac.shared.model.SorteerRichting.DESCENDING
+import net.atos.zac.shared.model.SorteerRichting.NONE
 
 enum class SorteerRichting(val value: String) {
     ASCENDING("asc"),
-    DESCENDING("desc")
+    DESCENDING("desc"),
+    NONE("")
 }
 
 fun fromValue(waarde: String?): SorteerRichting =
     when {
         DESCENDING.value == waarde -> DESCENDING
         ASCENDING.value == waarde -> ASCENDING
+        NONE.value == waarde -> NONE
         else -> throw IllegalArgumentException("Onbekende waarde '$waarde'")
     }


### PR DESCRIPTION
Allows for tables to remove the sorting and add the ability for the backend to search with non-sorting

Solves [PZ-2783](https://dimpact.atlassian.net/browse/PZ-2783)