### PR TITLE
feat(zaak-create): only allow `bedrijf` or `persoon` based on `zaaktype`

### DIFF
--- a/src/main/app/src/app/zaken/zaak-create/zaak-create.component.html
+++ b/src/main/app/src/app/zaken/zaak-create/zaak-create.component.html
@@ -9,8 +9,14 @@
       (klantGegevens)="initiatorSelected($event.klant)"
       [sideNav]="actionsSidenav"
       [initiator]="true"
-      [allowBedrijf]="true"
-      [allowPersoon]="true"
+      [allowBedrijf]="
+        form.controls.zaaktype.value?.zaakafhandelparameters
+          ?.betrokkeneKoppelingen?.kvkKoppelen ?? false
+      "
+      [allowPersoon]="
+        form.controls.zaaktype.value?.zaakafhandelparameters
+          ?.betrokkeneKoppelingen?.brpKoppelen ?? false
+      "
     ></zac-klant-koppel>
     <zac-bag-zoek
       *ngSwitchCase="'actie.bagObject.toevoegen'"


### PR DESCRIPTION
This pull request updates the logic for determining whether companies (`allowBedrijf`) and individuals (`allowPersoon`) can be linked in the `zaak-create` component. Instead of hardcoding these values as `true`, the new implementation dynamically derives them based on the `zaakafhandelparameters` of the selected `zaaktype`.

Solves 6690