### PR TITLE
fix: Only shows groups of that zaaktype in taak starten

### DIFF
--- a/src/main/app/src/app/formulieren/taken/taak-formulier-builder.ts
+++ b/src/main/app/src/app/formulieren/taken/taak-formulier-builder.ts
@@ -44,6 +44,7 @@ export class TaakFormulierBuilder {
           .label("actie.taak.toewijzing")
           .groepLabel("actie.taak.toekennen.groep")
           .groepRequired()
+          .setZaaktypeUuid(zaak.zaaktype.uuid)
           .medewerkerLabel("actie.taak.toekennen.medewerker")
           .build(),
       ],


### PR DESCRIPTION
Small fix to ensure that only groups that belong to the zaaktype can be chosen when starting a taak in that zaaktype. This was forgotten/overlooked when working on PZ-6452

Solves PZ-6753