### PR TITLE
fix(app): remove case opschorten details page after resuming the case

### DIFF
--- a/src/main/app/src/app/shared/indicaties/zaak-indicaties/zaak-indicaties.component.ts
+++ b/src/main/app/src/app/shared/indicaties/zaak-indicaties/zaak-indicaties.component.ts
@@ -53,7 +53,7 @@ export class ZaakIndicatiesComponent
             new Indicatie(
               indicatie,
               "pause",
-              this.getRedenOpschorting(),
+              `${this.translateService.instant("reden")}: ${this.getRedenOpschorting()}`,
             ).temporary(),
           );
           break;
@@ -86,7 +86,11 @@ export class ZaakIndicatiesComponent
           break;
         case ZaakIndicatie.VERLENGD:
           this.indicaties.push(
-            new Indicatie(indicatie, "update", this.getRedenVerlenging()),
+            new Indicatie(
+              indicatie,
+              "update",
+              `${this.translateService.instant("reden")}: ${this.getRedenVerlenging()}`,
+            ),
           );
           break;
       }

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -863,8 +863,6 @@ export class ZaakViewComponent
       moment(this.zaakOpschorting?.vanafDatumTijd),
       "days",
     );
-    const duurVerkortingOpschorting: number =
-      werkelijkeOpschortDuur - this.zaakOpschorting.duurDagen;
 
     const dialogData = new DialogData(
       [
@@ -876,6 +874,9 @@ export class ZaakViewComponent
           .build(),
       ],
       (results: any[]) => {
+        const duurVerkortingOpschorting: number =
+          werkelijkeOpschortDuur - (this.zaakOpschorting?.duurDagen ?? 0);
+
         const zaakOpschortGegevens: GeneratedType<"RESTZaakOpschortGegevens"> =
           {
             indicatieOpschorting: false,
@@ -916,6 +917,7 @@ export class ZaakViewComponent
         if (result) {
           this.utilService.openSnackbar("msg.zaak.hervat");
           this.updateZaak();
+          this.loadOpschorting();
         }
       });
   }


### PR DESCRIPTION
Frontend:

- refresh case details page after resuming case (by REST requesting opschorten state)
- more understandable tooltip text on case Opschorten and Verlengen indications

Solves PZ-6182