### PR TITLE
chore: removed more `any` types

### DIFF
--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -21,7 +21,7 @@ const TEST_PERSON_HENDRIKA_JANSE_PHONE_NUMBER = "0612345678";
 async function checkZaakAssignment(
   this: CustomWorld,
   zaakNumber: number,
-  userProfile: unknown,
+  userProfile: {  group: string; username: string; },
 ) {
   await this.expect(
     this.page

--- a/src/main/app/src/app/shared/http/zac-http-client.ts
+++ b/src/main/app/src/app/shared/http/zac-http-client.ts
@@ -128,7 +128,7 @@ export class ZacHttpClient {
 
   private replacePathParams(
     urlTemplate: string,
-    pathParams: Record<string, string | number | boolean>,
+    pathParams: Record<string, string | number | boolean | null>,
   ) {
     let url = urlTemplate;
 
@@ -149,8 +149,13 @@ export class ZacHttpClient {
     return url;
   }
 
-  private prepareUrl(url: string, pathParams?: any) {
-    if (pathParams) {
+  private prepareUrl(
+    url: string,
+    pathParams?: {
+      path?: Record<string, string | number | boolean | null>;
+    },
+  ) {
+    if (pathParams?.path) {
       return this.replacePathParams(url, pathParams.path);
     }
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete.component.ts
@@ -23,7 +23,7 @@ export class AutocompleteComponent
   data: AutocompleteFormField;
 
   options: Record<string, string>[];
-  filteredOptions: Observable<any[]>;
+  filteredOptions: Observable<unknown[]>;
   optionsChanged$: Subscription;
 
   constructor(public translate: TranslateService) {
@@ -69,11 +69,11 @@ export class AutocompleteComponent
     });
   }
 
-  displayFn = (obj: any): string => {
+  displayFn = (obj: unknown): string => {
     return obj?.[this.data.optionLabel] ?? obj;
   };
 
-  private _filter(filter: string): any[] {
+  private _filter(filter: string): unknown[] {
     const filterValue = filter.toLowerCase();
 
     return this.options.filter((option) => {
@@ -81,7 +81,7 @@ export class AutocompleteComponent
     });
   }
 
-  isEditing(): boolean {
+  isEditing() {
     return Boolean(this.data.formControl.value);
   }
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/file/file.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/file/file.component.ts
@@ -76,7 +76,7 @@ export class FileComponent extends FormComponent implements OnInit {
       }
 
       this.subscription = this.createRequest(file).subscribe({
-        next: (event: HttpEvent<any>) => {
+        next: (event: HttpEvent<unknown>) => {
           switch (event.type) {
             case HttpEventType.Sent:
               this.status = UploadStatus.BEZIG;
@@ -84,7 +84,7 @@ export class FileComponent extends FormComponent implements OnInit {
             case HttpEventType.ResponseHeader:
               break;
             case HttpEventType.UploadProgress:
-              this.progress = Math.round((event.loaded / event.total) * 100);
+              this.progress = Math.round((event.loaded / (event.total ?? event.loaded)) * 100);
               this.updateInput(`${file.name} | ${this.progress}%`);
               break;
             case HttpEventType.Response:
@@ -104,7 +104,7 @@ export class FileComponent extends FormComponent implements OnInit {
         },
       });
     } else {
-      this.updateInput(null);
+      this.updateInput("");
     }
   }
 
@@ -120,9 +120,9 @@ export class FileComponent extends FormComponent implements OnInit {
     this.updateInput(null);
   }
 
-  createRequest(file: File): Observable<any> {
+  createRequest(file: File) {
     this.updateInput(file.name);
-    const formData: FormData = new FormData();
+    const formData = new FormData();
     formData.append("filename", file.name);
     formData.append("filesize", file.size.toString());
     formData.append("type", file.type);

--- a/src/main/app/src/app/shared/material-form-builder/model/abstract-form-group-field.ts
+++ b/src/main/app/src/app/shared/material-form-builder/model/abstract-form-group-field.ts
@@ -13,7 +13,7 @@ export abstract class AbstractFormGroupField extends AbstractFormField {
     super();
   }
 
-  initControl(value: { [key: string]: FormControl<any> }): void {
+  initControl(value: Record<string, FormControl>): void {
     this.formControl = new FormGroup(value);
   }
 }

--- a/src/main/app/src/app/shared/paginator/paginator-language-initializer.ts
+++ b/src/main/app/src/app/shared/paginator/paginator-language-initializer.ts
@@ -12,7 +12,7 @@ export function paginatorLanguageInitializerFactory(
   injector: Injector,
 ) {
   return () =>
-    new Promise<any>((resolve: any) => {
+    new Promise((resolve) => {
       const locationInitialized = injector.get(
         LOCATION_INITIALIZED,
         Promise.resolve(null),

--- a/src/main/app/src/app/shared/static-text/static-text.component.ts
+++ b/src/main/app/src/app/shared/static-text/static-text.component.ts
@@ -19,9 +19,9 @@ import { TextIcon } from "../edit/text-icon";
   templateUrl: "./static-text.component.html",
   styleUrls: ["./static-text.component.less"],
 })
-export class StaticTextComponent implements OnInit, OnChanges {
+export class StaticTextComponent<T = unknown> implements OnInit, OnChanges {
   @Input() label?: string;
-  @Input() value?: any;
+  @Input() value?: T;
   @Input() icon?: TextIcon;
   @Input() maxLength?: number;
   @Output() iconClicked = new EventEmitter<void>();

--- a/src/main/app/src/app/shared/utils/form-data.ts
+++ b/src/main/app/src/app/shared/utils/form-data.ts
@@ -25,7 +25,7 @@ function parseFormValue(v: unknown) {
   return v.toString();
 }
 
-export function createFormData<T extends Record<string, any>>(
+export function createFormData<T extends Record<string, unknown>>(
   obj: T,
   mapper: FormDataMapper<T>,
 ): FormData {

--- a/src/main/app/src/app/shared/validators/customValidators.spec.ts
+++ b/src/main/app/src/app/shared/validators/customValidators.spec.ts
@@ -17,7 +17,7 @@ describe(CustomValidators.name, () => {
     });
   });
 
-  const createControl = (value: any): AbstractControl =>
+  const createControl = (value: unknown): AbstractControl =>
     ({
       value,
       errors: null,
@@ -100,7 +100,7 @@ describe(CustomValidators.name, () => {
   );
 
   describe("error messages", () => {
-    const createControl = (value: any): AbstractControl =>
+    const createControl = (value: unknown): AbstractControl =>
       new FormControl(value);
 
     it.each([

--- a/src/main/app/src/app/taken/model/taak.ts
+++ b/src/main/app/src/app/taken/model/taak.ts
@@ -25,7 +25,7 @@ export class Taak {
   status: TaakStatus;
   formulierDefinitieId: FormulierDefinitieID;
   formulierDefinitie: FormulierDefinitie;
-  formioFormulier: any;
+  formioFormulier: unknown;
   tabellen: Record<string, string[]>;
   taakdata: Record<string, string>;
   taakinformatie: Taakinformatie;


### PR DESCRIPTION
This pull request focuses on improving type safety across the codebase by replacing generic `any` types with more specific or appropriate types, such as `unknown`, `Record`, or explicitly defined structures. Additionally, it includes minor functional adjustments for better handling of edge cases and improved code clarity.

### Type Safety Improvements:

* Updated function parameters and return types to replace `any` with `unknown` or more specific types:
  - Changed `userProfile` parameter in `checkZaakAssignment` to a structured type `{ group: string; username: string; }` (`src/e2e/step-definitions/zaak.ts`).
  - Replaced `any` with `unknown` in `AutocompleteComponent` methods and properties, such as `filteredOptions` and `displayFn` (`src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete.component.ts`). [[1]](diffhunk://#diff-9a72b37f0922e94b7d4d6ba0c5fbb2445050dd9074555c013deaa7c08383a520L26-R26) [[2]](diffhunk://#diff-9a72b37f0922e94b7d4d6ba0c5fbb2445050dd9074555c013deaa7c08383a520L72-R84)
  - Updated `HttpEvent<any>` to `HttpEvent<unknown>` in `FileComponent` and adjusted progress calculation to handle potential `null` values for `event.total` (`src/main/app/src/app/shared/material-form-builder/form-components/file/file.component.ts`).
  - Replaced `any` with `unknown` in various utility and model files, such as `createFormData` and `formioFormulier` in `Taak` (`src/main/app/src/app/shared/utils/form-data.ts`, `src/main/app/src/app/taken/model/taak.ts`). [[1]](diffhunk://#diff-71ee4890496c012e2617597920858f3cd49f5332579e4356870ebfd1acb5d576L28-R28) [[2]](diffhunk://#diff-e9e5018a924c5ecb512c58d4f6441390ef5dc9d15fd2de9680314de918faf9a8L28-R28)

* Enhanced type definitions for objects and function parameters:
  - Updated `pathParams` in `replacePathParams` and `prepareUrl` to allow `null` values in addition to `string`, `number`, and `boolean` (`src/main/app/src/app/shared/http/zac-http-client.ts`). [[1]](diffhunk://#diff-fbf0f80a298dbed2966a33c4b700856e1559f3cebc5bd41057dbac68959ac046L131-R131) [[2]](diffhunk://#diff-fbf0f80a298dbed2966a33c4b700856e1559f3cebc5bd41057dbac68959ac046L152-R158)
  - Used `Record<string, FormControl>` instead of `{ [key: string]: FormControl<any> }` in `initControl` (`src/main/app/src/app/shared/material-form-builder/model/abstract-form-group-field.ts`).

### Functional Adjustments:

* Improved handling of edge cases:
  - Ensured `progress` calculation in `FileComponent` avoids `NaN` by using `event.loaded` as a fallback for `event.total` (`src/main/app/src/app/shared/material-form-builder/form-components/file/file.component.ts`).
  - Changed `updateInput` to use an empty string (`""`) instead of `null` for better consistency (`src/main/app/src/app/shared/material-form-builder/form-components/file/file.component.ts`).

* Simplified code by removing redundant type annotations:
  - Removed explicit type annotations like `: any` in `createRequest` and `Promise<any>` to rely on inferred types (`src/main/app/src/app/shared/material-form-builder/form-components/file/file.component.ts`, `src/main/app/src/app/shared/paginator/paginator-language-initializer.ts`). [[1]](diffhunk://#diff-f10fd1b5655641011a06035d915e2afea5be790a9479d053887c15511f294e18L123-R125) [[2]](diffhunk://#diff-0f35be448445b277c26d733f69b1f18d3a42b0747a9864fb3214a86c2b9acfa2L15-R15)

Solves PZ-6495