### PR TITLE
chore(dialog): added consistent headers

### DIFF
--- a/src/main/app/src/app/taken/taken-verdelen-dialog/taken-verdelen-dialog.component.html
+++ b/src/main/app/src/app/taken/taken-verdelen-dialog/taken-verdelen-dialog.component.html
@@ -3,12 +3,19 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-<h1 *ngIf="data.taken.length === 1" mat-dialog-title>
-  {{ "msg.verdelen.taak" | translate }}
-</h1>
-<h1 *ngIf="data.taken.length !== 1" mat-dialog-title>
-  {{ "msg.verdelen.taken" | translate: { aantal: data.taken.length } }}
-</h1>
+<mat-toolbar role="heading" class="gap-16" mat-dialog-title>
+  <mat-icon>assignment_ind</mat-icon>
+  <span *ngIf="data.taken.length === 1" class="flex-grow-1">
+    {{ "msg.verdelen.taak" | translate }}
+  </span>
+  <span *ngIf="data.taken.length !== 1" class="flex-grow-1">
+    {{ "msg.verdelen.taken" | translate: { aantal: data.taken.length } }}
+  </span>
+  <button mat-icon-button (click)="close()">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-toolbar>
+<mat-divider></mat-divider>
 
 <div mat-dialog-content>
   <mfb-form-field [field]="medewerkerGroepFormField"></mfb-form-field>

--- a/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.html
+++ b/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.html
@@ -3,7 +3,16 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-<h1 mat-dialog-title>{{ "title.taken.vrijgeven" | translate }}</h1>
+<mat-toolbar role="heading" class="gap-16" mat-dialog-title>
+  <mat-icon>clear_all</mat-icon>
+  <span class="flex-grow-1">
+    {{ "title.taken.vrijgeven" | translate }}
+  </span>
+  <button mat-icon-button (click)="close()">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-toolbar>
+<mat-divider></mat-divider>
 
 <div mat-dialog-content>
   <mfb-form-field [field]="redenFormField"></mfb-form-field>

--- a/src/main/app/src/app/zaken/zaken-verdelen-dialog/zaken-verdelen-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaken-verdelen-dialog/zaken-verdelen-dialog.component.html
@@ -3,12 +3,19 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-<h1 *ngIf="data.length == 1" mat-dialog-title>
-  {{ "title.zaak.verdelen" | translate }}
-</h1>
-<h1 *ngIf="data.length != 1" mat-dialog-title>
-  {{ "title.zaken.verdelen" | translate: { aantal: data.length } }}
-</h1>
+<mat-toolbar role="heading" class="gap-16" mat-dialog-title>
+  <mat-icon>assignment_ind</mat-icon>
+  <span *ngIf="data.length === 1" class="flex-grow-1">
+    {{ "title.zaak.verdelen" | translate }}
+  </span>
+  <span *ngIf="data.length !== 1" class="flex-grow-1">
+    {{ "title.zaken.verdelen" | translate: { aantal: data.length } }}
+  </span>
+  <button mat-icon-button (click)="close()">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-toolbar>
+<mat-divider></mat-divider>
 
 <div mat-dialog-content>
   <mfb-form-field [field]="medewerkerGroepFormField"></mfb-form-field>

--- a/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.html
@@ -3,17 +3,24 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-<h1 *ngIf="data.length == 1" mat-dialog-title>
-  {{ "title.zaak.vrijgeven" | translate }}
-</h1>
-<h1 *ngIf="data.length != 1" mat-dialog-title>
-  {{ "title.zaken.vrijgeven" | translate: { aantal: data.length } }}
-</h1>
+<mat-toolbar role="heading" class="gap-16" mat-dialog-title>
+  <mat-icon>clear_all</mat-icon>
+  <span *ngIf="data.length === 1" class="flex-grow-1">
+    {{ "title.zaak.vrijgeven" | translate }}
+  </span>
+  <span *ngIf="data.length !== 1" class="flex-grow-1">
+    {{ "title.zaken.vrijgeven" | translate: { aantal: data.length } }}
+  </span>
+  <button mat-icon-button (click)="close()">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-toolbar>
+<mat-divider></mat-divider>
 
 <div mat-dialog-content>
   <mfb-form-field [field]="redenFormField"></mfb-form-field>
-  <p *ngIf="data.length == 1">{{ "msg.vrijgeven.zaak" | translate }}</p>
-  <p *ngIf="data.length != 1">{{ "msg.vrijgeven.zaken" | translate }}</p>
+  <p *ngIf="data.length === 1">{{ "msg.vrijgeven.zaak" | translate }}</p>
+  <p *ngIf="data.length !== 1">{{ "msg.vrijgeven.zaken" | translate }}</p>
 </div>
 <div mat-dialog-actions>
   <button


### PR DESCRIPTION
This pull request refactors the dialog headers in multiple components to improve accessibility and visual consistency by replacing `<h1>` elements with `mat-toolbar` components and adding icons and close buttons. Additionally, it includes minor updates to conditional checks for consistency.

### Dialog Header Refactoring:
* Replaced `<h1>` elements with `mat-toolbar` components in `taken-verdelen-dialog`, adding an `assignment_ind` icon, a close button, and a divider for improved accessibility and design. (`src/main/app/src/app/taken/taken-verdelen-dialog/taken-verdelen-dialog.component.html`)
* Updated the `taken-vrijgeven-dialog` to use `mat-toolbar` with a `clear_all` icon, a close button, and a divider for consistency with other dialogs. (`src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.html`)
* Refactored `zaken-verdelen-dialog` to replace `<h1>` elements with `mat-toolbar`, adding an `assignment_ind` icon, a close button, and a divider for a unified look. (`src/main/app/src/app/zaken/zaken-verdelen-dialog/zaken-verdelen-dialog.component.html`)
* Modified `zaken-vrijgeven-dialog` to use `mat-toolbar` with a `clear_all` icon, a close button, and a divider, and updated conditional checks for consistency. (`src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.html`)

Solves PZ-6542