### PR TITLE
chore: remove domein overig reference value for clean environments

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/ReferenceTableRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ReferenceTableRestServiceTest.kt
@@ -11,7 +11,6 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
-import nl.info.zac.itest.config.ItestConfiguration.DOMEIN_OVERIG
 import nl.info.zac.itest.config.ItestConfiguration.DOMEIN_TEST_1
 import nl.info.zac.itest.config.ItestConfiguration.REFERENCE_TABLE_ADVIES_CODE
 import nl.info.zac.itest.config.ItestConfiguration.REFERENCE_TABLE_ADVIES_NAME
@@ -37,7 +36,6 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
     var communicationChannelReferenceTableId = 0
     var domeinReferenceTableId = 0
     var serverErrorTextErrorReferenceTableId = 0
-    var domeinOverigReferenceTableFieldId = 0
 
     Given("Default reference table data is provisioned on startup") {
         When("the reference tables are listed") {
@@ -76,7 +74,7 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
                                 "code": "$REFERENCE_TABLE_DOMEIN_CODE", 
                                 "naam": "$REFERENCE_TABLE_DOMEIN_NAME", 
                                 "systeem": true, 
-                                "aantalWaarden": 1
+                                "aantalWaarden": 0
                             },
                             {
                                 "code": "$REFERENCE_TABLE_SERVER_ERROR_ERROR_PAGINA_TEKST_CODE", 
@@ -175,7 +173,7 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
                 "$ZAC_API_URI/referentietabellen/$domeinReferenceTableId"
             )
             Then(
-                """the provisioned default communicatiekanalen are returned including 'E-formulier'"""
+                """no domeinen should be returned because none are provisioned"""
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
@@ -188,18 +186,12 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
                             "naam": "$REFERENCE_TABLE_DOMEIN_NAME",
                             "id" : $domeinReferenceTableId,
                             "systeem": true,
-                            "aantalWaarden": 1,
-                            "waarden": [
-                                { "naam": "$DOMEIN_OVERIG", "systemValue": true }                      
-                            ]
+                            "aantalWaarden": 0,
+                            "waarden": []
                         }
                         """.trimIndent()
                     )
                 }
-                domeinOverigReferenceTableFieldId = JSONObject(responseBody)
-                    .getJSONArray("waarden")
-                    .getJSONObject(0)
-                    .getInt("id")
             }
         }
         When("the get domeinen endpoint is called") {
@@ -213,8 +205,7 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
                 logger.info { "Response: $responseBody" }
                 response.isSuccessful shouldBe true
                 with(JSONArray(responseBody)) {
-                    length() shouldBe 1
-                    get(0) shouldBe DOMEIN_OVERIG
+                    length() shouldBe 0
                 }
             }
         }
@@ -288,12 +279,8 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
                         "id" : $domeinReferenceTableId,
                         "naam" : "$REFERENCE_TABLE_DOMEIN_NAME",
                         "systeem" : true,
-                        "waarden":
-                            [
-                                { "id" : $domeinOverigReferenceTableFieldId, "naam" : "$DOMEIN_OVERIG", "systemValue" : true },
-                                { "naam" : "$DOMEIN_TEST_1" }
-                            ]
-                        }
+                        "waarden": []
+                    }
                 """.trimIndent()
             )
             Then("the response should be 'ok'") {
@@ -307,9 +294,8 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
                             "code": "$REFERENCE_TABLE_DOMEIN_CODE",
                             "naam": "$REFERENCE_TABLE_DOMEIN_NAME",
                             "systeem": true,
-                            "aantalWaarden": 2,
+                            "aantalWaarden": 1,
                             "waarden": [
-                                { "naam": "$DOMEIN_OVERIG", "systemValue": true },
                                 { "naam": "$DOMEIN_TEST_1", "systemValue": false }                               
                             ]
                         }

--- a/src/itest/kotlin/nl/info/zac/itest/ReferenceTableRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ReferenceTableRestServiceTest.kt
@@ -294,7 +294,7 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
                             "code": "$REFERENCE_TABLE_DOMEIN_CODE",
                             "naam": "$REFERENCE_TABLE_DOMEIN_NAME",
                             "systeem": true,
-                            "aantalWaarden": 1,
+                            "aantalWaarden": 0,
                             "waarden": [
                                 { "naam": "$DOMEIN_TEST_1", "systemValue": false }                               
                             ]

--- a/src/itest/kotlin/nl/info/zac/itest/ReferenceTableRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ReferenceTableRestServiceTest.kt
@@ -274,12 +274,12 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
                 url = "$ZAC_API_URI/referentietabellen/$domeinReferenceTableId",
                 requestBodyAsString = """
                   {
-                        "aantalWaarden" : 1,
+                        "aantalWaarden" : 0,
                         "code" : "$REFERENCE_TABLE_DOMEIN_CODE",
                         "id" : $domeinReferenceTableId,
                         "naam" : "$REFERENCE_TABLE_DOMEIN_NAME",
                         "systeem" : true,
-                        "waarden": []
+                        "waarden": [ { "naam" : "$DOMEIN_TEST_1" } ]
                     }
                 """.trimIndent()
             )
@@ -294,7 +294,7 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
                             "code": "$REFERENCE_TABLE_DOMEIN_CODE",
                             "naam": "$REFERENCE_TABLE_DOMEIN_NAME",
                             "systeem": true,
-                            "aantalWaarden": 0,
+                            "aantalWaarden": 1,
                             "waarden": [
                                 { "naam": "$DOMEIN_TEST_1", "systemValue": false }                               
                             ]

--- a/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
@@ -57,7 +57,6 @@ object ItestConfiguration {
     const val CONFIG_GEMEENTE_NAAM = "FakeZacGemeente"
     const val COMMUNICATIEKANAAL_TEST_1 = "fakeCommunicatiekanaal1"
     const val COMMUNICATIEKANAAL_TEST_2 = "fakeCommunicatiekanaal2"
-    const val DOMEIN_OVERIG = "domein_overig"
     const val DOMEIN_TEST_1 = "domein_test_1"
     const val FORMULIER_DEFINITIE_AANVULLENDE_INFORMATIE = "AANVULLENDE_INFORMATIE"
     const val HUMAN_TASK_AANVULLENDE_INFORMATIE_NAAM = "Aanvullende informatie"

--- a/src/main/resources/schemas/V69__delete_domein_overig_referentie_waarde.sql
+++ b/src/main/resources/schemas/V69__delete_domein_overig_referentie_waarde.sql
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+-- Delete the obsolete 'domein_overig' row from the 'referentie_waarde' table because it is not used
+-- by ZAC and therefore is not needed. Only do this for clean environments on which no database migrations have
+-- been run and not for existing ones because then there is a risk that this value is already in use.
+DO
+$$
+BEGIN
+    IF (
+        SELECT COUNT(*) = (SELECT MAX(installed_rank) FROM flyway_schema_history)
+        FROM flyway_schema_history
+    ) THEN
+        -- Clean environment detected: safe to delete the obsolete 'domein_overig' row.
+        DELETE FROM ${schema}.referentie_waarde
+        WHERE id_referentie_tabel = (SELECT id_referentie_tabel FROM ${schema}.referentie_tabel WHERE code = 'DOMEIN')
+        AND naam = 'domein_overig';
+    ELSE
+        -- Not a clean environment, just change the 'domein_overig' row to a non-system value.
+        UPDATE ${schema}.referentie_waarde
+        SET is_systeem_waarde = FALSE
+        WHERE id_referentie_tabel = (SELECT id_referentie_tabel FROM ${schema}.referentie_tabel WHERE code = 'DOMEIN')
+        AND naam = 'domein_overig';
+    END IF;
+END;
+$$;


### PR DESCRIPTION
Remove `domein_overig` reference value for clean environments and change into non-system value for existing environments.

Solves PZ-6433