### PR TITLE
fix: fixed broken documents Solr reindexing by adding null handling on nullable fields

### DIFF
--- a/src/main/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverter.kt
+++ b/src/main/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverter.kt
@@ -82,16 +82,16 @@ class DocumentZoekObjectConverter @Inject constructor(
                 ondertekeningDatum = convertToDate(ondertekening.datum)
                 setIndicatie(DocumentIndicatie.ONDERTEKEND, true)
             }
-            informatieobject.locked?.let { setIndicatie(DocumentIndicatie.VERGRENDELD, it) }
+            setIndicatie(DocumentIndicatie.VERGRENDELD, informatieobject.locked)
+            // indicatieGebruiksRecht may be `null` according to the ZGW API specification,
+            // where a null value indicates that it is not known yet
             informatieobject.indicatieGebruiksrecht?.let {
                 setIndicatie(DocumentIndicatie.GEBRUIKSRECHT, it)
             }
-            informatieobject.url?.let {
-                setIndicatie(
-                    DocumentIndicatie.BESLUIT,
-                    brcClientService.isInformatieObjectGekoppeldAanBesluit(it)
-                )
-            }
+            setIndicatie(
+                DocumentIndicatie.BESLUIT,
+                brcClientService.isInformatieObjectGekoppeldAanBesluit(informatieobject.url)
+            )
             setIndicatie(DocumentIndicatie.VERZONDEN, informatieobject.verzenddatum != null)
             if (informatieobject.locked) {
                 enkelvoudigInformatieObjectLockService.readLock(informatieobjectUUID).userId?.let {

--- a/src/main/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverter.kt
+++ b/src/main/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverter.kt
@@ -82,12 +82,16 @@ class DocumentZoekObjectConverter @Inject constructor(
                 ondertekeningDatum = convertToDate(ondertekening.datum)
                 setIndicatie(DocumentIndicatie.ONDERTEKEND, true)
             }
-            setIndicatie(DocumentIndicatie.VERGRENDELD, informatieobject.locked)
-            setIndicatie(DocumentIndicatie.GEBRUIKSRECHT, informatieobject.indicatieGebruiksrecht)
-            setIndicatie(
-                DocumentIndicatie.BESLUIT,
-                brcClientService.isInformatieObjectGekoppeldAanBesluit(informatieobject.url)
-            )
+            informatieobject.locked?.let { setIndicatie(DocumentIndicatie.VERGRENDELD, it) }
+            informatieobject.indicatieGebruiksrecht?.let {
+                setIndicatie(DocumentIndicatie.GEBRUIKSRECHT, it)
+            }
+            informatieobject.url?.let {
+                setIndicatie(
+                    DocumentIndicatie.BESLUIT,
+                    brcClientService.isInformatieObjectGekoppeldAanBesluit(it)
+                )
+            }
             setIndicatie(DocumentIndicatie.VERZONDEN, informatieobject.verzenddatum != null)
             if (informatieobject.locked) {
                 enkelvoudigInformatieObjectLockService.readLock(informatieobjectUUID).userId?.let {

--- a/src/test/kotlin/nl/info/client/zgw/drc/model/DrcFixtures.kt
+++ b/src/test/kotlin/nl/info/client/zgw/drc/model/DrcFixtures.kt
@@ -29,7 +29,9 @@ fun createEnkelvoudigInformatieObject(
     vertrouwelijkheidaanduiding: VertrouwelijkheidaanduidingEnum? = VertrouwelijkheidaanduidingEnum.CONFIDENTIEEL,
     status: StatusEnum = StatusEnum.IN_BEWERKING,
     ontvangstdatum: LocalDate? = null,
-    formaat: String = "fakeformaat"
+    formaat: String = "fakeformaat",
+    informatieObjectType: URI = URI("http://example.com/informatieobjecttype/${UUID.randomUUID()}"),
+    bestandsomvang: Int = 1234,
 ) = EnkelvoudigInformatieObject(
     url,
     versie,
@@ -43,6 +45,8 @@ fun createEnkelvoudigInformatieObject(
     this.status = status
     this.ontvangstdatum = ontvangstdatum
     this.formaat = formaat
+    this.informatieobjecttype = informatieObjectType
+    this.bestandsomvang = bestandsomvang
 }
 
 fun createEnkelvoudigInformatieObjectCreateLockRequest(

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
@@ -225,7 +225,7 @@ class RestInformatieobjectConverterTest : BehaviorSpec({
                     informatieobjectTypeUUID shouldBe expectedUUID
                     informatieobjectTypeUUID shouldBe expectedUUID
                     versie shouldBe 1234
-                    bestandsomvang shouldBe 0
+                    bestandsomvang shouldBe 1234
                     vertrouwelijkheidaanduiding shouldBe VertrouwelijkheidaanduidingEnum.ZEER_GEHEIM.name
                 }
             }

--- a/src/test/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverterTest.kt
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package nl.info.zac.search.converter
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.checkUnnecessaryStub
+import io.mockk.every
+import io.mockk.mockk
+import net.atos.client.zgw.drc.DrcClientService
+import net.atos.client.zgw.zrc.ZrcClientService
+import nl.info.client.zgw.brc.BrcClientService
+import nl.info.client.zgw.drc.model.createEnkelvoudigInformatieObject
+import nl.info.client.zgw.model.createZaak
+import nl.info.client.zgw.model.createZaakInformatieobject
+import nl.info.client.zgw.ztc.ZtcClientService
+import nl.info.client.zgw.ztc.model.createInformatieObjectType
+import nl.info.client.zgw.ztc.model.createZaakType
+import nl.info.zac.enkelvoudiginformatieobject.EnkelvoudigInformatieObjectLockService
+import nl.info.zac.identity.IdentityService
+import java.net.URI
+import java.util.UUID
+
+class DocumentZoekObjectConverterTest : BehaviorSpec({
+    val identityService = mockk<IdentityService>()
+    val brcClientService = mockk<BrcClientService>()
+    val ztcClientService = mockk<ZtcClientService>()
+    val drcClientService = mockk<DrcClientService>()
+    val zrcClientService = mockk<ZrcClientService>()
+    val enkelvoudigInformatieObjectLockService = mockk<EnkelvoudigInformatieObjectLockService>()
+    val documentZoekObjectConverter = DocumentZoekObjectConverter(
+        identityService = identityService,
+        brcClientService = brcClientService,
+        ztcClientService = ztcClientService,
+        drcClientService = drcClientService,
+        zrcClientService = zrcClientService,
+        enkelvoudigInformatieObjectLockService = enkelvoudigInformatieObjectLockService
+    )
+
+    beforeEach {
+        checkUnnecessaryStub()
+    }
+
+    Given("An enkelvoudig informatieobject and a related zaakinformatieobject for a zaak") {
+        val documentUUID = UUID.randomUUID()
+        val zaaktypeUUID = UUID.randomUUID()
+        val informatieObjectType = createInformatieObjectType()
+        val enkelvoudigInformatieObject = createEnkelvoudigInformatieObject(uuid = documentUUID)
+        val zaakInformatieobject = createZaakInformatieobject(informatieobjectUUID = documentUUID)
+        val zaakType = createZaakType(uri = URI("https://example.com/zaaktypes/$zaaktypeUUID"))
+        val zaak = createZaak(
+            zaakTypeURI = zaakType.url,
+            archiefnominatie = null
+        )
+
+        every { drcClientService.readEnkelvoudigInformatieobject(documentUUID) } returns enkelvoudigInformatieObject
+        every { zrcClientService.listZaakinformatieobjecten(enkelvoudigInformatieObject) } returns listOf(zaakInformatieobject)
+        every { zrcClientService.readZaak(any<UUID>()) } returns zaak
+        every { ztcClientService.readZaaktype(any<URI>()) } returns zaakType
+        every { ztcClientService.readInformatieobjecttype(any<URI>()) } returns informatieObjectType
+        every { brcClientService.isInformatieObjectGekoppeldAanBesluit(any()) } returns false
+
+        When("convert is called on the UUID of the enkelvoudig informatieobject") {
+            val documentZoekObject = documentZoekObjectConverter.convert(documentUUID.toString())
+
+            Then("it should return the expected DocumentZoekObject") {
+                with(documentZoekObject!!) {
+                    identificatie shouldBe enkelvoudigInformatieObject.identificatie
+                    titel shouldBe enkelvoudigInformatieObject.titel
+                    beschrijving shouldBe enkelvoudigInformatieObject.beschrijving
+                    zaaktypeOmschrijving shouldBe zaakType.omschrijving
+                    zaaktypeUuid shouldBe zaaktypeUUID.toString()
+                    zaaktypeIdentificatie shouldBe zaakType.identificatie
+                    zaakIdentificatie shouldBe zaak.identificatie
+                    zaakUuid shouldBe zaak.uuid.toString()
+                    // because the archiefnominatie is null, the zaak should be considered 'afgehandeld'
+                    isZaakAfgehandeld shouldBe true
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverterTest.kt
@@ -50,7 +50,7 @@ class DocumentZoekObjectConverterTest : BehaviorSpec({
             An enkelvoudig informatieobject with no indicatiegebruiksrecht, no archiefnominatie 
             and a related zaakinformatieobject for a zaak
         """
-        ) {
+    ) {
         val documentUUID = UUID.randomUUID()
         val zaaktypeUUID = UUID.randomUUID()
         val informatieObjectType = createInformatieObjectType()
@@ -98,7 +98,7 @@ class DocumentZoekObjectConverterTest : BehaviorSpec({
             An enkelvoudig informatieobject with an 'indicatie gebruiksrecht', an archiefnominatie
             and a related zaakinformatieobject for a zaak
             """
-        ) {
+    ) {
         val documentUUID = UUID.randomUUID()
         val zaaktypeUUID = UUID.randomUUID()
         val informatieObjectType = createInformatieObjectType()

--- a/src/test/kotlin/nl/info/zac/search/converter/ZaakZoekObjectConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/converter/ZaakZoekObjectConverterTest.kt
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
-
 package nl.info.zac.search.converter
 
 import io.kotest.core.spec.style.BehaviorSpec


### PR DESCRIPTION
Fixed broken documents Solr reindexing by adding null handling on nullable fields.

Solves PZ-6601