### PR TITLE
chore: muted productaanvraag error handling

### DIFF
--- a/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
@@ -87,27 +87,24 @@ class ProductaanvraagService @Inject constructor(
             "Document toegevoegd tijdens het starten van de van de zaak vanuit een product aanvraag"
     }
 
-    @Suppress("TooGenericExceptionCaught")
     fun handleProductaanvraag(productaanvraagObjectUUID: UUID) {
-        try {
-            objectsClientService.readObject(productaanvraagObjectUUID).let {
-                if (isProductaanvraagDimpact(it)) {
-                    LOG.info { "Handle productaanvraag-Dimpact object UUID: $productaanvraagObjectUUID" }
-                    handleProductaanvraagDimpact(it)
-                }
+        productaanvraagObjectUUID
+            .runCatching(objectsClientService::readObject)
+            .onFailure { LOG.fine("Unable to read object with UUID: $productaanvraagObjectUUID") }
+            .onSuccess { modelObject ->
+                modelObject
+                    .takeIf(::isProductaanvraagDimpact)
+                    ?.runCatching {
+                        LOG.info("Handle productaanvraag-Dimpact object UUID: $productaanvraagObjectUUID")
+                        handleProductaanvraagDimpact(this)
+                    }?.onFailure {
+                        LOG.log(
+                            Level.WARNING,
+                            "Failed to handle productaanvraag-Dimpact object UUID: $productaanvraagObjectUUID",
+                            it
+                        )
+                    }
             }
-        } catch (runtimeException: RuntimeException) {
-            if (LOG.isLoggable(Level.FINE)) {
-                // Add the exception to the log message to make it easier to debug
-                LOG.log(
-                    Level.WARNING,
-                    "Failed to handle productaanvraag-Dimpact object UUID: $productaanvraagObjectUUID",
-                    runtimeException
-                )
-            } else {
-                LOG.warning("Failed to handle productaanvraag-Dimpact object UUID: $productaanvraagObjectUUID")
-            }
-        }
     }
 
     fun getAanvraaggegevens(productaanvraagObject: ModelObject): Map<String, Any> =
@@ -208,17 +205,18 @@ class ProductaanvraagService @Inject constructor(
                 if (initiatorAdded) {
                     LOG.warning(
                         "Multiple initiator betrokkenen found in productaanvraag for zaak '$zaak'. " +
-                            "Only the first one will be used."
+                                "Only the first one will be used."
                     )
                 } else {
                     addBetrokkene(betrokkene, ROLTYPE_OMSCHRIJVING_INITIATOR, zaak)
                 }
                 return true
             }
+
             ROLTYPE_OMSCHRIJVING_BEHANDELAAR -> {
                 LOG.warning(
                     "Betrokkene with role 'Behandelaar' is not supported in the mapping from a productaanvraag. " +
-                        "No betrokkene role created for zaak '$zaak'."
+                            "No betrokkene role created for zaak '$zaak'."
                 )
             }
 
@@ -239,36 +237,43 @@ class ProductaanvraagService @Inject constructor(
             Betrokkene.RolOmschrijvingGeneriek.ADVISEUR -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.ADVISEUR, zaak)
             }
+
             Betrokkene.RolOmschrijvingGeneriek.BELANGHEBBENDE -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.BELANGHEBBENDE, zaak)
             }
+
             Betrokkene.RolOmschrijvingGeneriek.BESLISSER -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.BESLISSER, zaak)
             }
+
             Betrokkene.RolOmschrijvingGeneriek.INITIATOR -> {
                 if (initiatorAdded) {
                     LOG.warning(
                         "Multiple initiator betrokkenen found in productaanvraag for zaak '$zaak'. " +
-                            "Only the first one will be used."
+                                "Only the first one will be used."
                     )
                 } else {
                     addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.INITIATOR, zaak)
                 }
                 return true
             }
+
             Betrokkene.RolOmschrijvingGeneriek.KLANTCONTACTER -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.KLANTCONTACTER, zaak)
             }
+
             Betrokkene.RolOmschrijvingGeneriek.MEDE_INITIATOR -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.MEDE_INITIATOR, zaak)
             }
+
             Betrokkene.RolOmschrijvingGeneriek.ZAAKCOORDINATOR -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.ZAAKCOORDINATOR, zaak)
             }
+
             else -> {
                 LOG.warning(
                     "Betrokkene with generic role '${betrokkene.rolOmschrijvingGeneriek}' is not supported in the " +
-                        "mapping from a productaanvraag. No role created for zaak '$zaak'."
+                            "mapping from a productaanvraag. No role created for zaak '$zaak'."
                 )
             }
         }
@@ -295,7 +300,7 @@ class ProductaanvraagService @Inject constructor(
             .firstOrNull()?.let { addRoles(betrokkene, it, zaak, roltypeOmschrijving) }
             ?: LOG.warning(
                 "Betrokkene with role '$roltypeOmschrijving' is not supported in the mapping from a " +
-                    "productaanvraag. No betrokkene role created for zaak '$zaak'."
+                        "productaanvraag. No betrokkene role created for zaak '$zaak'."
             )
     }
 
@@ -309,12 +314,13 @@ class ProductaanvraagService @Inject constructor(
         when {
             types.isEmpty() -> LOG.warning(
                 "No roltypen found for zaaktype '${zaak.zaaktype}' and ${prefix}roltype description " +
-                    "'$roltypeOmschrijving'. No betrokkene role created for zaak '$zaak'."
+                        "'$roltypeOmschrijving'. No betrokkene role created for zaak '$zaak'."
             )
+
             types.size > 1 -> LOG.warning(
                 "Multiple ${prefix}roltypen found for zaaktype '${zaak.zaaktype}', ${prefix}roltype description " +
-                    "'$roltypeOmschrijving' and zaak '$zaak'. " +
-                    "Using the first one (description: '${types.first().omschrijving}')."
+                        "'$roltypeOmschrijving' and zaak '$zaak'. " +
+                        "Using the first one (description: '${types.first().omschrijving}')."
             )
         }
     }
@@ -335,6 +341,7 @@ class ProductaanvraagService @Inject constructor(
                     zaak.url
                 )
             }
+
             betrokkene.vestigingsNummer != null -> {
                 addVestigingRole(
                     type,
@@ -342,10 +349,11 @@ class ProductaanvraagService @Inject constructor(
                     zaak.url
                 )
             }
+
             else -> {
                 LOG.warning(
                     "Betrokkene with ${prefix}roletype description `$roltypeOmschrijving` does not contain a BSN " +
-                        "or KVK vestigingsnummer. No betrokkene role created for zaak '$zaak'."
+                            "or KVK vestigingsnummer. No betrokkene role created for zaak '$zaak'."
                 )
             }
         }
@@ -431,16 +439,17 @@ class ProductaanvraagService @Inject constructor(
     private fun handleProductaanvraagDimpact(productaanvraagObject: ModelObject) {
         LOG.fine { "Start handling productaanvraag with object URL: ${productaanvraagObject.url}" }
         val productaanvraag = getProductaanvraag(productaanvraagObject)
-        val zaakafhandelparameters = zaakafhandelParameterBeheerService.findActiveZaakafhandelparametersByProductaanvraagtype(
-            productaanvraag.type
-        )
+        val zaakafhandelparameters =
+            zaakafhandelParameterBeheerService.findActiveZaakafhandelparametersByProductaanvraagtype(
+                productaanvraag.type
+            )
         if (zaakafhandelparameters.isNotEmpty()) {
             try {
                 if (zaakafhandelparameters.size > 1) {
                     LOG.warning(
                         "Multiple zaakafhandelparameters found for productaanvraag type '${productaanvraag.type}'. " +
-                            "Using the first one with zaaktype UUID: '${zaakafhandelparameters.first().zaakTypeUUID}' " +
-                            "and zaaktype omschrijving: '${zaakafhandelparameters.first().zaaktypeOmschrijving}'."
+                                "Using the first one with zaaktype UUID: '${zaakafhandelparameters.first().zaakTypeUUID}' " +
+                                "and zaaktype omschrijving: '${zaakafhandelparameters.first().zaaktypeOmschrijving}'."
                     )
                 }
                 val firstZaakafhandelparameters = zaakafhandelparameters.first()
@@ -469,8 +478,8 @@ class ProductaanvraagService @Inject constructor(
     private fun isProductaanvraagDimpact(productaanvraagObject: ModelObject) =
         productaanvraagObject.record.data.let {
             it.containsKey(PRODUCTAANVRAAG_FORMULIER_VELD_BRON) &&
-                it.containsKey(PRODUCTAANVRAAG_FORMULIER_VELD_TYPE) &&
-                it.containsKey(PRODUCTAANVRAAG_FORMULIER_VELD_AANVRAAGGEGEVENS)
+                    it.containsKey(PRODUCTAANVRAAG_FORMULIER_VELD_TYPE) &&
+                    it.containsKey(PRODUCTAANVRAAG_FORMULIER_VELD_AANVRAAGGEGEVENS)
         }
 
     private fun pairProductaanvraagInfoWithZaak(
@@ -542,9 +551,9 @@ class ProductaanvraagService @Inject constructor(
 
     private fun generateZaakExplanationFromProductaanvraag(productaanvraag: ProductaanvraagDimpact): String =
         (
-            "Aangemaakt vanuit ${productaanvraag.bron.naam} met kenmerk '${productaanvraag.bron.kenmerk}'." +
-                (productaanvraag.zaakgegevens?.toelichting?.let { " $it" } ?: "")
-            )
+                "Aangemaakt vanuit ${productaanvraag.bron.naam} met kenmerk '${productaanvraag.bron.kenmerk}'." +
+                        (productaanvraag.zaakgegevens?.toelichting?.let { " $it" } ?: "")
+                )
             // truncate to maximum length allowed by the ZGW APIs
             .take(TOELICHTING_MAX_LENGTH)
 

--- a/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
@@ -205,18 +205,17 @@ class ProductaanvraagService @Inject constructor(
                 if (initiatorAdded) {
                     LOG.warning(
                         "Multiple initiator betrokkenen found in productaanvraag for zaak '$zaak'. " +
-                                "Only the first one will be used."
+                            "Only the first one will be used."
                     )
                 } else {
                     addBetrokkene(betrokkene, ROLTYPE_OMSCHRIJVING_INITIATOR, zaak)
                 }
                 return true
             }
-
             ROLTYPE_OMSCHRIJVING_BEHANDELAAR -> {
                 LOG.warning(
                     "Betrokkene with role 'Behandelaar' is not supported in the mapping from a productaanvraag. " +
-                            "No betrokkene role created for zaak '$zaak'."
+                        "No betrokkene role created for zaak '$zaak'."
                 )
             }
 
@@ -237,43 +236,36 @@ class ProductaanvraagService @Inject constructor(
             Betrokkene.RolOmschrijvingGeneriek.ADVISEUR -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.ADVISEUR, zaak)
             }
-
             Betrokkene.RolOmschrijvingGeneriek.BELANGHEBBENDE -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.BELANGHEBBENDE, zaak)
             }
-
             Betrokkene.RolOmschrijvingGeneriek.BESLISSER -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.BESLISSER, zaak)
             }
-
             Betrokkene.RolOmschrijvingGeneriek.INITIATOR -> {
                 if (initiatorAdded) {
                     LOG.warning(
                         "Multiple initiator betrokkenen found in productaanvraag for zaak '$zaak'. " +
-                                "Only the first one will be used."
+                            "Only the first one will be used."
                     )
                 } else {
                     addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.INITIATOR, zaak)
                 }
                 return true
             }
-
             Betrokkene.RolOmschrijvingGeneriek.KLANTCONTACTER -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.KLANTCONTACTER, zaak)
             }
-
             Betrokkene.RolOmschrijvingGeneriek.MEDE_INITIATOR -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.MEDE_INITIATOR, zaak)
             }
-
             Betrokkene.RolOmschrijvingGeneriek.ZAAKCOORDINATOR -> {
                 addBetrokkeneGeneriek(betrokkene, OmschrijvingGeneriekEnum.ZAAKCOORDINATOR, zaak)
             }
-
             else -> {
                 LOG.warning(
                     "Betrokkene with generic role '${betrokkene.rolOmschrijvingGeneriek}' is not supported in the " +
-                            "mapping from a productaanvraag. No role created for zaak '$zaak'."
+                        "mapping from a productaanvraag. No role created for zaak '$zaak'."
                 )
             }
         }
@@ -300,7 +292,7 @@ class ProductaanvraagService @Inject constructor(
             .firstOrNull()?.let { addRoles(betrokkene, it, zaak, roltypeOmschrijving) }
             ?: LOG.warning(
                 "Betrokkene with role '$roltypeOmschrijving' is not supported in the mapping from a " +
-                        "productaanvraag. No betrokkene role created for zaak '$zaak'."
+                    "productaanvraag. No betrokkene role created for zaak '$zaak'."
             )
     }
 
@@ -314,13 +306,12 @@ class ProductaanvraagService @Inject constructor(
         when {
             types.isEmpty() -> LOG.warning(
                 "No roltypen found for zaaktype '${zaak.zaaktype}' and ${prefix}roltype description " +
-                        "'$roltypeOmschrijving'. No betrokkene role created for zaak '$zaak'."
+                    "'$roltypeOmschrijving'. No betrokkene role created for zaak '$zaak'."
             )
-
             types.size > 1 -> LOG.warning(
                 "Multiple ${prefix}roltypen found for zaaktype '${zaak.zaaktype}', ${prefix}roltype description " +
-                        "'$roltypeOmschrijving' and zaak '$zaak'. " +
-                        "Using the first one (description: '${types.first().omschrijving}')."
+                    "'$roltypeOmschrijving' and zaak '$zaak'. " +
+                    "Using the first one (description: '${types.first().omschrijving}')."
             )
         }
     }
@@ -341,7 +332,6 @@ class ProductaanvraagService @Inject constructor(
                     zaak.url
                 )
             }
-
             betrokkene.vestigingsNummer != null -> {
                 addVestigingRole(
                     type,
@@ -349,11 +339,10 @@ class ProductaanvraagService @Inject constructor(
                     zaak.url
                 )
             }
-
             else -> {
                 LOG.warning(
                     "Betrokkene with ${prefix}roletype description `$roltypeOmschrijving` does not contain a BSN " +
-                            "or KVK vestigingsnummer. No betrokkene role created for zaak '$zaak'."
+                        "or KVK vestigingsnummer. No betrokkene role created for zaak '$zaak'."
                 )
             }
         }
@@ -439,17 +428,16 @@ class ProductaanvraagService @Inject constructor(
     private fun handleProductaanvraagDimpact(productaanvraagObject: ModelObject) {
         LOG.fine { "Start handling productaanvraag with object URL: ${productaanvraagObject.url}" }
         val productaanvraag = getProductaanvraag(productaanvraagObject)
-        val zaakafhandelparameters =
-            zaakafhandelParameterBeheerService.findActiveZaakafhandelparametersByProductaanvraagtype(
-                productaanvraag.type
-            )
+        val zaakafhandelparameters = zaakafhandelParameterBeheerService.findActiveZaakafhandelparametersByProductaanvraagtype(
+            productaanvraag.type
+        )
         if (zaakafhandelparameters.isNotEmpty()) {
             try {
                 if (zaakafhandelparameters.size > 1) {
                     LOG.warning(
                         "Multiple zaakafhandelparameters found for productaanvraag type '${productaanvraag.type}'. " +
-                                "Using the first one with zaaktype UUID: '${zaakafhandelparameters.first().zaakTypeUUID}' " +
-                                "and zaaktype omschrijving: '${zaakafhandelparameters.first().zaaktypeOmschrijving}'."
+                            "Using the first one with zaaktype UUID: '${zaakafhandelparameters.first().zaakTypeUUID}' " +
+                            "and zaaktype omschrijving: '${zaakafhandelparameters.first().zaaktypeOmschrijving}'."
                     )
                 }
                 val firstZaakafhandelparameters = zaakafhandelparameters.first()
@@ -478,8 +466,8 @@ class ProductaanvraagService @Inject constructor(
     private fun isProductaanvraagDimpact(productaanvraagObject: ModelObject) =
         productaanvraagObject.record.data.let {
             it.containsKey(PRODUCTAANVRAAG_FORMULIER_VELD_BRON) &&
-                    it.containsKey(PRODUCTAANVRAAG_FORMULIER_VELD_TYPE) &&
-                    it.containsKey(PRODUCTAANVRAAG_FORMULIER_VELD_AANVRAAGGEGEVENS)
+                it.containsKey(PRODUCTAANVRAAG_FORMULIER_VELD_TYPE) &&
+                it.containsKey(PRODUCTAANVRAAG_FORMULIER_VELD_AANVRAAGGEGEVENS)
         }
 
     private fun pairProductaanvraagInfoWithZaak(
@@ -551,9 +539,9 @@ class ProductaanvraagService @Inject constructor(
 
     private fun generateZaakExplanationFromProductaanvraag(productaanvraag: ProductaanvraagDimpact): String =
         (
-                "Aangemaakt vanuit ${productaanvraag.bron.naam} met kenmerk '${productaanvraag.bron.kenmerk}'." +
-                        (productaanvraag.zaakgegevens?.toelichting?.let { " $it" } ?: "")
-                )
+            "Aangemaakt vanuit ${productaanvraag.bron.naam} met kenmerk '${productaanvraag.bron.kenmerk}'." +
+                (productaanvraag.zaakgegevens?.toelichting?.let { " $it" } ?: "")
+            )
             // truncate to maximum length allowed by the ZGW APIs
             .take(TOELICHTING_MAX_LENGTH)
 

--- a/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
@@ -97,7 +97,7 @@ class ProductaanvraagService @Inject constructor(
                 }
             }
         } catch (runtimeException: RuntimeException) {
-            if (LOG.isDebugEnabled) {
+            if (LOG.isLoggable(Level.FINE)) {
                 // Add the exception to the log message to make it easier to debug
                 LOG.log(
                     Level.WARNING,

--- a/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
@@ -97,11 +97,16 @@ class ProductaanvraagService @Inject constructor(
                 }
             }
         } catch (runtimeException: RuntimeException) {
-            LOG.log(
-                Level.WARNING,
-                "Failed to handle productaanvraag-Dimpact object UUID: $productaanvraagObjectUUID",
-                runtimeException
-            )
+            if (LOG.isDebugEnabled) {
+                // Add the exception to the log message to make it easier to debug
+                LOG.log(
+                    Level.WARNING,
+                    "Failed to handle productaanvraag-Dimpact object UUID: $productaanvraagObjectUUID",
+                    runtimeException
+                )
+            } else {
+                LOG.warning("Failed to handle productaanvraag-Dimpact object UUID: $productaanvraagObjectUUID")
+            }
         }
     }
 

--- a/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -853,7 +853,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
     }
     Given(
         """
-        a productaanvraag-dimpact object registration object can't be read and throws a RuntimeException
+        a productaanvraag-dimpact object registration object is not a productaanvraag type
         """
     ) {
         val productAanvraagObjectUUID = UUID.randomUUID()

--- a/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -851,6 +851,31 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             }
         }
     }
+    Given(
+        """
+        a productaanvraag-dimpact object registration object can't be read and throws a RuntimeException
+        """
+    ) {
+        val productAanvraagObjectUUID = UUID.randomUUID()
+        every { objectsClientService.readObject(productAanvraagObjectUUID) } throws RuntimeException("Failed")
+
+        When("the productaanvraag is handled") {
+            productaanvraagService.handleProductaanvraag(productAanvraagObjectUUID)
+
+            Then(
+                """
+                no exception is thrown, and no further actions are taken
+                """
+            ) {
+                verify(exactly = 0) {
+                    inboxProductaanvraagService.create(any())
+                    zgwApiService.createZaak(any())
+                    zrcClientService.createZaakobject(any())
+                    cmmnService.startCase(any(), any(), any(), any())
+                }
+            }
+        }
+    }
     Given("a list of bijlage URIs and a zaak URI") {
         val bijlageURIs = listOf(URI("dummyURI1"), URI("dummyURI2"))
         val enkelvoudigInformatieobjecten = listOf(


### PR DESCRIPTION
Do not log whole stack trace (except for debugging) when we fail to handle a productaanvraag-Dimpact object.

Solves PZ-6037