### PR TITLE
feat: stop using gh-pages branch for e2e report

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: write
   pages: write
+  id-token: write
 
 jobs:
   playwright:

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -53,20 +53,24 @@ jobs:
       - name: copy report to seperate folder
         if: always()
         run: "cd src/e2e && mv reports ${{ steps.date.outputs.date }} && mkdir reports && mv ${{ steps.date.outputs.date }} reports/"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+      - name: Upload pages artifact
         if: always()
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        id: artifact
         with:
           name: playwright-report
-          path: src/e2e/reports
-          retention-days: 7
+          path: 'src/e2e/reports'
+          retention-days: 180
+
       - name: Deploy to GitHub Pages
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./src/e2e/reports/ # directory of your reports
-          publish_branch: gh-pages # deploying to gh-pages branch
-          keep_files: true # retains files that are not part of the current publish
+        id: published_site
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+
       - name: Notify Slack
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         uses: 8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e # v3.18.0
@@ -112,7 +116,7 @@ jobs:
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": "*Report URL:*\n:link: https://infonl.github.io/dimpact-zaakafhandelcomponent/${{ steps.date.outputs.date }}/e2e-report.html"
+                        "text": "*Report URL (latest run only):*\n:link: ${{ steps.published_site.outputs.page_url }}/${{ steps.date.outputs.date }}/e2e-report.html\n*Archived report (max 6 months):* :floppy_disk: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact.outputs.artifact_id }}"
                       }
                     },
                     {
@@ -122,15 +126,15 @@ jobs:
                           "type": "button",
                           "text": {
                             "type": "plain_text",
-                            "text": "View Report"
+                            "text": "Latest Report"
                           },
-                          "url": "https://infonl.github.io/dimpact-zaakafhandelcomponent/${{ steps.date.outputs.date }}/e2e-report.html"
+                          "url": "${{ steps.published_site.outputs.page_url }}/${{ steps.date.outputs.date }}/e2e-report.html"
                         },
                         {
                           "type": "button",
                           "text": {
                             "type": "plain_text",
-                            "text": "View Run"
+                            "text": "Latest Run"
                           },
                           "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                         },
@@ -138,9 +142,9 @@ jobs:
                           "type": "button",
                           "text": {
                             "type": "plain_text",
-                            "text": "View Videos"
+                            "text": "Latest Videos"
                           },
-                          "url": "https://infonl.github.io/dimpact-zaakafhandelcomponent/${{ steps.date.outputs.date }}/videos.html"
+                          "url": "${{ steps.published_site.outputs.page_url }}/${{ steps.date.outputs.date }}/videos.html"
                         }
                       ]
                     }


### PR DESCRIPTION
**Before merging this we should modify the GitHub Pages configuration to use actions as source.**

* Will **only** publish the latest report unfortunately. That is a limitation that exists because with the actions-publish method, you cannot merge content, only replace.  
* Added link to the artefact in the slack message, so we can still access the report for older runs (up to 180 days)
* After merging this older reports will be lost. 

Afterwards the gh-pages branch can be removed, which allows up to free up 3,5GB of data out of the repository (probably needs some history rewriting)

Solves PZ-6313