### PR TITLE
chore: move the signaleringen endpoint to /internal

### DIFF
--- a/charts/zac/Chart.yaml
+++ b/charts/zac/Chart.yaml
@@ -6,7 +6,7 @@
 apiVersion: v2
 name: zaakafhandelcomponent
 description: A Helm chart for installing Zaakafhandelcomponent
-version: 1.0.48
+version: 1.0.49
 appVersion: '3.0'
 icon: https://raw.githubusercontent.com/infonl/dimpact-zaakafhandelcomponent/49f8dee60948282b546ebdfdc5cff6f8bbef0305/docs/manuals/ZAC-gebruikershandleiding/images/pic.svg
 dependencies:

--- a/charts/zac/README.md
+++ b/charts/zac/README.md
@@ -1,6 +1,6 @@
 # zaakafhandelcomponent
 
-![Version: 1.0.48](https://img.shields.io/badge/Version-1.0.48-informational?style=flat-square) ![AppVersion: 3.0](https://img.shields.io/badge/AppVersion-3.0-informational?style=flat-square)
+![Version: 1.0.49](https://img.shields.io/badge/Version-1.0.49-informational?style=flat-square) ![AppVersion: 3.0](https://img.shields.io/badge/AppVersion-3.0-informational?style=flat-square)
 
 A Helm chart for installing Zaakafhandelcomponent
 

--- a/charts/zac/templates/signaleren-cron-job.yaml
+++ b/charts/zac/templates/signaleren-cron-job.yaml
@@ -32,7 +32,7 @@ spec:
                 {{- toYaml .Values.signaleringen.resources | nindent 16 }}
               args:
                 - -s
-                - {{ printf "http://%s.%s/rest/admin/signaleringen/send-signaleringen" (include "zaakafhandelcomponent.fullname" .) .Release.Namespace }}
+                - {{ printf "http://%s.%s/rest/internal/signaleringen/send-signaleringen" (include "zaakafhandelcomponent.fullname" .) .Release.Namespace }}
           {{- with .Values.signaleringen.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/zac/templates/signaleren-delete-cron-job.yaml
+++ b/charts/zac/templates/signaleren-delete-cron-job.yaml
@@ -36,7 +36,7 @@ spec:
                 {{- toYaml .Values.signaleringen.resources | nindent 16 }}
               args:
                 - -X DELETE
-                - {{ printf "http://%s.%s/rest/admin/signaleringen/delete-old" (include "zaakafhandelcomponent.fullname" .) .Release.Namespace }}
+                - {{ printf "http://%s.%s/rest/internal/signaleringen/delete-old" (include "zaakafhandelcomponent.fullname" .) .Release.Namespace }}
           {{- with .Values.signaleringen.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/src/itest/kotlin/nl/info/zac/itest/SignaleringAdminRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/SignaleringAdminRestServiceTest.kt
@@ -104,7 +104,7 @@ class SignaleringAdminRestServiceTest : BehaviorSpec({
 
         When("the admin endpoint to send signaleringen is called") {
             val sendSignaleringenResponse = itestHttpClient.performGetRequest(
-                url = "$ZAC_API_URI/admin/signaleringen/send-signaleringen",
+                url = "$ZAC_API_URI/internal/signaleringen/send-signaleringen",
                 headers = Headers.headersOf(
                     "Content-Type",
                     "application/json"

--- a/src/itest/kotlin/nl/info/zac/itest/SignaleringRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/SignaleringRestServiceTest.kt
@@ -319,7 +319,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
     ) {
         When("signaleringen older than 0 days are deleted") {
             val response = itestHttpClient.performDeleteRequest(
-                "$ZAC_API_URI/admin/signaleringen/delete-old"
+                "$ZAC_API_URI/internal/signaleringen/delete-old"
             )
             val responseBody = response.body!!.string()
             logger.info { "Response: $responseBody" }

--- a/src/main/kotlin/nl/info/zac/app/admin/SignaleringAdminRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/SignaleringAdminRestService.kt
@@ -24,7 +24,11 @@ import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
 import org.eclipse.microprofile.config.inject.ConfigProperty
 
-@Path("admin/signaleringen")
+/**
+ * Internal REST service to send signaleringen and delete old signaleringen.
+ * Not intended to be called by the ZAC frontend but rather by a system cron job or similar.
+ */
+@Path("internal/signaleringen")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 @AllOpen

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -75,14 +75,6 @@
 
     <security-constraint>
         <web-resource-collection>
-            <web-resource-name>admin</web-resource-name>
-            <url-pattern>/rest/admin/*</url-pattern>
-            <http-method>GET</http-method>
-        </web-resource-collection>
-    </security-constraint>
-
-    <security-constraint>
-        <web-resource-collection>
             <web-resource-name>websocket</web-resource-name>
             <description>The authentication check happens in WebSocketServerEndPoint</description>
             <url-pattern>/websocket</url-pattern>


### PR DESCRIPTION
Move the signaleringen endpoint to the /internal URI so we can manage internal endpoint security easier.

Solves PZ-2846