### PR TITLE
chore: added code comment on why we set gebruiksrechten when adding a zaakinformatieobject

### DIFF
--- a/src/main/kotlin/nl/info/client/zgw/shared/ZGWApiService.kt
+++ b/src/main/kotlin/nl/info/client/zgw/shared/ZGWApiService.kt
@@ -202,6 +202,8 @@ class ZGWApiService @Inject constructor(
         val newInformatieObjectData = drcClientService.createEnkelvoudigInformatieobject(
             enkelvoudigInformatieObjectCreateLockRequest
         )
+        // Gebruiksrechten are required for every created zaak-informatieobject or else
+        // the zaak in question can no longer be aborted or closed (OpenZaak will return a 400 error on aborting or closing in that case).
         val gebruiksrechten = Gebruiksrechten().apply {
             informatieobject = newInformatieObjectData.url
             startdatum = convertToDateTime(newInformatieObjectData.creatiedatum).toOffsetDateTime()


### PR DESCRIPTION
Added code comment on why we set gebruiksrechten when adding a zaakinformatieobject so that we don't forget (again..).

Solves PZ-6451