### PR TITLE
feat: add API token authentication to signaleringen admin service

### DIFF
--- a/charts/zac/Chart.yaml
+++ b/charts/zac/Chart.yaml
@@ -6,7 +6,7 @@
 apiVersion: v2
 name: zaakafhandelcomponent
 description: A Helm chart for installing Zaakafhandelcomponent
-version: 1.0.56
+version: 1.0.57
 appVersion: '3.0'
 icon: https://raw.githubusercontent.com/infonl/dimpact-zaakafhandelcomponent/49f8dee60948282b546ebdfdc5cff6f8bbef0305/docs/manuals/ZAC-gebruikershandleiding/images/pic.svg
 dependencies:

--- a/charts/zac/README.md
+++ b/charts/zac/README.md
@@ -366,7 +366,7 @@ The Github workflow will perform helm-linting and will bump the version if neede
 | solr.service.ports.http | int | `80` |  |
 | solr.zookeeper.enabled | bool | `false` |  |
 | tolerations | list | `[]` | set toleration parameters |
-| zacInternalEndpointsApiKey | string | `""` |  |
+| zacInternalEndpointsApiKey | string | `""` | API key for authentication of internal ZAC endpoints |
 | zgwApis.clientId | string | `""` |  |
 | zgwApis.secret | string | `""` |  |
 | zgwApis.url | string | `""` |  |

--- a/charts/zac/README.md
+++ b/charts/zac/README.md
@@ -1,6 +1,6 @@
 # zaakafhandelcomponent
 
-![Version: 1.0.56](https://img.shields.io/badge/Version-1.0.56-informational?style=flat-square) ![AppVersion: 3.0](https://img.shields.io/badge/AppVersion-3.0-informational?style=flat-square)
+![Version: 1.0.57](https://img.shields.io/badge/Version-1.0.57-informational?style=flat-square) ![AppVersion: 3.0](https://img.shields.io/badge/AppVersion-3.0-informational?style=flat-square)
 
 A Helm chart for installing Zaakafhandelcomponent
 

--- a/charts/zac/ci/helm-testing-values.yaml
+++ b/charts/zac/ci/helm-testing-values.yaml
@@ -104,6 +104,8 @@ smartDocuments:
   # -- Fixed username for authentication
   fixedUserName: "fake"
 
+zacInternalEndpointsApiKey: "fakeZacInternalEndpointsApiKey"
+
 # signaleringen Configuration of the signaleren job
 signaleringen:
   # -- Delete any signaleringen older than this number of days when the corresponding admin endpoint is called.

--- a/charts/zac/ci/helm-testing-values.yaml
+++ b/charts/zac/ci/helm-testing-values.yaml
@@ -104,6 +104,7 @@ smartDocuments:
   # -- Fixed username for authentication
   fixedUserName: "fake"
 
+# -- API key for authentication of internal ZAC endpoints
 zacInternalEndpointsApiKey: "fakeZacInternalEndpointsApiKey"
 
 # signaleringen Configuration of the signaleren job

--- a/charts/zac/templates/signaleren-cron-job.yaml
+++ b/charts/zac/templates/signaleren-cron-job.yaml
@@ -31,7 +31,7 @@ spec:
               resources: 
                 {{- toYaml .Values.signaleringen.resources | nindent 16 }}
               args:
-                - -s
+                - -H "X-API-KEY: {{ .Values.zacInternalEndpointsApiKey }}"
                 - {{ printf "http://%s.%s/rest/internal/signaleringen/send-signaleringen" (include "zaakafhandelcomponent.fullname" .) .Release.Namespace }}
           {{- with .Values.signaleringen.nodeSelector }}
           nodeSelector:

--- a/charts/zac/templates/signaleren-cron-job.yaml
+++ b/charts/zac/templates/signaleren-cron-job.yaml
@@ -31,7 +31,7 @@ spec:
               resources: 
                 {{- toYaml .Values.signaleringen.resources | nindent 16 }}
               args:
-                - -H "X-API-KEY: {{ .Values.zacInternalEndpointsApiKey }}"
+                - {{ printf "-H 'X-API-KEY: %s'" .Values.zacInternalEndpointsApiKey }}
                 - {{ printf "http://%s.%s/rest/internal/signaleringen/send-signaleringen" (include "zaakafhandelcomponent.fullname" .) .Release.Namespace }}
           {{- with .Values.signaleringen.nodeSelector }}
           nodeSelector:

--- a/charts/zac/templates/signaleren-delete-cron-job.yaml
+++ b/charts/zac/templates/signaleren-delete-cron-job.yaml
@@ -36,7 +36,7 @@ spec:
                 {{- toYaml .Values.signaleringen.resources | nindent 16 }}
               args:
                 - -X DELETE
-                - -H "X-API-KEY: {{ .Values.zacInternalEndpointsApiKey }}"
+                - {{ printf "-H 'X-API-KEY: %s'" .Values.zacInternalEndpointsApiKey }}
                 - {{ printf "http://%s.%s/rest/internal/signaleringen/delete-old" (include "zaakafhandelcomponent.fullname" .) .Release.Namespace }}
           {{- with .Values.signaleringen.nodeSelector }}
           nodeSelector:

--- a/charts/zac/templates/signaleren-delete-cron-job.yaml
+++ b/charts/zac/templates/signaleren-delete-cron-job.yaml
@@ -36,6 +36,7 @@ spec:
                 {{- toYaml .Values.signaleringen.resources | nindent 16 }}
               args:
                 - -X DELETE
+                - -H "X-API-KEY: {{ .Values.zacInternalEndpointsApiKey }}"
                 - {{ printf "http://%s.%s/rest/internal/signaleringen/delete-old" (include "zaakafhandelcomponent.fullname" .) .Release.Namespace }}
           {{- with .Values.signaleringen.nodeSelector }}
           nodeSelector:

--- a/charts/zac/values.yaml
+++ b/charts/zac/values.yaml
@@ -101,7 +101,7 @@ bagApi:
 openForms:
   url: ""  # https://open-forms.example.com
 
-# API key for authentication of internal ZAC endpoints
+# -- API key for authentication of internal ZAC endpoints
 zacInternalEndpointsApiKey: ""
 
 smartDocuments:

--- a/src/itest/kotlin/nl/info/zac/itest/SignaleringAdminRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/SignaleringAdminRestServiceTest.kt
@@ -28,9 +28,11 @@ import nl.info.zac.itest.config.ItestConfiguration.TEST_USER_1_USERNAME
 import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID
 import nl.info.zac.itest.config.ItestConfiguration.ZAAK_DESCRIPTION_1
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
+import nl.info.zac.itest.config.ItestConfiguration.ZAC_INTERNAL_ENDPOINTS_API_KEY
 import nl.info.zac.itest.config.ItestConfiguration.zaakManual2Identification
 import nl.info.zac.itest.util.sleepForOpenZaakUniqueConstraint
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import org.json.JSONArray
 import org.json.JSONObject
 import java.time.format.DateTimeFormatter
@@ -102,14 +104,13 @@ class SignaleringAdminRestServiceTest : BehaviorSpec({
         val doHumanTaskPlanItemResponseBody = doHumanTaskPlanItemResponse.body!!.string()
         logger.info { "Start task response: $doHumanTaskPlanItemResponseBody" }
 
-        When("the admin endpoint to send signaleringen is called") {
+        When("The internal endpoint to send signaleringen is called with a valid API key") {
             val sendSignaleringenResponse = itestHttpClient.performGetRequest(
                 url = "$ZAC_API_URI/internal/signaleringen/send-signaleringen",
-                headers = Headers.headersOf(
-                    "Content-Type",
-                    "application/json"
-                ),
-                // the endpoint is a system / admin endpoint currently not requiring any authentication
+                headers = mapOf(
+                    "Content-Type" to "application/json",
+                    "X-API-KEY" to ZAC_INTERNAL_ENDPOINTS_API_KEY
+                ).toHeaders(),
                 addAuthorizationHeader = false
             )
 

--- a/src/itest/kotlin/nl/info/zac/itest/SignaleringRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/SignaleringRestServiceTest.kt
@@ -29,6 +29,7 @@ import nl.info.zac.itest.config.ItestConfiguration.ZAAK_PRODUCTAANVRAAG_1_OMSCHR
 import nl.info.zac.itest.config.ItestConfiguration.ZAAK_PRODUCTAANVRAAG_1_START_DATE
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import org.json.JSONArray
 import org.json.JSONObject
 import java.time.LocalDateTime
@@ -319,7 +320,12 @@ class SignaleringRestServiceTest : BehaviorSpec({
     ) {
         When("signaleringen older than 0 days are deleted") {
             val response = itestHttpClient.performDeleteRequest(
-                "$ZAC_API_URI/internal/signaleringen/delete-old"
+                url = "$ZAC_API_URI/internal/signaleringen/delete-old",
+                headers = mapOf(
+                    "Content-Type" to "application/json",
+                    "X-API-KEY" to ItestConfiguration.ZAC_INTERNAL_ENDPOINTS_API_KEY
+                ).toHeaders(),
+                addAuthorizationHeader = false
             )
             val responseBody = response.body!!.string()
             logger.info { "Response: $responseBody" }

--- a/src/main/kotlin/nl/info/zac/app/admin/SignaleringAdminRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/SignaleringAdminRestService.kt
@@ -18,6 +18,7 @@ import net.atos.zac.util.event.JobEvent
 import net.atos.zac.util.event.JobId
 import nl.info.zac.app.admin.model.RESTDeletedSignaleringenResponse
 import nl.info.zac.authentication.ActiveSession
+import nl.info.zac.authentication.InternalEndpoint
 import nl.info.zac.authentication.setFunctioneelGebruiker
 import nl.info.zac.signalering.SignaleringService
 import nl.info.zac.util.AllOpen
@@ -33,6 +34,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty
 @Produces(MediaType.APPLICATION_JSON)
 @AllOpen
 @NoArgConstructor
+@InternalEndpoint
 class SignaleringAdminRestService @Inject constructor(
     private val signaleringService: SignaleringService,
     private val eventingService: EventingService,

--- a/src/main/kotlin/nl/info/zac/authentication/SecurityUtil.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/SecurityUtil.kt
@@ -26,6 +26,10 @@ class SecurityUtil @Inject constructor(
          */
         const val LOGGED_IN_USER_SESSION_ATTRIBUTE = "logged-in-user"
 
+        /**
+         * Internal-only 'system user' which is used for internal ZAC API request not originating from an actual user.
+         * Requests to these internal API calls are typically initiated from external systems or cron jobs.
+         */
         val FUNCTIONEEL_GEBRUIKER = LoggedInUser(
             "FG",
             "",
@@ -60,7 +64,7 @@ fun getLoggedInUser(httpSession: HttpSession?): LoggedInUser? =
         FUNCTIONEEL_GEBRUIKER // No session in async context!
     }
 
-fun setLoggedInUser(httpSession: HttpSession, loggedInUser: LoggedInUser?) {
+fun setLoggedInUser(httpSession: HttpSession, loggedInUser: LoggedInUser) {
     httpSession.setAttribute(LOGGED_IN_USER_SESSION_ATTRIBUTE, loggedInUser)
 }
 

--- a/src/test/kotlin/nl/info/zac/admin/SignaleringAdminRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/admin/SignaleringAdminRestServiceTest.kt
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package nl.info.zac.admin
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.checkUnnecessaryStub
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.enterprise.inject.Instance
+import jakarta.servlet.http.HttpSession
+import net.atos.zac.event.EventingService
+import net.atos.zac.util.event.JobEvent
+import net.atos.zac.util.event.JobId
+import nl.info.zac.app.admin.SignaleringAdminRestService
+import nl.info.zac.authentication.LoggedInUser
+import nl.info.zac.signalering.SignaleringService
+
+class SignaleringAdminRestServiceTest : BehaviorSpec({
+    val signaleringService = mockk<SignaleringService>()
+    val eventingService = mockk<EventingService>()
+    val httpSession = mockk<HttpSession>()
+    val httpSessionInstance = mockk<Instance<HttpSession>>()
+    val deleteOlderThanDays = 123L
+    val signaleringAdminRestService = SignaleringAdminRestService(
+        signaleringService = signaleringService,
+        eventingService = eventingService,
+        httpSession = httpSessionInstance,
+        deleteOlderThanDays = deleteOlderThanDays
+    )
+
+    beforeEach {
+        checkUnnecessaryStub()
+    }
+
+    Given("A valid HTTP session") {
+        every { httpSessionInstance.get() } returns httpSession
+        every { httpSession.setAttribute(any(), any()) } just Runs
+        every { eventingService.send(any<JobEvent>()) } just Runs
+        val loggedInUserSlot = slot<LoggedInUser>()
+
+        When("sendSignaleringen is called") {
+            val result = signaleringAdminRestService.sendSignaleringen()
+
+            Then("it should set the functioneel gebruiker in the HTTP session") {
+                verify { httpSession.setAttribute("logged-in-user", capture(loggedInUserSlot)) }
+                with(loggedInUserSlot.captured) {
+                    id shouldBe "FG"
+                    firstName shouldBe ""
+                    lastName shouldBe "Functionele gebruiker"
+                    roles shouldBe setOf("functionele_gebruiker")
+                }
+            }
+
+            And("it should send the signaleringen job event") {
+                verify { eventingService.send(JobEvent(JobId.SIGNALERINGEN_JOB)) }
+            }
+
+            And("it should return a success message with the job name") {
+                result shouldBe "Started sending signaleringen using job: 'Signaleringen verzenden'"
+            }
+        }
+    }
+
+    Given("An invalid HTTP session") {
+        every { httpSessionInstance.get() } throws IllegalStateException("No active session")
+
+        When("sendSignaleringen is called") {
+            val exception = shouldThrow<IllegalStateException> {
+                signaleringAdminRestService.sendSignaleringen()
+            }
+
+            Then("it should throw an IllegalStateException") {
+                exception.message shouldBe "No active session"
+            }
+        }
+    }
+})


### PR DESCRIPTION
Added API token authentication to signaleringen admin service. Adjusted the ZAC Kubernetes signaleringen cronjobs accordingly.

Solves PZ-6589