### PR TITLE
chore: added documentation and integration test for optional ADDITIONAL_ALLOWED_FILE_TYPES environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,11 @@
 # ZAC environment variables
 # -------------------------
 
-# Optional parameter specifying comma-seperated allowed file types (without a leading '.' character)
-# for file uploads next to the default ones.
+# Optional variable specifying a comma-seperated list of allowed file type extensions (without a leading '.' character)
+# for file uploads in addition to the default hardcoded ones. E.g. "md,properties".
+# Note that if you specify any additional allowed file types, these may end up being stored
+# in the ZGW DRC API without a 'formaat' field (= media type) unless ZAC contains a mapping for the file type in question
+# to the related media type. This mapping is currently hardcoded.
 ADDITIONAL_ALLOWED_FILE_TYPES=
 # Keycloak ZAC realm
 AUTH_REALM=zaakafhandelcomponent

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@
 # ZAC environment variables
 # -------------------------
 
+# Optional parameter specifying comma-seperated allowed file types (without a leading '.' character)
+# for file uploads next to the default ones.
+ADDITIONAL_ALLOWED_FILE_TYPES=
 # Keycloak ZAC realm
 AUTH_REALM=zaakafhandelcomponent
 # Keycloak ZAC client

--- a/.env.tpl
+++ b/.env.tpl
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: EUPL-1.2+
 #
 
-# This file contains a list of environment variables that need to be set when running ZAC locally.
+# This file contains a list of environment variables that need to, or in case of optional variables can be, set when running ZAC locally.
 
 # To use this file you need to use the 1Password CLI extensions.
 # Please see the docs/INSTALL.md file for instructions.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -662,6 +662,7 @@ services:
     # By default, we use the most recent ZAC Docker Image. Change this if you wish to use a specific version.
     image: ${ZAC_DOCKER_IMAGE:-ghcr.io/infonl/zaakafhandelcomponent:latest}
     environment:
+      - ADDITIONAL_ALLOWED_FILE_TYPES=${ADDITIONAL_ALLOWED_FILE_TYPES:-}
       - AUTH_REALM=zaakafhandelcomponent
       - AUTH_RESOURCE=zaakafhandelcomponent
       - AUTH_SECRET=keycloakZaakafhandelcomponentClientSecret

--- a/src/itest/kotlin/nl/info/zac/itest/ConfigurationRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ConfigurationRestServiceTest.kt
@@ -111,7 +111,9 @@ class ConfigurationRestServiceTest : BehaviorSpec({
                 response.code shouldBe HTTP_STATUS_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                responseBody shouldEqualJson "[]"
+                responseBody shouldEqualJson """
+                    [ "dummyFileExtension1", "dummyFileExtension2"]
+                """.trimIndent()
             }
         }
         When("the gemeente name is retrieved") {

--- a/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
@@ -36,6 +36,11 @@ object ItestConfiguration {
 
     const val ACTIE_INTAKE_AFRONDEN = "INTAKE_AFRONDEN"
     const val ACTIE_ZAAK_AFHANDELEN = "ZAAK_AFHANDELEN"
+
+    /**
+     * Dummy additional allowed file types just for testing purposes.
+     */
+    const val ADDITIONAL_ALLOWED_FILE_TYPES = "dummyFileExtension1,dummyFileExtension2"
     const val BAG_MOCK_BASE_URI = "http://bag-wiremock.local:8080"
     const val BAG_TEST_ADRES_1_IDENTIFICATION = "0363200003761447"
     const val BETROKKENE_TYPE_NATUURLIJK_PERSOON = "NATUURLIJK_PERSOON"

--- a/src/itest/kotlin/nl/info/zac/itest/config/ProjectConfig.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ProjectConfig.kt
@@ -14,6 +14,7 @@ import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.client.KeycloakClient
 import nl.info.zac.itest.client.ZacClient
+import nl.info.zac.itest.config.ItestConfiguration.ADDITIONAL_ALLOWED_FILE_TYPES
 import nl.info.zac.itest.config.ItestConfiguration.BAG_MOCK_BASE_URI
 import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.KEYCLOAK_HEALTH_READY_URL
@@ -58,6 +59,7 @@ class ProjectConfig : AbstractProjectConfig() {
         ZAC_DEFAULT_DOCKER_IMAGE
     }
     private val dockerComposeEnvironment = mapOf(
+        "ADDITIONAL_ALLOWED_FILE_TYPES" to ADDITIONAL_ALLOWED_FILE_TYPES,
         "BAG_API_CLIENT_MP_REST_URL" to "$BAG_MOCK_BASE_URI/lvbag/individuelebevragingen/v2/",
         "KVK_API_CLIENT_MP_REST_URL" to KVK_MOCK_BASE_URI,
         "OFFICE_CONVERTER_CLIENT_MP_REST_URL" to OFFICE_CONVERTER_BASE_URI,


### PR DESCRIPTION
Added documentation and integration test for optional ADDITIONAL_ALLOWED_FILE_TYPES environment variable. Note that this env var is not currently used for backend validation when uploading a file. Also, it should in future probably be moved to a reference table instead of an environment variable.

Solves PZ-5883