### PR TITLE
fix: e2e test

### DIFF
--- a/src/e2e/step-definitions/external-systems.ts
+++ b/src/e2e/step-definitions/external-systems.ts
@@ -22,12 +22,9 @@ When(
   "Employee {string} clicks on Create Document button for the new zaak",
   { timeout: ONE_MINUTE_IN_MS },
   async function (this: CustomWorld, user) {
-    await this.page.getByText("note_addDocument maken").click();
+  await this.page.getByRole("button", { name: /Document maken/i }).click();
 
-    const sidebar = this.page.locator("div.sidenav-title");
-    await sidebar.waitFor({ state: "visible" });
-    await sidebar.getByText("Document maken");
-  },
+    await this.page.getByRole("heading", { name: "Document maken", }).waitFor({ state: "visible" });
 );
 
 When(

--- a/src/e2e/step-definitions/external-systems.ts
+++ b/src/e2e/step-definitions/external-systems.ts
@@ -22,9 +22,12 @@ When(
   "Employee {string} clicks on Create Document button for the new zaak",
   { timeout: ONE_MINUTE_IN_MS },
   async function (this: CustomWorld, user) {
-  await this.page.getByRole("button", { name: /Document maken/i }).click();
+    await this.page.getByRole("button", { name: /Document maken/i }).click();
 
-    await this.page.getByRole("heading", { name: "Document maken", }).waitFor({ state: "visible" });
+    await this.page
+      .getByRole("heading", { name: "Document maken" })
+      .waitFor({ state: "visible" });
+  },
 );
 
 When(


### PR DESCRIPTION
This pull request updates a test step definition in the `src/e2e/step-definitions/external-systems.ts` file to improve the reliability and clarity of element selection in the test.

Improvements to element selection:

* Replaced the use of `getByText` with `getByRole` for selecting the "Create Document" button. This change makes the selection more robust and accessible by targeting the button role with a regex for its name.
* Updated the logic for waiting for the "Document maken" sidebar to appear by using `getByRole` to target a heading with a specific name. This improves clarity and ensures the test waits for the correct element. And is according to the [testing librarty priority](https://testing-library.com/docs/queries/about/#priority)

Solves broken E2E test