### PR TITLE
chore: removed custom JWT token generation in ZGW API clients

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/EnkelvoudigInformatieObjectRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/EnkelvoudigInformatieObjectRestServiceTest.kt
@@ -129,7 +129,6 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
                           "informatieobjectTypeOmschrijving" : "$INFORMATIE_OBJECT_TYPE_BIJLAGE_OMSCHRIJVING",
                           "informatieobjectTypeUUID" : "$INFORMATIE_OBJECT_TYPE_BIJLAGE_UUID",
                           "isBesluitDocument" : false,
-                          "link" : "",
                           "rechten" : {
                             "lezen" : true,
                             "ondertekenen" : true,
@@ -325,7 +324,6 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
                       "informatieobjectTypeOmschrijving" : "$INFORMATIE_OBJECT_TYPE_BIJLAGE_OMSCHRIJVING",
                       "informatieobjectTypeUUID" : "$INFORMATIE_OBJECT_TYPE_BIJLAGE_UUID",
                       "isBesluitDocument" : false,
-                      "link" : "",
                       "rechten" : {
                         "lezen" : true,
                         "ondertekenen" : true,

--- a/src/itest/kotlin/nl/info/zac/itest/MailRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/MailRestServiceTest.kt
@@ -119,7 +119,6 @@ class MailRestServiceTest : BehaviorSpec({
                   "informatieobjectTypeOmschrijving" : "e-mail",
                   "informatieobjectTypeUUID" : "$TEST_INFORMATIE_OBJECT_TYPE_1_UUID",
                   "isBesluitDocument" : false,
-                  "link" : "",
                   "rechten" : {
                     "lezen" : true,
                     "ondertekenen" : true,

--- a/src/main/java/net/atos/client/zgw/shared/util/ZGWClientHeadersFactory.java
+++ b/src/main/java/net/atos/client/zgw/shared/util/ZGWClientHeadersFactory.java
@@ -51,10 +51,6 @@ public class ZGWClientHeadersFactory implements ClientHeadersFactory {
         }
     }
 
-    public String generateJWTToken() {
-        return JWTTokenGenerator.generate(clientId, secret, loggedInUserInstance.get());
-    }
-
     public void setAuditToelichting(final String toelichting) {
         final LoggedInUser loggedInUser = loggedInUserInstance.get();
         if (loggedInUser != null) {

--- a/src/main/java/net/atos/client/zgw/zrc/ZrcClient.java
+++ b/src/main/java/net/atos/client/zgw/zrc/ZrcClient.java
@@ -130,9 +130,17 @@ public interface ZrcClient {
     @Path("statussen")
     Status statusCreate(final Status status);
 
+    @GET
+    @Path("statussen/{status_uuid}")
+    Status statusRead(@PathParam("status_uuid") final UUID statusUUID);
+
     @POST
     @Path("resultaten")
     Resultaat resultaatCreate(final Resultaat resultaat);
+
+    @GET
+    @Path("resultaten/{uuid}")
+    Resultaat resultaatRead(@PathParam("uuid") final UUID resultaatUUID);
 
     @PUT
     @Path("resultaten/{uuid}")

--- a/src/main/java/net/atos/client/zgw/zrc/model/ZaakInformatieobject.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/ZaakInformatieobject.java
@@ -6,7 +6,7 @@
 package net.atos.client.zgw.zrc.model;
 
 import static net.atos.client.zgw.shared.util.DateTimeUtil.DATE_TIME_FORMAT_WITH_MILLISECONDS;
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.net.URI;
 import java.time.ZonedDateTime;

--- a/src/main/java/net/atos/zac/app/admin/converter/RESTZaaktypeOverzichtConverter.java
+++ b/src/main/java/net/atos/zac/app/admin/converter/RESTZaaktypeOverzichtConverter.java
@@ -5,7 +5,7 @@
 
 package net.atos.zac.app.admin.converter;
 
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 import static nl.info.client.zgw.ztc.model.extensions.ZaakTypeExtensionsKt.isNuGeldig;
 import static nl.info.client.zgw.ztc.model.extensions.ZaakTypeExtensionsKt.isServicenormBeschikbaar;
 

--- a/src/main/java/net/atos/zac/app/bag/converter/RestBagConverter.java
+++ b/src/main/java/net/atos/zac/app/bag/converter/RestBagConverter.java
@@ -5,7 +5,7 @@
 
 package net.atos.zac.app.bag.converter;
 
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.math.BigDecimal;
 import java.util.List;

--- a/src/main/java/net/atos/zac/app/inboxdocumenten/InboxDocumentenRESTService.java
+++ b/src/main/java/net/atos/zac/app/inboxdocumenten/InboxDocumentenRESTService.java
@@ -4,7 +4,7 @@
  */
 package net.atos.zac.app.inboxdocumenten;
 
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectDownloadService.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/EnkelvoudigInformatieObjectDownloadService.java
@@ -5,7 +5,7 @@
 
 package net.atos.zac.app.informatieobjecten;
 
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjectConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjectConverter.java
@@ -4,7 +4,7 @@
  */
 package net.atos.zac.app.informatieobjecten.converter;
 
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 import static nl.info.zac.app.configuratie.model.RestTaalKt.toRestTaal;
 import static nl.info.zac.app.identity.model.RestUserKt.toRestUser;
 import static nl.info.zac.configuratie.ConfiguratieService.OMSCHRIJVING_TAAK_DOCUMENT;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjecttypeConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjecttypeConverter.java
@@ -5,7 +5,7 @@
 
 package net.atos.zac.app.informatieobjecten.converter;
 
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.net.URI;
 import java.util.List;

--- a/src/main/java/net/atos/zac/app/mailtemplate/MailtemplateRESTService.java
+++ b/src/main/java/net/atos/zac/app/mailtemplate/MailtemplateRESTService.java
@@ -4,7 +4,7 @@
  */
 package net.atos.zac.app.mailtemplate;
 
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.util.UUID;
 

--- a/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTService.java
+++ b/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTService.java
@@ -5,7 +5,7 @@
 package net.atos.zac.app.ontkoppeldedocumenten;
 
 import static net.atos.zac.policy.PolicyService.assertPolicy;
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/net/atos/zac/documenten/InboxDocumentenService.java
+++ b/src/main/java/net/atos/zac/documenten/InboxDocumentenService.java
@@ -5,7 +5,7 @@
 
 package net.atos.zac.documenten;
 
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.time.ZoneId;
 import java.util.ArrayList;

--- a/src/main/java/net/atos/zac/documenten/OntkoppeldeDocumentenService.java
+++ b/src/main/java/net/atos/zac/documenten/OntkoppeldeDocumentenService.java
@@ -6,7 +6,7 @@
 package net.atos.zac.documenten;
 
 import static net.atos.zac.util.ValidationUtil.valideerObject;
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
+++ b/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
@@ -31,7 +31,7 @@ import static net.atos.zac.mailtemplates.model.MailTemplateVariabelen.ZAAK_TOELI
 import static net.atos.zac.mailtemplates.model.MailTemplateVariabelen.ZAAK_TYPE;
 import static net.atos.zac.mailtemplates.model.MailTemplateVariabelen.ZAAK_URL;
 import static net.atos.zac.util.StringUtil.joinNonBlankWith;
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;

--- a/src/main/java/net/atos/zac/policy/PolicyService.java
+++ b/src/main/java/net/atos/zac/policy/PolicyService.java
@@ -10,7 +10,7 @@ import static net.atos.client.zgw.zrc.util.StatusTypeUtil.isIntake;
 import static net.atos.zac.flowable.task.TaakVariabelenService.readZaaktypeOmschrijving;
 import static net.atos.zac.flowable.util.TaskUtil.isOpen;
 import static nl.info.client.zgw.drc.model.generated.StatusEnum.DEFINITIEF;
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 import static nl.info.zac.enkelvoudiginformatieobject.util.EnkelvoudigInformatieObjectCheckersKt.isSigned;
 
 import jakarta.enterprise.context.ApplicationScoped;

--- a/src/main/java/net/atos/zac/signalering/event/SignaleringEventObserver.java
+++ b/src/main/java/net/atos/zac/signalering/event/SignaleringEventObserver.java
@@ -5,7 +5,7 @@
 
 package net.atos.zac.signalering.event;
 
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.net.URI;
 import java.util.Optional;

--- a/src/main/java/net/atos/zac/signalering/model/Signalering.java
+++ b/src/main/java/net/atos/zac/signalering/model/Signalering.java
@@ -11,7 +11,7 @@ import static net.atos.zac.signalering.model.SignaleringSubject.ZAAK;
 import static net.atos.zac.signalering.model.SignaleringTarget.GROUP;
 import static net.atos.zac.signalering.model.SignaleringTarget.USER;
 import static net.atos.zac.util.FlywayIntegrator.SCHEMA;
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.time.ZonedDateTime;
 

--- a/src/main/java/net/atos/zac/signalering/model/SignaleringVerzondenZoekParameters.java
+++ b/src/main/java/net/atos/zac/signalering/model/SignaleringVerzondenZoekParameters.java
@@ -10,7 +10,7 @@ import static net.atos.zac.signalering.model.SignaleringSubject.TAAK;
 import static net.atos.zac.signalering.model.SignaleringSubject.ZAAK;
 import static net.atos.zac.signalering.model.SignaleringTarget.GROUP;
 import static net.atos.zac.signalering.model.SignaleringTarget.USER;
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/main/java/net/atos/zac/signalering/model/SignaleringZoekParameters.java
+++ b/src/main/java/net/atos/zac/signalering/model/SignaleringZoekParameters.java
@@ -10,7 +10,7 @@ import static net.atos.zac.signalering.model.SignaleringSubject.TAAK;
 import static net.atos.zac.signalering.model.SignaleringSubject.ZAAK;
 import static net.atos.zac.signalering.model.SignaleringTarget.GROUP;
 import static net.atos.zac.signalering.model.SignaleringTarget.USER;
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/main/java/net/atos/zac/websocket/event/ScreenEventType.java
+++ b/src/main/java/net/atos/zac/websocket/event/ScreenEventType.java
@@ -8,7 +8,7 @@ package net.atos.zac.websocket.event;
 import static net.atos.zac.event.Opcode.DELETED;
 import static net.atos.zac.event.Opcode.SKIPPED;
 import static net.atos.zac.event.Opcode.UPDATED;
-import static nl.info.client.zgw.util.UriUtilsKt.extractUuid;
+import static nl.info.client.zgw.util.ZgwUriUtilsKt.extractUuid;
 
 import java.net.URI;
 import java.util.EnumSet;

--- a/src/main/kotlin/nl/info/client/zgw/util/ZgwUriUtils.kt
+++ b/src/main/kotlin/nl/info/client/zgw/util/ZgwUriUtils.kt
@@ -8,7 +8,7 @@ import java.net.URI
 import java.util.UUID
 
 /**
- * Extracts the UUID from the last part of the path of the ZGW resource URI (i.e. after the last '/').
+ * Extracts the UUID from the last part of the path of the ZGW resource URI (i.e.: after the last '/').
  *
  * @throws IllegalArgumentException if the last part of the path cannot be converted to a UUID
  */
@@ -16,5 +16,15 @@ fun URI.extractUuid(): UUID = extractUuid(this.path).let(UUID::fromString)
 
 fun extractedUuidIsEqual(a: URI?, b: URI?): Boolean =
     a?.let { b?.let { extractUuid(a.path) == extractUuid(b.path) } } ?: (a == null && b == null)
+
+/**
+ * For security reasons, validate that the provided ZGW API URI starts with the value of the configured
+ * ZGW API clients base URI.
+ */
+fun validateZgwApiUri(zgwApiURI: URI, zgwApiBaseURI: String) {
+    check(zgwApiURI.toString().startsWith(zgwApiBaseURI)) {
+        "URI '$zgwApiURI' does not start with value for configured ZGW API clients base URI: '$zgwApiBaseURI'"
+    }
+}
 
 private fun extractUuid(path: String): String = path.substringAfterLast("/")

--- a/src/test/kotlin/nl/info/client/zgw/ztc/ZtcClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/ztc/ZtcClientServiceTest.kt
@@ -12,10 +12,8 @@ import io.kotest.matchers.shouldBe
 import io.mockk.checkUnnecessaryStub
 import io.mockk.every
 import io.mockk.mockk
-import net.atos.client.zgw.shared.util.ZGWClientHeadersFactory
 import nl.info.client.zgw.ztc.ZtcClientService.Companion.MAX_CACHE_SIZE
 import nl.info.client.zgw.ztc.model.createZaakType
-import nl.info.zac.configuratie.ConfiguratieService
 import java.net.URI
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -23,12 +21,8 @@ import kotlin.time.Duration.Companion.seconds
 
 class ZtcClientServiceTest : BehaviorSpec({
     val ztcClient = mockk<ZtcClient>()
-    val zgwClientHeadersFactory = mockk<ZGWClientHeadersFactory>()
-    val configuratieService = mockk<ConfiguratieService>()
     val ztcClientService = ZtcClientService(
-        ztcClient = ztcClient,
-        zgwClientHeadersFactory = zgwClientHeadersFactory,
-        configuratieService = configuratieService,
+        ztcClient = ztcClient
     )
     val initialUUID = UUID.randomUUID()
     val expectedZaakType = createZaakType()
@@ -88,7 +82,7 @@ class ZtcClientServiceTest : BehaviorSpec({
         }
 
         When("reading more zaak types than the cache can hold") {
-            (1..MAX_CACHE_SIZE + 1).forEach {
+            (1..MAX_CACHE_SIZE + 1).forEach { _ ->
                 val generatedUUID = UUID.randomUUID()
                 every {
                     ztcClient.zaaktypeRead(generatedUUID)


### PR DESCRIPTION
Removed custom JWT token generation that was used only for certain functions in the ZGW API clients.

Solves PZ-6618