### PR TITLE
chore: switch to using latest tag for BRP personen mock Docker Image so that Renovate can update it

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -255,8 +255,8 @@ services:
       - "8181:8181"
 
   brp-personen-mock:
-    # We use the 'latest' tag here because an unconventional versioning scheme is used for these Docker images which Renovate does not support.
-    image: ghcr.io/brp-api/personen-mock:2.6.0-latest@sha256:cfa6f238f37c748595b336d0582ecf9685b67096ad625d8c9b13c84f8914c64c
+    # We use the 'latest' tag here because an unconventional versioning scheme is used for these Docker images which Renovate does not support
+    image: ghcr.io/brp-api/personen-mock:2.6.0-latest
     environment:
       - ASPNETCORE_ENVIRONMENT=Release
       - ASPNETCORE_URLS=http://+:5010

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -255,7 +255,8 @@ services:
       - "8181:8181"
 
   brp-personen-mock:
-    image: ghcr.io/brp-api/personen-mock:2.6.0-202504011526@sha256:cfa6f238f37c748595b336d0582ecf9685b67096ad625d8c9b13c84f8914c64c
+    # We use the 'latest' tag here because an unconventional versioning scheme is used for these Docker images which Renovate does not support.
+    image: ghcr.io/brp-api/personen-mock:2.6.0-latest@sha256:cfa6f238f37c748595b336d0582ecf9685b67096ad625d8c9b13c84f8914c64c
     environment:
       - ASPNETCORE_ENVIRONMENT=Release
       - ASPNETCORE_URLS=http://+:5010


### PR DESCRIPTION
Switch to using latest tag for BRP personen mock Docker Image so that Renovate can update it.

Solves PZ-6699