### PR TITLE
chore: remove `any`

### DIFF
--- a/src/main/app/src/app/formulieren/formulier/velden/documenten/documenten-formulier-veld.component.ts
+++ b/src/main/app/src/app/formulieren/formulier/velden/documenten/documenten-formulier-veld.component.ts
@@ -103,8 +103,9 @@ export class DocumentenFormulierVeldComponent implements OnInit {
   getDocumentenVariable(): Observable<
     GeneratedType<"RestEnkelvoudigInformatieobject">[]
   > {
-    const uuids: string =
-      this.zaak.zaakdata[this.veldDefinitie.meerkeuzeOpties];
+    const uuids = String(
+      this.zaak.zaakdata[this.veldDefinitie.meerkeuzeOpties],
+    );
     if (uuids) {
       const zoekparameters = new InformatieobjectZoekParameters();
       zoekparameters.informatieobjectUUIDs = uuids.split(";");

--- a/src/main/app/src/app/taken/taken-mijn/taken-mijn.component.ts
+++ b/src/main/app/src/app/taken/taken-mijn/taken-mijn.component.ts
@@ -1,9 +1,15 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import { AfterViewInit, Component, OnInit, ViewChild } from "@angular/core";
+import {
+  AfterViewInit,
+  Component,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+} from "@angular/core";
 
 import { detailExpand } from "../../shared/animations/animations";
 
@@ -34,7 +40,7 @@ import { TakenMijnDatasource } from "./taken-mijn-datasource";
 })
 export class TakenMijnComponent
   extends WerklijstComponent
-  implements AfterViewInit, OnInit
+  implements AfterViewInit, OnInit, OnDestroy
 {
   dataSource: TakenMijnDatasource;
   @ViewChild(MatPaginator) paginator: MatPaginator;

--- a/src/main/app/src/app/taken/taken-werkvoorraad/taken-werkvoorraad.component.ts
+++ b/src/main/app/src/app/taken/taken-werkvoorraad/taken-werkvoorraad.component.ts
@@ -6,6 +6,7 @@
 import {
   AfterViewInit,
   Component,
+  OnDestroy,
   OnInit,
   signal,
   ViewChild,
@@ -49,7 +50,7 @@ import { TakenWerkvoorraadDatasource } from "./taken-werkvoorraad-datasource";
 })
 export class TakenWerkvoorraadComponent
   extends WerklijstComponent
-  implements AfterViewInit, OnInit
+  implements AfterViewInit, OnInit, OnDestroy
 {
   selection = new SelectionModel<TaakZoekObject>(true, []);
   dataSource: TakenWerkvoorraadDatasource;

--- a/src/main/app/src/app/zaken/besluit-view/besluit-view.component.ts
+++ b/src/main/app/src/app/zaken/besluit-view/besluit-view.component.ts
@@ -52,7 +52,7 @@ export class BesluitViewComponent implements OnInit, OnChanges {
   @Input({ required: true }) result!: GeneratedType<"RestZaakResultaat">;
   @Input({ required: true }) readonly!: boolean;
   @Output() besluitWijzigen = new EventEmitter<GeneratedType<"RestDecision">>();
-  @Output() doIntrekking = new EventEmitter<any>();
+  @Output() doIntrekking = new EventEmitter();
   readonly indicatiesLayout = IndicatiesLayout;
   histories: Record<string, MatTableDataSource<HistorieRegel>> = {};
 
@@ -139,7 +139,7 @@ export class BesluitViewComponent implements OnInit, OnChanges {
         this.maakToelichtingField(),
         this.maakMessageField(besluit),
       ],
-      (results: any[]) => this.saveIntrekking(results),
+      (results) => this.saveIntrekking(results),
       this.translate.instant("msg.besluit.intrekken"),
     );
     dialogData.confirmButtonActionKey = "actie.besluit.intrekken";
@@ -148,7 +148,7 @@ export class BesluitViewComponent implements OnInit, OnChanges {
     });
   }
 
-  saveIntrekking(results: any[]): Observable<null> {
+  saveIntrekking(results: unknown): Observable<null> {
     this.doIntrekking.emit(results);
     return of(null);
   }

--- a/src/main/app/src/app/zaken/model/zaak.ts
+++ b/src/main/app/src/app/zaken/model/zaak.ts
@@ -55,5 +55,5 @@ export class Zaak {
   isProcesGestuurd: boolean;
   rechten: ZaakRechten;
   indicaties: ZaakIndicatie[];
-  zaakdata: Record<string, any>;
+  zaakdata: Record<string, unknown>;
 }

--- a/src/main/app/src/app/zaken/zaak-create/zaak-create.component.ts
+++ b/src/main/app/src/app/zaken/zaak-create/zaak-create.component.ts
@@ -140,7 +140,7 @@ export class ZaakCreateComponent {
           initiatorIdentificatie: initiator?.identificatie,
           initiatorIdentificatieType: initiator?.identificatieType,
           vertrouwelijkheidaanduiding: vertrouwelijkheidaanduiding?.value,
-        } as any as GeneratedType<"RESTZaakAanmaakGegevens">["zaak"],
+        } as unknown as GeneratedType<"RESTZaakAanmaakGegevens">["zaak"],
         bagObjecten: bagObjecten,
         inboxProductaanvraag: this.inboxProductaanvraag,
       })

--- a/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
+++ b/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
@@ -234,7 +234,7 @@ export class CaseDetailsEditComponent implements OnDestroy, OnInit {
 
   private createDateFormField(
     id: string,
-    value: any,
+    value: string,
     enabled: boolean,
     validators: ValidatorFn[],
   ): DateFormField {
@@ -353,14 +353,15 @@ export class CaseDetailsEditComponent implements OnDestroy, OnInit {
     this.reasonField.formControl.enable();
   }
 
-  private createZaakPatch(update: Record<string, any>) {
+  private createZaakPatch(update: Record<string, unknown>) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { assignment, reason, ...updates } = update;
 
     return {
       ...updates,
-      groep: assignment.groep,
-      behandelaar: assignment.medewerker,
+      groep: (assignment as { groep: GeneratedType<"RestGroup"> }).groep,
+      behandelaar: (assignment as { medewerker: GeneratedType<"RestUser"> })
+        .medewerker,
     } satisfies Partial<Zaak>;
   }
 

--- a/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.ts
+++ b/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.ts
@@ -236,7 +236,7 @@ export class ZaakDocumentenComponent
             { document: informatieobject.titel },
           );
         }
-        const dialogData = new DialogData(
+        const dialogData = new DialogData<unknown, { reden?: string }>(
           [
             new TextareaFormFieldBuilder()
               .id("reden")
@@ -245,11 +245,11 @@ export class ZaakDocumentenComponent
               .maxlength(200)
               .build(),
           ],
-          (results: Record<string, any>) =>
+          ({ reden }) =>
             this.zakenService.ontkoppelInformatieObject({
               zaakUUID: this.zaak.uuid,
               documentUUID: informatieobject.uuid,
-              reden: results?.reden,
+              reden: reden,
             }),
           melding,
         );

--- a/src/main/app/src/app/zaken/zaak-link/zaak-link.component.ts
+++ b/src/main/app/src/app/zaken/zaak-link/zaak-link.component.ts
@@ -142,7 +142,7 @@ export class ZaakLinkComponent implements OnInit, OnDestroy {
       );
   }
 
-  selectCase(row: any) {
+  selectCase(row: unknown) {
     console.log("Selected case: ", row);
   }
 

--- a/src/main/app/src/app/zaken/zaakdata/zaakdata-form/zaakdata-form.component.ts
+++ b/src/main/app/src/app/zaken/zaakdata/zaakdata-form/zaakdata-form.component.ts
@@ -1,10 +1,15 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos
+ * SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
 import { Component, Input } from "@angular/core";
-import { FormArray, FormControl, FormGroup } from "@angular/forms";
+import {
+  AbstractControl,
+  FormArray,
+  FormControl,
+  FormGroup,
+} from "@angular/forms";
 
 @Component({
   selector: "zac-zaakdata-form",
@@ -12,7 +17,11 @@ import { FormArray, FormControl, FormGroup } from "@angular/forms";
   styleUrls: ["./zaakdata-form.component.less"],
 })
 export class ZaakdataFormComponent {
-  @Input() formItem: any;
+  @Input({ required: true }) formItem!:
+    | FormControl
+    | FormGroup
+    | FormArray
+    | AbstractControl;
   @Input() label?: string;
 
   getType() {


### PR DESCRIPTION
This pull request introduces several updates, primarily focused on improving type safety by replacing `any` with more specific types, adding `OnDestroy` lifecycle hooks to components, and updating copyright information. Below is a summary of the key changes:

### Type Safety Improvements:
* Replaced `any` with `unknown` or more specific types in multiple files, such as `BesluitViewComponent`, `Zaak`, `ZaakCreateComponent`, and `ZaakDocumentenComponent`. This ensures better type checking and reduces potential runtime errors. [[1]](diffhunk://#diff-df39433a1a2f46240f7cb8651588bc698070c90ec9025cc9818eeb80ee02a048L55-R55) [[2]](diffhunk://#diff-df39433a1a2f46240f7cb8651588bc698070c90ec9025cc9818eeb80ee02a048L151-R151) [[3]](diffhunk://#diff-cd4cd4a2dec784f00a9f51bf3594ba288435e2b6de28ca9d11001fadecab96c5L58-R58) [[4]](diffhunk://#diff-e8053199587909e95a7ae3b336b2a4bd4df4a22f6ddc529c4c93d1c81ee0526aL143-R143) [[5]](diffhunk://#diff-f0fd51e348bf68cd55b8d594d6c0cff97bc84670e76fbec025697af72ae5a7daL239-R239)

* Updated method signatures and property types to use stricter typing, such as replacing `any[]` with `unknown` or more specific structures. [[1]](diffhunk://#diff-df39433a1a2f46240f7cb8651588bc698070c90ec9025cc9818eeb80ee02a048L142-R142) [[2]](diffhunk://#diff-a7b8de2b20ec5a86f971410a498af5df82b22e82a60b4b31b5e78495abba3e0aL356-R364) [[3]](diffhunk://#diff-4d9e1ed8eac1de2b8b7928f8a5f4969340574ea21203e445026063245271ad0dL145-R145)

### Lifecycle Hook Additions:
* Added the `OnDestroy` lifecycle hook to `TakenMijnComponent` and `TakenWerkvoorraadComponent` to prepare these components for proper cleanup and resource management. [[1]](diffhunk://#diff-20967ab1da51b72134599d134c2abd5f9cbe3267cffbec47af283d89977d257cL37-R43) [[2]](diffhunk://#diff-e5fa18fbbabc6d05049b9bbd6d27c0dc10cbc35c4c120778c9a7d2c5b53b61b0L52-R53)

### Functional and Code Refinements:
* Improved the handling of `zaakdata` by converting it to `Record<string, unknown>` for better type safety.
* Updated the `createZaakPatch` method to use type assertions for `assignment` properties, ensuring more explicit and safer type handling.

### Copyright Updates:
* Updated copyright headers in multiple files to include "2025 Lifely" alongside "Atos." [[1]](diffhunk://#diff-20967ab1da51b72134599d134c2abd5f9cbe3267cffbec47af283d89977d257cL2-R12) [[2]](diffhunk://#diff-c8d23a72ec558f2f0bd15e4a769a875f2fabb3c2bcef15ee1b00b04789cc6a22L2-R24)

### Miscellaneous:
* Adjusted the `getDocumentenVariable` method to ensure `uuids` are always treated as strings by wrapping the value in `String()`.

Solves [PZ-6494](https://dimpact.atlassian.net/browse/PZ-6494)