### PR TITLE
fix: fix WildFly Prometheus metrics scraping by adding a `fallback_scrape_protocol` setting

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -368,6 +368,8 @@ services:
       - "4317:4317" # OTLP gRPC receiver
       - "4318:4318" # OTLP http receiver
       - "55679:55679" # zpages extension
+    depends_on:
+      - tempo
     profiles: [ "metrics" ]
 
   # Observability traces data store

--- a/scripts/docker-compose/imports/prometheus/prometheus.yaml
+++ b/scripts/docker-compose/imports/prometheus/prometheus.yaml
@@ -4,6 +4,10 @@ global:
 
 scrape_configs:
   - job_name: 'prometheus'
+    # Specify a fallback scrape protocol because the WildFly OpenTelemetry endpoint
+    # currently does not seem to specify a Content-Type header resulting the following errors in the Prometheus logs:
+    # "non-compliant scrape target sending blank Content-Type and no fallback_scrape_protocol specified for target"
+    fallback_scrape_protocol: 'PrometheusText1.0.0'
     static_configs:
       # listen to the ZAC/WildFly management port exposed on localhost
       - targets: [ 'host.docker.internal:9990' ]


### PR DESCRIPTION
Fixed WildFly Prometheus metrics scraping by adding a `fallback_scrape_protocol` setting. This fixes these errors in the Prometheus logs:

> "time=2025-04-14T15:26:03.921Z level=ERROR source=scrape.go:1609 msg="Failed to determine correct type of scrape target." component="scrape manager" scrape_pool=prometheus target=http://host.docker.internal:9990/metrics content_type="" fallback_media_type="" err="non-compliant scrape target sending blank Content-Type and no fallback_scrape_protocol specified for target" 

Solves PZ-6295