### PR TITLE
fix(medewerker-groep.component): make sure to apply validator

### DIFF
--- a/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep.component.ts
@@ -107,12 +107,12 @@ export class MedewerkerGroepComponent extends FormComponent implements OnInit {
           return idTooLong ? { idTooLong: true } : null;
         });
 
-        this.data.groep.setValidators(validators);
-        this.data.groep.updateValueAndValidity();
-
         if (this.data.groep.hasValidator(Validators.required)) {
           validators.push(Validators.required);
         }
+
+        this.data.groep.setValidators(validators);
+        this.data.groep.updateValueAndValidity();
 
         const group = groups.find(
           ({ id }) => id === this.data.groep.defaultValue.id,
@@ -136,6 +136,7 @@ export class MedewerkerGroepComponent extends FormComponent implements OnInit {
         if (this.data.medewerker.hasValidator(Validators.required)) {
           validators.push(Validators.required);
         }
+
         this.data.medewerker.setValidators(validators);
 
         const user = users.find(({ id }) => id === defaultUserId);


### PR DESCRIPTION
This pull request refactors the `MedewerkerGroepComponent` class by reorganizing the order of operations for setting validators and updating form control validity.

### Refactoring of validation logic:

* [`src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep.component.ts`](diffhunk://#diff-171f8ec6b0933ee9c47315ff8bd996d8899977b9bb2fef8151f76fa8c7e7364fL110-R116): Moved the `setValidators` and `updateValueAndValidity` calls for `this.data.groep` to occur after checking for the `Validators.required` condition, ensuring proper validator configuration order.

Solves PZ-6240