### PR TITLE
feat: add endpoint to return only those groups with access to a zaaktype

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
@@ -186,6 +186,39 @@ object ItestConfiguration {
     const val TEST_GROUP_RAADPLEGERS_DESCRIPTION = "Test group Raadplegers"
     const val TEST_GROUP_DOMEIN_TEST_1_ID = "test-group-domein-test-1"
     const val TEST_GROUP_DOMEIN_TEST_1_DESCRIPTION = "Test group which has access to domein_test_1 only"
+    const val TEST_GROUPS_ALL =
+        """
+            [
+                {
+                    "id": "$TEST_GROUP_FUNCTIONAL_ADMINS_ID",
+                    "naam": "$TEST_GROUP_FUNCTIONAL_ADMINS_DESCRIPTION"
+                },
+                {
+                    "id": "$TEST_GROUP_RECORD_MANAGERS_ID",
+                    "naam": "$TEST_GROUP_RECORD_MANAGERS_DESCRIPTION"
+                },
+                {
+                    "id": "$TEST_GROUP_COORDINATORS_ID",
+                    "naam": "$TEST_GROUP_COORDINATORS_DESCRIPTION"
+                },
+                {
+                    "id": "$TEST_GROUP_BEHANDELAARS_ID",
+                    "naam": "$TEST_GROUP_BEHANDELAARS_DESCRIPTION"
+                },
+                {
+                    "id": "$TEST_GROUP_RAADPLEGERS_ID",
+                    "naam": "$TEST_GROUP_RAADPLEGERS_DESCRIPTION"
+                },
+                {
+                    "id": "$TEST_GROUP_A_ID",
+                    "naam": "$TEST_GROUP_A_DESCRIPTION"
+                },
+                {
+                    "id": "$TEST_GROUP_DOMEIN_TEST_1_ID",
+                    "naam": "$TEST_GROUP_DOMEIN_TEST_1_DESCRIPTION"
+                }
+            ]
+        """
 
     /**
      * Constants used in the Informatieobjecten tests

--- a/src/main/kotlin/nl/info/client/keycloak/KeycloakEmployeesAdminClientConfiguration.kt
+++ b/src/main/kotlin/nl/info/client/keycloak/KeycloakEmployeesAdminClientConfiguration.kt
@@ -24,14 +24,14 @@ class KeycloakEmployeesAdminClientConfiguration @Inject constructor(
     @ConfigProperty(name = "AUTH_SERVER")
     private val keycloakUrl: String,
 
-    @ConfigProperty(name = "KEYCLOAK_ADMIN_CLIENT_ID")
-    private val clientId: String,
-
-    @ConfigProperty(name = "KEYCLOAK_ADMIN_CLIENT_SECRET")
-    private val clientSecret: String,
-
     @ConfigProperty(name = "AUTH_REALM")
     private val realmName: String,
+
+    @ConfigProperty(name = "KEYCLOAK_ADMIN_CLIENT_ID")
+    private val zacAdminClientId: String,
+
+    @ConfigProperty(name = "KEYCLOAK_ADMIN_CLIENT_SECRET")
+    private val zacAdminClientSecret: String
 ) {
     companion object {
         private val LOG = Logger.getLogger(KeycloakEmployeesAdminClientConfiguration::class.java.name)
@@ -42,14 +42,14 @@ class KeycloakEmployeesAdminClientConfiguration @Inject constructor(
     fun build(): RealmResource {
         LOG.info(
             "Building Keycloak admin client using: url: '$keycloakUrl', realm: '$realmName', " +
-                "client id: '$clientId', client secret: '*******'"
+                "client id: '$zacAdminClientId', client secret: '*******'"
         )
         return KeycloakBuilder.builder()
             .serverUrl(keycloakUrl)
             .realm(realmName)
             .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
-            .clientId(clientId)
-            .clientSecret(clientSecret)
+            .clientId(zacAdminClientId)
+            .clientSecret(zacAdminClientSecret)
             .build()
             .realm(realmName)
     }

--- a/src/main/kotlin/nl/info/zac/app/identity/IdentityRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/identity/IdentityRestService.kt
@@ -23,6 +23,7 @@ import nl.info.zac.authentication.LoggedInUser
 import nl.info.zac.identity.IdentityService
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
+import java.util.UUID
 
 @Singleton
 @Path("identity")
@@ -37,6 +38,11 @@ class IdentityRestService @Inject constructor(
     @GET
     @Path("groups")
     fun listGroups(): List<RestGroup> = identityService.listGroups().toRestGroups()
+
+    @GET
+    @Path("groups/zaaktype/{zaaktypeUuid}")
+    fun listGroupsForZaaktypeUuid(@PathParam("zaaktypeUuid") zaaktypeUuid: UUID): List<RestGroup> =
+        identityService.listGroupsForZaaktypeUuid(zaaktypeUuid).toRestGroups()
 
     @GET
     @Path("groups/{groupId}/users")

--- a/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
@@ -27,8 +27,8 @@ class UserPrincipalFilter @Inject constructor(
 ) : Filter {
     companion object {
         private val LOG = Logger.getLogger(UserPrincipalFilter::class.java.name)
-        private const val ROL_DOMEIN_ELK_ZAAKTYPE = "domein_elk_zaaktype"
         private const val GROUP_MEMBERSHIP_CLAIM_NAME = "group_membership"
+        const val ROL_DOMEIN_ELK_ZAAKTYPE = "domein_elk_zaaktype"
     }
 
     override fun doFilter(

--- a/src/main/kotlin/nl/info/zac/identity/IdentityService.kt
+++ b/src/main/kotlin/nl/info/zac/identity/IdentityService.kt
@@ -8,6 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.inject.Named
 import net.atos.zac.admin.ZaakafhandelParameterService
+import nl.info.zac.authentication.UserPrincipalFilter.Companion.ROL_DOMEIN_ELK_ZAAKTYPE
 import nl.info.zac.identity.exception.GroupNotFoundException
 import nl.info.zac.identity.exception.UserNotFoundException
 import nl.info.zac.identity.exception.UserNotInGroupException
@@ -18,8 +19,10 @@ import nl.info.zac.identity.model.toGroup
 import nl.info.zac.identity.model.toUser
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
+import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.keycloak.admin.client.resource.RealmResource
 import java.util.UUID
+import kotlin.collections.filter
 
 @AllOpen
 @NoArgConstructor
@@ -28,7 +31,10 @@ import java.util.UUID
 class IdentityService @Inject constructor(
     @Named("keycloakZacRealmResource")
     private val keycloakZacRealmResource: RealmResource,
-    private val zaakafhandelParameterService: ZaakafhandelParameterService
+    private val zaakafhandelParameterService: ZaakafhandelParameterService,
+
+    @ConfigProperty(name = "AUTH_RESOURCE")
+    private val zacKeycloakClientId: String,
 ) {
     fun listUsers(): List<User> = keycloakZacRealmResource.users()
         .list()
@@ -38,20 +44,21 @@ class IdentityService @Inject constructor(
     fun listGroups(): List<Group> = keycloakZacRealmResource.groups()
         // retrieve groups with 'full representation' or else the group attributes will not be filled
         .groups("", 0, Integer.MAX_VALUE, false)
-        .map { it.toGroup() }
+        .map { it.toGroup(zacKeycloakClientId) }
         .sortedBy { it.name }
 
     /**
-     * Returns the list of groups that have access to the given zaaktype UUID based on the ZAC domain roles of this group.
+     * Returns the list of groups that have access to the given zaaktype UUID based on the ZAC domain roles (if any)
+     * of this group and the domein (if any) configured in the zaakafhandelparameters for this zaaktype.
      */
     fun listGroupsForZaaktypeUuid(zaaktypeUuid: UUID): List<Group> {
         // retrieve groups with 'full representation' or else the group attributes will not be filled
         val groups = keycloakZacRealmResource.groups()
             .groups("", 0, Integer.MAX_VALUE, false)
-            .map { it.toGroup() }
+            .map { it.toGroup(zacKeycloakClientId) }
         val domein = zaakafhandelParameterService.readZaakafhandelParameters(zaaktypeUuid).domein
         return groups
-            .filter { domein == null || it.zacDomainRoles.contains(domein) }
+            .filter { (domein == null || domein == ROL_DOMEIN_ELK_ZAAKTYPE) || it.zacClientRoles.contains(domein) }
             .sortedBy { it.name }
     }
 
@@ -64,7 +71,7 @@ class IdentityService @Inject constructor(
     fun readGroup(groupId: String): Group = keycloakZacRealmResource.groups()
         // retrieve groups with 'full representation' or else the group attributes will not be filled
         .groups(groupId, true, 0, 1, false)
-        .firstOrNull()?.toGroup()
+        .firstOrNull()?.toGroup(zacKeycloakClientId)
         // is this fallback really needed? better to return null or throw a custom exception
         ?: Group(groupId)
 

--- a/src/main/kotlin/nl/info/zac/identity/IdentityService.kt
+++ b/src/main/kotlin/nl/info/zac/identity/IdentityService.kt
@@ -44,16 +44,16 @@ class IdentityService @Inject constructor(
     /**
      * Returns the list of groups that have access to the given zaaktype UUID based on the ZAC domain roles of this group.
      */
-    fun listGroupsForZaaktypeUuid(zaaktypeUuid: UUID): List<Group> = keycloakZacRealmResource.groups()
+    fun listGroupsForZaaktypeUuid(zaaktypeUuid: UUID): List<Group> {
         // retrieve groups with 'full representation' or else the group attributes will not be filled
-        .groups("", 0, Integer.MAX_VALUE, false)
-        .map { it.toGroup() }
-        .filter {
-            it.zacDomainRoles.contains(
-                zaakafhandelParameterService.readZaakafhandelParameters(zaaktypeUuid).domein
-            )
-        }
-        .sortedBy { it.name }
+        val groups = keycloakZacRealmResource.groups()
+            .groups("", 0, Integer.MAX_VALUE, false)
+            .map { it.toGroup() }
+        val domein = zaakafhandelParameterService.readZaakafhandelParameters(zaaktypeUuid).domein
+        return groups
+            .filter { domein == null || it.zacDomainRoles.contains(domein) }
+            .sortedBy { it.name }
+    }
 
     fun readUser(userId: String): User = keycloakZacRealmResource.users()
         .searchByUsername(userId, true)

--- a/src/main/kotlin/nl/info/zac/identity/model/Group.kt
+++ b/src/main/kotlin/nl/info/zac/identity/model/Group.kt
@@ -6,12 +6,16 @@ package nl.info.zac.identity.model
 
 import org.keycloak.representations.idm.GroupRepresentation
 
+const val DOMAIN_ROLE_PREFIX = "domein_"
+
 data class Group(
     val id: String,
 
     val name: String,
 
-    val email: String? = null
+    val email: String? = null,
+
+    val zacDomainRoles: List<String> = emptyList()
 ) {
     /**
      * Constructor for creating an unknown Group, a group with a given group id which is not known in the identity system.
@@ -25,10 +29,12 @@ data class Group(
 }
 
 fun GroupRepresentation.toGroup(): Group =
+    // Confusingly the terms `group name` and `group description` are used in the Keycloak admin UI,
+    // however in the Keycloak API these are called `id` and `name` respectively.
     Group(
-        // better to rename 'id' field as 'name' and 'name' field as 'description'
         id = name,
-        // maybe we want a separate description field in the Group class
         name = attributes?.get("description")?.single()?.toString() ?: name,
-        email = attributes?.get("email")?.single().toString()
+        email = attributes?.get("email")?.single().toString(),
+        // TODO: get ZAC client name from configuration
+        zacDomainRoles = clientRoles["zaakafhandelcomponent"]?.filter { it.startsWith(DOMAIN_ROLE_PREFIX) } ?: emptyList()
     )

--- a/src/main/kotlin/nl/info/zac/identity/model/Group.kt
+++ b/src/main/kotlin/nl/info/zac/identity/model/Group.kt
@@ -27,13 +27,22 @@ data class Group(
     )
 }
 
+/**
+ * Converts a [GroupRepresentation] to a [Group], mapping the Keycloak
+ * group name, group description, and Keycloak ZAC client roles.
+ * Somewhat confusingly, we map the Keycloak group name to our group id,
+ * and the Keycloak group description attribute (if any) to our group name.
+ * The Keycloak group id is a UUID and is not of interest to us.
+ * The Keycloak group name is the unique group name in the ZAC Keycloak realm,
+ * and we treat this as the group id in our system.
+ *
+ * @param keycloakClientId The client ID of the Keycloak client.
+ * @return A [Group] object representing the group.
+ */
 fun GroupRepresentation.toGroup(keycloakClientId: String): Group =
-    // Confusingly the terms `group name` and `group description` are used in the Keycloak admin UI,
-    // however in the Keycloak API these are called `id` and `name` respectively.
     Group(
         id = name,
         name = attributes?.get("description")?.singleOrNull() ?: name,
         email = attributes?.get("email")?.singleOrNull(),
-        // also map the client roles for the ZAC Keycloak client
         zacClientRoles = clientRoles[keycloakClientId].orEmpty()
     )

--- a/src/main/kotlin/nl/info/zac/identity/model/Group.kt
+++ b/src/main/kotlin/nl/info/zac/identity/model/Group.kt
@@ -6,7 +6,6 @@ package nl.info.zac.identity.model
 
 import org.keycloak.representations.idm.GroupRepresentation
 
-const val DOMAIN_ROLE_PREFIX = "domein_"
 
 data class Group(
     val id: String,
@@ -15,7 +14,7 @@ data class Group(
 
     val email: String? = null,
 
-    val zacDomainRoles: List<String> = emptyList()
+    val zacClientRoles: List<String> = emptyList()
 ) {
     /**
      * Constructor for creating an unknown Group, a group with a given group id which is not known in the identity system.
@@ -28,13 +27,13 @@ data class Group(
     )
 }
 
-fun GroupRepresentation.toGroup(): Group =
+fun GroupRepresentation.toGroup(keycloakClientId: String): Group =
     // Confusingly the terms `group name` and `group description` are used in the Keycloak admin UI,
     // however in the Keycloak API these are called `id` and `name` respectively.
     Group(
         id = name,
-        name = attributes?.get("description")?.single()?.toString() ?: name,
-        email = attributes?.get("email")?.single().toString(),
-        // TODO: get ZAC client name from configuration
-        zacDomainRoles = clientRoles["zaakafhandelcomponent"]?.filter { it.startsWith(DOMAIN_ROLE_PREFIX) } ?: emptyList()
+        name = attributes?.get("description")?.singleOrNull() ?: name,
+        email = attributes?.get("email")?.singleOrNull(),
+        // also map the client roles for the ZAC Keycloak client
+        zacClientRoles = clientRoles[keycloakClientId].orEmpty()
     )

--- a/src/main/kotlin/nl/info/zac/identity/model/Group.kt
+++ b/src/main/kotlin/nl/info/zac/identity/model/Group.kt
@@ -6,7 +6,6 @@ package nl.info.zac.identity.model
 
 import org.keycloak.representations.idm.GroupRepresentation
 
-
 data class Group(
     val id: String,
 

--- a/src/test/kotlin/nl/info/test/org/keycloak/representations/idm/KeycloakRepresentationsIdmFixtures.kt
+++ b/src/test/kotlin/nl/info/test/org/keycloak/representations/idm/KeycloakRepresentationsIdmFixtures.kt
@@ -26,9 +26,11 @@ fun createUserRepresentation(
 fun createGroupRepresentation(
     id: String = "fakeGroupId",
     name: String = "fakeGroupName",
-    attributes: Map<String, List<String>> = mapOf("fakeKey" to listOf("fakeValue"))
+    attributes: Map<String, List<String>> = mapOf("fakeKey" to listOf("fakeValue")),
+    clientRoles: Map<String, List<String>> = emptyMap()
 ) = GroupRepresentation().apply {
     this.id = id
     this.name = name
     this.attributes = attributes
+    this.clientRoles = clientRoles
 }

--- a/src/test/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
@@ -49,7 +49,7 @@ class ZaakafhandelParametersRestServiceTest : BehaviorSpec({
     val smartDocumentsTemplatesService = mockk<SmartDocumentsTemplatesService>()
     val policyService = mockk<PolicyService>()
     val realmResource = mockk<RealmResource>()
-    val identityService = IdentityService(realmResource)
+    val identityService = mockk<IdentityService>()
 
     val zaakafhandelParametersRestService = ZaakafhandelParametersRestService(
         ztcClientService = ztcClientService,

--- a/src/test/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
@@ -28,13 +28,9 @@ import nl.info.zac.exception.ErrorCode.ERROR_CODE_PRODUCTAANVRAAGTYPE_ALREADY_IN
 import nl.info.zac.exception.ErrorCode.ERROR_CODE_USER_NOT_IN_GROUP
 import nl.info.zac.exception.InputValidationFailedException
 import nl.info.zac.identity.IdentityService
+import nl.info.zac.identity.exception.UserNotInGroupException
 import nl.info.zac.smartdocuments.SmartDocumentsTemplatesService
 import nl.info.zac.smartdocuments.exception.SmartDocumentsConfigurationException
-import org.keycloak.admin.client.resource.RealmResource
-import org.keycloak.admin.client.resource.UserResource
-import org.keycloak.admin.client.resource.UsersResource
-import org.keycloak.representations.idm.GroupRepresentation
-import org.keycloak.representations.idm.UserRepresentation
 import java.util.UUID
 
 class ZaakafhandelParametersRestServiceTest : BehaviorSpec({
@@ -48,9 +44,7 @@ class ZaakafhandelParametersRestServiceTest : BehaviorSpec({
     val caseDefinitionConverter = mockk<RESTCaseDefinitionConverter>()
     val smartDocumentsTemplatesService = mockk<SmartDocumentsTemplatesService>()
     val policyService = mockk<PolicyService>()
-    val realmResource = mockk<RealmResource>()
     val identityService = mockk<IdentityService>()
-
     val zaakafhandelParametersRestService = ZaakafhandelParametersRestService(
         ztcClientService = ztcClientService,
         configuratieService = configuratieService,
@@ -245,30 +239,20 @@ class ZaakafhandelParametersRestServiceTest : BehaviorSpec({
         }
     }
 
-    Given("A behandelaar is set") {
-        When("the behandelaar is not part of the behandelaar group") {
-            every { policyService.readOverigeRechten().beheren } returns true
+    Given("A behandelaar is set but the behandelaar is not part of the behandelaar group") {
+        val zaakafhandelParameters = createZaakafhandelParameters(id = null)
+        val behandelaarId = "fakeBehandelaarId"
+        val behandelaarGroupId = "fakeBehandelaarGroupId"
+        every { policyService.readOverigeRechten().beheren } returns true
+        every {
+            identityService.checkIfUserIsInGroup(behandelaarId, behandelaarGroupId)
+        } throws UserNotInGroupException()
 
-            val userId = "1"
-            val userResources = mockk<UsersResource>()
-            every { userResources.searchByUsername(any(), true) } returns listOf(
-                mockk<UserRepresentation> {
-                    every { id } returns userId
-                }
-            )
-            every { userResources.get(userId) } returns mockk<UserResource> {
-                every { groups() } returns emptyList<GroupRepresentation>()
-            }
-            every { realmResource.users() } returns userResources
-
+        When("zaakafhandelparameters are created") {
             val restZaakafhandelParameters = createRestZaakAfhandelParameters(
-                defaultBehandelaarId = "defaultBehandelaarId",
-                defaultGroupId = "defaultGroupId"
+                defaultBehandelaarId = behandelaarId,
+                defaultGroupId = behandelaarGroupId
             )
-            val zaakafhandelParameters = createZaakafhandelParameters(
-                id = null
-            )
-
             val exception = shouldThrow<InputValidationFailedException> {
                 zaakafhandelParametersRestService.createOrUpdateZaakafhandelparameters(
                     restZaakafhandelParameters

--- a/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
@@ -12,21 +12,22 @@ import io.mockk.checkUnnecessaryStub
 import io.mockk.every
 import io.mockk.mockk
 import net.atos.zac.admin.ZaakafhandelParameterService
-import net.atos.zac.admin.model.ZaakafhandelParameters
 import nl.info.test.org.keycloak.representations.idm.createGroupRepresentation
 import nl.info.test.org.keycloak.representations.idm.createUserRepresentation
 import nl.info.zac.identity.exception.GroupNotFoundException
 import nl.info.zac.identity.exception.UserNotFoundException
 import nl.info.zac.identity.exception.UserNotInGroupException
-import nl.info.zac.identity.model.Group
 import nl.info.zac.identity.model.getFullName
 import org.keycloak.admin.client.resource.RealmResource
-import java.util.UUID
 
 class IdentityServiceTest : BehaviorSpec({
     val realmResource = mockk<RealmResource>()
     val zaakafhandelParameterService = mockk<ZaakafhandelParameterService>()
-    val identityService = IdentityService(realmResource, zaakafhandelParameterService)
+    val identityService = IdentityService(
+        keycloakZacRealmResource = realmResource,
+        zaakafhandelParameterService = zaakafhandelParameterService,
+        zacKeycloakClientId = "fakeZacKeycloakClientId"
+    )
 
     beforeEach {
         checkUnnecessaryStub()

--- a/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
@@ -11,17 +11,22 @@ import io.kotest.matchers.shouldBe
 import io.mockk.checkUnnecessaryStub
 import io.mockk.every
 import io.mockk.mockk
+import net.atos.zac.admin.ZaakafhandelParameterService
+import net.atos.zac.admin.model.ZaakafhandelParameters
 import nl.info.test.org.keycloak.representations.idm.createGroupRepresentation
 import nl.info.test.org.keycloak.representations.idm.createUserRepresentation
 import nl.info.zac.identity.exception.GroupNotFoundException
 import nl.info.zac.identity.exception.UserNotFoundException
 import nl.info.zac.identity.exception.UserNotInGroupException
+import nl.info.zac.identity.model.Group
 import nl.info.zac.identity.model.getFullName
 import org.keycloak.admin.client.resource.RealmResource
+import java.util.UUID
 
 class IdentityServiceTest : BehaviorSpec({
     val realmResource = mockk<RealmResource>()
-    val identityService = IdentityService(realmResource)
+    val zaakafhandelParameterService = mockk<ZaakafhandelParameterService>()
+    val identityService = IdentityService(realmResource, zaakafhandelParameterService)
 
     beforeEach {
         checkUnnecessaryStub()

--- a/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-
 package nl.info.zac.identity
 
 import io.kotest.assertions.throwables.shouldThrow
@@ -19,14 +18,16 @@ import nl.info.zac.identity.exception.UserNotFoundException
 import nl.info.zac.identity.exception.UserNotInGroupException
 import nl.info.zac.identity.model.getFullName
 import org.keycloak.admin.client.resource.RealmResource
+import java.util.UUID
 
 class IdentityServiceTest : BehaviorSpec({
+    val zacKeycloakClientId = "fakeZacKeycloakClientId"
     val realmResource = mockk<RealmResource>()
     val zaakafhandelParameterService = mockk<ZaakafhandelParameterService>()
     val identityService = IdentityService(
         keycloakZacRealmResource = realmResource,
         zaakafhandelParameterService = zaakafhandelParameterService,
-        zacKeycloakClientId = "fakeZacKeycloakClientId"
+        zacKeycloakClientId = zacKeycloakClientId
     )
 
     beforeEach {
@@ -282,6 +283,85 @@ class IdentityServiceTest : BehaviorSpec({
             }
 
             Then("an exception is thrown") {}
+        }
+    }
+
+    Given(
+        """
+            One Keycloak group with a ZAC client role that is equal to the domein role configured in the 
+            zaakafhandelparameters for a zaaktype uuid, and another Keycloak group with a different ZAC client role.
+        """.trimIndent()
+    ) {
+        val zaaktypeUuid = UUID.randomUUID()
+        val domeinRole = "fakeDomeinRole"
+        val groupRepresentation1 = createGroupRepresentation(
+            name = "fakeGroupName1",
+            attributes = mapOf("description" to listOf("fakeGroupDescription1")),
+            clientRoles = mapOf(zacKeycloakClientId to listOf(domeinRole))
+        )
+        val groupRepresentation2 = createGroupRepresentation(
+            name = "fakeGroupName2",
+            clientRoles = mapOf(zacKeycloakClientId to listOf("otherRole"))
+        )
+        every {
+            realmResource.groups().groups("", 0, Integer.MAX_VALUE, false)
+        } returns listOf(groupRepresentation1, groupRepresentation2)
+        every { zaakafhandelParameterService.readZaakafhandelParameters(zaaktypeUuid).domein } returns domeinRole
+
+        When("groups for the zaaktype UUID are listed") {
+            val groups = identityService.listGroupsForZaaktypeUuid(zaaktypeUuid)
+
+            Then("only groups with matching domain roles are returned") {
+                groups.size shouldBe 1
+                with(groups[0]) {
+                    id shouldBe "fakeGroupName1"
+                    name shouldBe "fakeGroupDescription1"
+                    zacClientRoles shouldBe listOf(domeinRole)
+                }
+            }
+        }
+    }
+
+    Given("Zaaktype UUID with domain allowing all zaaktypes") {
+        val zaaktypeUuid = UUID.randomUUID()
+        val groupRepresentation1 = createGroupRepresentation(
+            name = "fakeGroupId1",
+            clientRoles = mapOf(zacKeycloakClientId to listOf("fakeDomeinRole1")),
+        )
+        val groupRepresentation2 = createGroupRepresentation(
+            name = "fakeGroupId2",
+            clientRoles = mapOf(zacKeycloakClientId to listOf("fakeDomeinRole2")),
+        )
+        every {
+            realmResource.groups().groups("", 0, Integer.MAX_VALUE, false)
+        } returns listOf(groupRepresentation1, groupRepresentation2)
+        every {
+            zaakafhandelParameterService.readZaakafhandelParameters(zaaktypeUuid).domein
+        } returns "domein_elk_zaaktype"
+
+        When("groups for the zaaktype UUID are listed") {
+            val groups = identityService.listGroupsForZaaktypeUuid(zaaktypeUuid)
+
+            Then("all groups are returned, sorted by name") {
+                groups.size shouldBe 2
+                groups[0].id shouldBe "fakeGroupId1"
+                groups[1].id shouldBe "fakeGroupId2"
+            }
+        }
+    }
+
+    Given("Zaaktype UUID with empty group list") {
+        val zaaktypeUuid = UUID.randomUUID()
+        val domain = "anyDomain"
+        every { realmResource.groups().groups("", 0, Integer.MAX_VALUE, false) } returns emptyList()
+        every { zaakafhandelParameterService.readZaakafhandelParameters(zaaktypeUuid).domein } returns domain
+
+        When("groups for the zaaktype UUID are listed") {
+            val groups = identityService.listGroupsForZaaktypeUuid(zaaktypeUuid)
+
+            Then("no groups are returned") {
+                groups.size shouldBe 0
+            }
         }
     }
 })

--- a/src/test/kotlin/nl/info/zac/identity/model/IdentityFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/identity/model/IdentityFixtures.kt
@@ -8,11 +8,13 @@ package nl.info.zac.identity.model
 fun createGroup(
     id: String = "fakeId",
     name: String = "fakeName",
-    email: String = "fake-group@example.com"
+    email: String = "fake-group@example.com",
+    zacClientRoles: List<String> = emptyList()
 ) = Group(
-    id,
-    name,
-    email
+    id = id,
+    name = name,
+    email = email,
+    zacClientRoles = zacClientRoles
 )
 
 fun createUser(
@@ -22,9 +24,9 @@ fun createUser(
     fullName: String = "fakeFullName",
     email: String = "fake@example.com"
 ) = User(
-    id,
-    firstName,
-    lastName,
-    fullName,
-    email
+    id = id,
+    firstName = firstName,
+    lastName = lastName,
+    displayName = fullName,
+    email = email
 )


### PR DESCRIPTION
Add endpoint to return only those groups that have access to a certain zaaktype based on the ZAC Keycloak client (domein) roles and the configuration of a domein role in the zaakafhandelparameters for this zaaktype.

Solves PZ-6318