### PR TITLE
fix: fixed broken Helm Chart deployment

### DIFF
--- a/charts/zac/Chart.yaml
+++ b/charts/zac/Chart.yaml
@@ -6,7 +6,7 @@
 apiVersion: v2
 name: zaakafhandelcomponent
 description: A Helm chart for installing Zaakafhandelcomponent
-version: 1.0.57
+version: 1.0.58
 appVersion: '3.0'
 icon: https://raw.githubusercontent.com/infonl/dimpact-zaakafhandelcomponent/49f8dee60948282b546ebdfdc5cff6f8bbef0305/docs/manuals/ZAC-gebruikershandleiding/images/pic.svg
 dependencies:

--- a/charts/zac/README.md
+++ b/charts/zac/README.md
@@ -1,6 +1,6 @@
 # zaakafhandelcomponent
 
-![Version: 1.0.57](https://img.shields.io/badge/Version-1.0.57-informational?style=flat-square) ![AppVersion: 3.0](https://img.shields.io/badge/AppVersion-3.0-informational?style=flat-square)
+![Version: 1.0.58](https://img.shields.io/badge/Version-1.0.58-informational?style=flat-square) ![AppVersion: 3.0](https://img.shields.io/badge/AppVersion-3.0-informational?style=flat-square)
 
 A Helm chart for installing Zaakafhandelcomponent
 

--- a/charts/zac/templates/signaleren-cron-job.yaml
+++ b/charts/zac/templates/signaleren-cron-job.yaml
@@ -31,7 +31,8 @@ spec:
               resources: 
                 {{- toYaml .Values.signaleringen.resources | nindent 16 }}
               args:
-                - {{ printf "-H 'X-API-KEY: %s'" .Values.zacInternalEndpointsApiKey }}
+                - -H
+                - 'X-API-KEY: {{ .Values.zacInternalEndpointsApiKey }}'
                 - {{ printf "http://%s.%s/rest/internal/signaleringen/send-signaleringen" (include "zaakafhandelcomponent.fullname" .) .Release.Namespace }}
           {{- with .Values.signaleringen.nodeSelector }}
           nodeSelector:

--- a/charts/zac/templates/signaleren-delete-cron-job.yaml
+++ b/charts/zac/templates/signaleren-delete-cron-job.yaml
@@ -36,7 +36,8 @@ spec:
                 {{- toYaml .Values.signaleringen.resources | nindent 16 }}
               args:
                 - -X DELETE
-                - {{ printf "-H 'X-API-KEY: %s'" .Values.zacInternalEndpointsApiKey }}
+                - -H
+                - 'X-API-KEY: {{ .Values.zacInternalEndpointsApiKey }}'
                 - {{ printf "http://%s.%s/rest/internal/signaleringen/delete-old" (include "zaakafhandelcomponent.fullname" .) .Release.Namespace }}
           {{- with .Values.signaleringen.nodeSelector }}
           nodeSelector:


### PR DESCRIPTION
Fixed broken Helm Chart deployment due to recent change with `zacInternalEndpointsApiKey` value.

Solves PZ-6624