### PR TITLE
feat: re-use gh-pages branch for e2e report

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -12,7 +12,6 @@ on:
 permissions:
   contents: write
   pages: write
-  id-token: write
 
 jobs:
   playwright:
@@ -54,23 +53,20 @@ jobs:
       - name: copy report to seperate folder
         if: always()
         run: "cd src/e2e && mv reports ${{ steps.date.outputs.date }} && mkdir reports && mv ${{ steps.date.outputs.date }} reports/"
-
-      - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
-
-      - name: Upload pages artifact
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
-        id: artifact
         with:
-          path: 'src/e2e/reports'
-          retention-days: 180
-
+          
+          path: src/e2e/reports
+          retention-days: 7
       - name: Deploy to GitHub Pages
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
-        id: published_site
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
-
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./src/e2e/reports/ # directory of your reports
+          publish_branch: gh-pages # deploying to gh-pages branch
+          keep_files: true # retains files that are not part of the current publish
       - name: Notify Slack
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         uses: 8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e # v3.18.0
@@ -116,7 +112,7 @@ jobs:
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": "*Report URL (latest run only):*\n:link: ${{ steps.published_site.outputs.page_url }}/${{ steps.date.outputs.date }}/e2e-report.html\n*Archived report (max 6 months):* :floppy_disk: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact.outputs.artifact_id }}"
+                        "text": "*Report URL:*\n:link: https://infonl.github.io/dimpact-zaakafhandelcomponent/${{ steps.date.outputs.date }}/e2e-report.html"
                       }
                     },
                     {
@@ -126,15 +122,15 @@ jobs:
                           "type": "button",
                           "text": {
                             "type": "plain_text",
-                            "text": "Latest Report"
+                            "text": "View Report"
                           },
-                          "url": "${{ steps.published_site.outputs.page_url }}/${{ steps.date.outputs.date }}/e2e-report.html"
+                          "url": "https://infonl.github.io/dimpact-zaakafhandelcomponent/${{ steps.date.outputs.date }}/e2e-report.html"
                         },
                         {
                           "type": "button",
                           "text": {
                             "type": "plain_text",
-                            "text": "Latest Run"
+                            "text": "View Run"
                           },
                           "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                         },
@@ -142,9 +138,9 @@ jobs:
                           "type": "button",
                           "text": {
                             "type": "plain_text",
-                            "text": "Latest Videos"
+                            "text": "View Videos"
                           },
-                          "url": "${{ steps.published_site.outputs.page_url }}/${{ steps.date.outputs.date }}/videos.html"
+                          "url": "https://infonl.github.io/dimpact-zaakafhandelcomponent/${{ steps.date.outputs.date }}/videos.html"
                         }
                       ]
                     }


### PR DESCRIPTION
This reverts commit 0dd38ab0dce6144d6a966d1aab57e998a1c0b977.

By changing over to the new way of publishing pages we also mangled publishing of the Helm Charts. 

Solves PZ-6367