### PR TITLE
chore(dialog): consistent dialog headings

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.html
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.html
@@ -4,7 +4,7 @@
   -->
 
 <mat-toolbar role="heading" class="gap-16">
-  <mat-icon>upload_file</mat-icon>
+  <mat-icon>note_add</mat-icon>
   <span class="flex-grow-1">{{ "actie.document.maken" | translate }}</span>
   <button mat-icon-button (click)="sideNav.close()">
     <mat-icon>close</mat-icon>

--- a/src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.html
@@ -3,15 +3,16 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-<div mat-dialog-title>
-  <h3>
-    <mat-icon>pause</mat-icon>
+<mat-toolbar role="heading" class="gap-16" mat-dialog-title>
+  <mat-icon>pause</mat-icon>
+  <span class="flex-grow-1">
     {{ "actie.zaak.opschorten" | translate }}
-  </h3>
+  </span>
   <button mat-icon-button (click)="close()">
     <mat-icon>close</mat-icon>
   </button>
-</div>
+</mat-toolbar>
+<mat-divider></mat-divider>
 
 <div mat-dialog-content>
   <mfb-form [formFields]="formFields"></mfb-form>

--- a/src/main/app/src/app/zaken/zaak-verlengen-dialog/zaak-verlengen-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaak-verlengen-dialog/zaak-verlengen-dialog.component.html
@@ -3,15 +3,16 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-<div mat-dialog-title>
-  <h3>
-    <mat-icon>update</mat-icon>
+<mat-toolbar role="heading" class="gap-16" mat-dialog-title>
+  <mat-icon>update</mat-icon>
+  <span class="flex-grow-1">
     {{ "actie.zaak.verlengen" | translate }}
-  </h3>
+  </span>
   <button mat-icon-button (click)="close()">
     <mat-icon>close</mat-icon>
   </button>
-</div>
+</mat-toolbar>
+<mat-divider></mat-divider>
 
 <div mat-dialog-content>
   <mfb-form [formFields]="formFields"></mfb-form>


### PR DESCRIPTION
This pull request updates the UI components in several files to improve consistency and accessibility. The changes include replacing `mat-dialog-title` with `mat-toolbar` for a more uniform header design and updating icons for better clarity.

### UI Consistency Improvements:

* [`src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.html`](diffhunk://#diff-2de747e628aa1f9225d61c080654213025b85942d255e4ed5e5cf871056ef0ccL7-R7): Changed the icon from `upload_file` to `note_add` to better reflect the purpose of the action.
* [`src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.html`](diffhunk://#diff-846594bd13f281109eb823b5c24cf284d8cdb7677fcae328000ac44e670e4422L6-R15): Replaced the `<div>` with `mat-dialog-title` by a `mat-toolbar` for a consistent header style, added a `mat-divider` for visual separation, and adjusted the layout.
* [`src/main/app/src/app/zaken/zaak-verlengen-dialog/zaak-verlengen-dialog.component.html`](diffhunk://#diff-cba32f170cb032838adefd92732fe6f54c727795433f7522768e9b1843f4d2b5L6-R15): Updated the header from `<div>` with `mat-dialog-title` to `mat-toolbar`, added a `mat-divider`, and improved the layout for consistency with other dialog components.

Solves PZ-6542