### PR TITLE
chore: fix duplicate operation id warnings when generating OpenAPI spec

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,8 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.github.gradle.node.npm.task.NpmTask
 import io.gitlab.arturbosch.detekt.Detekt
-import io.smallrye.openapi.api.OpenApiConfig
+import io.smallrye.openapi.api.OpenApiConfig.DuplicateOperationIdBehavior
+import io.smallrye.openapi.api.OpenApiConfig.OperationIdStrategy
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 import java.util.Locale
 
@@ -276,7 +277,11 @@ node {
 smallryeOpenApi {
     infoTitle.set("Zaakafhandelcomponent backend API")
     schemaFilename.set("META-INF/openapi/openapi")
-    operationIdStrategy.set(OpenApiConfig.OperationIdStrategy.METHOD)
+    operationIdStrategy.set(OperationIdStrategy.METHOD)
+    // note that the duplicateOperationIdBehavior property is not yet working, but we add it
+    // anyway, hoping that the following issue will be resolved in a future version of the plugin:
+    // https://github.com/smallrye/smallrye-open-api/issues/2230
+    duplicateOperationIdBehavior.set(DuplicateOperationIdBehavior.FAIL)
     outputFileTypeFilter.set("YAML")
 }
 

--- a/src/main/java/net/atos/zac/app/formulieren/FormulierDefinitieRESTService.java
+++ b/src/main/java/net/atos/zac/app/formulieren/FormulierDefinitieRESTService.java
@@ -35,7 +35,7 @@ public class FormulierDefinitieRESTService {
     private PolicyService policyService;
 
     @GET
-    public List<RESTFormulierDefinitie> list() {
+    public List<RESTFormulierDefinitie> listFormDefinitions() {
         assertPolicy(policyService.readOverigeRechten().beheren());
         return service.listFormulierDefinities().stream()
                 .map(formulierDefinitie -> converter.convert(formulierDefinitie, false))
@@ -43,7 +43,7 @@ public class FormulierDefinitieRESTService {
     }
 
     @POST
-    public RESTFormulierDefinitie create(final RESTFormulierDefinitie restFormulierDefinitie) {
+    public RESTFormulierDefinitie createFormDefinition(final RESTFormulierDefinitie restFormulierDefinitie) {
         assertPolicy(policyService.readOverigeRechten().beheren());
         return converter.convert(
                 service.createFormulierDefinitie(converter.convert(restFormulierDefinitie)), true);
@@ -51,7 +51,7 @@ public class FormulierDefinitieRESTService {
 
     @GET
     @Path("{id}")
-    public RESTFormulierDefinitie read(@PathParam("id") final long id) {
+    public RESTFormulierDefinitie readFormDefinition(@PathParam("id") final long id) {
         assertPolicy(policyService.readOverigeRechten().beheren());
         return converter.convert(
                 service.readFormulierDefinitie(id), true);
@@ -59,13 +59,13 @@ public class FormulierDefinitieRESTService {
 
     @GET
     @Path("runtime/{systeemnaam}")
-    public RESTFormulierDefinitie find(@PathParam("systeemnaam") final String systeemnaam) {
+    public RESTFormulierDefinitie findFormDefinition(@PathParam("systeemnaam") final String systeemnaam) {
         assertPolicy(policyService.readOverigeRechten().beheren());
         return converter.convert(service.readFormulierDefinitie(systeemnaam), true);
     }
 
     @PUT
-    public RESTFormulierDefinitie update(final RESTFormulierDefinitie restFormulierDefinitie) {
+    public RESTFormulierDefinitie updateFormDefinition(final RESTFormulierDefinitie restFormulierDefinitie) {
         assertPolicy(policyService.readOverigeRechten().beheren());
         return converter.convert(
                 service.updateFormulierDefinitie(converter.convert(restFormulierDefinitie)), true);
@@ -73,7 +73,7 @@ public class FormulierDefinitieRESTService {
 
     @DELETE
     @Path("{id}")
-    public void delete(@PathParam("id") final long id) {
+    public void deleteFormDefinition(@PathParam("id") final long id) {
         assertPolicy(policyService.readOverigeRechten().beheren());
         service.deleteFormulierDefinitie(id);
     }

--- a/src/main/java/net/atos/zac/app/inboxdocumenten/InboxDocumentenRESTService.java
+++ b/src/main/java/net/atos/zac/app/inboxdocumenten/InboxDocumentenRESTService.java
@@ -51,9 +51,6 @@ public class InboxDocumentenRESTService {
     private ZrcClientService zrcClientService;
 
     @Inject
-    private RESTInboxDocumentConverter inboxDocumentConverter;
-
-    @Inject
     private RESTInboxDocumentListParametersConverter listParametersConverter;
 
     @Inject
@@ -63,7 +60,7 @@ public class InboxDocumentenRESTService {
 
     @PUT
     @Path("")
-    public RESTResultaat<RESTInboxDocument> list(final RESTInboxDocumentListParameters restListParameters) {
+    public RESTResultaat<RESTInboxDocument> listInboxDocuments(final RESTInboxDocumentListParameters restListParameters) {
         PolicyService.assertPolicy(policyService.readWerklijstRechten().inbox());
         final InboxDocumentListParameters listParameters = listParametersConverter.convert(restListParameters);
         var inboxDocuments = inboxDocumentenService.list(listParameters);
@@ -75,14 +72,14 @@ public class InboxDocumentenRESTService {
                 )
         ).toList();
         return new RESTResultaat<>(
-                inboxDocumentConverter.convert(inboxDocuments, informationObjectTypeUUIDs),
+                RESTInboxDocumentConverter.convert(inboxDocuments, informationObjectTypeUUIDs),
                 inboxDocumentenService.count(listParameters)
         );
     }
 
     @DELETE
     @Path("{id}")
-    public void delete(@PathParam("id") final long id) {
+    public void deleteInboxDocument(@PathParam("id") final long id) {
         PolicyService.assertPolicy(policyService.readWerklijstRechten().inbox());
         final Optional<InboxDocument> inboxDocument = inboxDocumentenService.find(id);
         if (inboxDocument.isEmpty()) {

--- a/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTService.java
+++ b/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTService.java
@@ -86,7 +86,7 @@ public class OntkoppeldeDocumentenRESTService {
 
     @PUT
     @Path("")
-    public RESTResultaat<RESTOntkoppeldDocument> list(final RESTOntkoppeldDocumentListParameters restListParameters) {
+    public RESTResultaat<RESTOntkoppeldDocument> listDetachedDocuments(final RESTOntkoppeldDocumentListParameters restListParameters) {
         assertPolicy(policyService.readWerklijstRechten().inbox());
         final OntkoppeldDocumentListParameters listParameters = listParametersConverter.convert(restListParameters);
         final OntkoppeldeDocumentenResultaat resultaat = ontkoppeldeDocumentenService.getResultaat(listParameters);
@@ -115,7 +115,7 @@ public class OntkoppeldeDocumentenRESTService {
 
     @DELETE
     @Path("{id}")
-    public void delete(@PathParam("id") final long id) {
+    public void deleteDetachedDocument(@PathParam("id") final long id) {
         assertPolicy(policyService.readWerklijstRechten().ontkoppeldeDocumentenVerwijderen());
         final Optional<OntkoppeldDocument> ontkoppeldDocument = ontkoppeldeDocumentenService.find(id);
         if (ontkoppeldDocument.isEmpty()) {

--- a/src/main/java/net/atos/zac/app/productaanvragen/InboxProductaanvragenRESTService.java
+++ b/src/main/java/net/atos/zac/app/productaanvragen/InboxProductaanvragenRESTService.java
@@ -60,7 +60,7 @@ public class InboxProductaanvragenRESTService {
 
     @PUT
     @Path("")
-    public RESTResultaat<RESTInboxProductaanvraag> list(final RESTInboxProductaanvraagListParameters restListParameters) {
+    public RESTResultaat<RESTInboxProductaanvraag> listInboxProductaanvragen(final RESTInboxProductaanvraagListParameters restListParameters) {
         assertPolicy(policyService.readWerklijstRechten().inbox());
         final InboxProductaanvraagListParameters listParameters = listParametersConverter.convert(restListParameters);
         final InboxProductaanvraagResultaat resultaat = inboxProductaanvraagService.list(listParameters);
@@ -94,7 +94,7 @@ public class InboxProductaanvragenRESTService {
 
     @DELETE
     @Path("{id}")
-    public void delete(@PathParam("id") final long id) {
+    public void deleteInboxProductaanvraag(@PathParam("id") final long id) {
         PolicyService.assertPolicy(policyService.readWerklijstRechten().inboxProductaanvragenVerwijderen());
         inboxProductaanvraagService.delete(id);
     }

--- a/src/main/java/net/atos/zac/app/productaanvragen/InboxProductaanvragenRESTService.java
+++ b/src/main/java/net/atos/zac/app/productaanvragen/InboxProductaanvragenRESTService.java
@@ -60,7 +60,9 @@ public class InboxProductaanvragenRESTService {
 
     @PUT
     @Path("")
-    public RESTResultaat<RESTInboxProductaanvraag> listInboxProductaanvragen(final RESTInboxProductaanvraagListParameters restListParameters) {
+    public RESTResultaat<RESTInboxProductaanvraag> listInboxProductaanvragen(
+            final RESTInboxProductaanvraagListParameters restListParameters
+    ) {
         assertPolicy(policyService.readWerklijstRechten().inbox());
         final InboxProductaanvraagListParameters listParameters = listParametersConverter.convert(restListParameters);
         final InboxProductaanvraagResultaat resultaat = inboxProductaanvraagService.list(listParameters);

--- a/src/main/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/admin/ZaakafhandelParametersRestService.kt
@@ -192,28 +192,17 @@ class ZaakafhandelParametersRestService @Inject constructor(
     ): List<RESTZaakbeeindigReden> =
         createHardcodedZaakTerminationReasons() + readManagedZaakTerminationReasons(zaaktypeUUID)
 
-    private fun createHardcodedZaakTerminationReasons() =
-        listOf(
-            RESTZaakbeeindigReden().apply {
-                id = INADMISSIBLE_TERMINATION_ID
-                naam = INADMISSIBLE_TERMINATION_REASON
-            }
-        )
-
-    private fun readManagedZaakTerminationReasons(zaaktypeUUID: UUID?): List<RESTZaakbeeindigReden> =
-        zaakafhandelParameterService.readZaakafhandelParameters(zaaktypeUUID).zaakbeeindigParameters
-            .map { it.zaakbeeindigReden }
-            .let { RESTZaakbeeindigRedenConverter.convertZaakbeeindigRedenen(it) }
-
     /**
-     * Retrieve all resultaattypes for a zaaktype
+     * Retrieve all resultaattypes for a zaaktype.
+     * This function is identical except for the policy check to [nl.info.zac.app.zaak.ZaakRestService.listResultaattypesForZaaktype]
+     * and should be merged with that function.
      *
      * @param zaaktypeUUID the id of the zaaktype
      * @return list of resultaattypes
      */
     @GET
     @Path("resultaattypes/{zaaktypeUUID}")
-    fun listResultaattypes(@PathParam("zaaktypeUUID") zaaktypeUUID: UUID): List<RestResultaattype> {
+    fun listResultaattypesForZaaktypeForAdmins(@PathParam("zaaktypeUUID") zaaktypeUUID: UUID): List<RestResultaattype> {
         assertPolicy(policyService.readOverigeRechten().beheren)
         return ztcClientService.readResultaattypen(
             ztcClientService.readZaaktype(zaaktypeUUID).url
@@ -227,7 +216,7 @@ class ZaakafhandelParametersRestService @Inject constructor(
      */
     @GET
     @Path("formulierdefinities")
-    fun listFormulierDefinities(): List<RESTTaakFormulierDefinitie> =
+    fun listTaskFormDefinitions(): List<RESTTaakFormulierDefinitie> =
         FormulierDefinitie.entries.toTypedArray()
             .map {
                 RESTTaakFormulierDefinitie(
@@ -284,6 +273,19 @@ class ZaakafhandelParametersRestService @Inject constructor(
 
         smartDocumentsTemplatesService.storeTemplatesMapping(restTemplateGroups, zaakafhandelParameterUUID)
     }
+
+    private fun createHardcodedZaakTerminationReasons() =
+        listOf(
+            RESTZaakbeeindigReden().apply {
+                id = INADMISSIBLE_TERMINATION_ID
+                naam = INADMISSIBLE_TERMINATION_REASON
+            }
+        )
+
+    private fun readManagedZaakTerminationReasons(zaaktypeUUID: UUID?): List<RESTZaakbeeindigReden> =
+        zaakafhandelParameterService.readZaakafhandelParameters(zaaktypeUUID).zaakbeeindigParameters
+            .map { it.zaakbeeindigReden }
+            .let { RESTZaakbeeindigRedenConverter.convertZaakbeeindigRedenen(it) }
 
     private fun checkIfProductaanvraagtypeIsNotAlreadyInUse(
         productaanvraagtype: String,

--- a/src/main/kotlin/net/atos/zac/app/task/TaskRestService.kt
+++ b/src/main/kotlin/net/atos/zac/app/task/TaskRestService.kt
@@ -256,9 +256,9 @@ class TaskRestService @Inject constructor(
         zaakVariabelenService.readProcessZaakdata(restTask.zaakUuid)
             .filterNot {
                 it.key.equals(ZaakVariabelenService.VAR_ZAAK_UUID) ||
-                        it.key.equals(
-                            ZaakVariabelenService.VAR_ZAAKTYPE_UUUID
-                        )
+                    it.key.equals(
+                        ZaakVariabelenService.VAR_ZAAKTYPE_UUUID
+                    )
             }
 
     private fun processHardCodedFormTask(restTask: RestTask, zaak: Zaak): Task {

--- a/src/main/kotlin/nl/info/zac/app/search/SearchRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/SearchRestService.kt
@@ -50,7 +50,7 @@ class SearchRestService @Inject constructor(
 ) {
     @PUT
     @Path("list")
-    fun list(restZoekParameters: RestZoekParameters): RestZoekResultaat<out AbstractRestZoekObject?> {
+    fun listSearchResults(restZoekParameters: RestZoekParameters): RestZoekResultaat<out AbstractRestZoekObject> {
         when (restZoekParameters.type) {
             ZoekObjectType.ZAAK, ZoekObjectType.TAAK -> PolicyService.assertPolicy(
                 policyService.readWerklijstRechten().zakenTaken

--- a/src/test/kotlin/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTServiceTest.kt
@@ -116,7 +116,8 @@ class OntkoppeldeDocumentenRESTServiceTest : BehaviorSpec({
         } throws ZgwErrorException(ZgwError(null, null, null, 400, null, null))
 
         When("the delete endpoint is called with the id of that document") {
-            val exception = shouldThrow<ZgwErrorException> { ontkoppeldeDocumentenRESTService.deleteDetachedDocument(document.id) }
+            val exception =
+                shouldThrow<ZgwErrorException> { ontkoppeldeDocumentenRESTService.deleteDetachedDocument(document.id) }
 
             Then("the exception from OpenZaak is rethrown") {
                 exception.zgwError.status shouldBe 400
@@ -146,7 +147,12 @@ class OntkoppeldeDocumentenRESTServiceTest : BehaviorSpec({
         } returns mutableListOf(zaakInformatieObject)
 
         When("the delete endpoint is called with the id of that document") {
-            val exception = shouldThrow<IllegalStateException> { ontkoppeldeDocumentenRESTService.deleteDetachedDocument(document.id) }
+            val exception =
+                shouldThrow<IllegalStateException> {
+                    ontkoppeldeDocumentenRESTService.deleteDetachedDocument(
+                        document.id
+                    )
+                }
 
             Then("the an IllegalStateException should be thrown") {
                 exception shouldNotBe null

--- a/src/test/kotlin/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTServiceTest.kt
@@ -64,7 +64,7 @@ class OntkoppeldeDocumentenRESTServiceTest : BehaviorSpec({
         } returns Optional.empty()
 
         When("the delete endpoint is called with that id") {
-            ontkoppeldeDocumentenRESTService.delete(id)
+            ontkoppeldeDocumentenRESTService.deleteDetachedDocument(id)
 
             Then("there are no exceptions") {
             }
@@ -90,7 +90,7 @@ class OntkoppeldeDocumentenRESTServiceTest : BehaviorSpec({
         } just runs
 
         When("the delete endpoint is called with the id of that document") {
-            ontkoppeldeDocumentenRESTService.delete(document.id)
+            ontkoppeldeDocumentenRESTService.deleteDetachedDocument(document.id)
 
             Then("the document is deleted") {
                 verify(exactly = 1) {
@@ -116,7 +116,7 @@ class OntkoppeldeDocumentenRESTServiceTest : BehaviorSpec({
         } throws ZgwErrorException(ZgwError(null, null, null, 400, null, null))
 
         When("the delete endpoint is called with the id of that document") {
-            val exception = shouldThrow<ZgwErrorException> { ontkoppeldeDocumentenRESTService.delete(document.id) }
+            val exception = shouldThrow<ZgwErrorException> { ontkoppeldeDocumentenRESTService.deleteDetachedDocument(document.id) }
 
             Then("the exception from OpenZaak is rethrown") {
                 exception.zgwError.status shouldBe 400
@@ -146,7 +146,7 @@ class OntkoppeldeDocumentenRESTServiceTest : BehaviorSpec({
         } returns mutableListOf(zaakInformatieObject)
 
         When("the delete endpoint is called with the id of that document") {
-            val exception = shouldThrow<IllegalStateException> { ontkoppeldeDocumentenRESTService.delete(document.id) }
+            val exception = shouldThrow<IllegalStateException> { ontkoppeldeDocumentenRESTService.deleteDetachedDocument(document.id) }
 
             Then("the an IllegalStateException should be thrown") {
                 exception shouldNotBe null
@@ -182,7 +182,7 @@ class OntkoppeldeDocumentenRESTServiceTest : BehaviorSpec({
         } just runs
 
         When("the delete endpoint is called with the id of that document") {
-            ontkoppeldeDocumentenRESTService.delete(document.id)
+            ontkoppeldeDocumentenRESTService.deleteDetachedDocument(document.id)
 
             Then("the document is deleted") {
                 verify(exactly = 1) {

--- a/src/test/kotlin/net/atos/zac/app/task/TaskRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/task/TaskRestServiceTest.kt
@@ -136,7 +136,7 @@ class TaskRestServiceTest : BehaviorSpec({
         When("the task is assigned with a user who has permission") {
             every { policyService.readTaakRechten(task) } returns createTaakRechtenAllDeny(toekennen = true)
 
-            taskRestService.assign(restTaakToekennenGegevens)
+            taskRestService.assignTask(restTaakToekennenGegevens)
 
             Then(
                 "the task is correctly assigned"
@@ -155,7 +155,7 @@ class TaskRestServiceTest : BehaviorSpec({
             every { policyService.readTaakRechten(task) } returns createTaakRechtenAllDeny()
 
             val exception = shouldThrow<PolicyException> {
-                taskRestService.assign(restTaakToekennenGegevens)
+                taskRestService.assignTask(restTaakToekennenGegevens)
             }
 
             Then("it throws exception with no message") { exception.message shouldBe null }
@@ -347,7 +347,7 @@ class TaskRestServiceTest : BehaviorSpec({
             } returns createWerklijstRechtenAllDeny(zakenTakenVerdelen = true)
 
             runTest(testDispatcher) {
-                taskRestService.distributeFromList(restTaakVerdelenGegevens)
+                taskRestService.assignTasksFromList(restTaakVerdelenGegevens)
             }
 
             Then("the tasks are assigned to the group and user") {
@@ -361,7 +361,7 @@ class TaskRestServiceTest : BehaviorSpec({
             every { policyService.readWerklijstRechten() } returns createWerklijstRechtenAllDeny()
 
             val exception = shouldThrow<PolicyException> {
-                taskRestService.distributeFromList(restTaakVerdelenGegevens)
+                taskRestService.assignTasksFromList(restTaakVerdelenGegevens)
             }
 
             Then("it throws exception with no message") { exception.message shouldBe null }
@@ -385,7 +385,7 @@ class TaskRestServiceTest : BehaviorSpec({
 
         When("the 'verdelen vanuit lijst' function is called") {
             runTest(testDispatcher) {
-                taskRestService.releaseFromList(restTaakVrijgevenGegevens)
+                taskRestService.releaseTaskFromList(restTaakVrijgevenGegevens)
             }
 
             Then("the tasks are assigned to the group and user") {

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
@@ -389,7 +389,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                 )
             } just runs
 
-            val returnedRestZaak = zaakRestService.assign(restZaakToekennenGegevens)
+            val returnedRestZaak = zaakRestService.assignZaak(restZaakToekennenGegevens)
 
             Then("the zaak is assigned both to the group and the user, and the zaken search index is updated") {
                 returnedRestZaak shouldBe restZaak
@@ -434,7 +434,7 @@ class ZaakRestServiceTest : BehaviorSpec({
 
         When("the zaak is assigned to an unknown group") {
             shouldThrow<UserNotInGroupException> {
-                zaakRestService.assign(restZaakToekennenGegevensUnknownGroup)
+                zaakRestService.assignZaak(restZaakToekennenGegevensUnknownGroup)
             }
 
             Then("an exception is thrown") {}
@@ -481,7 +481,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                 )
             } just runs
 
-            val returnedRestZaak = zaakRestService.assign(restZaakToekennenGegevens)
+            val returnedRestZaak = zaakRestService.assignZaak(restZaakToekennenGegevens)
 
             Then("the zaak is assigned both to the group and the user, and the zaken search index is updated") {
                 returnedRestZaak shouldBe restZaak
@@ -563,7 +563,7 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { zrcClientService.patchZaak(capture(patchZaakUUIDSlot), capture(patchZaakSlot)) } returns zaak
 
         When("the zaken are linked") {
-            zaakRestService.koppelZaak(restZaakLinkData)
+            zaakRestService.linkZaak(restZaakLinkData)
 
             Then("the two zaken are successfully linked") {
                 verify(exactly = 2) {
@@ -608,7 +608,7 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { eventingService.send(any<ScreenEvent>()) } just runs
 
         When("the zaken are linked") {
-            zaakRestService.koppelZaak(restZaakLinkData)
+            zaakRestService.linkZaak(restZaakLinkData)
 
             Then(
                 """
@@ -642,7 +642,7 @@ class ZaakRestServiceTest : BehaviorSpec({
 
         When("the zaken are linked") {
             val exception = shouldThrow<PolicyException> {
-                zaakRestService.koppelZaak(restZakenVerdeelGegevens)
+                zaakRestService.linkZaak(restZakenVerdeelGegevens)
             }
 
             Then("a policy exception should be thrown") {
@@ -671,7 +671,7 @@ class ZaakRestServiceTest : BehaviorSpec({
         } returns zaak
 
         When("the zaken are unlinked") {
-            zaakRestService.ontkoppelZaak(restZaakLinkData)
+            zaakRestService.unlinkZaak(restZaakLinkData)
 
             Then("the two zaken are successfully unlinked") {
                 verify(exactly = 1) {
@@ -928,7 +928,7 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { cmmnService.terminateCase(zaak.uuid) } returns Unit
 
         When("aborted with the hardcoded 'niet ontvankelijk' zaakbeeindigreden") {
-            zaakRestService.afbreken(
+            zaakRestService.terminateZaak(
                 zaak.uuid,
                 RESTZaakAfbrekenGegevens(zaakbeeindigRedenId = INADMISSIBLE_TERMINATION_ID)
             )
@@ -976,7 +976,7 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { cmmnService.terminateCase(zaak.uuid) } returns Unit
 
         When("aborted with managed zaakbeeindigreden") {
-            zaakRestService.afbreken(zaak.uuid, RESTZaakAfbrekenGegevens(zaakbeeindigRedenId = "-2"))
+            zaakRestService.terminateZaak(zaak.uuid, RESTZaakAfbrekenGegevens(zaakbeeindigRedenId = "-2"))
 
             Then("it is ended with result") {
                 verify(exactly = 1) {
@@ -989,7 +989,7 @@ class ZaakRestServiceTest : BehaviorSpec({
 
         When("aborted with invalid zaakbeeindigreden id") {
             val exception = shouldThrow<IllegalArgumentException> {
-                zaakRestService.afbreken(zaak.uuid, RESTZaakAfbrekenGegevens(zaakbeeindigRedenId = "not a number"))
+                zaakRestService.terminateZaak(zaak.uuid, RESTZaakAfbrekenGegevens(zaakbeeindigRedenId = "not a number"))
             }
 
             Then("it throws an error") {


### PR DESCRIPTION
Fixed duplicate operation id warnings when generating the ZAC OpenAPI spec.
 
Solves PZ-6150