### PR TITLE
feat: added authorization check for 'beheerder' role only on /admin URI

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/AppContainerTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/AppContainerTest.kt
@@ -8,35 +8,61 @@ import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
+import nl.info.zac.itest.client.authenticate
+import nl.info.zac.itest.config.ItestConfiguration.TEST_BEHANDELAAR_1_PASSWORD
+import nl.info.zac.itest.config.ItestConfiguration.TEST_BEHANDELAAR_1_USERNAME
+import nl.info.zac.itest.config.ItestConfiguration.TEST_USER_1_PASSWORD
+import nl.info.zac.itest.config.ItestConfiguration.TEST_USER_1_USERNAME
+import nl.info.zac.itest.config.ItestConfiguration.ZAC_BASE_URI
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_MANAGEMENT_URI
+import java.net.HttpURLConnection.HTTP_FORBIDDEN
+import java.net.HttpURLConnection.HTTP_OK
 
 class AppContainerTest : BehaviorSpec({
     val itestHttpClient = ItestHttpClient()
 
     Given("ZAC Docker container and all related Docker containers are running") {
         When("the health endpoint is called") {
+            val response = itestHttpClient.performGetRequest(
+                url = "$ZAC_MANAGEMENT_URI/health"
+            )
             Then("the response should be ok and the status should be UP") {
-                itestHttpClient.performGetRequest(
-                    url = "$ZAC_MANAGEMENT_URI/health"
-                ).use { response ->
-                    response.isSuccessful shouldBe true
-                    with(response.body!!.string()) {
-                        shouldContainJsonKeyValue("status", "UP")
-                    }
+                response.isSuccessful shouldBe true
+                with(response.body!!.string()) {
+                    shouldContainJsonKeyValue("status", "UP")
                 }
             }
         }
         When("the metrics endpoint is called") {
+            val response = itestHttpClient.performGetRequest(
+                url = "$ZAC_MANAGEMENT_URI/metrics"
+            )
             Then("the response should be ok and the the uptime var should be present") {
-                itestHttpClient.performGetRequest(
-                    url = "$ZAC_MANAGEMENT_URI/metrics"
-                ).use { response ->
-                    response.isSuccessful shouldBe true
-                    with(response.body!!.string()) {
-                        contains("base_jvm_uptime_seconds").shouldBe(true)
-                    }
+                response.isSuccessful shouldBe true
+                with(response.body!!.string()) {
+                    contains("base_jvm_uptime_seconds").shouldBe(true)
                 }
             }
+        }
+        When("/admin is requested for a user who has the 'beheerder' role") {
+            authenticate(username = TEST_USER_1_USERNAME, password = TEST_USER_1_USERNAME)
+            val response = itestHttpClient.performGetRequest(
+                url = "$ZAC_BASE_URI/admin"
+            )
+            Then("the response should be ok") {
+                response.code shouldBe HTTP_OK
+            }
+        }
+        When("/admin is requested for a user who does not have the 'beheerder' role") {
+            authenticate(username = TEST_BEHANDELAAR_1_USERNAME, password = TEST_BEHANDELAAR_1_PASSWORD)
+            val response = itestHttpClient.performGetRequest(
+                url = "$ZAC_BASE_URI/admin"
+            )
+            Then("the response should be forbidden") {
+                response.code shouldBe HTTP_FORBIDDEN
+            }
+            // re-authenticate using testuser1 since currently all subsequent integration tests rely on this user being logged in
+            authenticate(username = TEST_USER_1_USERNAME, password = TEST_USER_1_PASSWORD)
         }
     }
 })

--- a/src/itest/kotlin/nl/info/zac/itest/BagRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/BagRestServiceTest.kt
@@ -14,8 +14,6 @@ import nl.info.zac.itest.client.ZacClient
 import nl.info.zac.itest.config.ItestConfiguration.BAG_MOCK_BASE_URI
 import nl.info.zac.itest.config.ItestConfiguration.BAG_TEST_ADRES_1_IDENTIFICATION
 import nl.info.zac.itest.config.ItestConfiguration.DATE_TIME_2000_01_01
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_ID
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_ZAAK_CREATED
@@ -23,6 +21,8 @@ import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_INDIENEN_AANSPRAKELI
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.util.shouldEqualJsonIgnoringExtraneousFields
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
+import java.net.HttpURLConnection.HTTP_OK
 import java.util.UUID
 
 @Order(TEST_SPEC_ORDER_AFTER_ZAAK_CREATED)
@@ -44,7 +44,7 @@ class BagRestServiceTest : BehaviorSpec({
                 "the response should be a 200 HTTP response with the expected addresses that match the search criteria"
             ) {
                 val responseBody = response.body!!.string()
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJsonIgnoringExtraneousFields """
                     {
@@ -196,7 +196,7 @@ class BagRestServiceTest : BehaviorSpec({
                 """.trimIndent()
             )
             Then("it is successfully added to the zaak") {
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
 
                 // retrieve the BAG objects for the zaak
                 itestHttpClient.performGetRequest(
@@ -248,7 +248,7 @@ class BagRestServiceTest : BehaviorSpec({
             )
             Then("the BAG object is successfully returned") {
                 val responseBody = response.body!!.string()
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJsonIgnoringExtraneousFields """
                     {

--- a/src/itest/kotlin/nl/info/zac/itest/ConfigurationRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ConfigurationRestServiceTest.kt
@@ -13,9 +13,9 @@ import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.config.ItestConfiguration.CONFIG_GEMEENTE_CODE
 import nl.info.zac.itest.config.ItestConfiguration.CONFIG_GEMEENTE_NAAM
 import nl.info.zac.itest.config.ItestConfiguration.CONFIG_MAX_FILE_SIZE_IN_MB
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.util.shouldEqualJsonIgnoringOrder
+import java.net.HttpURLConnection.HTTP_OK
 
 class ConfigurationRestServiceTest : BehaviorSpec({
     val itestHttpClient = ItestHttpClient()
@@ -28,7 +28,7 @@ class ConfigurationRestServiceTest : BehaviorSpec({
             )
 
             Then("the available talen are returned") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJsonIgnoringOrder """
@@ -78,7 +78,7 @@ class ConfigurationRestServiceTest : BehaviorSpec({
             )
 
             Then("the default taal is returned") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJson """
@@ -98,7 +98,7 @@ class ConfigurationRestServiceTest : BehaviorSpec({
             )
 
             Then("the max file size is returned") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 response.body!!.string().toLong() shouldBe CONFIG_MAX_FILE_SIZE_IN_MB
             }
         }
@@ -108,7 +108,7 @@ class ConfigurationRestServiceTest : BehaviorSpec({
             )
 
             Then("no additional file types are returned because ZAC does not provide any by default") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJson """
@@ -122,7 +122,7 @@ class ConfigurationRestServiceTest : BehaviorSpec({
             )
 
             Then("the gemeente name is returned") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJson "\"$CONFIG_GEMEENTE_NAAM\""
@@ -134,7 +134,7 @@ class ConfigurationRestServiceTest : BehaviorSpec({
             )
 
             Then("the gemeente code is returned") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJson "\"$CONFIG_GEMEENTE_CODE\""
@@ -146,7 +146,7 @@ class ConfigurationRestServiceTest : BehaviorSpec({
             )
 
             Then("'true' is returned because BPMN support is enabled for the integration tests") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJson "true"

--- a/src/itest/kotlin/nl/info/zac/itest/CsvRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/CsvRESTServiceTest.kt
@@ -11,12 +11,12 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_REINDEXING
 import nl.info.zac.itest.config.ItestConfiguration.TOTAL_COUNT_ZAKEN
 import nl.info.zac.itest.config.ItestConfiguration.TOTAL_COUNT_ZAKEN_AFGEROND
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import org.junit.jupiter.api.Order
+import java.net.HttpURLConnection.HTTP_OK
 
 /**
  * Since we run this test after [IndexingAdminRestServiceTest], we expect
@@ -109,7 +109,7 @@ class CsvRESTServiceTest : BehaviorSpec({
                  one for each open zaak
                 """
             ) {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
 

--- a/src/itest/kotlin/nl/info/zac/itest/DocumentCreationRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/DocumentCreationRestServiceTest.kt
@@ -12,9 +12,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.client.urlEncode
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_BAD_REQUEST
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_SEE_OTHER
 import nl.info.zac.itest.config.ItestConfiguration.SMART_DOCUMENTS_FILE_ID
 import nl.info.zac.itest.config.ItestConfiguration.SMART_DOCUMENTS_FILE_TITLE
 import nl.info.zac.itest.config.ItestConfiguration.SMART_DOCUMENTS_MOCK_BASE_URI
@@ -29,6 +26,9 @@ import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
 import okhttp3.FormBody
 import okhttp3.Headers
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_BAD_REQUEST
+import java.net.HttpURLConnection.HTTP_OK
+import java.net.HttpURLConnection.HTTP_SEE_OTHER
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
@@ -61,7 +61,7 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
             Then("the response should be OK and the response should contain a redirect URL to SmartDocuments") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
 
                 with(responseBody) {
                     shouldContainJsonKeyValue(
@@ -93,7 +93,7 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
             Then("the response should be OK and the response should contain a redirect URL to Smartdocuments") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
 
                 with(responseBody) {
                     shouldContainJsonKeyValue(
@@ -120,7 +120,7 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
             Then("the response should be 400 Client Error") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_BAD_REQUEST
+                response.code shouldBe HTTP_BAD_REQUEST
                 responseBody shouldContain "must not be null"
             }
         }
@@ -155,7 +155,7 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
                 val locationHeader = response.header("Location")!!
                 logger.info { "Location header: $locationHeader" }
 
-                response.code shouldBe HTTP_STATUS_SEE_OTHER
+                response.code shouldBe HTTP_SEE_OTHER
                 locationHeader shouldContain "static/smart-documents-result.html" +
                     "?zaak=$ZAAK_PRODUCTAANVRAAG_1_IDENTIFICATION" +
                     "&doc=" + SMART_DOCUMENTS_FILE_TITLE.urlEncode() +
@@ -195,7 +195,7 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
                 val locationHeader = response.header("Location")!!
                 logger.info { "Location header: $locationHeader" }
 
-                response.code shouldBe HTTP_STATUS_SEE_OTHER
+                response.code shouldBe HTTP_SEE_OTHER
                 locationHeader shouldContain "static/smart-documents-result.html" +
                     "?zaak=$ZAAK_PRODUCTAANVRAAG_1_IDENTIFICATION" +
                     "&taak=$task1ID" +
@@ -233,7 +233,7 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
                 val locationHeader = response.header("Location")!!
                 logger.info { "Location header: $locationHeader" }
 
-                response.code shouldBe HTTP_STATUS_SEE_OTHER
+                response.code shouldBe HTTP_SEE_OTHER
                 locationHeader shouldContain "static/smart-documents-result.html" +
                     "?zaak=$ZAAK_PRODUCTAANVRAAG_1_IDENTIFICATION" +
                     "&doc=" + SMART_DOCUMENTS_FILE_TITLE.urlEncode() +
@@ -270,7 +270,7 @@ class DocumentCreationRestServiceTest : BehaviorSpec({
                 val locationHeader = response.header("Location")!!
                 logger.info { "Location header: $locationHeader" }
 
-                response.code shouldBe HTTP_STATUS_SEE_OTHER
+                response.code shouldBe HTTP_SEE_OTHER
                 locationHeader shouldContain "static/smart-documents-result.html" +
                     "?zaak=$ZAAK_PRODUCTAANVRAAG_1_IDENTIFICATION" +
                     "&taak=$task1ID" +

--- a/src/itest/kotlin/nl/info/zac/itest/EnkelvoudigInformatieObjectRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/EnkelvoudigInformatieObjectRestServiceTest.kt
@@ -19,7 +19,6 @@ import nl.info.zac.itest.config.ItestConfiguration.DOCUMENT_STATUS_IN_BEWERKING
 import nl.info.zac.itest.config.ItestConfiguration.DOCUMENT_UPDATED_FILE_TITLE
 import nl.info.zac.itest.config.ItestConfiguration.DOCUMENT_VERTROUWELIJKHEIDS_AANDUIDING_OPENBAAR
 import nl.info.zac.itest.config.ItestConfiguration.DOCUMENT_VERTROUWELIJKHEIDS_AANDUIDING_VERTROUWELIJK
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.INFORMATIE_OBJECT_TYPE_BIJLAGE_OMSCHRIJVING
 import nl.info.zac.itest.config.ItestConfiguration.INFORMATIE_OBJECT_TYPE_BIJLAGE_UUID
 import nl.info.zac.itest.config.ItestConfiguration.INFORMATIE_OBJECT_TYPE_FACTUUR_OMSCHRIJVING
@@ -45,6 +44,7 @@ import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 import java.io.File
+import java.net.HttpURLConnection.HTTP_OK
 import java.net.URLDecoder
 import java.time.LocalDate
 import java.time.ZonedDateTime
@@ -114,7 +114,7 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
             Then("the response should be OK and contain information for the created document and uploaded file") {
                 val responseBody = response.body!!.string()
                 logger.info { "$endpointUrl response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 responseBody shouldEqualJsonIgnoringExtraneousFields """
                          {
                           "bestandsnaam" : "$TEST_PDF_FILE_NAME",
@@ -191,7 +191,7 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "$endpointUrl response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 with(responseBody) {
                     shouldContainJsonKeyValue("auteur", TEST_USER_1_NAME)
                     shouldContainJsonKeyValue("status", DOCUMENT_STATUS_IN_BEWERKING)
@@ -227,7 +227,7 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
                 "the response should be OK"
             ) {
                 logger.info { "$endpointUrl status code: ${response.code}" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
             }
         }
         When("the huidigeversie endpoint is called") {
@@ -242,7 +242,7 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 with(responseBody) {
                     shouldContainJsonKeyValue("auteur", TEST_USER_1_NAME)
                     shouldContainJsonKeyValue("status", DOCUMENT_STATUS_DEFINITIEF)
@@ -309,7 +309,7 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "$endpointUrl response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 responseBody shouldEqualJsonIgnoringExtraneousFields """
                     {
                       "bestandsnaam" : "$TEST_TXT_FILE_NAME",
@@ -356,7 +356,7 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
             }
         }
         When("the get enkelvoudiginformatieobject endpoint is called") {
@@ -366,7 +366,7 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
             Then("the response should be OK and should contain information about the document converted to PDF") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 responseBody shouldEqualJsonIgnoringExtraneousFields """
                          {
                           "bestandsnaam" : "$TEST_TXT_CONVERTED_TO_PDF_FILE_NAME",
@@ -437,7 +437,7 @@ class EnkelvoudigInformatieObjectRestServiceTest : BehaviorSpec({
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "$endpointUrl response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 with(responseBody) {
                     shouldContainJsonKeyValue("auteur", TEST_USER_1_NAME)
                     shouldContainJsonKeyValue("beschrijving", "taak-document")

--- a/src/itest/kotlin/nl/info/zac/itest/KlantRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/KlantRestServiceTest.kt
@@ -15,7 +15,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.config.ItestConfiguration.BETROKKENE_IDENTIFACTION_TYPE_VESTIGING
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.ROLTYPE_COUNT
 import nl.info.zac.itest.config.ItestConfiguration.TEST_KVK_ADRES_1
 import nl.info.zac.itest.config.ItestConfiguration.TEST_KVK_EERSTE_HANDELSNAAM_1
@@ -49,6 +48,7 @@ import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_INDIENEN_AANSPRAKELI
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import org.json.JSONArray
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_OK
 
 /**
  * This test assumes a roltype has been created in a previously run test.
@@ -64,7 +64,7 @@ class KlantRestServiceTest : BehaviorSpec({
                 url = "$ZAC_API_URI/klanten/roltype"
             )
             Then("the response should be a 200 HTTP response with the correct amount of roltypen") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 with(responseBody) {
@@ -88,7 +88,7 @@ class KlantRestServiceTest : BehaviorSpec({
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 responseBody shouldEqualJson """
                     {
                       "bsn": "$TEST_PERSON_HENDRIKA_JANSE_BSN",
@@ -110,7 +110,7 @@ class KlantRestServiceTest : BehaviorSpec({
                 url = "$ZAC_API_URI/klanten/vestiging/$TEST_KVK_VESTIGINGSNUMMER_1"
             )
             Then("the vestiging is returned with the expected data") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 // since there is customer contact data linked to this vestiging in our Open Klant container
@@ -135,7 +135,7 @@ class KlantRestServiceTest : BehaviorSpec({
                 url = "$ZAC_API_URI/klanten/vestigingsprofiel/$TEST_KVK_VESTIGINGSNUMMER_1"
             )
             Then("the vestigingsprofiel is returned with the expected data") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 with(responseBody) {
@@ -176,7 +176,7 @@ class KlantRestServiceTest : BehaviorSpec({
                 ).toString()
             )
             Then("the expected companies as defined in the KVK mock are returned") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 with(responseBody) {
@@ -209,7 +209,7 @@ class KlantRestServiceTest : BehaviorSpec({
             Then("the response should be a 200 HTTP response with the customer contactmomenten") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 responseBody shouldEqualJson """
                     {
                       "foutmelding": "",
@@ -244,7 +244,7 @@ class KlantRestServiceTest : BehaviorSpec({
             Then("the response should be ok and the test company should be returned without contact data") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 responseBody shouldEqualJson """
                     {
                       "adres": "$TEST_KVK_ADRES_1, $TEST_KVK_PLAATS_1",
@@ -269,7 +269,7 @@ class KlantRestServiceTest : BehaviorSpec({
             Then("the response should be ok and the test company should be returned without contact data") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 responseBody shouldEqualJson """
                   [ 
                     {
@@ -342,7 +342,7 @@ class KlantRestServiceTest : BehaviorSpec({
             Then("the response should be ok and the test company should be returned without contact data") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 responseBody shouldEqualJson
                     """
                     [

--- a/src/itest/kotlin/nl/info/zac/itest/MailRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/MailRestServiceTest.kt
@@ -12,8 +12,6 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldStartWith
 import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.config.ItestConfiguration.GREENMAIL_API_URI
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.TEST_INFORMATIE_OBJECT_TYPE_1_UUID
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_TASK_COMPLETED
 import nl.info.zac.itest.config.ItestConfiguration.TEST_TXT_FILE_NAME
@@ -24,6 +22,8 @@ import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
 import nl.info.zac.itest.util.shouldEqualJsonIgnoringExtraneousFields
 import okhttp3.Headers
 import org.json.JSONArray
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
+import java.net.HttpURLConnection.HTTP_OK
 import java.net.URLEncoder
 import java.time.LocalDate
 
@@ -64,14 +64,14 @@ class MailRestServiceTest : BehaviorSpec({
             Then("the response should be 'no-content'") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
             }
 
             And("the received mail should contain the right details") {
                 val receivedMailsResponse = itestHttpClient.performGetRequest(
                     url = "$GREENMAIL_API_URI/user/$receiverMail/messages/"
                 )
-                receivedMailsResponse.code shouldBe HTTP_STATUS_OK
+                receivedMailsResponse.code shouldBe HTTP_OK
 
                 val receivedMails = JSONArray(receivedMailsResponse.body!!.string())
                 with(receivedMails) {
@@ -104,7 +104,7 @@ class MailRestServiceTest : BehaviorSpec({
                 )
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 // the email PDF should always be the first
                 JSONArray(responseBody)[0].toString() shouldEqualJsonIgnoringExtraneousFields """
                 {

--- a/src/itest/kotlin/nl/info/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/NotificationsTest.kt
@@ -15,9 +15,6 @@ import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.config.ItestConfiguration
 import nl.info.zac.itest.config.ItestConfiguration.BETROKKENE_IDENTIFACTION_TYPE_VESTIGING
 import nl.info.zac.itest.config.ItestConfiguration.BETROKKENE_IDENTIFICATION_TYPE_BSN
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_FORBIDDEN
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.OBJECTS_BASE_URI
 import nl.info.zac.itest.config.ItestConfiguration.OBJECTTYPE_UUID_PRODUCTAANVRAAG_DIMPACT
 import nl.info.zac.itest.config.ItestConfiguration.OBJECT_PRODUCTAANVRAAG_1_BRON_KENMERK
@@ -50,6 +47,9 @@ import okhttp3.Headers
 import org.json.JSONArray
 import org.json.JSONObject
 import org.testcontainers.containers.wait.strategy.Wait
+import java.net.HttpURLConnection.HTTP_FORBIDDEN
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
+import java.net.HttpURLConnection.HTTP_OK
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -77,7 +77,7 @@ class NotificationsTest : BehaviorSpec({
                 ).toString()
             )
             Then("the response should be forbidden") {
-                response.code shouldBe HTTP_STATUS_FORBIDDEN
+                response.code shouldBe HTTP_FORBIDDEN
             }
         }
     }
@@ -120,7 +120,7 @@ class NotificationsTest : BehaviorSpec({
                 """the response should be 'no content', a zaak should be created in OpenZaak
                         and a zaak productaanvraag proces of type 'Productaanvraag-Dimpact' should be started in ZAC"""
             ) {
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
 
                 // retrieve the newly created zaak and check the contents
                 itestHttpClient.performGetRequest(
@@ -157,7 +157,7 @@ class NotificationsTest : BehaviorSpec({
                 url = "$ZAC_API_URI/zaken/zaak/$zaakProductaanvraag1Uuid/betrokkene",
             )
             Then("the response should be a 200 HTTP response with a list consisting of the betrokkenen") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJsonIgnoringExtraneousFields """
@@ -221,7 +221,7 @@ class NotificationsTest : BehaviorSpec({
                 """the response should be 'no content', a zaak should be created in OpenZaak
                         and a zaak productaanvraag proces of type 'Productaanvraag-Dimpact' should be started in ZAC"""
             ) {
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
 
                 // retrieve the newly created zaak and check the contents
                 itestHttpClient.performGetRequest(
@@ -280,7 +280,7 @@ class NotificationsTest : BehaviorSpec({
             Then(
                 """the response should be 'no content' and a corresponding error message should be logged in ZAC"""
             ) {
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
 
                 // we expect ZAC to log an error message indicating that the resourceURL is invalid
                 dockerComposeContainer.waitingFor(
@@ -342,7 +342,7 @@ class NotificationsTest : BehaviorSpec({
                     ).toString(),
                     addAuthorizationHeader = false
                 )
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
                 // because of the retries using eventually, we can end up with duplicate messages. that's ok.
                 websocketListener.messagesReceived.size shouldBeGreaterThan 0
             }
@@ -408,7 +408,7 @@ class NotificationsTest : BehaviorSpec({
                     ).toString(),
                     addAuthorizationHeader = false
                 )
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
                 // because of the retries using eventually, we can end up with duplicate messages. that's ok.
                 websocketListener.messagesReceived.size shouldBeGreaterThan 0
             }

--- a/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
@@ -14,9 +14,6 @@ import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.client.ZacClient
 import nl.info.zac.itest.config.ItestConfiguration.DATE_TIME_2024_01_31
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NOT_FOUND
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.OPEN_NOTIFICATIONS_API_SECRET_KEY
 import nl.info.zac.itest.config.ItestConfiguration.OPEN_ZAAK_BASE_URI
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
@@ -31,6 +28,9 @@ import okhttp3.Headers
 import okhttp3.Headers.Companion.toHeaders
 import org.json.JSONArray
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_NOT_FOUND
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
+import java.net.HttpURLConnection.HTTP_OK
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -170,7 +170,7 @@ class NotificationsZaakDestroyTest : BehaviorSpec({
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
                 // Retrieve the zaak and check that the zaakdata is no longer available.
                 // Note that in this test scenario the zaak is not deleted from OpenZaak
                 // and so ZAC should still return the zaak.
@@ -178,7 +178,7 @@ class NotificationsZaakDestroyTest : BehaviorSpec({
                 zacClient.retrieveZaak(zaakUUID).run {
                     val responseBody = this.body!!.string()
                     logger.info { "Response: $responseBody" }
-                    this.code shouldBe HTTP_STATUS_OK
+                    this.code shouldBe HTTP_OK
                     responseBody.shouldContainJsonKeyValue("uuid", zaakUUID.toString())
                     responseBody.shouldContainJsonKeyValue("zaakdata", "")
                 }
@@ -198,7 +198,7 @@ class NotificationsZaakDestroyTest : BehaviorSpec({
                 ).run {
                     val responseBody = body!!.string()
                     logger.info { "Response: $responseBody" }
-                    this.code shouldBe HTTP_STATUS_NOT_FOUND
+                    this.code shouldBe HTTP_NOT_FOUND
                     responseBody shouldEqualJson """
                         {"message":"No historic task with id '$aanvullendeInformatieTaskID' found"}
                     """.trimIndent()

--- a/src/itest/kotlin/nl/info/zac/itest/PlanItemsRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/PlanItemsRESTServiceTest.kt
@@ -14,7 +14,6 @@ import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.client.ZacClient
 import nl.info.zac.itest.config.ItestConfiguration.FORMULIER_DEFINITIE_AANVULLENDE_INFORMATIE
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.HUMAN_TASK_AANVULLENDE_INFORMATIE_NAAM
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_ID
@@ -23,6 +22,7 @@ import nl.info.zac.itest.config.ItestConfiguration.ZAAK_PRODUCTAANVRAAG_1_UITERL
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
 import org.json.JSONArray
+import java.net.HttpURLConnection.HTTP_OK
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -143,7 +143,7 @@ class PlanItemsRESTServiceTest : BehaviorSpec({
                 logger.info { "Response: $responseBody" }
 
                 with(zacResponse) {
-                    code shouldBe HTTP_STATUS_OK
+                    code shouldBe HTTP_OK
 
                     with(responseBody) {
                         shouldContainJsonKeyValue("uiterlijkeEinddatumAfdoening", fataleDatum.toString())

--- a/src/itest/kotlin/nl/info/zac/itest/SignaleringAdminRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/SignaleringAdminRestServiceTest.kt
@@ -17,7 +17,6 @@ import nl.info.zac.itest.client.ZacClient
 import nl.info.zac.itest.config.ItestConfiguration.DATE_2024_01_01
 import nl.info.zac.itest.config.ItestConfiguration.DATE_TIME_2024_01_01
 import nl.info.zac.itest.config.ItestConfiguration.GREENMAIL_API_URI
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GEMEENTE_EMAIL_ADDRESS
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_ID
@@ -35,6 +34,7 @@ import okhttp3.Headers
 import okhttp3.Headers.Companion.toHeaders
 import org.json.JSONArray
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_OK
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
@@ -63,7 +63,7 @@ class SignaleringAdminRestServiceTest : BehaviorSpec({
             requestBodyAsString = """{"mail":true,"subjecttype":"TAAK","type":"TAAK_VERLOPEN"}""",
             addAuthorizationHeader = true
         )
-        response.code shouldBe HTTP_STATUS_OK
+        response.code shouldBe HTTP_OK
 
         lateinit var zaakUuid: UUID
         zacClient.createZaak(
@@ -115,7 +115,7 @@ class SignaleringAdminRestServiceTest : BehaviorSpec({
             )
 
             Then("the response should be 'ok' and a task signalering email should be sent") {
-                sendSignaleringenResponse.code shouldBe HTTP_STATUS_OK
+                sendSignaleringenResponse.code shouldBe HTTP_OK
                 val sendSignaleringenResponseBody = sendSignaleringenResponse.body!!.string()
                 logger.info { "Response: $sendSignaleringenResponseBody" }
                 sendSignaleringenResponseBody shouldBe "Started sending signaleringen using job: 'Signaleringen verzenden'"
@@ -126,7 +126,7 @@ class SignaleringAdminRestServiceTest : BehaviorSpec({
                     val receivedMailsResponse = itestHttpClient.performGetRequest(
                         url = "$GREENMAIL_API_URI/user/$TEST_USER_1_EMAIL/messages/"
                     )
-                    receivedMailsResponse.code shouldBe HTTP_STATUS_OK
+                    receivedMailsResponse.code shouldBe HTTP_OK
                     receivedMails = JSONArray(receivedMailsResponse.body!!.string())
                     receivedMails.length() shouldBe 1
                 }

--- a/src/itest/kotlin/nl/info/zac/itest/SignaleringRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/SignaleringRestServiceTest.kt
@@ -14,9 +14,6 @@ import io.kotest.matchers.date.shouldBeBetween
 import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.config.ItestConfiguration
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_BAD_REQUEST
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.OPEN_ZAAK_BASE_URI
 import nl.info.zac.itest.config.ItestConfiguration.OPEN_ZAAK_EXTERNAL_URI
 import nl.info.zac.itest.config.ItestConfiguration.START_DATE
@@ -32,6 +29,9 @@ import okhttp3.Headers
 import okhttp3.Headers.Companion.toHeaders
 import org.json.JSONArray
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_BAD_REQUEST
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
+import java.net.HttpURLConnection.HTTP_OK
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -72,7 +72,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
                 )
 
                 Then("the response should be 'ok'") {
-                    response.code shouldBe HTTP_STATUS_OK
+                    response.code shouldBe HTTP_OK
                 }
             }
         }
@@ -96,7 +96,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
             )
 
             Then("the response should be 'ok'") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
             }
         }
     }
@@ -109,7 +109,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
         )
         var responseBody = zaakInformatieObjectenResponse.body!!.string()
         logger.info { "Response: $responseBody" }
-        zaakInformatieObjectenResponse.code shouldBe HTTP_STATUS_OK
+        zaakInformatieObjectenResponse.code shouldBe HTTP_OK
         val zaakInformatieObjectenUrl = JSONArray(responseBody)
             .getJSONObject(0)
             .getString("url")
@@ -120,7 +120,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
         )
         responseBody = zaakRollenResponse.body!!.string()
         logger.info { "Response: $responseBody" }
-        zaakRollenResponse.code shouldBe HTTP_STATUS_OK
+        zaakRollenResponse.code shouldBe HTTP_OK
         val zaakRollenUrl = JSONObject(responseBody)
             .getJSONArray("results")
             .getJSONObject(0)
@@ -155,7 +155,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
             Then("the response should be 'no content'") {
                 responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
             }
         }
 
@@ -184,7 +184,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
             Then("the response should be 'no content'") {
                 responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
             }
         }
 
@@ -213,7 +213,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
             Then("the response should be 'no content'") {
                 responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
             }
         }
     }
@@ -281,7 +281,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
             logger.info { "Response: $responseBody" }
 
             Then("400 should be returned") {
-                response.code shouldBe HTTP_STATUS_BAD_REQUEST
+                response.code shouldBe HTTP_BAD_REQUEST
                 responseBody.shouldContainJsonKeyValue("message", "Requested page 2 must be <= 1")
             }
         }

--- a/src/itest/kotlin/nl/info/zac/itest/TaskRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/TaskRestServiceTest.kt
@@ -17,7 +17,6 @@ import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.config.ItestConfiguration
 import nl.info.zac.itest.config.ItestConfiguration.FORMULIER_DEFINITIE_AANVULLENDE_INFORMATIE
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
 import nl.info.zac.itest.config.ItestConfiguration.HUMAN_TASK_AANVULLENDE_INFORMATIE_NAAM
 import nl.info.zac.itest.config.ItestConfiguration.SCREEN_EVENT_TYPE_TAKEN_VERDELEN
 import nl.info.zac.itest.config.ItestConfiguration.SCREEN_EVENT_TYPE_TAKEN_VRIJGEVEN
@@ -33,6 +32,7 @@ import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
 import nl.info.zac.itest.util.WebSocketTestListener
 import org.json.JSONArray
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
 import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
 
@@ -143,7 +143,7 @@ class TaskRestServiceTest : BehaviorSpec({
             Then("the task is assigned correctly") {
                 val assignTasksResponseBody = assignTasksResponse.body!!.string()
                 logger.info { "Response: $assignTasksResponseBody" }
-                assignTasksResponse.code shouldBe HTTP_STATUS_NO_CONTENT
+                assignTasksResponse.code shouldBe HTTP_NO_CONTENT
                 // the backend process is asynchronous, so we need to wait a bit until the tasks are assigned
                 eventually(10.seconds) {
                     websocketListener.messagesReceived.size shouldBe 1
@@ -192,7 +192,7 @@ class TaskRestServiceTest : BehaviorSpec({
             Then("the task is released correctly") {
                 val assignTasksResponseBody = releaseTasksResponse.body!!.string()
                 logger.info { "Response: $assignTasksResponseBody" }
-                releaseTasksResponse.code shouldBe HTTP_STATUS_NO_CONTENT
+                releaseTasksResponse.code shouldBe HTTP_NO_CONTENT
                 // the backend process is asynchronous, so we need to wait a bit until the tasks are released
                 eventually(10.seconds) {
                     websocketListener.messagesReceived.size shouldBe 1

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakKoppelenRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakKoppelenRestServiceTest.kt
@@ -12,11 +12,13 @@ import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_SEARCH
 import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_DESCRIPTION
 import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION
+import nl.info.zac.itest.config.ItestConfiguration.ZAAK_MANUAL_2000_03_IDENTIFICATION
 import nl.info.zac.itest.config.ItestConfiguration.ZAAK_MANUAL_2024_01_IDENTIFICATION
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
 import nl.info.zac.itest.util.shouldEqualJsonIgnoringOrderAndExtraneousFields
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
 import java.net.HttpURLConnection.HTTP_OK
 import java.util.UUID
 
@@ -33,6 +35,7 @@ class ZaakKoppelenRestServiceTest : BehaviorSpec({
     val itestHttpClient = ItestHttpClient()
     val logger = KotlinLogging.logger {}
     lateinit var zaakUUID: UUID
+    lateinit var teKoppelenZaakUuid: UUID
 
     Given("ZAC Docker container is running and the zaakafhandelparameters have been created") {
         itestHttpClient.performGetRequest(
@@ -44,12 +47,26 @@ class ZaakKoppelenRestServiceTest : BehaviorSpec({
                 zaakUUID = getString("uuid").let(UUID::fromString)
             }
         }
+        itestHttpClient.performGetRequest(
+            "$ZAC_API_URI/zaken/zaak/id/$ZAAK_MANUAL_2000_03_IDENTIFICATION"
+        ).use { getZaakResponse ->
+            val responseBody = getZaakResponse.body!!.string()
+            logger.info { "Response: $responseBody" }
+            with(JSONObject(responseBody)) {
+                teKoppelenZaakUuid = getString("uuid").let(UUID::fromString)
+            }
+        }
 
-        When("searching for a HOOFDZAAK linkable zaken with 'ZAAK-2000' zaak identifier") {
+        When(
+            """
+            searching for a DEELZAAK linkable zaken with 'ZAAK-2000' zaak identifier and then link the linkable
+            zaak
+            """.trimIndent()
+        ) {
             val response = itestHttpClient.performGetRequest(
                 url = "$ZAC_API_URI/zaken/gekoppelde-zaken/$zaakUUID/zoek-koppelbare-zaken" +
                     "?zoekZaakIdentifier=$ZOEK_ZAAK_IDENTIFIER" +
-                    "&relationType=HOOFDZAAK" +
+                    "&relationType=DEELZAAK" +
                     "&rows=$ROWS_DEFAULT" +
                     "&page=$PAGE_DEFAULT"
             )
@@ -87,7 +104,7 @@ class ZaakKoppelenRestServiceTest : BehaviorSpec({
                       "type": "ZAAK"
                     },
                     {
-                      "identificatie": "ZAAK-2000-0000000003",
+                      "identificatie": "$ZAAK_MANUAL_2000_03_IDENTIFICATION",
                       "isKoppelbaar": true,
                       "omschrijving": "fakeOmschrijving",
                       "zaaktypeOmschrijving": "$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION",
@@ -118,14 +135,33 @@ class ZaakKoppelenRestServiceTest : BehaviorSpec({
             }
         }
 
+        When("link $ZAAK_MANUAL_2000_03_IDENTIFICATION as hoofdzaak to $ZAAK_MANUAL_2024_01_IDENTIFICATION") {
+            val response = itestHttpClient.performPatchRequest(
+                url = "$ZAC_API_URI/zaken/zaak/koppel",
+                requestBodyAsString = """
+                {
+                     "zaakUuid": "$teKoppelenZaakUuid",
+                     "teKoppelenZaakUuid": "$zaakUUID",
+                     "relatieType": "HOOFDZAAK"
+                }
+                """.trimIndent()
+            )
+
+            Then("successfully links the zaak") {
+                response.code shouldBe HTTP_NO_CONTENT
+            }
+        }
+
         When(
-            "searching for a DEELZAAK linkable zaken with 'ZAAK-2000' zaak identifier but without the 'rows' " +
-                "and 'page' request parameters"
+            """
+            searching for a HOOFDZAAK linkable zaken with 'ZAAK-2000' zaak identifier but without the 'rows' and 
+            'page' request parameters
+            """.trimIndent()
         ) {
             val response = itestHttpClient.performGetRequest(
                 url = "$ZAC_API_URI/zaken/gekoppelde-zaken/$zaakProductaanvraag1Uuid/zoek-koppelbare-zaken" +
                     "?zoekZaakIdentifier=$ZOEK_ZAAK_IDENTIFIER" +
-                    "&relationType=DEELZAAK"
+                    "&relationType=HOOFDZAAK"
             )
 
             Then("returns list of zaken each with a linkable flag") {
@@ -161,7 +197,7 @@ class ZaakKoppelenRestServiceTest : BehaviorSpec({
                       "type": "ZAAK"
                     },
                     {
-                      "identificatie": "ZAAK-2000-0000000003",
+                      "identificatie": "$ZAAK_MANUAL_2000_03_IDENTIFICATION",
                       "isKoppelbaar": false,
                       "omschrijving": "fakeOmschrijving",
                       "zaaktypeOmschrijving": "$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION",

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakKoppelenRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakKoppelenRestServiceTest.kt
@@ -9,17 +9,15 @@ import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_SEARCH
 import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_DESCRIPTION
 import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION
-import nl.info.zac.itest.config.ItestConfiguration.ZAAK_MANUAL_2000_03_IDENTIFICATION
 import nl.info.zac.itest.config.ItestConfiguration.ZAAK_MANUAL_2024_01_IDENTIFICATION
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
 import nl.info.zac.itest.util.shouldEqualJsonIgnoringOrderAndExtraneousFields
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_OK
 import java.util.UUID
 
 private const val ROWS_DEFAULT = 10
@@ -35,7 +33,6 @@ class ZaakKoppelenRestServiceTest : BehaviorSpec({
     val itestHttpClient = ItestHttpClient()
     val logger = KotlinLogging.logger {}
     lateinit var zaakUUID: UUID
-    lateinit var teKoppelenZaakUuid: UUID
 
     Given("ZAC Docker container is running and the zaakafhandelparameters have been created") {
         itestHttpClient.performGetRequest(
@@ -47,32 +44,18 @@ class ZaakKoppelenRestServiceTest : BehaviorSpec({
                 zaakUUID = getString("uuid").let(UUID::fromString)
             }
         }
-        itestHttpClient.performGetRequest(
-            "$ZAC_API_URI/zaken/zaak/id/$ZAAK_MANUAL_2000_03_IDENTIFICATION"
-        ).use { getZaakResponse ->
-            val responseBody = getZaakResponse.body!!.string()
-            logger.info { "Response: $responseBody" }
-            with(JSONObject(responseBody)) {
-                teKoppelenZaakUuid = getString("uuid").let(UUID::fromString)
-            }
-        }
 
-        When(
-            """
-            searching for a DEELZAAK linkable zaken with 'ZAAK-2000' zaak identifier and then link the linkable
-            zaak
-            """.trimIndent()
-        ) {
+        When("searching for a HOOFDZAAK linkable zaken with 'ZAAK-2000' zaak identifier") {
             val response = itestHttpClient.performGetRequest(
                 url = "$ZAC_API_URI/zaken/gekoppelde-zaken/$zaakUUID/zoek-koppelbare-zaken" +
                     "?zoekZaakIdentifier=$ZOEK_ZAAK_IDENTIFIER" +
-                    "&relationType=DEELZAAK" +
+                    "&relationType=HOOFDZAAK" +
                     "&rows=$ROWS_DEFAULT" +
                     "&page=$PAGE_DEFAULT"
             )
 
             Then("returns list of zaken each with a linkable flag") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJsonIgnoringOrderAndExtraneousFields """
@@ -104,7 +87,7 @@ class ZaakKoppelenRestServiceTest : BehaviorSpec({
                       "type": "ZAAK"
                     },
                     {
-                      "identificatie": "$ZAAK_MANUAL_2000_03_IDENTIFICATION",
+                      "identificatie": "ZAAK-2000-0000000003",
                       "isKoppelbaar": true,
                       "omschrijving": "fakeOmschrijving",
                       "zaaktypeOmschrijving": "$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION",
@@ -135,37 +118,18 @@ class ZaakKoppelenRestServiceTest : BehaviorSpec({
             }
         }
 
-        When("link $ZAAK_MANUAL_2000_03_IDENTIFICATION as hoofdzaak to $ZAAK_MANUAL_2024_01_IDENTIFICATION") {
-            val response = itestHttpClient.performPatchRequest(
-                url = "$ZAC_API_URI/zaken/zaak/koppel",
-                requestBodyAsString = """
-                {
-                     "zaakUuid": "$teKoppelenZaakUuid",
-                     "teKoppelenZaakUuid": "$zaakUUID",
-                     "relatieType": "HOOFDZAAK"
-                }
-                """.trimIndent()
-            )
-
-            Then("successfully links the zaak") {
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
-            }
-        }
-
         When(
-            """
-            searching for a HOOFDZAAK linkable zaken with 'ZAAK-2000' zaak identifier but without the 'rows' and 
-            'page' request parameters
-            """.trimIndent()
+            "searching for a DEELZAAK linkable zaken with 'ZAAK-2000' zaak identifier but without the 'rows' " +
+                "and 'page' request parameters"
         ) {
             val response = itestHttpClient.performGetRequest(
                 url = "$ZAC_API_URI/zaken/gekoppelde-zaken/$zaakProductaanvraag1Uuid/zoek-koppelbare-zaken" +
                     "?zoekZaakIdentifier=$ZOEK_ZAAK_IDENTIFIER" +
-                    "&relationType=HOOFDZAAK"
+                    "&relationType=DEELZAAK"
             )
 
             Then("returns list of zaken each with a linkable flag") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJsonIgnoringOrderAndExtraneousFields """
@@ -197,7 +161,7 @@ class ZaakKoppelenRestServiceTest : BehaviorSpec({
                       "type": "ZAAK"
                     },
                     {
-                      "identificatie": "$ZAAK_MANUAL_2000_03_IDENTIFICATION",
+                      "identificatie": "ZAAK-2000-0000000003",
                       "isKoppelbaar": false,
                       "omschrijving": "fakeOmschrijving",
                       "zaaktypeOmschrijving": "$ZAAKTYPE_MELDING_KLEIN_EVENEMENT_DESCRIPTION",

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceBesluitTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceBesluitTest.kt
@@ -16,8 +16,6 @@ import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.client.ZacClient
 import nl.info.zac.itest.config.ItestConfiguration.ACTIE_INTAKE_AFRONDEN
 import nl.info.zac.itest.config.ItestConfiguration.DATE_TIME_2000_01_01
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_ID
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_ZAAK_UPDATED
@@ -26,6 +24,8 @@ import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.util.sleepForOpenZaakUniqueConstraint
 import org.json.JSONArray
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
+import java.net.HttpURLConnection.HTTP_OK
 import java.time.LocalDate
 import java.util.UUID
 
@@ -79,7 +79,7 @@ class ZaakRestServiceBesluitTest : BehaviorSpec({
             """.trimIndent()
         ).run {
             logger.info { "Response: ${body!!.string()}" }
-            code shouldBe HTTP_STATUS_NO_CONTENT
+            code shouldBe HTTP_NO_CONTENT
         }
         itestHttpClient.performGetRequest(
             "$ZAC_API_URI/zaken/resultaattypes/$ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID"
@@ -123,7 +123,7 @@ class ZaakRestServiceBesluitTest : BehaviorSpec({
                 """.trimIndent()
             ).run {
                 logger.info { "Response: ${body!!.string()}" }
-                code shouldBe HTTP_STATUS_OK
+                code shouldBe HTTP_OK
             }
 
             Then("the besluit has been created successfully") {
@@ -132,7 +132,7 @@ class ZaakRestServiceBesluitTest : BehaviorSpec({
                 ).use { response ->
                     val responseBody = response.body!!.string()
                     logger.info { "Response: $responseBody" }
-                    response.code shouldBe HTTP_STATUS_OK
+                    response.code shouldBe HTTP_OK
                     val besluiten = JSONArray(responseBody)
                     besluiten.shouldHaveSize(1)
                     besluiten.getJSONObject(0).run {
@@ -177,7 +177,7 @@ class ZaakRestServiceBesluitTest : BehaviorSpec({
             ).use { response ->
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 with(responseBody) {
                     shouldContainJsonKeyValue("isIngetrokken", false)
                     shouldContainJsonKeyValue("toelichting", updateReason)
@@ -190,7 +190,7 @@ class ZaakRestServiceBesluitTest : BehaviorSpec({
                 ).use { response ->
                     val responseBody = response.body!!.string()
                     logger.info { "Response: $responseBody" }
-                    response.code shouldBe HTTP_STATUS_OK
+                    response.code shouldBe HTTP_OK
                     val besluiten = JSONArray(responseBody)
                     besluiten.shouldHaveSize(1)
                     besluiten.getJSONObject(0).run {
@@ -225,7 +225,7 @@ class ZaakRestServiceBesluitTest : BehaviorSpec({
             ).use { response ->
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 with(responseBody) {
                     shouldContainJsonKeyValue("isIngetrokken", true)
                     shouldContainJsonKeyValue("toelichting", "fakeBesluitUpdateToelichting")
@@ -239,7 +239,7 @@ class ZaakRestServiceBesluitTest : BehaviorSpec({
                 ).use { response ->
                     val responseBody = response.body!!.string()
                     logger.info { "Response: $responseBody" }
-                    response.code shouldBe HTTP_STATUS_OK
+                    response.code shouldBe HTTP_OK
                     val besluiten = JSONArray(responseBody)
                     besluiten.shouldHaveSize(1)
                     with(besluiten.getJSONObject(0).toString()) {

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceBpmnTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceBpmnTest.kt
@@ -12,13 +12,13 @@ import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.client.ZacClient
 import nl.info.zac.itest.config.ItestConfiguration.DATE_TIME_2000_01_01
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_ID
 import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_BPMN_TEST_UUID
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import org.json.JSONArray
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_OK
 import java.util.UUID
 
 /**
@@ -41,7 +41,7 @@ class ZaakRestServiceBpmnTest : BehaviorSpec({
         ).run {
             val responseBody = body!!.string()
             logger.info { "Response: $responseBody" }
-            code shouldBe HTTP_STATUS_OK
+            code shouldBe HTTP_OK
             JSONObject(responseBody).run {
                 getJSONObject("zaakdata").run {
                     zaakUUID = getString("zaakUUID").run(UUID::fromString)
@@ -53,7 +53,7 @@ class ZaakRestServiceBpmnTest : BehaviorSpec({
         ).run {
             val responseBody = body!!.string()
             logger.info { "Response: $responseBody" }
-            code shouldBe HTTP_STATUS_OK
+            code shouldBe HTTP_OK
             takenCreateResponse = responseBody
         }
 
@@ -80,7 +80,7 @@ class ZaakRestServiceBpmnTest : BehaviorSpec({
             ).run {
                 val responseBody = body!!.string()
                 logger.info { "Response: $responseBody" }
-                code shouldBe HTTP_STATUS_OK
+                code shouldBe HTTP_OK
                 takenPatchResponse = responseBody
             }
 
@@ -94,7 +94,7 @@ class ZaakRestServiceBpmnTest : BehaviorSpec({
                 zacClient.retrieveZaak(zaakUUID).use { response ->
                     val responseBody = response.body!!.string()
                     logger.info { "Response: $responseBody" }
-                    response.code shouldBe HTTP_STATUS_OK
+                    response.code shouldBe HTTP_OK
                     responseBody.run {
                         shouldContainJsonKeyValue("isOpen", true)
                         shouldNotContainJsonKey("resultaat")

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceCompleteTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceCompleteTest.kt
@@ -20,8 +20,6 @@ import nl.info.zac.itest.config.ItestConfiguration.ACTIE_INTAKE_AFRONDEN
 import nl.info.zac.itest.config.ItestConfiguration.ACTIE_ZAAK_AFHANDELEN
 import nl.info.zac.itest.config.ItestConfiguration.DATE_TIME_2000_01_01
 import nl.info.zac.itest.config.ItestConfiguration.GREENMAIL_API_URI
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_ID
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_ZAAK_UPDATED
@@ -30,6 +28,8 @@ import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.util.sleepForOpenZaakUniqueConstraint
 import org.json.JSONArray
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
+import java.net.HttpURLConnection.HTTP_OK
 import java.util.UUID
 
 /**
@@ -81,7 +81,7 @@ class ZaakRestServiceCompleteTest : BehaviorSpec({
             }
             """.trimIndent()
         ).run {
-            code shouldBe HTTP_STATUS_NO_CONTENT
+            code shouldBe HTTP_NO_CONTENT
         }
         itestHttpClient.performGetRequest(
             "$ZAC_API_URI/zaken/resultaattypes/$ZAAKTYPE_INDIENEN_AANSPRAKELIJKSTELLING_DOOR_DERDEN_BEHANDELEN_UUID"
@@ -118,14 +118,14 @@ class ZaakRestServiceCompleteTest : BehaviorSpec({
                 }
                 """.trimIndent()
             ).run {
-                code shouldBe HTTP_STATUS_NO_CONTENT
+                code shouldBe HTTP_NO_CONTENT
             }
 
             Then("the zaak should be closed and have a result") {
                 zacClient.retrieveZaak(zaakUUID).use { response ->
                     val responseBody = response.body!!.string()
                     logger.info { "Response: $responseBody" }
-                    response.code shouldBe HTTP_STATUS_OK
+                    response.code shouldBe HTTP_OK
                     responseBody.run {
                         shouldContainJsonKeyValue("isOpen", false)
                         shouldContainJsonKey("resultaat")
@@ -143,14 +143,14 @@ class ZaakRestServiceCompleteTest : BehaviorSpec({
                     {"reden":"fakeReason"}
                 """.trimIndent()
             ).run {
-                code shouldBe HTTP_STATUS_NO_CONTENT
+                code shouldBe HTTP_NO_CONTENT
             }
 
             Then("the zaak should be open and should no longer have a result") {
                 zacClient.retrieveZaak(zaakUUID).use { response ->
                     val responseBody = response.body!!.string()
                     logger.info { "Response: $responseBody" }
-                    response.code shouldBe HTTP_STATUS_OK
+                    response.code shouldBe HTTP_OK
                     responseBody.run {
                         shouldContainJsonKeyValue("isOpen", true)
                         shouldNotContainJsonKey("resultaat")
@@ -174,14 +174,14 @@ class ZaakRestServiceCompleteTest : BehaviorSpec({
                     }
                 """.trimIndent()
             ).run {
-                code shouldBe HTTP_STATUS_NO_CONTENT
+                code shouldBe HTTP_NO_CONTENT
             }
 
             Then("the zaak should be closed and have a result") {
                 zacClient.retrieveZaak(zaakUUID).use { response ->
                     val responseBody = response.body!!.string()
                     logger.info { "Response: $responseBody" }
-                    response.code shouldBe HTTP_STATUS_OK
+                    response.code shouldBe HTTP_OK
                     responseBody.run {
                         shouldContainJsonKeyValue("isOpen", false)
                         shouldContainJsonKey("resultaat")
@@ -256,14 +256,14 @@ class ZaakRestServiceCompleteTest : BehaviorSpec({
                 }
                 """.trimIndent()
             ).run {
-                code shouldBe HTTP_STATUS_NO_CONTENT
+                code shouldBe HTTP_NO_CONTENT
             }
 
             Then("email should be sent with correct details") {
                 val receivedMailsResponse = itestHttpClient.performGetRequest(
                     url = "$GREENMAIL_API_URI/user/$receiverMail/messages/"
                 )
-                receivedMailsResponse.code shouldBe HTTP_STATUS_OK
+                receivedMailsResponse.code shouldBe HTTP_OK
 
                 val responseBody = receivedMailsResponse.body!!.string()
                 logger.info { "Response: $responseBody" }

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceExtensionTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceExtensionTest.kt
@@ -11,10 +11,10 @@ import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_ZAAK_CREATED
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.config.ItestConfiguration.zaakProductaanvraag1Uuid
+import java.net.HttpURLConnection.HTTP_OK
 
 /**
  * Integration test to test the functionality of extending a zaak.
@@ -47,7 +47,7 @@ class ZaakRestServiceExtensionTest : BehaviorSpec({
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 with(responseBody) {
                     shouldContainJsonKeyValue("redenVerlenging", reason)
                     shouldContainJsonKeyValue("duurVerlenging", "$daysExtended dagen")

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceLinkParentChildZaken.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceLinkParentChildZaken.kt
@@ -12,8 +12,6 @@ import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.client.ZacClient
 import nl.info.zac.itest.config.ItestConfiguration.DATE_2000_01_01
 import nl.info.zac.itest.config.ItestConfiguration.DATE_TIME_2000_01_01
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_DESCRIPTION
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GROUP_A_ID
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_ZAAK_CREATED
@@ -23,6 +21,8 @@ import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEM
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.util.shouldEqualJsonIgnoringOrderAndExtraneousFields
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
+import java.net.HttpURLConnection.HTTP_OK
 import java.util.UUID
 
 /**
@@ -82,12 +82,12 @@ class ZaakRestServiceLinkParentChildZaken : BehaviorSpec({
             Then("the parent-child relationship between the two zaken should be established") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
 
                 // retrieve the first zaak and check if the parent-child relationship has been established
                 val response = zacClient.retrieveZaak(zaak1UUID)
                 with(response) {
-                    code shouldBe HTTP_STATUS_OK
+                    code shouldBe HTTP_OK
                     val responseBody = response.body!!.string()
                     logger.info { "Response: $responseBody" }
                     JSONObject(responseBody).getJSONArray("gerelateerdeZaken").run {
@@ -120,12 +120,12 @@ class ZaakRestServiceLinkParentChildZaken : BehaviorSpec({
             Then("the parent-child relationship between the two zaken should be removed") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
 
                 // retrieve the zaak and check if the parent-child relationship has been removed
                 val response = zacClient.retrieveZaak(zaak1UUID)
                 with(response) {
-                    code shouldBe HTTP_STATUS_OK
+                    code shouldBe HTTP_OK
                     val responseBody = response.body!!.string()
                     logger.info { "Response: $responseBody" }
                     JSONObject(responseBody).getJSONArray("gerelateerdeZaken").run {

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceTest.kt
@@ -27,8 +27,6 @@ import nl.info.zac.itest.config.ItestConfiguration.DATE_2020_01_15
 import nl.info.zac.itest.config.ItestConfiguration.DATE_2023_09_21
 import nl.info.zac.itest.config.ItestConfiguration.DATE_TIME_2020_01_01
 import nl.info.zac.itest.config.ItestConfiguration.DOCUMENT_VERTROUWELIJKHEIDS_AANDUIDING_OPENBAAR
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_NO_CONTENT
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_OK
 import nl.info.zac.itest.config.ItestConfiguration.INFORMATIE_OBJECT_TYPE_BIJLAGE_UUID
 import nl.info.zac.itest.config.ItestConfiguration.ROLTYPE_NAME_BELANGHEBBENDE
 import nl.info.zac.itest.config.ItestConfiguration.ROLTYPE_NAME_MEDEAANVRAGER
@@ -60,6 +58,8 @@ import nl.info.zac.itest.util.WebSocketTestListener
 import nl.info.zac.itest.util.shouldEqualJsonIgnoringOrderAndExtraneousFields
 import org.json.JSONArray
 import org.json.JSONObject
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
+import java.net.HttpURLConnection.HTTP_OK
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.random.Random
@@ -94,7 +94,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                 toelichting = ZAAK_EXPLANATION_1
             )
             Then("the response should be a 200 HTTP response with the created zaak") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJsonIgnoringOrderAndExtraneousFields """
@@ -357,7 +357,7 @@ class ZaakRestServiceTest : BehaviorSpec({
             val response = zacClient.retrieveZaak(zaak2UUID)
             Then("the response should be a 200 HTTP response and contain the created zaak") {
                 with(response) {
-                    code shouldBe HTTP_STATUS_OK
+                    code shouldBe HTTP_OK
                     val responseBody = response.body!!.string()
                     logger.info { "Response: $responseBody" }
                     with(JSONObject(responseBody)) {
@@ -380,7 +380,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                 """.trimIndent()
             )
             Then("the response should be a 200 OK HTTP response") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 with(responseBody) {
@@ -410,7 +410,7 @@ class ZaakRestServiceTest : BehaviorSpec({
             Then("the response should be a 200 HTTP response with the changed zaak data") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 with(responseBody) {
                     shouldContainJsonKeyValue("uuid", zaak2UUID.toString())
                     shouldContainJsonKeyValue("communicatiekanaal", COMMUNICATIEKANAAL_TEST_2)
@@ -463,7 +463,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                 """.trimIndent()
             )
             Then("the response should be a 200 OK HTTP response") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 with(responseBody) {
@@ -490,7 +490,7 @@ class ZaakRestServiceTest : BehaviorSpec({
             Then("the response should be a 200 HTTP response with the changed zaak data") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 with(responseBody) {
                     shouldContainJsonKey("zaakgeometrie")
                     val geometrie = JSONObject(responseBody)["zaakgeometrie"].toString()
@@ -524,7 +524,7 @@ class ZaakRestServiceTest : BehaviorSpec({
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 responseBody shouldEqualJsonIgnoringOrderAndExtraneousFields """
                     {
                       "besluiten": [],
@@ -581,7 +581,7 @@ class ZaakRestServiceTest : BehaviorSpec({
             Then("the response should be a 200 HTTP response with the changed zaak data without zaakgeometrie") {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 with(responseBody) {
                     shouldNotContainJsonKey("zaakgeometrie")
                 }
@@ -594,7 +594,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                 url = "$ZAC_API_URI/zaken/zaak/$zaak2UUID/betrokkene",
             )
             Then("the response should be a 200 HTTP response with a list consisting of the betrokkenen") {
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
                 with(JSONArray(responseBody)) {
@@ -667,7 +667,7 @@ class ZaakRestServiceTest : BehaviorSpec({
             ) {
                 val lijstVerdelenResponseBody = lijstVerdelenResponse.body!!.string()
                 logger.info { "Response: $lijstVerdelenResponseBody" }
-                lijstVerdelenResponse.code shouldBe HTTP_STATUS_NO_CONTENT
+                lijstVerdelenResponse.code shouldBe HTTP_NO_CONTENT
                 // the backend process is asynchronous, so we need to wait a bit until the zaken are assigned
                 eventually(10.seconds) {
                     zakenVerdelenWebsocketListener.messagesReceived.size shouldBe 1
@@ -677,14 +677,14 @@ class ZaakRestServiceTest : BehaviorSpec({
                         getJSONObject("objectId").getString("resource") shouldBe uniqueResourceId.toString()
                     }
                     zacClient.retrieveZaak(zaakProductaanvraag1Uuid).use { response ->
-                        response.code shouldBe HTTP_STATUS_OK
+                        response.code shouldBe HTTP_OK
                         with(JSONObject(response.body!!.string())) {
                             getJSONObject("groep").getString("id") shouldBe TEST_GROUP_A_ID
                             getJSONObject("behandelaar").getString("id") shouldBe TEST_USER_2_ID
                         }
                     }
                     zacClient.retrieveZaak(zaak2UUID).use { response ->
-                        response.code shouldBe HTTP_STATUS_OK
+                        response.code shouldBe HTTP_OK
                         with(JSONObject(response.body!!.string())) {
                             getJSONObject("groep").getString("id") shouldBe TEST_GROUP_A_ID
                             getJSONObject("behandelaar").getString("id") shouldBe TEST_USER_2_ID
@@ -709,7 +709,7 @@ class ZaakRestServiceTest : BehaviorSpec({
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_OK
+                response.code shouldBe HTTP_OK
                 with(responseBody) {
                     shouldContainJsonKeyValue("uuid", zaakProductaanvraag1Uuid.toString())
                     JSONObject(this).getJSONObject("behandelaar").apply {
@@ -718,7 +718,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                     }
                 }
                 with(zacClient.retrieveZaak(zaakProductaanvraag1Uuid)) {
-                    code shouldBe HTTP_STATUS_OK
+                    code shouldBe HTTP_OK
                     JSONObject(body!!.string()).apply {
                         getJSONObject("behandelaar").apply {
                             getString("id") shouldBe TEST_USER_1_USERNAME
@@ -771,12 +771,12 @@ class ZaakRestServiceTest : BehaviorSpec({
             ) {
                 val responseBody = response.body!!.string()
                 logger.info { "Response: $responseBody" }
-                response.code shouldBe HTTP_STATUS_NO_CONTENT
+                response.code shouldBe HTTP_NO_CONTENT
                 // the backend process is asynchronous, so we need to wait a bit until the zaken are assigned
                 eventually(10.seconds) {
                     websocketListener.messagesReceived.size shouldBe 1
                     with(zacClient.retrieveZaak(zaakProductaanvraag1Uuid)) {
-                        code shouldBe HTTP_STATUS_OK
+                        code shouldBe HTTP_OK
                         JSONObject(body!!.string()).apply {
                             getJSONObject("groep").apply {
                                 getString("id") shouldBe TEST_GROUP_A_ID
@@ -786,7 +786,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                         }
                     }
                     with(zacClient.retrieveZaak(zaak2UUID)) {
-                        code shouldBe HTTP_STATUS_OK
+                        code shouldBe HTTP_OK
                         JSONObject(body!!.string()).apply {
                             getJSONObject("groep").apply {
                                 getString("id") shouldBe TEST_GROUP_A_ID

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakafhandelParametersRestServiceSmartDocumentsTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakafhandelParametersRestServiceSmartDocumentsTest.kt
@@ -10,7 +10,6 @@ import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import nl.info.zac.itest.client.ItestHttpClient
-import nl.info.zac.itest.config.ItestConfiguration.HTTP_STATUS_BAD_REQUEST
 import nl.info.zac.itest.config.ItestConfiguration.INFORMATIE_OBJECT_TYPE_BIJLAGE_UUID
 import nl.info.zac.itest.config.ItestConfiguration.SMART_DOCUMENTS_GROUP_1_ID
 import nl.info.zac.itest.config.ItestConfiguration.SMART_DOCUMENTS_GROUP_1_NAME
@@ -34,6 +33,7 @@ import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_TASK_RE
 import nl.info.zac.itest.config.ItestConfiguration.ZAAKTYPE_MELDING_KLEIN_EVENEMENT_UUID
 import nl.info.zac.itest.config.ItestConfiguration.ZAC_API_URI
 import nl.info.zac.itest.util.shouldEqualJsonIgnoringOrder
+import java.net.HttpURLConnection.HTTP_BAD_REQUEST
 
 @Order(TEST_SPEC_ORDER_AFTER_TASK_RETRIEVED)
 class ZaakafhandelParametersRestServiceSmartDocumentsTest : BehaviorSpec({
@@ -244,7 +244,7 @@ class ZaakafhandelParametersRestServiceSmartDocumentsTest : BehaviorSpec({
                 val storeResponseBody = storeResponse.body!!.string()
                 logger.info { "Response: $storeResponseBody" }
 
-                storeResponse.code shouldBe HTTP_STATUS_BAD_REQUEST
+                storeResponse.code shouldBe HTTP_BAD_REQUEST
                 storeResponseBody shouldBe """{"message":"msg.error.smartdocuments.not.configured"}"""
             }
         }

--- a/src/itest/kotlin/nl/info/zac/itest/client/ItestHttpClient.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/client/ItestHttpClient.kt
@@ -178,8 +178,8 @@ class ItestHttpClient {
         headers.newBuilder().add(Header.AUTHORIZATION.name, determineBearerToken(url)).build()
 
     private fun determineBearerToken(url: String) = "Bearer " + if (URI(url).port == OPEN_ZAAK_EXTERNAL_PORT) {
-        generateToken()
+        generateOpenZaakJwtToken()
     } else {
-        KeycloakClient.requestAccessToken()
+        refreshAccessToken()
     }
 }

--- a/src/itest/kotlin/nl/info/zac/itest/client/KeycloakClient.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/client/KeycloakClient.kt
@@ -21,59 +21,57 @@ lateinit var refreshToken: String
 private val okHttpClient = OkHttpClient.Builder().build()
 private val logger = KotlinLogging.logger {}
 
-object KeycloakClient {
-    private const val ACCESS_TOKEN_ATTRIBUTE = "access_token"
-    private const val REFRESH_TOKEN_ATTRIBUTE = "refresh_token"
+private const val ACCESS_TOKEN_ATTRIBUTE = "access_token"
+private const val REFRESH_TOKEN_ATTRIBUTE = "refresh_token"
 
-    fun authenticate(
-        username: String = TEST_USER_1_USERNAME,
-        password: String = TEST_USER_1_PASSWORD
-    ) = okHttpClient.newCall(
+fun authenticate(
+    username: String = TEST_USER_1_USERNAME,
+    password: String = TEST_USER_1_PASSWORD
+) = okHttpClient.newCall(
+    Request.Builder()
+        .headers(Headers.headersOf("Content-Type", "application/x-www-form-urlencoded"))
+        .url("$KEYCLOAK_HOSTNAME_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token")
+        .post(
+            FormBody.Builder()
+                .add("client_id", KEYCLOAK_CLIENT)
+                .add("grant_type", "password")
+                .add("username", username)
+                .add("password", password)
+                .add("client_secret", KEYCLOAK_CLIENT_SECRET)
+                .build()
+        )
+        .build()
+).execute().apply {
+    logger.info { "--- authenticate status code: $code ---" }
+    refreshToken = JSONObject(this.body!!.string()).getString(REFRESH_TOKEN_ATTRIBUTE)
+}
+
+/**
+ * Always request a new access token using the current refresh token to make sure we remain
+ * authenticated and our access token does not expire.
+ * Note that this assumes that subsequent calls to this method are done quickly enough so that the
+ * refresh token does not expire in the meantime.
+ */
+fun refreshAccessToken(): String {
+    okHttpClient.newCall(
         Request.Builder()
             .headers(Headers.headersOf("Content-Type", "application/x-www-form-urlencoded"))
             .url("$KEYCLOAK_HOSTNAME_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token")
             .post(
                 FormBody.Builder()
                     .add("client_id", KEYCLOAK_CLIENT)
-                    .add("grant_type", "password")
-                    .add("username", username)
-                    .add("password", password)
+                    .add("grant_type", REFRESH_TOKEN_ATTRIBUTE)
+                    .add(REFRESH_TOKEN_ATTRIBUTE, refreshToken)
                     .add("client_secret", KEYCLOAK_CLIENT_SECRET)
                     .build()
             )
             .build()
     ).execute().apply {
-        logger.info { "--- authenticate status code: $code ---" }
-        refreshToken = JSONObject(this.body!!.string()).getString(REFRESH_TOKEN_ATTRIBUTE)
-    }
-
-    /**
-     * Always request a new access token using the current refresh token to make sure we remain
-     * authenticated and our access token does not expire.
-     * Note that this assumes that subsequent calls to this method are done quickly enough so that the
-     * refresh token does not expire in the meantime.
-     */
-    fun requestAccessToken(): String {
-        okHttpClient.newCall(
-            Request.Builder()
-                .headers(Headers.headersOf("Content-Type", "application/x-www-form-urlencoded"))
-                .url("$KEYCLOAK_HOSTNAME_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token")
-                .post(
-                    FormBody.Builder()
-                        .add("client_id", KEYCLOAK_CLIENT)
-                        .add("grant_type", REFRESH_TOKEN_ATTRIBUTE)
-                        .add(REFRESH_TOKEN_ATTRIBUTE, refreshToken)
-                        .add("client_secret", KEYCLOAK_CLIENT_SECRET)
-                        .build()
-                )
-                .build()
-        ).execute().apply {
-            with(JSONObject(this.body!!.string())) {
-                if (has(REFRESH_TOKEN_ATTRIBUTE)) {
-                    refreshToken = getString(REFRESH_TOKEN_ATTRIBUTE)
-                }
-                return getString(ACCESS_TOKEN_ATTRIBUTE)
+        with(JSONObject(this.body!!.string())) {
+            if (has(REFRESH_TOKEN_ATTRIBUTE)) {
+                refreshToken = getString(REFRESH_TOKEN_ATTRIBUTE)
             }
+            return getString(ACCESS_TOKEN_ATTRIBUTE)
         }
     }
 }

--- a/src/itest/kotlin/nl/info/zac/itest/client/OpenZaakClient.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/client/OpenZaakClient.kt
@@ -12,7 +12,7 @@ import nl.info.zac.itest.config.ItestConfiguration.TEST_USER_1_NAME
 import nl.info.zac.itest.config.ItestConfiguration.TEST_USER_1_USERNAME
 import java.util.Date
 
-fun generateToken(): String =
+fun generateOpenZaakJwtToken(): String =
     JWT.create().withIssuer(OPEN_ZAAK_CLIENT_ID)
         .withIssuedAt(Date())
         .withHeader(mapOf("client_identifier" to OPEN_ZAAK_CLIENT_ID))

--- a/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
@@ -21,13 +21,6 @@ object ItestConfiguration {
     private const val ZAC_MANAGEMENT_PORT = 9990
     private const val GREENMAIL_API_PORT = 18083
 
-    const val HTTP_STATUS_OK = 200
-    const val HTTP_STATUS_NO_CONTENT = 204
-    const val HTTP_STATUS_SEE_OTHER = 303
-    const val HTTP_STATUS_BAD_REQUEST = 400
-    const val HTTP_STATUS_FORBIDDEN = 403
-    const val HTTP_STATUS_NOT_FOUND = 404
-
     /**
      * Temporarily increase the HTTP read timeout to 60 seconds to allow for
      * the slow 'document-creation/create-document-attended' endpoint to complete on slower computers.
@@ -168,6 +161,7 @@ object ItestConfiguration {
     const val TEST_COORDINATOR_1_USERNAME = "coordinator1"
     const val TEST_COORDINATOR_1_NAME = "Test Coordinator1"
     const val TEST_BEHANDELAAR_1_USERNAME = "behandelaar1"
+    const val TEST_BEHANDELAAR_1_PASSWORD = "behandelaar1"
     const val TEST_BEHANDELAAR_1_NAME = "Test Behandelaar1"
     const val TEST_RAADPLEGER_1_ID = "raadpleger1"
     const val TEST_RAADPLEGER_1_NAME = "Test Raadpleger1"
@@ -319,10 +313,12 @@ object ItestConfiguration {
      */
     const val ZAC_DEFAULT_DOCKER_IMAGE = "ghcr.io/infonl/zaakafhandelcomponent:dev"
 
+    const val ZAC_BASE_URI = "http://localhost:$ZAC_CONTAINER_PORT"
+
     /**
      * The ZAC API URI from outside the Docker network.
      */
-    const val ZAC_API_URI = "http://localhost:$ZAC_CONTAINER_PORT/rest"
+    const val ZAC_API_URI = "$ZAC_BASE_URI/rest"
 
     /**
      * The ZAC websocket base URI from outside the Docker network.

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -46,6 +46,10 @@
         <role-name>zaakafhandelcomponent_user</role-name>
     </security-role>
 
+    <security-role>
+        <role-name>beheerder</role-name>
+    </security-role>
+
     <security-constraint>
         <display-name>Deny all HTTP methods on '/rest/notificaties' except POST</display-name>
         <web-resource-collection>
@@ -123,6 +127,17 @@
             <http-method-omission>GET</http-method-omission>
         </web-resource-collection>
         <auth-constraint/>
+    </security-constraint>
+
+    <security-constraint>
+        <display-name>Require the 'beheerder' role on `/admin/*`</display-name>
+        <web-resource-collection>
+            <web-resource-name>admin</web-resource-name>
+            <url-pattern>/admin/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>beheerder</role-name>
+        </auth-constraint>
     </security-constraint>
 
     <security-constraint>


### PR DESCRIPTION
Added authorization check for 'beheerder' role only on /admin URI in `web.xml`. Added integration test for this in `AppContainerTest` class. Refactored other integration tests to use existing constants for HTTP status codes instead of using our own.

Solves PZ-6653