### PR TITLE
test(E2E): validate that the "no acknowledgement" indication is set

### DIFF
--- a/src/e2e/features/2-zaken-toevoegen.feature
+++ b/src/e2e/features/2-zaken-toevoegen.feature
@@ -9,5 +9,6 @@ Feature: Zaken toevoegen
     When "Bob" wants to create a new zaak
     Then "Bob" sees the created zaak
     Then "Bob" sees the zaak initiator
+    Then "Bob" sees the indication that no acknowledgment has been sent
     Given "Bob" navigates to "zac" with path "/zaken/werkvoorraad"
     Then "Bob" sees the created zaak

--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -244,7 +244,7 @@ Then(
 Then(
   "{string} sees the zaak initiator",
   { timeout: ONE_MINUTE_IN_MS },
-  async function (this: CustomWorld) {
+  async function (this: CustomWorld, user: z.infer<typeof worldUsers>) {
     await this.page.getByText(TEST_PERSON_HENDRIKA_JANSE_NAME);
     await this.page.getByText(/initiator/i).click();
     await this.expect(
@@ -259,7 +259,7 @@ Then(
 Then(
     "{string} sees the indication that no acknowledgment has been sent",
     { timeout: ONE_MINUTE_IN_MS },
-    async function (this: CustomWorld) {
+    async function (this: CustomWorld, user: z.infer<typeof worldUsers>) {
       await this.expect(
         this.page.getByRole("option", { name: "Geen bevestiging verstuurd"}),
       ).toBeVisible();

--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -257,14 +257,14 @@ Then(
 );
 
 Then(
-    "{string} sees the indication that no acknowledgment has been sent",
-    { timeout: ONE_MINUTE_IN_MS },
-    async function (this: CustomWorld, user: z.infer<typeof worldUsers>) {
-      await this.expect(
-        this.page.getByRole("option", { name: "Geen bevestiging verstuurd"}),
-      ).toBeVisible();
-    },
-)
+  "{string} sees the indication that no acknowledgment has been sent",
+  { timeout: ONE_MINUTE_IN_MS },
+  async function (this: CustomWorld, user: z.infer<typeof worldUsers>) {
+    await this.expect(
+      this.page.getByRole("option", { name: "Geen bevestiging verstuurd" }),
+    ).toBeVisible();
+  },
+);
 
 Then(
   "Employee {string} clicks on the first zaak in the zaak-werkvoorraad with delay",

--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -244,7 +244,7 @@ Then(
 Then(
   "{string} sees the zaak initiator",
   { timeout: ONE_MINUTE_IN_MS },
-  async function (this: CustomWorld, user: z.infer<typeof worldUsers>) {
+  async function (this: CustomWorld) {
     await this.page.getByText(TEST_PERSON_HENDRIKA_JANSE_NAME);
     await this.page.getByText(/initiator/i).click();
     await this.expect(
@@ -255,6 +255,16 @@ Then(
     ).toBeVisible();
   },
 );
+
+Then(
+    "{string} sees the indication that no acknowledgment has been sent",
+    { timeout: ONE_MINUTE_IN_MS },
+    async function (this: CustomWorld) {
+      await this.expect(
+        this.page.getByRole("option", { name: "Geen bevestiging verstuurd"}),
+      ).toBeVisible();
+    },
+)
 
 Then(
   "Employee {string} clicks on the first zaak in the zaak-werkvoorraad with delay",


### PR DESCRIPTION
This pull request introduces a new feature to the end-to-end (E2E) tests for verifying that a user can see an indication when no acknowledgment has been sent for a "zaak" (case). The changes include updates to the feature file and the corresponding step definitions.

### Updates to E2E tests:

* [`src/e2e/features/2-zaken-toevoegen.feature`](diffhunk://#diff-9179cb8d57f529f7fb196d94e12294b29958874368cbb8b0e11c5ac9ea14d5b0R12): Added a new scenario step to check that "Bob" sees an indication when no acknowledgment has been sent for a created zaak.

* [`src/e2e/step-definitions/zaak.ts`](diffhunk://#diff-14162a669617ec1a3d444c5fbd477deb3e031abda24ac142b631cf818cf9ccffR259-R268): Implemented a new step definition to verify the visibility of the "Geen bevestiging verstuurd" (No acknowledgment sent) indication using the `getByRole` method.

Solves PZ-5641