### PR TITLE
feature(app): No Confirmation Sent - indication added

### DIFF
--- a/src/main/app/src/app/shared/indicaties/zaak-indicaties/zaak-indicaties.component.ts
+++ b/src/main/app/src/app/shared/indicaties/zaak-indicaties/zaak-indicaties.component.ts
@@ -17,6 +17,7 @@ export enum ZaakIndicatie {
   HOOFDZAAK = "HOOFDZAAK",
   DEELZAAK = "DEELZAAK",
   VERLENGD = "VERLENGD",
+  ONTVANGSTBEVESTIGING_NIET_VERSTUURD = "ONTVANGSTBEVESTIGING_NIET_VERSTUURD",
 }
 
 @Component({
@@ -93,6 +94,17 @@ export class ZaakIndicatiesComponent
             ),
           );
           break;
+        case ZaakIndicatie.ONTVANGSTBEVESTIGING_NIET_VERSTUURD:
+          this.indicaties.push(
+            new Indicatie(
+              indicatie,
+              "unsubscribe",
+              this.translateService.instant(
+                "indicatie.ONTVANGSTBEVESTIGING_NIET_VERSTUURD",
+              ),
+            ),
+          );
+          break;
       }
     });
   }
@@ -100,21 +112,21 @@ export class ZaakIndicatiesComponent
   private getRedenOpschorting(): string {
     return this.zaakZoekObject
       ? this.zaakZoekObject.redenOpschorting
-      : this.zaak.redenOpschorting;
+      : (this.zaak.redenOpschorting ?? "");
   }
 
   private getStatusToelichting(): string {
     return this.zaakZoekObject
       ? this.zaakZoekObject.statusToelichting
-      : this.zaak.status.toelichting;
+      : (this.zaak.status?.toelichting ?? "");
   }
 
   private getDeelZaakToelichting(): string {
-    if (this.zaak) {
+    if (this.zaak.gerelateerdeZaken?.length) {
       const hoofdzaakID = this.zaak.gerelateerdeZaken.find(
         (gerelateerdeZaak) =>
           gerelateerdeZaak.relatieType === ZaakRelatietype.HOOFDZAAK,
-      ).identificatie;
+      )?.identificatie;
       return this.translateService.instant("msg.zaak.relatie", {
         identificatie: hoofdzaakID,
       });
@@ -123,7 +135,7 @@ export class ZaakIndicatiesComponent
   }
 
   private getHoofdzaakToelichting(): string {
-    if (this.zaak) {
+    if (this.zaak.gerelateerdeZaken?.length) {
       const deelzaken = this.zaak.gerelateerdeZaken.filter(
         (gerelateerdeZaak) =>
           gerelateerdeZaak.relatieType === ZaakRelatietype.DEELZAAK,

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -362,10 +362,7 @@ export class ZaakViewComponent
     this.menu = [new HeaderMenuItem("zaak")];
 
     if (this.zaak.rechten.behandelen && !this.zaak.isProcesGestuurd) {
-      if (
-        !this.zaak.isOntvangstbevestigingVerstuurd &&
-        this.zaak.rechten.versturenOntvangstbevestiging
-      ) {
+      if (this.zaak.rechten.versturenOntvangstbevestiging) {
         this.menu.push(
           new ButtonMenuItem(
             "actie.ontvangstbevestiging.versturen",

--- a/src/main/app/src/assets/i18n/en.json
+++ b/src/main/app/src/assets/i18n/en.json
@@ -458,7 +458,7 @@
   "indicatie.VERGRENDELD": "is locked",
   "indicatie.VERLENGD": "has been extended",
   "indicatie.VERZONDEN": "has been sent",
-  "indicatie.ONTVANGSTBEVESTIGING_NIET_VERSTUURD": "No confirmation email sent",
+  "indicatie.ONTVANGSTBEVESTIGING_NIET_VERSTUURD": "No confirmation sent",
   "informatieobject.status": "State",
   "informatieobject.status.definitief": "Final",
   "informatieobject.status.in_bewerking": "Being modified",

--- a/src/main/app/src/assets/i18n/en.json
+++ b/src/main/app/src/assets/i18n/en.json
@@ -458,6 +458,7 @@
   "indicatie.VERGRENDELD": "is locked",
   "indicatie.VERLENGD": "has been extended",
   "indicatie.VERZONDEN": "has been sent",
+  "indicatie.ONTVANGSTBEVESTIGING_NIET_VERSTUURD": "No confirmation email sent",
   "informatieobject.status": "State",
   "informatieobject.status.definitief": "Final",
   "informatieobject.status.in_bewerking": "Being modified",

--- a/src/main/app/src/assets/i18n/nl.json
+++ b/src/main/app/src/assets/i18n/nl.json
@@ -458,6 +458,7 @@
   "indicatie.VERGRENDELD": "is vergrendeld",
   "indicatie.VERLENGD": "is verlengd",
   "indicatie.VERZONDEN": "is verzonden",
+  "indicatie.ONTVANGSTBEVESTIGING_NIET_VERSTUURD": "Geen bevestiging verstuurd",
   "informatieobject.status": "Status",
   "informatieobject.status.definitief": "Definitief",
   "informatieobject.status.in_bewerking": "In bewerking",


### PR DESCRIPTION
FE - 'No Confirmation Sent' - indication added

- added indicator
- for now no reason available but required in Indicator component; so fallback msg atm; we need to elaborate on proper solution
- Some TS error fixes
- base of branch is `feature/PZ-4440-add-isOntvangstbevestigingVerstuurd-value-as-indicator`

Solves PZ-4439