### PR TITLE
feat(zaak-view): hide `betrokkene` tab when settings are turned off

### DIFF
--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -524,7 +524,7 @@
               </div>
             </mat-tab>
 
-            <mat-tab *ngIf="betrokkenen.data.length > 0">
+            <mat-tab *ngIf="showBetrokkeneKoppelingen()">
               <ng-template mat-tab-label>
                 <mat-icon>groups</mat-icon>
                 {{ "betrokkenen" | translate }}

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -1486,11 +1486,11 @@ export class ZaakViewComponent
 
   protected showBetrokkeneKoppelingen() {
     const brpAllowed =
-        !!this.zaak.zaaktype.zaakafhandelparameters?.betrokkeneKoppelingen
-            ?.brpKoppelen;
+      !!this.zaak.zaaktype.zaakafhandelparameters?.betrokkeneKoppelingen
+        ?.brpKoppelen;
     const kvkAllowed =
-        !!this.zaak.zaaktype.zaakafhandelparameters?.betrokkeneKoppelingen
-            ?.kvkKoppelen;
+      !!this.zaak.zaaktype.zaakafhandelparameters?.betrokkeneKoppelingen
+        ?.kvkKoppelen;
 
     return Boolean(brpAllowed || kvkAllowed) && !!this.betrokkenen.data.length;
   }

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -1483,4 +1483,15 @@ export class ZaakViewComponent
           ?.brpKoppelen,
     );
   }
+
+  protected showBetrokkeneKoppelingen() {
+    const brpAllowed =
+        !!this.zaak.zaaktype.zaakafhandelparameters?.betrokkeneKoppelingen
+            ?.brpKoppelen;
+    const kvkAllowed =
+        !!this.zaak.zaaktype.zaakafhandelparameters?.betrokkeneKoppelingen
+            ?.kvkKoppelen;
+
+    return Boolean(brpAllowed || kvkAllowed) && !!this.betrokkenen.data.length;
+  }
 }


### PR DESCRIPTION
This pull request updates the `ZaakViewComponent` to improve the logic for displaying the "Betrokkenen" tab in the user interface. The changes introduce a new method to encapsulate the display condition, making the code more readable and maintainable.

### Changes to improve display logic:

* [`src/main/app/src/app/zaken/zaak-view/zaak-view.component.html`](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL527-R527): Replaced the inline condition for showing the "Betrokkenen" tab with a call to the new `showBetrokkeneKoppelingen()` method.

* [`src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts`](diffhunk://#diff-14b5c3c4e0d3f425036177305b195cf3a0676481590bebf604ceba13ae75ecbdR1486-R1496): Added the `showBetrokkeneKoppelingen()` method to centralize the logic for determining whether the "Betrokkenen" tab should be displayed. This method checks if either `brpKoppelen` or `kvkKoppelen` is allowed and ensures that there is data in `betrokkenen`.

