### PR TITLE
fix: continue indexing zaken on IllegalStateException

### DIFF
--- a/src/main/kotlin/nl/info/client/zgw/shared/ZGWApiService.kt
+++ b/src/main/kotlin/nl/info/client/zgw/shared/ZGWApiService.kt
@@ -38,7 +38,6 @@ import java.time.Period
 import java.time.ZonedDateTime
 import java.util.UUID
 import java.util.logging.Logger
-import kotlin.jvm.optionals.getOrNull
 
 /**
  * Service class for ZGW API's.
@@ -270,27 +269,45 @@ class ZGWApiService @Inject constructor(
         }
 
     fun findInitiatorRoleForZaak(zaak: Zaak): Rol<*>? {
-        val roleTypes = ztcClientService.findRoltypen(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR)
-        if (roleTypes.size > 1) {
-            LOG.warning("Multiple initiator role types found for zaaktype: '${zaak.zaaktype}', using the first one.")
+        val roleTypes = ztcClientService.findRoltypen(zaak.zaaktype, OmschrijvingGeneriekEnum.INITIATOR).also {
+            if (it.size > 1) {
+                LOG.warning(
+                    "Multiple initiator role types found for zaaktype: '${zaak.zaaktype}', using the first one."
+                )
+            }
         }
-        val rolType = roleTypes.firstOrNull() ?: return null
-        val roles = zrcClientService.listRollen(RolListParameters(zaak.url, rolType.url)).results
-        if (roles.size > 1) {
-            error("More then one initiator role found for zaak with UUID: '${zaak.uuid}' (count: ${roles.size})")
+        return roleTypes.firstOrNull()?.let { rolType ->
+            val roles = zrcClientService.listRollen(RolListParameters(zaak.url, rolType.url)).results.also {
+                check(it.size <= 1) {
+                    "More than one initiator role found for zaak with UUID: '${zaak.uuid}' (count: ${it.size})"
+                }
+            }
+            roles.firstOrNull()
         }
-        return roles.firstOrNull()
     }
 
     private fun findBehandelaarRoleForZaak(
         zaak: Zaak,
         betrokkeneType: BetrokkeneType
-    ): Rol<*>? = ztcClientService.findRoltypen(zaak.zaaktype, OmschrijvingGeneriekEnum.BEHANDELAAR)
-        // there should be one and only one 'behandelaar' role type
-        // but in case there are multiple, we take the first one
-        .firstOrNull()?.let {
-            zrcClientService.listRollen(RolListParameters(zaak.url, it.url, betrokkeneType)).singleResult.getOrNull()
+    ): Rol<*>? {
+        val roleTypes = ztcClientService.findRoltypen(zaak.zaaktype, OmschrijvingGeneriekEnum.BEHANDELAAR).also {
+            if (it.size > 1) {
+                LOG.warning(
+                    "Multiple behandelaar role types found for zaaktype: '${zaak.zaaktype}', using the first one."
+                )
+            }
         }
+        return roleTypes.firstOrNull()?.let { roleType ->
+            val roles = zrcClientService.listRollen(
+                RolListParameters(zaak.url, roleType.url, betrokkeneType)
+            ).results.also {
+                check(it.size <= 1) {
+                    "More than one behandelaar role found for zaak with UUID: '${zaak.uuid}' (count: ${it.size})"
+                }
+            }
+            roles.firstOrNull()
+        }
+    }
 
     private fun createStatusForZaak(zaakURI: URI, statustypeURI: URI, toelichting: String?): Status {
         val status = Status(zaakURI, statustypeURI, ZonedDateTime.now())

--- a/src/main/kotlin/nl/info/zac/search/IndexingService.kt
+++ b/src/main/kotlin/nl/info/zac/search/IndexingService.kt
@@ -342,6 +342,8 @@ class IndexingService @Inject constructor(
             throw IndexingException(SOLR_INDEXING_ERROR_MESSAGE, jaxbException)
         } catch (processingException: ProcessingException) {
             throw IndexingException(SOLR_INDEXING_ERROR_MESSAGE, processingException)
+        } catch (illegalStateException: IllegalStateException) {
+            throw IndexingException(SOLR_INDEXING_ERROR_MESSAGE, illegalStateException)
         }
     }
 

--- a/src/test/kotlin/nl/info/client/zgw/model/ZrcFixtures.kt
+++ b/src/test/kotlin/nl/info/client/zgw/model/ZrcFixtures.kt
@@ -111,12 +111,12 @@ fun createRolMedewerker(
 )
 
 fun createRolNatuurlijkPersoon(
-    zaaktypeURI: URI = URI("https://example.com/${UUID.randomUUID()}"),
-    rolType: RolType = createRolType(zaakTypeUri = zaaktypeURI),
+    zaakURI: URI = URI("https://example.com/${UUID.randomUUID()}"),
+    rolType: RolType = createRolType(zaakTypeUri = zaakURI),
     toelichting: String = "fakeToelichting",
     natuurlijkPersoon: NatuurlijkPersoon = createNatuurlijkPersoon()
 ) = RolNatuurlijkPersoon(
-    zaaktypeURI,
+    zaakURI,
     rolType,
     toelichting,
     natuurlijkPersoon

--- a/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
@@ -348,7 +348,7 @@ class ZaakServiceTest : BehaviorSpec({
         )
         val identification = "fakeBSN"
         val roleAdviseur = createRolNatuurlijkPersoon(
-            zaakURI = zaak.zaaktype,
+            zaakURI = zaak.url,
             rolType = roleTypeAdviseur,
             natuurlijkPersoon = createNatuurlijkPersoon(bsn = identification)
         )

--- a/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
@@ -348,7 +348,7 @@ class ZaakServiceTest : BehaviorSpec({
         )
         val identification = "fakeBSN"
         val roleAdviseur = createRolNatuurlijkPersoon(
-            zaaktypeURI = zaak.zaaktype,
+            zaakURI = zaak.zaaktype,
             rolType = roleTypeAdviseur,
             natuurlijkPersoon = createNatuurlijkPersoon(bsn = identification)
         )
@@ -389,7 +389,7 @@ class ZaakServiceTest : BehaviorSpec({
         )
         val identification = "fakeBSN"
         val roleAdviseur = createRolNatuurlijkPersoon(
-            zaaktypeURI = zaak.zaaktype,
+            zaakURI = zaak.zaaktype,
             rolType = roleTypeAdviseur,
             natuurlijkPersoon = createNatuurlijkPersoon(bsn = identification)
         )
@@ -422,7 +422,7 @@ class ZaakServiceTest : BehaviorSpec({
         val zaak = createZaak()
         val rolNatuurlijkPersonen = listOf<Rol<*>>(
             createRolNatuurlijkPersoon(
-                zaaktypeURI = zaak.zaaktype,
+                zaakURI = zaak.zaaktype,
                 rolType = createRolType(omschrijvingGeneriek = OmschrijvingGeneriekEnum.BELANGHEBBENDE)
             ),
             createRolOrganisatorischeEenheid(
@@ -430,11 +430,11 @@ class ZaakServiceTest : BehaviorSpec({
                 rolType = createRolType(omschrijvingGeneriek = OmschrijvingGeneriekEnum.BESLISSER)
             ),
             createRolNatuurlijkPersoon(
-                zaaktypeURI = zaak.zaaktype,
+                zaakURI = zaak.zaaktype,
                 rolType = createRolType(omschrijvingGeneriek = OmschrijvingGeneriekEnum.INITIATOR)
             ),
             createRolNatuurlijkPersoon(
-                zaaktypeURI = zaak.zaaktype,
+                zaakURI = zaak.zaaktype,
                 rolType = createRolType(omschrijvingGeneriek = OmschrijvingGeneriekEnum.BEHANDELAAR)
             )
         )


### PR DESCRIPTION
Continue indexing zaken on IllegalStateException to fixed crashed indexing process when an IllegalStateException occurs. Improved error handling.

Solves PZ-6622