### PR TITLE
feat(release): next ZAC minor release

### DIFF
--- a/charts/zac/Chart.yaml
+++ b/charts/zac/Chart.yaml
@@ -6,8 +6,8 @@
 apiVersion: v2
 name: zaakafhandelcomponent
 description: A Helm chart for installing Zaakafhandelcomponent
-version: 1.0.61
-appVersion: '3.0'
+version: 1.0.62
+appVersion: '3.6'
 icon: https://raw.githubusercontent.com/infonl/dimpact-zaakafhandelcomponent/49f8dee60948282b546ebdfdc5cff6f8bbef0305/docs/manuals/ZAC-gebruikershandleiding/images/pic.svg
 dependencies:
 - name: opentelemetry-collector

--- a/charts/zac/README.md
+++ b/charts/zac/README.md
@@ -1,6 +1,6 @@
 # zaakafhandelcomponent
 
-![Version: 1.0.61](https://img.shields.io/badge/Version-1.0.61-informational?style=flat-square) ![AppVersion: 3.0](https://img.shields.io/badge/AppVersion-3.0-informational?style=flat-square)
+![Version: 1.0.62](https://img.shields.io/badge/Version-1.0.62-informational?style=flat-square) ![AppVersion: 3.6](https://img.shields.io/badge/AppVersion-3.6-informational?style=flat-square)
 
 A Helm chart for installing Zaakafhandelcomponent
 


### PR DESCRIPTION
This PR will create the next ZAC minor release: 3.6.0

The change is in the Helm Chart to update the appVersion to pick this new release by default.

#minor
Solves PZ-6665