### PR TITLE
chore: renamed all copyright statements from Lifely to INFO.nl

### DIFF
--- a/.ct/chart_schema.yaml
+++ b/.ct/chart_schema.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 
 name: str()

--- a/.ct/lintconf.yaml
+++ b/.ct/lintconf.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 
 ---

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/.env.tpl
+++ b/.env.tpl
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: <YYYY> Lifely
+# SPDX-FileCopyrightText: <YYYY> INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Build, test & deploy

--- a/.github/workflows/check-for-conventional-commits.yml
+++ b/.github/workflows/check-for-conventional-commits.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Check for conventional commits

--- a/.github/workflows/check-markdown-links.yaml
+++ b/.github/workflows/check-markdown-links.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Check Markdown Links

--- a/.github/workflows/check-spdx-license-headers.yml
+++ b/.github/workflows/check-spdx-license-headers.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Check SPDX License Headers

--- a/.github/workflows/clean-up-cache-on-pr-close.yml
+++ b/.github/workflows/clean-up-cache-on-pr-close.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Cleanup cache after PR close

--- a/.github/workflows/clean-up-old-zac-docker-images.yml
+++ b/.github/workflows/clean-up-old-zac-docker-images.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Clean up old ZAC Docker Images

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: "CodeQL"

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 
 name: Helm chart release

--- a/.github/workflows/helm-chart-testing.yml
+++ b/.github/workflows/helm-chart-testing.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 
 name: Helm chart linting and testing

--- a/.github/workflows/remove-stale-branches.yml
+++ b/.github/workflows/remove-stale-branches.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Remove stale branches

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Playwright Tests

--- a/.github/workflows/snyk-code-scan.yml
+++ b/.github/workflows/snyk-code-scan.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Snyk Security code scanner

--- a/.github/workflows/trivy-docker-image-scan.yml
+++ b/.github/workflows/trivy-docker-image-scan.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 name: Scheduled Trivy Docker image scan

--- a/.github/workflows/update-trivy-scanner-cache.yml
+++ b/.github/workflows/update-trivy-scanner-cache.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 # Note: This workflow only downloads the Trivy scanner databases and adds them to the cache.

--- a/.github/workflows/validate-json-yaml-files.yaml
+++ b/.github/workflows/validate-json-yaml-files.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Lifely
+# SPDX-FileCopyrightText: 2025 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 
 name: Validate json and yaml files in the repo

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2025 Lifely
+# SPDX-FileCopyrightText: 2025 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 
 #
@@ -8,7 +8,7 @@
 header:
   license:
     content: |      
-       SPDX-FileCopyrightText: 2025 Lifely
+       SPDX-FileCopyrightText: 2025 INFO.nl
        SPDX-License-Identifier: EUPL-1.2+
     pattern: |
        SPDX-FileCopyrightText: .*

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2025 Lifely
+# SPDX-FileCopyrightText: 2025 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 # Configuration file for https://github.com/UmbrellaDocs/linkspector and related GitHub action

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ We use the following code and API conventions:
 The license information for this project can be found in [LICENSE.md](LICENSE.md).
 We use [SPDX](https://spdx.dev/) license identifiers in source code files.
 
-When adding a new source code file or modifying an existing one as a Lifely/INFO developer, please update the `SPDX` license identifier accordingly:
+When adding a new source code file or modifying an existing one as a INFO.nl developer, please update the `SPDX` license identifier accordingly:
 
 ### Adding a new source code file
 
@@ -28,7 +28,7 @@ For most source code files (e.g. `.ts`, `.js`, `.kt` and `.java` files) please a
 
 ```
 /*
- * SPDX-FileCopyrightText: <YYYY> Lifely
+ * SPDX-FileCopyrightText: <YYYY> INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 ```
@@ -39,7 +39,7 @@ For other file types (e.g. `.html` and `.xml` files) please add the following SP
 
 ```
  <!--
-  ~ SPDX-FileCopyrightText: <YYYY> Lifely
+  ~ SPDX-FileCopyrightText: <YYYY> INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 ```
@@ -48,7 +48,7 @@ Finally, for e.g. `.sh` files please add:
 
 ```
 #
-# SPDX-FileCopyrightText: <YYYY> Lifely
+# SPDX-FileCopyrightText: <YYYY> INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 ```
@@ -58,12 +58,12 @@ For example, in IntelliJ IDEA please follow the instructions on https://www.jetb
 
 ### Modifying an existing source code file
 
-If the file does not already include `Lifely` in the copyright text, please update the SPDX license identifier 
-on the top of the file by adding a `, <YYYY> Lifely` to the `SPDX-FileCopyrightText` identifier where `<YYYY>` is the current year. E.g.:
+If the file does not already include `INFO.nl` in the copyright text, please update the SPDX license identifier 
+on the top of the file by adding a `, <YYYY> INFO.nl` to the `SPDX-FileCopyrightText` identifier where `<YYYY>` is the current year. E.g.:
 
 ```
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+# SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 
@@ -11,8 +11,8 @@ ARG versionNumber
 LABEL name="zaakafhandelcomponent"
 LABEL summary="Zaakafhandelcomponent (ZAC) developed for Dimpact"
 LABEL description="The zaakafhandelcomponent (ZAC) is an open-source, generic, workflow-based component for managing 'zaken' in the context of zaakgericht werken, a Dutch approach to case management."
-LABEL maintainer="Lifely/INFO"
-LABEL vendor="Lifely/INFO"
+LABEL maintainer="INFO.nl"
+LABEL vendor="INFO.nl"
 LABEL url="https://github.com/infonl/dimpact-zaakafhandelcomponent"
 LABEL git_commit=$commitHash
 # Unset labels set by the Temurin Ubi9 base Docker image

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 # Licence
 
 Original work Copyright @ Atos, 2021 - 2022
-Modified and new work, starting in 2023, Copyright Lifely
+Modified and new work, starting in 2023, Copyright INFO.nl
 
 Licensed under the EUPL-1.2-or-later
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ in the context of [zaakgericht werken](https://www.noraonline.nl/wiki/Zaakgerich
 It is used by various Dutch municipalities.
 
 ZAC was initially [developed by Atos](https://github.com/NL-AMS-LOCGOV/zaakafhandelcomponent).
-Starting July 2023 the development of ZAC was taken over by Lifely and INFO, where INFO is a partner of Lifely.
+Starting July 2023 the development of ZAC was taken over by Lifely and INFO.nl, where INFO.nl is a partner of Lifely.
 
 ## Contributing
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/charts/.gitignore
+++ b/charts/.gitignore
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/charts/zac/Chart.yaml
+++ b/charts/zac/Chart.yaml
@@ -6,7 +6,7 @@
 apiVersion: v2
 name: zaakafhandelcomponent
 description: A Helm chart for installing Zaakafhandelcomponent
-version: 1.0.65
+version: 1.0.66
 appVersion: '3.6'
 icon: https://raw.githubusercontent.com/infonl/dimpact-zaakafhandelcomponent/49f8dee60948282b546ebdfdc5cff6f8bbef0305/docs/manuals/ZAC-gebruikershandleiding/images/pic.svg
 dependencies:

--- a/charts/zac/Chart.yaml
+++ b/charts/zac/Chart.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+# SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/charts/zac/README.md
+++ b/charts/zac/README.md
@@ -1,6 +1,6 @@
 # zaakafhandelcomponent
 
-![Version: 1.0.65](https://img.shields.io/badge/Version-1.0.65-informational?style=flat-square) ![AppVersion: 3.6](https://img.shields.io/badge/AppVersion-3.6-informational?style=flat-square)
+![Version: 1.0.66](https://img.shields.io/badge/Version-1.0.66-informational?style=flat-square) ![AppVersion: 3.6](https://img.shields.io/badge/AppVersion-3.6-informational?style=flat-square)
 
 A Helm chart for installing Zaakafhandelcomponent
 

--- a/charts/zac/ci/helm-testing-values.yaml
+++ b/charts/zac/ci/helm-testing-values.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+# SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/charts/zac/values.yaml
+++ b/charts/zac/values.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+# SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 codecov:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 services:

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -172,7 +172,7 @@ This way you can test a locally running ZAC or you can test ZAC running on e.g. 
 
 #### Set up Postman for ZAC
 
-As a Lifely developer you can use our shared Postman ZAC collection in our [ZAC API TEST Postman team workspace](https://zaakafhandelcomponent.postman.co/workspace/aec6c5c4-affd-490b-9c81-e8b1cf339d22).
+As a INFO.nl developer you can use our shared Postman ZAC collection in our [ZAC API TEST Postman team workspace](https://zaakafhandelcomponent.postman.co/workspace/aec6c5c4-affd-490b-9c81-e8b1cf339d22).
 Alternatively you can set up a Postman collection yourself using the instructions below.
 
 To use our shared Postman collection you need to be a member of our Zaakafhandelcomponent Postman team (max 3 members for the free Postman version).

--- a/docs/development/updatingDependencies.md
+++ b/docs/development/updatingDependencies.md
@@ -47,7 +47,7 @@ something like: `https://<open-zaak-url>/zaken/api/v1/schema/openapi.yaml` and p
 2. Replace the existing OpenAPI specification in the [api-secs](../../src/main/resources/api-specs) folder with the new version.
 3. Do a diff of the newly generated OpenAPI specification with the current version and make sure that
 any manual changes that were made to the current version are also made to the new version (if they still apply).
-These manual changes are indicated with a code comment containing the term `Lifely`.
+These manual changes are indicated with a code comment containing the term `INFO.nl`.
 Some of these manual changes include:
    1. Added `readOnly: false` attributes to properties that were missing a setter (or constructor) in the generated
 Java client code but which need to be set by ZAC.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 
@@ -39,7 +39,7 @@ description:
 
 legal:
   license: EUPL-1.2+
-  mainCopyrightOwner: Lifely
+  mainCopyrightOwner: INFO.nl
   repoOwner: INFO
 
 maintenance:

--- a/scripts/docker-compose/check-for-running-containers.sh
+++ b/scripts/docker-compose/check-for-running-containers.sh
@@ -3,7 +3,7 @@
 set -e
 
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/scripts/docker-compose/fix-permissions.sh
+++ b/scripts/docker-compose/fix-permissions.sh
@@ -3,7 +3,7 @@
 set -e
 
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/scripts/docker-compose/imports/objects-api/init/init.sh
+++ b/scripts/docker-compose/imports/objects-api/init/init.sh
@@ -8,7 +8,7 @@ set -e
 sleep 10
 
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/scripts/docker-compose/imports/openzaak/zac-scripts/copy-test-pdf-and-start-openzaak.sh
+++ b/scripts/docker-compose/imports/openzaak/zac-scripts/copy-test-pdf-and-start-openzaak.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/scripts/docker-compose/setup-linux.sh
+++ b/scripts/docker-compose/setup-linux.sh
@@ -3,7 +3,7 @@
 set -e
 
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/scripts/docker/build-docker-image.sh
+++ b/scripts/docker/build-docker-image.sh
@@ -3,7 +3,7 @@
 set -e
 
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/scripts/file-templates/publiccode-yaml-template.yaml
+++ b/scripts/file-templates/publiccode-yaml-template.yaml
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 
@@ -39,7 +39,7 @@ description:
 
 legal:
   license: EUPL-1.2+
-  mainCopyrightOwner: Lifely
+  mainCopyrightOwner: INFO.nl
   repoOwner: INFO
 
 maintenance:

--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -1,4 +1,4 @@
-[//]: # (SPDX-FileCopyrightText: 2023 Lifely
+[//]: # (SPDX-FileCopyrightText: 2023 INFO.nl
 [//]: # (SPDX-License-Identifier: EUPL-1.2+)
 
 # Testing GitHub Actions using ACT

--- a/scripts/python/dependencies/brp_version_extractor.py
+++ b/scripts/python/dependencies/brp_version_extractor.py
@@ -1,4 +1,4 @@
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 
 import requests

--- a/scripts/python/dependencies/docker_version_extractor.py
+++ b/scripts/python/dependencies/docker_version_extractor.py
@@ -1,4 +1,4 @@
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 
 import requests

--- a/scripts/python/dependencies/github_tag_version_extractor.py
+++ b/scripts/python/dependencies/github_tag_version_extractor.py
@@ -1,4 +1,4 @@
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 
 import requests

--- a/scripts/python/dependencies/kvk_version_extractor.py
+++ b/scripts/python/dependencies/kvk_version_extractor.py
@@ -1,4 +1,4 @@
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 
 import requests

--- a/scripts/python/dependencies/postgresql_version_extractor.py
+++ b/scripts/python/dependencies/postgresql_version_extractor.py
@@ -1,4 +1,4 @@
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 
 import requests

--- a/scripts/python/dependencies/version_data.py
+++ b/scripts/python/dependencies/version_data.py
@@ -1,5 +1,5 @@
 #
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 #
 class VersionData:

--- a/scripts/python/dependencies/versions.py
+++ b/scripts/python/dependencies/versions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 
 from kvk_version_extractor import KvkVersionExtractor

--- a/scripts/python/init-pyenv.sh
+++ b/scripts/python/init-pyenv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 # To setup a python virtual environment, with required libraries, run this script with the following command:

--- a/scripts/python/podiumd/component_version.py
+++ b/scripts/python/podiumd/component_version.py
@@ -1,4 +1,4 @@
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/scripts/python/podiumd/podiumd_version.py
+++ b/scripts/python/podiumd/podiumd_version.py
@@ -1,5 +1,5 @@
 #
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/scripts/python/podiumd/podiumd_version_builder.py
+++ b/scripts/python/podiumd/podiumd_version_builder.py
@@ -1,5 +1,5 @@
 #
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 #
 import urllib.request

--- a/scripts/python/podiumd/podiumd_version_comparator.py
+++ b/scripts/python/podiumd/podiumd_version_comparator.py
@@ -1,4 +1,4 @@
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 
 class PodiumdVersionComparator:

--- a/scripts/python/podiumd/versions.py
+++ b/scripts/python/podiumd/versions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-#  SPDX-FileCopyrightText: 2024 Lifely
+#  SPDX-FileCopyrightText: 2024 INFO.nl
 #  SPDX-License-Identifier: EUPL-1.2+
 
 from podiumd_version_builder import PodiumdVersionBuilder

--- a/scripts/python/requirements.txt
+++ b/scripts/python/requirements.txt
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 argparse

--- a/scripts/solr/reindex-zac-solr-data.sh
+++ b/scripts/solr/reindex-zac-solr-data.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 set -e

--- a/scripts/wildfly/install-wildfly.sh
+++ b/scripts/wildfly/install-wildfly.sh
@@ -3,7 +3,7 @@
 set -e
 
 #
-# SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+# SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/scripts/zap/README.md
+++ b/scripts/zap/README.md
@@ -1,7 +1,7 @@
 
 # ZA Proxy (ZAP) setup
 ```text
-SPDX-FileCopyrightText: 2024 Lifely
+SPDX-FileCopyrightText: 2024 INFO.nl
 SPDX-License-Identifier: EUPL-1.2+
 ```
 

--- a/scripts/zap/default.config
+++ b/scripts/zap/default.config
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 # zap-baseline rule configuration file

--- a/scripts/zap/sample.context
+++ b/scripts/zap/sample.context
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-  SPDX-FileCopyrightText: 2024 Lifely
+  SPDX-FileCopyrightText: 2024 INFO.nl
   SPDX-License-Identifier: EUPL-1.2+
 -->
 <configuration>

--- a/scripts/zap/zap-docker-full-scan.sh
+++ b/scripts/zap/zap-docker-full-scan.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/.gitignore
+++ b/src/e2e/.gitignore
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/src/e2e/cucumber.js
+++ b/src/e2e/cucumber.js
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 // cucumber.js

--- a/src/e2e/features/1-login.feature
+++ b/src/e2e/features/1-login.feature
@@ -1,5 +1,5 @@
 # 
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 # 
 Feature: Login

--- a/src/e2e/features/2-zaken-toevoegen.feature
+++ b/src/e2e/features/2-zaken-toevoegen.feature
@@ -1,5 +1,5 @@
 # 
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 # 
 Feature: Zaken toevoegen

--- a/src/e2e/features/3-open-formulieren.feature
+++ b/src/e2e/features/3-open-formulieren.feature
@@ -1,5 +1,5 @@
 # 
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 # 
 Feature: Open Formulieren

--- a/src/e2e/features/4-smartdocuments.feature
+++ b/src/e2e/features/4-smartdocuments.feature
@@ -1,5 +1,5 @@
 # 
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 # 
 Feature: SmartDocuments

--- a/src/e2e/features/5-taken-toevoegen.feature
+++ b/src/e2e/features/5-taken-toevoegen.feature
@@ -1,5 +1,5 @@
 # 
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 # 
 Feature: Taken toevoegen

--- a/src/e2e/features/6-zaken-verdelen-vrijgeven.feature
+++ b/src/e2e/features/6-zaken-verdelen-vrijgeven.feature
@@ -1,5 +1,5 @@
 # 
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 # 
 Feature: Zaken verdelen / vrijgeven

--- a/src/e2e/features/7-taken-verdelen-vrijgeven.feature
+++ b/src/e2e/features/7-taken-verdelen-vrijgeven.feature
@@ -1,5 +1,5 @@
 # 
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 # 
 Feature: Taken verdelen / vrijgeven

--- a/src/e2e/features/8-personen.feature
+++ b/src/e2e/features/8-personen.feature
@@ -1,5 +1,5 @@
 # 
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 # 
 Feature: Personen

--- a/src/e2e/generate-report.mjs
+++ b/src/e2e/generate-report.mjs
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/step-definitions/authentication.ts
+++ b/src/e2e/step-definitions/authentication.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/step-definitions/common.ts
+++ b/src/e2e/step-definitions/common.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 import { Given, Then, When } from "@cucumber/cucumber";

--- a/src/e2e/step-definitions/external-systems.ts
+++ b/src/e2e/step-definitions/external-systems.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/step-definitions/hooks.ts
+++ b/src/e2e/step-definitions/hooks.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/step-definitions/open-forms.ts
+++ b/src/e2e/step-definitions/open-forms.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/step-definitions/persoon.ts
+++ b/src/e2e/step-definitions/persoon.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/step-definitions/taken-verdelen.ts
+++ b/src/e2e/step-definitions/taken-verdelen.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/step-definitions/zaken-verdelen.ts
+++ b/src/e2e/step-definitions/zaken-verdelen.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/support/indienen-aansprakelijkstelling-door-derden/profiles/alice.ts
+++ b/src/e2e/support/indienen-aansprakelijkstelling-door-derden/profiles/alice.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/support/indienen-aansprakelijkstelling-door-derden/profiles/index.ts
+++ b/src/e2e/support/indienen-aansprakelijkstelling-door-derden/profiles/index.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/support/indienen-aansprakelijkstelling-door-derden/profiles/robert.ts
+++ b/src/e2e/support/indienen-aansprakelijkstelling-door-derden/profiles/robert.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/support/indienen-aansprakelijkstelling-door-derden/profiles/types.ts
+++ b/src/e2e/support/indienen-aansprakelijkstelling-door-derden/profiles/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/support/worlds/userProfiles.ts
+++ b/src/e2e/support/worlds/userProfiles.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/support/worlds/world.ts
+++ b/src/e2e/support/worlds/world.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/utils/TestStorage.service.ts
+++ b/src/e2e/utils/TestStorage.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/e2e/utils/schemes.ts
+++ b/src/e2e/utils/schemes.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/AanvullendeInformatieTaskCompleteTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/AanvullendeInformatieTaskCompleteTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/AppContainerTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/AppContainerTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/BagRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/BagRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/ConfigurationRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ConfigurationRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/CsvRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/CsvRESTServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/DocumentCreationRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/DocumentCreationRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/EnkelvoudigInformatieObjectRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/EnkelvoudigInformatieObjectRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/FormioFormulierenRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/FormioFormulierenRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/HealthCheckRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/HealthCheckRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/IdentityServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/IdentityServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/IndexingAdminRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/IndexingAdminRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/IndexingRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/IndexingRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/InformatieobjectenHistorieTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/InformatieobjectenHistorieTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/KlantRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/KlantRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/MailRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/MailRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/NotificationsTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/NotificationsZaakDestroyTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/PlanItemsRESTServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/PlanItemsRESTServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/ProcessDefinitionRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ProcessDefinitionRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/ReferenceTableRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ReferenceTableRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/SearchRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/SearchRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/SignaleringAdminRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/SignaleringAdminRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/SignaleringRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/SignaleringRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/TaskRestServiceCompleteTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/TaskRestServiceCompleteTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/TaskRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/TaskRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakKoppelenRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakKoppelenRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceBesluitTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceBesluitTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceBpmnTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceBpmnTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceCompleteTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceCompleteTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceExtensionTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceExtensionTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceHistoryTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceHistoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceLinkParentChildZaken.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceLinkParentChildZaken.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakafhandelParametersRestServiceSmartDocumentsTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakafhandelParametersRestServiceSmartDocumentsTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/ZaakafhandelParametersRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakafhandelParametersRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/ZaaktypeBpmnProcessDefinitionRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaaktypeBpmnProcessDefinitionRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest

--- a/src/itest/kotlin/nl/info/zac/itest/client/HttpClientHelper.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/client/HttpClientHelper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/client/ItestHttpClient.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/client/ItestHttpClient.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest.client

--- a/src/itest/kotlin/nl/info/zac/itest/client/KeycloakClient.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/client/KeycloakClient.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest.client

--- a/src/itest/kotlin/nl/info/zac/itest/client/OpenZaakClient.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/client/OpenZaakClient.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest.client

--- a/src/itest/kotlin/nl/info/zac/itest/client/URLHelper.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/client/URLHelper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/client/ZacClient.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/client/ZacClient.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest.client

--- a/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ItestConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest.config

--- a/src/itest/kotlin/nl/info/zac/itest/config/OneShotStartupWaitStrategy.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/OneShotStartupWaitStrategy.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/config/ProjectConfig.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ProjectConfig.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest.config

--- a/src/itest/kotlin/nl/info/zac/itest/util/JsonHelpers.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/util/JsonHelpers.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/util/SleepHelpers.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/util/SleepHelpers.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/itest/kotlin/nl/info/zac/itest/util/WebSocketTestListener.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/util/WebSocketTestListener.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.itest.util

--- a/src/itest/resources/kotest.properties
+++ b/src/itest/resources/kotest.properties
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 
 # disable Kotest autoscanning for faster test execution

--- a/src/main/app/.browserslistrc
+++ b/src/main/app/.browserslistrc
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/src/main/app/.eslintrc.js
+++ b/src/main/app/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 // Configured using https://github.com/angular-eslint/angular-eslint/blob/main/docs/CONFIGURING_ESLINTRC.md

--- a/src/main/app/.gitignore
+++ b/src/main/app/.gitignore
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/src/main/app/.prettierignore
+++ b/src/main/app/.prettierignore
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/src/main/app/globalJest.js
+++ b/src/main/app/globalJest.js
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 module.exports = async () => {

--- a/src/main/app/jest.config.js
+++ b/src/main/app/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/setupJest.ts
+++ b/src/main/app/setupJest.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/admin/formulier-definitie-edit/formulier-definitie-edit.component.ts
+++ b/src/main/app/src/app/admin/formulier-definitie-edit/formulier-definitie-edit.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/formulier-definitie-edit/tekstvlak-edit-dialog/tekstvlak-edit-dialog.component.html
+++ b/src/main/app/src/app/admin/formulier-definitie-edit/tekstvlak-edit-dialog/tekstvlak-edit-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/admin/formulier-definitie-edit/tekstvlak-edit-dialog/tekstvlak-edit-dialog.component.spec.ts
+++ b/src/main/app/src/app/admin/formulier-definitie-edit/tekstvlak-edit-dialog/tekstvlak-edit-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/admin/formulier-definities/formulier-definities.component.ts
+++ b/src/main/app/src/app/admin/formulier-definities/formulier-definities.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/groep-signaleringen/groep-signaleringen.component.ts
+++ b/src/main/app/src/app/admin/groep-signaleringen/groep-signaleringen.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/inrichtingscheck/inrichtingscheck.component.ts
+++ b/src/main/app/src/app/admin/inrichtingscheck/inrichtingscheck.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/mailtemplate/mailtemplate.component.ts
+++ b/src/main/app/src/app/admin/mailtemplate/mailtemplate.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/mailtemplates/mailtemplates.component.ts
+++ b/src/main/app/src/app/admin/mailtemplates/mailtemplates.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.html
+++ b/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.spec.ts
+++ b/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.ts
+++ b/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024-2025 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024-2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form-item/smart-documents-form-item.component.html
+++ b/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form-item/smart-documents-form-item.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   ~
   -->

--- a/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form-item/smart-documents-form-item.component.less
+++ b/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form-item/smart-documents-form-item.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form-item/smart-documents-form-item.component.ts
+++ b/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form-item/smart-documents-form-item.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form.component.html
+++ b/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2024-2025 Lifely
+  ~ SPDX-FileCopyrightText: 2024-2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form.component.less
+++ b/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form.component.ts
+++ b/src/main/app/src/app/admin/parameter-edit/smart-documents-form/smart-documents-form.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/parameters/parameters.component.html
+++ b/src/main/app/src/app/admin/parameters/parameters.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/admin/parameters/parameters.component.spec.ts
+++ b/src/main/app/src/app/admin/parameters/parameters.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/parameters/parameters.component.ts
+++ b/src/main/app/src/app/admin/parameters/parameters.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024-2025 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024-2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/referentie-tabel/referentie-tabel.component.ts
+++ b/src/main/app/src/app/admin/referentie-tabel/referentie-tabel.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/referentie-tabellen/referentie-tabellen.component.ts
+++ b/src/main/app/src/app/admin/referentie-tabellen/referentie-tabellen.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/signaleringen-settings-beheer.service.ts
+++ b/src/main/app/src/app/admin/signaleringen-settings-beheer.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 20242 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/smart-documents.service.spec.ts
+++ b/src/main/app/src/app/admin/smart-documents.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/smart-documents.service.test-data.ts
+++ b/src/main/app/src/app/admin/smart-documents.service.test-data.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/smart-documents.service.ts
+++ b/src/main/app/src/app/admin/smart-documents.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/zaakafhandel-parameters-resolver.service.ts
+++ b/src/main/app/src/app/admin/zaakafhandel-parameters-resolver.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/admin/zaakafhandel-parameters.service.ts
+++ b/src/main/app/src/app/admin/zaakafhandel-parameters.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024-2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024-2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/app.module.ts
+++ b/src/main/app/src/app/app.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/bag/bag-zaken-tabel/bag-zaken-tabel.component.html
+++ b/src/main/app/src/app/bag/bag-zaken-tabel/bag-zaken-tabel.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/bag/bag-zaken-tabel/bag-zaken-tabel.component.ts
+++ b/src/main/app/src/app/bag/bag-zaken-tabel/bag-zaken-tabel.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/bag/bag.service.ts
+++ b/src/main/app/src/app/bag/bag.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/bag/zoek/bag-zoek/bag-zoek.component.html
+++ b/src/main/app/src/app/bag/zoek/bag-zoek/bag-zoek.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024-2025 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024-2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/configuratie/configuratie.service.spec.ts
+++ b/src/main/app/src/app/configuratie/configuratie.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/configuratie/configuratie.service.ts
+++ b/src/main/app/src/app/configuratie/configuratie.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/core/core.module.ts
+++ b/src/main/app/src/app/core/core.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/core/service/util.service.spec.ts
+++ b/src/main/app/src/app/core/service/util.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/core/service/util.service.ts
+++ b/src/main/app/src/app/core/service/util.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/core/toolbar/toolbar.component.html
+++ b/src/main/app/src/app/core/toolbar/toolbar.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/core/toolbar/toolbar.component.less
+++ b/src/main/app/src/app/core/toolbar/toolbar.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/core/toolbar/toolbar.component.ts
+++ b/src/main/app/src/app/core/toolbar/toolbar.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/dashboard/dashboard-card/dashboard-card.component.ts
+++ b/src/main/app/src/app/dashboard/dashboard-card/dashboard-card.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/dashboard/dashboard.component.html
+++ b/src/main/app/src/app/dashboard/dashboard.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/dashboard/dashboard.component.ts
+++ b/src/main/app/src/app/dashboard/dashboard.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/dashboard/model/dashboard-card-instelling.ts
+++ b/src/main/app/src/app/dashboard/model/dashboard-card-instelling.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/dashboard/model/dashboard-card.ts
+++ b/src/main/app/src/app/dashboard/model/dashboard-card.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/dashboard/taken-card/taken-card.component.ts
+++ b/src/main/app/src/app/dashboard/taken-card/taken-card.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/dashboard/zaak-waarschuwingen-card/zaak-waarschuwingen-card.component.ts
+++ b/src/main/app/src/app/dashboard/zaak-waarschuwingen-card/zaak-waarschuwingen-card.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/dashboard/zaken-card/zaken-card.component.ts
+++ b/src/main/app/src/app/dashboard/zaken-card/zaken-card.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/documenten/model/ontkoppeld-document.ts
+++ b/src/main/app/src/app/documenten/model/ontkoppeld-document.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atosm 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atosm 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/documenten/model/ontkoppelde-documenten-resultaat.ts
+++ b/src/main/app/src/app/documenten/model/ontkoppelde-documenten-resultaat.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.html
+++ b/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.ts
+++ b/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/formulieren/formulier/formulier.component.ts
+++ b/src/main/app/src/app/formulieren/formulier/formulier.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/formulieren/taken/model/advies.ts
+++ b/src/main/app/src/app/formulieren/taken/model/advies.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/formulieren/taken/taak-formulier-builder.ts
+++ b/src/main/app/src/app/formulieren/taken/taak-formulier-builder.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/formulieren/taken/taak-formulieren.service.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/taak-formulieren.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/formulieren/taken/taak-formulieren.service.ts
+++ b/src/main/app/src/app/formulieren/taken/taak-formulieren.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/formulieren/zaken/model/melding-klein-evenement.ts
+++ b/src/main/app/src/app/formulieren/zaken/model/melding-klein-evenement.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/formulieren/zaken/zaak-formulieren.service.spec.ts
+++ b/src/main/app/src/app/formulieren/zaken/zaak-formulieren.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/formulieren/zaken/zaak-formulieren.service.ts
+++ b/src/main/app/src/app/formulieren/zaken/zaak-formulieren.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/fout-afhandeling/dialog/actie-onmogelijk-dialog.component.html
+++ b/src/main/app/src/app/fout-afhandeling/dialog/actie-onmogelijk-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/fout-afhandeling/dialog/actie-onmogelijk-dialog.component.ts
+++ b/src/main/app/src/app/fout-afhandeling/dialog/actie-onmogelijk-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/fout-afhandeling/dialog/dialog.component.less
+++ b/src/main/app/src/app/fout-afhandeling/dialog/dialog.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/fout-afhandeling/dialog/fout-detailed-dialog.component.html
+++ b/src/main/app/src/app/fout-afhandeling/dialog/fout-detailed-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/fout-afhandeling/dialog/fout-detailed-dialog.component.ts
+++ b/src/main/app/src/app/fout-afhandeling/dialog/fout-detailed-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/fout-afhandeling/dialog/fout-dialog.component.html
+++ b/src/main/app/src/app/fout-afhandeling/dialog/fout-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/fout-afhandeling/dialog/fout-dialog.component.ts
+++ b/src/main/app/src/app/fout-afhandeling/dialog/fout-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/gebruikersvoorkeuren/zoekopdracht/zoekfilters.model.ts
+++ b/src/main/app/src/app/gebruikersvoorkeuren/zoekopdracht/zoekfilters.model.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/identity/identity.service.ts
+++ b/src/main/app/src/app/identity/identity.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/indexing/indexing.service.ts
+++ b/src/main/app/src/app/indexing/indexing.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.html
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.spec.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.html
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2024-2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2024-2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.spec.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024-2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024-2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.html
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.less
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-verzenden/informatie-object-verzenden.component.html
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-verzenden/informatie-object-verzenden.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.html
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.less
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2023 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2023 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 @import "/variables";

--- a/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.spec.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/informatie-objecten/informatie-objecten.module.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-objecten.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/informatie-objecten/informatie-objecten.service.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-objecten.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/informatie-objecten/model/document-creation-data.ts
+++ b/src/main/app/src/app/informatie-objecten/model/document-creation-data.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/informatie-objecten/model/document-verplaats-gegevens.ts
+++ b/src/main/app/src/app/informatie-objecten/model/document-verplaats-gegevens.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/informatie-objecten/model/file-icon.spec.ts
+++ b/src/main/app/src/app/informatie-objecten/model/file-icon.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/informatie-objecten/model/file-icon.ts
+++ b/src/main/app/src/app/informatie-objecten/model/file-icon.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 - 2023 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 - 2023 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/klant-zaken-tabel/klant-zaken-tabel.component.html
+++ b/src/main/app/src/app/klanten/klant-zaken-tabel/klant-zaken-tabel.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/klanten/klant-zaken-tabel/klant-zaken-tabel.component.ts
+++ b/src/main/app/src/app/klanten/klant-zaken-tabel/klant-zaken-tabel.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/klanten.service.spec.ts
+++ b/src/main/app/src/app/klanten/klanten.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/klanten.service.ts
+++ b/src/main/app/src/app/klanten/klanten.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/koppel/klanten/klant-koppel-betrokkene.component.ts
+++ b/src/main/app/src/app/klanten/koppel/klanten/klant-koppel-betrokkene.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/koppel/klanten/klant-koppel-initiator.component.ts
+++ b/src/main/app/src/app/klanten/koppel/klanten/klant-koppel-initiator.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/koppel/klanten/klant-koppel.component.ts
+++ b/src/main/app/src/app/klanten/koppel/klanten/klant-koppel.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024-2025 Lifely
+ * SPDX-FileCopyrightText: 2024-2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/model/bedrijven/bedrijf.ts
+++ b/src/main/app/src/app/klanten/model/bedrijven/bedrijf.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/model/klanten/klant-gegevens.ts
+++ b/src/main/app/src/app/klanten/model/klanten/klant-gegevens.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/model/klanten/klant.ts
+++ b/src/main/app/src/app/klanten/model/klanten/klant.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/persoon-view/persoon-resolver.service.ts
+++ b/src/main/app/src/app/klanten/persoon-view/persoon-resolver.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/persoon-view/persoon-view.component.ts
+++ b/src/main/app/src/app/klanten/persoon-view/persoon-view.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/persoonsgegevens/persoonsgegevens.component.html
+++ b/src/main/app/src/app/klanten/persoonsgegevens/persoonsgegevens.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/klanten/persoonsgegevens/persoonsgegevens.component.spec.ts
+++ b/src/main/app/src/app/klanten/persoonsgegevens/persoonsgegevens.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText:  2025 Lifely
+ * SPDX-FileCopyrightText:  2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/persoonsgegevens/persoonsgegevens.component.ts
+++ b/src/main/app/src/app/klanten/persoonsgegevens/persoonsgegevens.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/zoek/form-communicatie-service.ts
+++ b/src/main/app/src/app/klanten/zoek/form-communicatie-service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/klanten/zoek/personen/persoon-zoek.component.ts
+++ b/src/main/app/src/app/klanten/zoek/personen/persoon-zoek.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/mail/mail-create/mail-create.component.html
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/mail/mail-create/mail-create.component.ts
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/mail/mail.service.ts
+++ b/src/main/app/src/app/mail/mail.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.html
+++ b/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/mailtemplate/mailtemplate.service.ts
+++ b/src/main/app/src/app/mailtemplate/mailtemplate.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/notities/notities.component.spec.ts
+++ b/src/main/app/src/app/notities/notities.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/notities/notities.component.ts
+++ b/src/main/app/src/app/notities/notities.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/plan-items/model/human-task-data.ts
+++ b/src/main/app/src/app/plan-items/model/human-task-data.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/plan-items/model/process-task-data.ts
+++ b/src/main/app/src/app/plan-items/model/process-task-data.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/plan-items/model/user-event-listener-data.ts
+++ b/src/main/app/src/app/plan-items/model/user-event-listener-data.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/plan-items/plan-items.service.spec.ts
+++ b/src/main/app/src/app/plan-items/plan-items.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/productaanvragen/inbox-productaanvragen-list/inbox-productaanvragen-list.component.html
+++ b/src/main/app/src/app/productaanvragen/inbox-productaanvragen-list/inbox-productaanvragen-list.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/productaanvragen/inbox-productaanvragen-list/inbox-productaanvragen-list.component.ts
+++ b/src/main/app/src/app/productaanvragen/inbox-productaanvragen-list/inbox-productaanvragen-list.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/batch-progress/batch-process.service.spec.ts
+++ b/src/main/app/src/app/shared/batch-progress/batch-process.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/shared/batch-progress/batch-process.service.ts
+++ b/src/main/app/src/app/shared/batch-progress/batch-process.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/dialog/dialog-data.ts
+++ b/src/main/app/src/app/shared/dialog/dialog-data.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/dialog/dialog.component.html
+++ b/src/main/app/src/app/shared/dialog/dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/dialog/dialog.component.less
+++ b/src/main/app/src/app/shared/dialog/dialog.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/dialog/dialog.component.ts
+++ b/src/main/app/src/app/shared/dialog/dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/directives/file-drag-and-drop.directive.ts
+++ b/src/main/app/src/app/shared/directives/file-drag-and-drop.directive.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/directives/outside-click.directive.ts
+++ b/src/main/app/src/app/shared/directives/outside-click.directive.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/document-icon/document-icon.component.html
+++ b/src/main/app/src/app/shared/document-icon/document-icon.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/document-icon/document-icon.component.ts
+++ b/src/main/app/src/app/shared/document-icon/document-icon.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/document-viewer/document-viewer.component.html
+++ b/src/main/app/src/app/shared/document-viewer/document-viewer.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/document-viewer/document-viewer.component.less
+++ b/src/main/app/src/app/shared/document-viewer/document-viewer.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/document-viewer/document-viewer.component.ts
+++ b/src/main/app/src/app/shared/document-viewer/document-viewer.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/dynamic-table/column-picker/column-picker-value.ts
+++ b/src/main/app/src/app/shared/dynamic-table/column-picker/column-picker-value.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/dynamic-table/filter/clientMatcher.ts
+++ b/src/main/app/src/app/shared/dynamic-table/filter/clientMatcher.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/dynamic-table/model/zoeken-column.ts
+++ b/src/main/app/src/app/shared/dynamic-table/model/zoeken-column.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/edit/edit-behandelaar/edit-behandelaar.component.ts
+++ b/src/main/app/src/app/shared/edit/edit-behandelaar/edit-behandelaar.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/edit/edit-groep-behandelaar/edit-groep-behandelaar.component.ts
+++ b/src/main/app/src/app/shared/edit/edit-groep-behandelaar/edit-groep-behandelaar.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/form/auto-complete/auto-complete.html
+++ b/src/main/app/src/app/shared/form/auto-complete/auto-complete.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   ~
   -->

--- a/src/main/app/src/app/shared/form/auto-complete/auto-complete.ts
+++ b/src/main/app/src/app/shared/form/auto-complete/auto-complete.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/shared/form/date/date.html
+++ b/src/main/app/src/app/shared/form/date/date.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   ~
   -->

--- a/src/main/app/src/app/shared/form/date/date.ts
+++ b/src/main/app/src/app/shared/form/date/date.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/shared/form/helpers.ts
+++ b/src/main/app/src/app/shared/form/helpers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/shared/form/input/input.html
+++ b/src/main/app/src/app/shared/form/input/input.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   ~
   -->

--- a/src/main/app/src/app/shared/form/input/input.ts
+++ b/src/main/app/src/app/shared/form/input/input.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/shared/form/select/select.html
+++ b/src/main/app/src/app/shared/form/select/select.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   ~
   -->

--- a/src/main/app/src/app/shared/form/select/select.ts
+++ b/src/main/app/src/app/shared/form/select/select.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/shared/form/textarea/textarea.html
+++ b/src/main/app/src/app/shared/form/textarea/textarea.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   ~
   -->

--- a/src/main/app/src/app/shared/form/textarea/textarea.ts
+++ b/src/main/app/src/app/shared/form/textarea/textarea.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/shared/http/zac-http-client.spec.ts
+++ b/src/main/app/src/app/shared/http/zac-http-client.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/http/zac-http-client.ts
+++ b/src/main/app/src/app/shared/http/zac-http-client.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/indicaties/indicaties.component.ts
+++ b/src/main/app/src/app/shared/indicaties/indicaties.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/indicaties/persoon-indicaties/persoon-indicaties.component.ts
+++ b/src/main/app/src/app/shared/indicaties/persoon-indicaties/persoon-indicaties.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/shared/location/location-util.ts
+++ b/src/main/app/src/app/shared/location/location-util.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/location/location.service.ts
+++ b/src/main/app/src/app/shared/location/location.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete-validators.spec.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete-validators.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete-validators.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete-validators.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely, 2025 Dimpact
+  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl, 2025 Dimpact
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete.component.less
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely, 2025 Dimpact
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl, 2025 Dimpact
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/checkbox/checkbox.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/checkbox/checkbox.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/date/date.component.less
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/date/date.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/file-input/file-input-control.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/file-input/file-input-control.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/file-input/file-input.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/file-input/file-input.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/file/file.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/file/file.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/hidden/hidden-form-field-builder.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/hidden/hidden-form-field-builder.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/hidden/hidden-form-field.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/hidden/hidden-form-field.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/hidden/hidden.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/hidden/hidden.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/hidden/hidden.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/hidden/hidden.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/html-editor/html-editor-variabelen-kies-menu.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/html-editor/html-editor-variabelen-kies-menu.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/html-editor/html-editor-variabelen-kies-menu.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/html-editor/html-editor-variabelen-kies-menu.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/input/input.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/input/input.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/input/input.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/input/input.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep-field-builder.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep-field-builder.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep-form-field.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep-form-field.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep.component.less
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep.component.spec.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024-2025 Lifely
+ * SPDX-FileCopyrightText: 2024-2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/medewerker-groep/medewerker-groep.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/radio/radio.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/radio/radio.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 <div class="radio-form-field">

--- a/src/main/app/src/app/shared/material-form-builder/form-components/radio/radio.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/radio/radio.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/select/select.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/select/select.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/material-form-builder/form-components/select/select.component.less
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/select/select.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 ::ng-deep .mat-mdc-select-arrow-wrapper {

--- a/src/main/app/src/app/shared/material-form-builder/form-components/taak-document-upload/taak-document-upload.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/taak-document-upload/taak-document-upload.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 - 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 - 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/material-form-builder/material-form-builder.module.ts
+++ b/src/main/app/src/app/shared/material-form-builder/material-form-builder.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/model/abstract-file-form-field-builder.ts
+++ b/src/main/app/src/app/shared/material-form-builder/model/abstract-file-form-field-builder.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/model/abstract-form-field-builder.ts
+++ b/src/main/app/src/app/shared/material-form-builder/model/abstract-form-field-builder.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material-form-builder/service/google-maps.service.spec.ts
+++ b/src/main/app/src/app/shared/material-form-builder/service/google-maps.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material/mat-zac-error.ts
+++ b/src/main/app/src/app/shared/material/mat-zac-error.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/material/narrow-checkbox.directive.ts
+++ b/src/main/app/src/app/shared/material/narrow-checkbox.directive.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/order/order-util.spec.ts
+++ b/src/main/app/src/app/shared/order/order-util.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/shared/order/order-util.ts
+++ b/src/main/app/src/app/shared/order/order-util.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023-2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023-2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/pipes/capitalizeFirstLetter.pipe.ts
+++ b/src/main/app/src/app/shared/pipes/capitalizeFirstLetter.pipe.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/pipes/datum.pipe.spec.ts
+++ b/src/main/app/src/app/shared/pipes/datum.pipe.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/pipes/empty.pipe.spec.ts
+++ b/src/main/app/src/app/shared/pipes/empty.pipe.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/pipes/mimetypeToExtension.pipe.spec.ts
+++ b/src/main/app/src/app/shared/pipes/mimetypeToExtension.pipe.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/pipes/mimetypeToExtension.pipe.ts
+++ b/src/main/app/src/app/shared/pipes/mimetypeToExtension.pipe.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/pipes/slice.pipe.ts
+++ b/src/main/app/src/app/shared/pipes/slice.pipe.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/pipes/slice.spec.ts
+++ b/src/main/app/src/app/shared/pipes/slice.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/pipes/vertrouwelijkaanduiding-to-translation-key.pipe.spec.ts
+++ b/src/main/app/src/app/shared/pipes/vertrouwelijkaanduiding-to-translation-key.pipe.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/pipes/vertrouwelijkaanduiding-to-translation-key.pipe.ts
+++ b/src/main/app/src/app/shared/pipes/vertrouwelijkaanduiding-to-translation-key.pipe.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/progress-dialog/progress-dialog.component.html
+++ b/src/main/app/src/app/shared/progress-dialog/progress-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/progress-dialog/progress-dialog.component.less
+++ b/src/main/app/src/app/shared/progress-dialog/progress-dialog.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 .progress-dialog {

--- a/src/main/app/src/app/shared/progress-dialog/progress-dialog.component.ts
+++ b/src/main/app/src/app/shared/progress-dialog/progress-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 import { Component, Inject } from "@angular/core";

--- a/src/main/app/src/app/shared/progress-snackbar/progress-snackbar.component.html
+++ b/src/main/app/src/app/shared/progress-snackbar/progress-snackbar.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/progress-snackbar/progress-snackbar.component.less
+++ b/src/main/app/src/app/shared/progress-snackbar/progress-snackbar.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/progress-snackbar/progress-snackbar.component.ts
+++ b/src/main/app/src/app/shared/progress-snackbar/progress-snackbar.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/read-more/read-more.component.ts
+++ b/src/main/app/src/app/shared/read-more/read-more.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/shared.module.ts
+++ b/src/main/app/src/app/shared/shared.module.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/side-nav/menu-item/button-menu-item.ts
+++ b/src/main/app/src/app/shared/side-nav/menu-item/button-menu-item.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/side-nav/menu-item/menu-item.ts
+++ b/src/main/app/src/app/shared/side-nav/menu-item/menu-item.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/side-nav/menu-item/subscription-button-menu-item.ts
+++ b/src/main/app/src/app/shared/side-nav/menu-item/subscription-button-menu-item.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024-2025 Lifely
+ * SPDX-FileCopyrightText: 2024-2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/side-nav/side-nav.component.html
+++ b/src/main/app/src/app/shared/side-nav/side-nav.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/side-nav/side-nav.component.ts
+++ b/src/main/app/src/app/shared/side-nav/side-nav.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/table-zoek-filters/date-range-filter/date-range-filter.component.ts
+++ b/src/main/app/src/app/shared/table-zoek-filters/date-range-filter/date-range-filter.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021-2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/table-zoek-filters/facet-filter/facet-filter.component.html
+++ b/src/main/app/src/app/shared/table-zoek-filters/facet-filter/facet-filter.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/table-zoek-filters/facet-filter/facet-filter.component.ts
+++ b/src/main/app/src/app/shared/table-zoek-filters/facet-filter/facet-filter.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021-2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/table-zoek-filters/tekst-filter/tekst-filter.component.html
+++ b/src/main/app/src/app/shared/table-zoek-filters/tekst-filter/tekst-filter.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/shared/table-zoek-filters/tekst-filter/tekst-filter.component.ts
+++ b/src/main/app/src/app/shared/table-zoek-filters/tekst-filter/tekst-filter.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021-2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/utils/constants.ts
+++ b/src/main/app/src/app/shared/utils/constants.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/utils/date-conditionals.spec.ts
+++ b/src/main/app/src/app/shared/utils/date-conditionals.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/utils/form-data.spec.ts
+++ b/src/main/app/src/app/shared/utils/form-data.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/utils/form-data.ts
+++ b/src/main/app/src/app/shared/utils/form-data.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/utils/generated-types.ts
+++ b/src/main/app/src/app/shared/utils/generated-types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/validators/customValidators.spec.ts
+++ b/src/main/app/src/app/shared/validators/customValidators.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/validators/customValidators.ts
+++ b/src/main/app/src/app/shared/validators/customValidators.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/version/version.component.ts
+++ b/src/main/app/src/app/shared/version/version.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/signaleringen.service.spec.ts
+++ b/src/main/app/src/app/signaleringen.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/signaleringen.service.ts
+++ b/src/main/app/src/app/signaleringen.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/signaleringen/signaleringen-settings.service.ts
+++ b/src/main/app/src/app/signaleringen/signaleringen-settings.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/signaleringen/signaleringen-settings/signaleringen-settings.component.ts
+++ b/src/main/app/src/app/signaleringen/signaleringen-settings/signaleringen-settings.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/taken/model/taak.ts
+++ b/src/main/app/src/app/taken/model/taak.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.html
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Dimpact, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Dimpact, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.less
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.spec.ts
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.ts
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Dimpact, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Dimpact, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/taken/taken-mijn/taken-mijn.component.html
+++ b/src/main/app/src/app/taken/taken-mijn/taken-mijn.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/taken/taken-mijn/taken-mijn.component.ts
+++ b/src/main/app/src/app/taken/taken-mijn/taken-mijn.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/taken/taken-verdelen-dialog/taken-verdelen-dialog.component.ts
+++ b/src/main/app/src/app/taken/taken-verdelen-dialog/taken-verdelen-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.ts
+++ b/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/taken/taken-werkvoorraad/taken-werkvoorraad.component.html
+++ b/src/main/app/src/app/taken/taken-werkvoorraad/taken-werkvoorraad.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/taken/taken-werkvoorraad/taken-werkvoorraad.component.ts
+++ b/src/main/app/src/app/taken/taken-werkvoorraad/taken-werkvoorraad.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/taken/taken.service.spec.ts
+++ b/src/main/app/src/app/taken/taken.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/besluit-create/besluit-create.component.html
+++ b/src/main/app/src/app/zaken/besluit-create/besluit-create.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 <mat-toolbar role="heading" class="gap-16">

--- a/src/main/app/src/app/zaken/besluit-create/besluit-create.component.ts
+++ b/src/main/app/src/app/zaken/besluit-create/besluit-create.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/besluit-edit/besluit-edit.component.html
+++ b/src/main/app/src/app/zaken/besluit-edit/besluit-edit.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/besluit-edit/besluit-edit.component.ts
+++ b/src/main/app/src/app/zaken/besluit-edit/besluit-edit.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/besluit-view/besluit-view.component.html
+++ b/src/main/app/src/app/zaken/besluit-view/besluit-view.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 <mat-accordion>

--- a/src/main/app/src/app/zaken/besluit-view/besluit-view.component.less
+++ b/src/main/app/src/app/zaken/besluit-view/besluit-view.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/besluit-view/besluit-view.component.ts
+++ b/src/main/app/src/app/zaken/besluit-view/besluit-view.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.html
+++ b/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 <mat-toolbar role="heading" class="gap-16" mat-dialog-title>

--- a/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.ts
+++ b/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/model/zaak-overzicht-dashboard.ts
+++ b/src/main/app/src/app/zaken/model/zaak-overzicht-dashboard.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/model/zaak.ts
+++ b/src/main/app/src/app/zaken/model/zaak.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/model/zaaktype.ts
+++ b/src/main/app/src/app/zaken/model/zaaktype.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-create/zaak-create.component.html
+++ b/src/main/app/src/app/zaken/zaak-create/zaak-create.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 <mat-sidenav-container>

--- a/src/main/app/src/app/zaken/zaak-create/zaak-create.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaak-create/zaak-create.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/zaken/zaak-create/zaak-create.component.ts
+++ b/src/main/app/src/app/zaken/zaak-create/zaak-create.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2024 Dimpact, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2024 Dimpact, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.html
+++ b/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.less
+++ b/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
+++ b/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.html
+++ b/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.ts
+++ b/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-link/zaak-link.component.html
+++ b/src/main/app/src/app/zaken/zaak-link/zaak-link.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaak-link/zaak-link.component.less
+++ b/src/main/app/src/app/zaken/zaak-link/zaak-link.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 @import "/variables";

--- a/src/main/app/src/app/zaken/zaak-link/zaak-link.component.ts
+++ b/src/main/app/src/app/zaken/zaak-link/zaak-link.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-ontkoppelen/zaak-ontkoppelen-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaak-ontkoppelen/zaak-ontkoppelen-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.less
+++ b/src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 .readonly {

--- a/src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-verkort/zaak-verkort.component.html
+++ b/src/main/app/src/app/zaken/zaak-verkort/zaak-verkort.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaak-verkort/zaak-verkort.component.less
+++ b/src/main/app/src/app/zaken/zaak-verkort/zaak-verkort.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-verlengen-dialog/zaak-verlengen-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaak-verlengen-dialog/zaak-verlengen-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaak-verlengen-dialog/zaak-verlengen-dialog.component.less
+++ b/src/main/app/src/app/zaken/zaak-verlengen-dialog/zaak-verlengen-dialog.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 .readonly {

--- a/src/main/app/src/app/zaken/zaak-verlengen-dialog/zaak-verlengen-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaak-verlengen-dialog/zaak-verlengen-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024-2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024-2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024-2025 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024-2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaakdata/zaakdata-form/zaakdata-form.component.ts
+++ b/src/main/app/src/app/zaken/zaakdata/zaakdata-form/zaakdata-form.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaakdata/zaakdata.component.html
+++ b/src/main/app/src/app/zaken/zaakdata/zaakdata.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaken-afgehandeld/zaken-afgehandeld.component.html
+++ b/src/main/app/src/app/zaken/zaken-afgehandeld/zaken-afgehandeld.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaken-afgehandeld/zaken-afgehandeld.component.less
+++ b/src/main/app/src/app/zaken/zaken-afgehandeld/zaken-afgehandeld.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaken-mijn/zaken-mijn.component.html
+++ b/src/main/app/src/app/zaken/zaken-mijn/zaken-mijn.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaken-verdelen-dialog/zaken-verdelen-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaken-verdelen-dialog/zaken-verdelen-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaken-werkvoorraad/zaken-werkvoorraad.component.html
+++ b/src/main/app/src/app/zaken/zaken-werkvoorraad/zaken-werkvoorraad.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2021 - 2022 Atos, 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zaken/zaken-werkvoorraad/zaken-werkvoorraad.component.ts
+++ b/src/main/app/src/app/zaken/zaken-werkvoorraad/zaken-werkvoorraad.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaken.service.spec.ts
+++ b/src/main/app/src/app/zaken/zaken.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zaken.service.ts
+++ b/src/main/app/src/app/zaken/zaken.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zaken/zoek/locatie-zoek/locatie-zoek.component.html
+++ b/src/main/app/src/app/zaken/zoek/locatie-zoek/locatie-zoek.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/app/src/app/zoeken/model/zoek-object.ts
+++ b/src/main/app/src/app/zoeken/model/zoek-object.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/zoeken/zoeken.service.ts
+++ b/src/main/app/src/app/zoeken/zoeken.service.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/assets/werklijsten.less
+++ b/src/main/app/src/assets/werklijsten.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/flex.less
+++ b/src/main/app/src/flex.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/static/smart-documents-result.html
+++ b/src/main/app/src/static/smart-documents-result.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 <!doctype html>

--- a/src/main/app/src/styles.less
+++ b/src/main/app/src/styles.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024-2025 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024-2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/test-helpers.ts
+++ b/src/main/app/src/test-helpers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/app/src/variables.less
+++ b/src/main/app/src/variables.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 @primary-background-color: #3f51b5;

--- a/src/main/java/net/atos/client/bag/api/AdresApi.java
+++ b/src/main/java/net/atos/client/bag/api/AdresApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/bag/api/AdresUitgebreidApi.java
+++ b/src/main/java/net/atos/client/bag/api/AdresUitgebreidApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/bag/api/AdresseerbaarObjectApi.java
+++ b/src/main/java/net/atos/client/bag/api/AdresseerbaarObjectApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/bag/api/AlgemeneInformatieApi.java
+++ b/src/main/java/net/atos/client/bag/api/AlgemeneInformatieApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/bag/api/BronhouderApi.java
+++ b/src/main/java/net/atos/client/bag/api/BronhouderApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/bag/api/LigplaatsApi.java
+++ b/src/main/java/net/atos/client/bag/api/LigplaatsApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/bag/api/NummeraanduidingApi.java
+++ b/src/main/java/net/atos/client/bag/api/NummeraanduidingApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/bag/api/OpenbareRuimteApi.java
+++ b/src/main/java/net/atos/client/bag/api/OpenbareRuimteApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/bag/api/PandApi.java
+++ b/src/main/java/net/atos/client/bag/api/PandApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/bag/api/StandplaatsApi.java
+++ b/src/main/java/net/atos/client/bag/api/StandplaatsApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/bag/api/VerblijfsobjectApi.java
+++ b/src/main/java/net/atos/client/bag/api/VerblijfsobjectApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/bag/api/WoonplaatsApi.java
+++ b/src/main/java/net/atos/client/bag/api/WoonplaatsApi.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/KlantClient.java
+++ b/src/main/java/net/atos/client/klant/KlantClient.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Actor.java
+++ b/src/main/java/net/atos/client/klant/model/Actor.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ActorForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/ActorForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ActorIdentificatieGeautomatiseerdeActor.java
+++ b/src/main/java/net/atos/client/klant/model/ActorIdentificatieGeautomatiseerdeActor.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ActorIdentificatieMedewerker.java
+++ b/src/main/java/net/atos/client/klant/model/ActorIdentificatieMedewerker.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ActorIdentificatieOrganisatorischeEenheid.java
+++ b/src/main/java/net/atos/client/klant/model/ActorIdentificatieOrganisatorischeEenheid.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ActorKlantcontact.java
+++ b/src/main/java/net/atos/client/klant/model/ActorKlantcontact.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Actoridentificator.java
+++ b/src/main/java/net/atos/client/klant/model/Actoridentificator.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/BaseActorSerializer.java
+++ b/src/main/java/net/atos/client/klant/model/BaseActorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/BasePartijSerializer.java
+++ b/src/main/java/net/atos/client/klant/model/BasePartijSerializer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Betrokkene.java
+++ b/src/main/java/net/atos/client/klant/model/Betrokkene.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/BetrokkeneCorrespondentieadres.java
+++ b/src/main/java/net/atos/client/klant/model/BetrokkeneCorrespondentieadres.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/BetrokkeneForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/BetrokkeneForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/BetrokkeneKlantcontactReadOnly.java
+++ b/src/main/java/net/atos/client/klant/model/BetrokkeneKlantcontactReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Bezoekadres.java
+++ b/src/main/java/net/atos/client/klant/model/Bezoekadres.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Bijlage.java
+++ b/src/main/java/net/atos/client/klant/model/Bijlage.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/BijlageForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/BijlageForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/BijlageIdentificator.java
+++ b/src/main/java/net/atos/client/klant/model/BijlageIdentificator.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/BlankEnum.java
+++ b/src/main/java/net/atos/client/klant/model/BlankEnum.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Categorie.java
+++ b/src/main/java/net/atos/client/klant/model/Categorie.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/CategorieForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/CategorieForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/CategorieRelatie.java
+++ b/src/main/java/net/atos/client/klant/model/CategorieRelatie.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/CategorieRelatieForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/CategorieRelatieForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/CodeObjecttypeEnum.java
+++ b/src/main/java/net/atos/client/klant/model/CodeObjecttypeEnum.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/CodeRegisterEnum.java
+++ b/src/main/java/net/atos/client/klant/model/CodeRegisterEnum.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/CodeSoortObjectIdEnum.java
+++ b/src/main/java/net/atos/client/klant/model/CodeSoortObjectIdEnum.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Contactnaam.java
+++ b/src/main/java/net/atos/client/klant/model/Contactnaam.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Contactpersoon.java
+++ b/src/main/java/net/atos/client/klant/model/Contactpersoon.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ContactpersoonPartijSerializer.java
+++ b/src/main/java/net/atos/client/klant/model/ContactpersoonPartijSerializer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ContactpersoonPersoon.java
+++ b/src/main/java/net/atos/client/klant/model/ContactpersoonPersoon.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/DigitaalAdres.java
+++ b/src/main/java/net/atos/client/klant/model/DigitaalAdres.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/DigitaalAdresForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/DigitaalAdresForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ExpandBetrokkene.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandBetrokkene.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ExpandBetrokkeneAllOfExpand.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandBetrokkeneAllOfExpand.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ExpandDigitaalAdres.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandDigitaalAdres.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ExpandDigitaalAdresAllOfExpand.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandDigitaalAdresAllOfExpand.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ExpandKlantcontact.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandKlantcontact.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ExpandKlantcontactAllOfExpand.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandKlantcontactAllOfExpand.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ExpandPartij.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandPartij.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/ExpandPartijAllOfExpand.java
+++ b/src/main/java/net/atos/client/klant/model/ExpandPartijAllOfExpand.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/GeautomatiseerdeActor.java
+++ b/src/main/java/net/atos/client/klant/model/GeautomatiseerdeActor.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/GeautomatiseerdeActorActorSerializer.java
+++ b/src/main/java/net/atos/client/klant/model/GeautomatiseerdeActorActorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/InterneTaak.java
+++ b/src/main/java/net/atos/client/klant/model/InterneTaak.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/InterneTaakForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/InterneTaakForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Klantcontact.java
+++ b/src/main/java/net/atos/client/klant/model/Klantcontact.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/KlantcontactForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/KlantcontactForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/MaakKlantcontact.java
+++ b/src/main/java/net/atos/client/klant/model/MaakKlantcontact.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Medewerker.java
+++ b/src/main/java/net/atos/client/klant/model/Medewerker.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/MedewerkerActorSerializer.java
+++ b/src/main/java/net/atos/client/klant/model/MedewerkerActorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Onderwerpobject.java
+++ b/src/main/java/net/atos/client/klant/model/Onderwerpobject.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/OnderwerpobjectForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/OnderwerpobjectForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/OnderwerpobjectKlantcontactReadOnly.java
+++ b/src/main/java/net/atos/client/klant/model/OnderwerpobjectKlantcontactReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Onderwerpobjectidentificator.java
+++ b/src/main/java/net/atos/client/klant/model/Onderwerpobjectidentificator.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Organisatie.java
+++ b/src/main/java/net/atos/client/klant/model/Organisatie.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/OrganisatiePartijSerializer.java
+++ b/src/main/java/net/atos/client/klant/model/OrganisatiePartijSerializer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/OrganisatorischeEenheid.java
+++ b/src/main/java/net/atos/client/klant/model/OrganisatorischeEenheid.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/OrganisatorischeEenheidActorSerializer.java
+++ b/src/main/java/net/atos/client/klant/model/OrganisatorischeEenheidActorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedActorKlantcontactList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedActorKlantcontactList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedActorList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedActorList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedBetrokkeneList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedBetrokkeneList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedBijlageList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedBijlageList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedCategorieList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedCategorieList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedCategorieRelatieList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedCategorieRelatieList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedDigitaalAdresList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedDigitaalAdresList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedExpandBetrokkeneList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedExpandBetrokkeneList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedExpandDigitaalAdresList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedExpandDigitaalAdresList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedExpandKlantcontactList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedExpandKlantcontactList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedExpandPartijList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedExpandPartijList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedInterneTaakList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedInterneTaakList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedKlantcontactList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedKlantcontactList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedOnderwerpobjectList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedOnderwerpobjectList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedPartijIdentificatorList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedPartijIdentificatorList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedPartijList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedPartijList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedRekeningnummerList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedRekeningnummerList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PaginatedVertegenwoordigdenList.java
+++ b/src/main/java/net/atos/client/klant/model/PaginatedVertegenwoordigdenList.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Partij.java
+++ b/src/main/java/net/atos/client/klant/model/Partij.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PartijBezoekadres.java
+++ b/src/main/java/net/atos/client/klant/model/PartijBezoekadres.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PartijCorrespondentieadres.java
+++ b/src/main/java/net/atos/client/klant/model/PartijCorrespondentieadres.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PartijForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/PartijForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PartijForeignkeyBase.java
+++ b/src/main/java/net/atos/client/klant/model/PartijForeignkeyBase.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PartijIdentificatieContactpersoon.java
+++ b/src/main/java/net/atos/client/klant/model/PartijIdentificatieContactpersoon.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PartijIdentificatieOrganisatie.java
+++ b/src/main/java/net/atos/client/klant/model/PartijIdentificatieOrganisatie.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PartijIdentificatiePersoon.java
+++ b/src/main/java/net/atos/client/klant/model/PartijIdentificatiePersoon.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PartijIdentificator.java
+++ b/src/main/java/net/atos/client/klant/model/PartijIdentificator.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PartijIdentificatorForeignkey.java
+++ b/src/main/java/net/atos/client/klant/model/PartijIdentificatorForeignkey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PartijIdentificatorGroepType.java
+++ b/src/main/java/net/atos/client/klant/model/PartijIdentificatorGroepType.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PartijPolymorphic.java
+++ b/src/main/java/net/atos/client/klant/model/PartijPolymorphic.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedActor.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedActor.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedActorKlantcontact.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedActorKlantcontact.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedBetrokkene.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedBetrokkene.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedBijlage.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedBijlage.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedCategorie.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedCategorie.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedCategorieRelatie.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedCategorieRelatie.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedDigitaalAdres.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedDigitaalAdres.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedInterneTaak.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedInterneTaak.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedKlantcontact.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedKlantcontact.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedOnderwerpobject.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedOnderwerpobject.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedPartij.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedPartij.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedPartijIdentificator.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedPartijIdentificator.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedRekeningnummer.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedRekeningnummer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PatchedVertegenwoordigden.java
+++ b/src/main/java/net/atos/client/klant/model/PatchedVertegenwoordigden.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Persoon.java
+++ b/src/main/java/net/atos/client/klant/model/Persoon.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PersoonContact.java
+++ b/src/main/java/net/atos/client/klant/model/PersoonContact.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/PersoonPartijSerializer.java
+++ b/src/main/java/net/atos/client/klant/model/PersoonPartijSerializer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Rekeningnummer.java
+++ b/src/main/java/net/atos/client/klant/model/Rekeningnummer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/RekeningnummerForeignKey.java
+++ b/src/main/java/net/atos/client/klant/model/RekeningnummerForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/RolEnum.java
+++ b/src/main/java/net/atos/client/klant/model/RolEnum.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/SoortActorEnum.java
+++ b/src/main/java/net/atos/client/klant/model/SoortActorEnum.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/SoortDigitaalAdresEnum.java
+++ b/src/main/java/net/atos/client/klant/model/SoortDigitaalAdresEnum.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/SoortPartijEnum.java
+++ b/src/main/java/net/atos/client/klant/model/SoortPartijEnum.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/StatusEnum.java
+++ b/src/main/java/net/atos/client/klant/model/StatusEnum.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/klant/model/Vertegenwoordigden.java
+++ b/src/main/java/net/atos/client/klant/model/Vertegenwoordigden.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/drc/DrcClient.java
+++ b/src/main/java/net/atos/client/zgw/drc/DrcClient.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/drc/exception/DrcRuntimeException.java
+++ b/src/main/java/net/atos/client/zgw/drc/exception/DrcRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/drc/exception/DrcRuntimeResponseExceptionMapper.java
+++ b/src/main/java/net/atos/client/zgw/drc/exception/DrcRuntimeResponseExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/shared/exception/ValidationErrorException.java
+++ b/src/main/java/net/atos/client/zgw/shared/exception/ValidationErrorException.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/shared/exception/ZgwErrorException.java
+++ b/src/main/java/net/atos/client/zgw/shared/exception/ZgwErrorException.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/shared/exception/ZgwErrorExceptionMapper.java
+++ b/src/main/java/net/atos/client/zgw/shared/exception/ZgwErrorExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.shared.exception;

--- a/src/main/java/net/atos/client/zgw/shared/exception/ZgwValidationErrorResponseExceptionMapper.java
+++ b/src/main/java/net/atos/client/zgw/shared/exception/ZgwValidationErrorResponseExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.shared.exception;

--- a/src/main/java/net/atos/client/zgw/shared/model/ValidationZgwError.java
+++ b/src/main/java/net/atos/client/zgw/shared/model/ValidationZgwError.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.shared.model;

--- a/src/main/java/net/atos/client/zgw/shared/model/ZgwError.java
+++ b/src/main/java/net/atos/client/zgw/shared/model/ZgwError.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.shared.model;

--- a/src/main/java/net/atos/client/zgw/shared/util/ZGWClientHeadersFactory.java
+++ b/src/main/java/net/atos/client/zgw/shared/util/ZGWClientHeadersFactory.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/ZrcClient.java
+++ b/src/main/java/net/atos/client/zgw/zrc/ZrcClient.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.zrc;

--- a/src/main/java/net/atos/client/zgw/zrc/ZrcClientService.java
+++ b/src/main/java/net/atos/client/zgw/zrc/ZrcClientService.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.zrc;

--- a/src/main/java/net/atos/client/zgw/zrc/exception/ZrcResponseExceptionMapper.java
+++ b/src/main/java/net/atos/client/zgw/zrc/exception/ZrcResponseExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.zrc.exception;

--- a/src/main/java/net/atos/client/zgw/zrc/exception/ZrcRuntimeException.java
+++ b/src/main/java/net/atos/client/zgw/zrc/exception/ZrcRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/GeometryCollection.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/GeometryCollection.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/GeometryToBeDeleted.kt
+++ b/src/main/java/net/atos/client/zgw/zrc/model/GeometryToBeDeleted.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/HoofdzaakZaakPatch.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/HoofdzaakZaakPatch.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.zrc.model;

--- a/src/main/java/net/atos/client/zgw/zrc/model/NatuurlijkPersoon.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/NatuurlijkPersoon.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.zrc.model;

--- a/src/main/java/net/atos/client/zgw/zrc/model/Point2D.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Point2D.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/Polygon.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Polygon.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/Rol.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Rol.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/RolMedewerker.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/RolMedewerker.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/RolNatuurlijkPersoon.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/RolNatuurlijkPersoon.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/RolNietNatuurlijkPersoon.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/RolNietNatuurlijkPersoon.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/RolOrganisatorischeEenheid.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/RolOrganisatorischeEenheid.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/RolVestiging.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/RolVestiging.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/model/ZaakUuid.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/ZaakUuid.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.zrc.model;

--- a/src/main/java/net/atos/client/zgw/zrc/util/GeometryJsonbDeserializer.java
+++ b/src/main/java/net/atos/client/zgw/zrc/util/GeometryJsonbDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/client/zgw/zrc/util/StatusTypeUtil.java
+++ b/src/main/java/net/atos/client/zgw/zrc/util/StatusTypeUtil.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.zrc.util;

--- a/src/main/java/net/atos/client/zgw/zrc/util/ZaakUtil.java
+++ b/src/main/java/net/atos/client/zgw/zrc/util/ZaakUtil.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.zgw.zrc.util;

--- a/src/main/java/net/atos/zac/admin/ZaakafhandelParameterService.java
+++ b/src/main/java/net/atos/zac/admin/ZaakafhandelParameterService.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/admin/model/BetrokkeneKoppelingen.java
+++ b/src/main/java/net/atos/zac/admin/model/BetrokkeneKoppelingen.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/admin/model/UserEventListenerParameters.java
+++ b/src/main/java/net/atos/zac/admin/model/UserEventListenerParameters.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.admin.model;

--- a/src/main/java/net/atos/zac/admin/model/ZaakafhandelParameters.java
+++ b/src/main/java/net/atos/zac/admin/model/ZaakafhandelParameters.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/app/admin/converter/RestHumanTaskReferenceTableConverter.java
+++ b/src/main/java/net/atos/zac/app/admin/converter/RestHumanTaskReferenceTableConverter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/app/admin/model/RESTTaakFormulierDefinitie.java
+++ b/src/main/java/net/atos/zac/app/admin/model/RESTTaakFormulierDefinitie.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.admin.model;

--- a/src/main/java/net/atos/zac/app/admin/model/RESTTaakFormulierVeldDefinitie.java
+++ b/src/main/java/net/atos/zac/app/admin/model/RESTTaakFormulierVeldDefinitie.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.admin.model;

--- a/src/main/java/net/atos/zac/app/inboxdocumenten/InboxDocumentenRESTService.java
+++ b/src/main/java/net/atos/zac/app/inboxdocumenten/InboxDocumentenRESTService.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.inboxdocumenten;

--- a/src/main/java/net/atos/zac/app/inboxdocumenten/converter/RESTInboxDocumentConverter.java
+++ b/src/main/java/net/atos/zac/app/inboxdocumenten/converter/RESTInboxDocumentConverter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.inboxdocumenten.converter;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjectConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RestInformatieobjectConverter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.informatieobjecten.converter;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/RestEnkelvoudigInformatieFileUpload.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/RestEnkelvoudigInformatieFileUpload.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.informatieobjecten.model;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadForm.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadForm.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.informatieobjecten.model.validation;

--- a/src/main/java/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadFormValidator.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadFormValidator.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.informatieobjecten.model.validation;

--- a/src/main/java/net/atos/zac/app/mail/converter/RESTMailGegevensConverter.java
+++ b/src/main/java/net/atos/zac/app/mail/converter/RESTMailGegevensConverter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.mail.converter;

--- a/src/main/java/net/atos/zac/app/mailtemplate/MailtemplateRESTService.java
+++ b/src/main/java/net/atos/zac/app/mailtemplate/MailtemplateRESTService.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.mailtemplate;

--- a/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTService.java
+++ b/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTService.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.ontkoppeldedocumenten;

--- a/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/converter/RESTOntkoppeldDocumentConverter.java
+++ b/src/main/java/net/atos/zac/app/ontkoppeldedocumenten/converter/RESTOntkoppeldDocumentConverter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.ontkoppeldedocumenten.converter;

--- a/src/main/java/net/atos/zac/app/util/EnkelvoudigInformatieObjectStatusEnumReader.java
+++ b/src/main/java/net/atos/zac/app/util/EnkelvoudigInformatieObjectStatusEnumReader.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.util;

--- a/src/main/java/net/atos/zac/app/util/RESTTaalReader.java
+++ b/src/main/java/net/atos/zac/app/util/RESTTaalReader.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.util;

--- a/src/main/java/net/atos/zac/app/util/UUIDReader.java
+++ b/src/main/java/net/atos/zac/app/util/UUIDReader.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.util;

--- a/src/main/java/net/atos/zac/event/AbstractEvent.java
+++ b/src/main/java/net/atos/zac/event/AbstractEvent.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/flowable/ZaakVariabelenService.java
+++ b/src/main/java/net/atos/zac/flowable/ZaakVariabelenService.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable;

--- a/src/main/java/net/atos/zac/flowable/delegate/UpdateZaakJavaDelegate.java
+++ b/src/main/java/net/atos/zac/flowable/delegate/UpdateZaakJavaDelegate.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.delegate;

--- a/src/main/java/net/atos/zac/flowable/processengine/ProcessEngineLookupImpl.java
+++ b/src/main/java/net/atos/zac/flowable/processengine/ProcessEngineLookupImpl.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/flowable/task/CreateUserTaskInterceptor.java
+++ b/src/main/java/net/atos/zac/flowable/task/CreateUserTaskInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/flowable/task/FlowableTaskService.java
+++ b/src/main/java/net/atos/zac/flowable/task/FlowableTaskService.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/flowable/task/TaakVariabelenService.java
+++ b/src/main/java/net/atos/zac/flowable/task/TaakVariabelenService.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/flowable/task/exception/TaskNotFoundException.java
+++ b/src/main/java/net/atos/zac/flowable/task/exception/TaskNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/flowable/task/model/ValueChangeData.java
+++ b/src/main/java/net/atos/zac/flowable/task/model/ValueChangeData.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/flowable/util/TaskUtil.java
+++ b/src/main/java/net/atos/zac/flowable/util/TaskUtil.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.util;

--- a/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
+++ b/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.mailtemplates;

--- a/src/main/java/net/atos/zac/mailtemplates/model/MailLink.java
+++ b/src/main/java/net/atos/zac/mailtemplates/model/MailLink.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.mailtemplates.model;

--- a/src/main/java/net/atos/zac/policy/PolicyService.java
+++ b/src/main/java/net/atos/zac/policy/PolicyService.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/policy/output/WerklijstRechten.java
+++ b/src/main/java/net/atos/zac/policy/output/WerklijstRechten.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.policy.output;

--- a/src/main/java/net/atos/zac/productaanvraag/util/BetalingStatusEnumJsonAdapter.java
+++ b/src/main/java/net/atos/zac/productaanvraag/util/BetalingStatusEnumJsonAdapter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.productaanvraag.util;

--- a/src/main/java/net/atos/zac/productaanvraag/util/GeometryTypeEnumJsonAdapter.java
+++ b/src/main/java/net/atos/zac/productaanvraag/util/GeometryTypeEnumJsonAdapter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.productaanvraag.util;

--- a/src/main/java/net/atos/zac/productaanvraag/util/IndicatieMachtigingEnumJsonAdapter.java
+++ b/src/main/java/net/atos/zac/productaanvraag/util/IndicatieMachtigingEnumJsonAdapter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.productaanvraag.util;

--- a/src/main/java/net/atos/zac/productaanvraag/util/RolOmschrijvingGeneriekEnumJsonAdapter.java
+++ b/src/main/java/net/atos/zac/productaanvraag/util/RolOmschrijvingGeneriekEnumJsonAdapter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.productaanvraag.util;

--- a/src/main/java/net/atos/zac/signalering/event/SignaleringEventObserver.java
+++ b/src/main/java/net/atos/zac/signalering/event/SignaleringEventObserver.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/signalering/model/SignaleringTarget.java
+++ b/src/main/java/net/atos/zac/signalering/model/SignaleringTarget.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/signalering/model/SignaleringType.java
+++ b/src/main/java/net/atos/zac/signalering/model/SignaleringType.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/signalering/model/SignaleringZoekParameters.java
+++ b/src/main/java/net/atos/zac/signalering/model/SignaleringZoekParameters.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/solr/SolrDeployerService.java
+++ b/src/main/java/net/atos/zac/solr/SolrDeployerService.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/util/JsonLoggingFilter.java
+++ b/src/main/java/net/atos/zac/util/JsonLoggingFilter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/java/net/atos/zac/util/MediaTypes.kt
+++ b/src/main/java/net/atos/zac/util/MediaTypes.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.util

--- a/src/main/java/net/atos/zac/util/SerializableByYasson.java
+++ b/src/main/java/net/atos/zac/util/SerializableByYasson.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Lifely
+ * SPDX-FileCopyrightText: 2023-2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.util;

--- a/src/main/java/net/atos/zac/util/time/LocalDateReader.java
+++ b/src/main/java/net/atos/zac/util/time/LocalDateReader.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.util.time;

--- a/src/main/java/net/atos/zac/util/time/ZonedDateTimeParamConverter.java
+++ b/src/main/java/net/atos/zac/util/time/ZonedDateTimeParamConverter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.util.time;

--- a/src/main/java/net/atos/zac/util/time/ZonedDateTimeParamConverterProvider.java
+++ b/src/main/java/net/atos/zac/util/time/ZonedDateTimeParamConverterProvider.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.util.time;

--- a/src/main/java/net/atos/zac/util/time/ZonedDateTimeReader.java
+++ b/src/main/java/net/atos/zac/util/time/ZonedDateTimeReader.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.util.time;

--- a/src/main/java/net/atos/zac/webdav/WebdavHelper.java
+++ b/src/main/java/net/atos/zac/webdav/WebdavHelper.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.webdav;

--- a/src/main/java/net/atos/zac/webdav/WebdavStore.java
+++ b/src/main/java/net/atos/zac/webdav/WebdavStore.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.webdav;

--- a/src/main/java/net/atos/zac/websocket/WebsocketHandshakeInterceptor.java
+++ b/src/main/java/net/atos/zac/websocket/WebsocketHandshakeInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.websocket;

--- a/src/main/java/net/atos/zac/websocket/event/ScreenEventObserver.java
+++ b/src/main/java/net/atos/zac/websocket/event/ScreenEventObserver.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.websocket.event;

--- a/src/main/kotlin/net/atos/zac/app/formulieren/FormulierDefinitieRESTService.kt
+++ b/src/main/kotlin/net/atos/zac/app/formulieren/FormulierDefinitieRESTService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Dimpact, 2025 Lifely
+ * SPDX-FileCopyrightText: 2023 Dimpact, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.formulieren

--- a/src/main/kotlin/net/atos/zac/app/formulieren/converter/RESTFormulierDefinitieConverters.kt
+++ b/src/main/kotlin/net/atos/zac/app/formulieren/converter/RESTFormulierDefinitieConverters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.formulieren.converter

--- a/src/main/kotlin/net/atos/zac/app/formulieren/converter/RESTFormulierVeldDefinitieConverters.kt
+++ b/src/main/kotlin/net/atos/zac/app/formulieren/converter/RESTFormulierVeldDefinitieConverters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.formulieren.converter

--- a/src/main/kotlin/net/atos/zac/app/formulieren/model/FormulierData.kt
+++ b/src/main/kotlin/net/atos/zac/app/formulieren/model/FormulierData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2024 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.formulieren.model

--- a/src/main/kotlin/net/atos/zac/app/formulieren/model/RESTFormulierDefinitie.kt
+++ b/src/main/kotlin/net/atos/zac/app/formulieren/model/RESTFormulierDefinitie.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.formulieren.model

--- a/src/main/kotlin/net/atos/zac/app/formulieren/model/RESTFormulierVeldDefinitie.kt
+++ b/src/main/kotlin/net/atos/zac/app/formulieren/model/RESTFormulierVeldDefinitie.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.formulieren.model

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/AanvullendeInformatieTaskListener.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/AanvullendeInformatieTaskListener.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.cmmn

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/CMMNService.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/CMMNService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.cmmn

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/CmmnEngineLookupImpl.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/CmmnEngineLookupImpl.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.cmmn

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/CompleteTaskInterceptor.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/CompleteTaskInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.cmmn

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/EndCaseLifecycleListener.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/EndCaseLifecycleListener.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.cmmn

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/UpdateZaakLifecycleListener.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/UpdateZaakLifecycleListener.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.cmmn

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/ZacCreateHumanTaskInterceptor.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/ZacCreateHumanTaskInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.cmmn

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/exception/CmmnExceptions.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/exception/CmmnExceptions.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.cmmn.exception

--- a/src/main/kotlin/net/atos/zac/formulieren/FormulierDefinitieService.kt
+++ b/src/main/kotlin/net/atos/zac/formulieren/FormulierDefinitieService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.formulieren

--- a/src/main/kotlin/net/atos/zac/formulieren/FormulierRuntimeService.kt
+++ b/src/main/kotlin/net/atos/zac/formulieren/FormulierRuntimeService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.formulieren

--- a/src/main/kotlin/net/atos/zac/formulieren/ResolveDefaultValueContext.kt
+++ b/src/main/kotlin/net/atos/zac/formulieren/ResolveDefaultValueContext.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.formulieren

--- a/src/main/kotlin/net/atos/zac/formulieren/model/FormulierDefinitie.kt
+++ b/src/main/kotlin/net/atos/zac/formulieren/model/FormulierDefinitie.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.formulieren.model

--- a/src/main/kotlin/net/atos/zac/formulieren/model/FormulierVeldDefinitie.kt
+++ b/src/main/kotlin/net/atos/zac/formulieren/model/FormulierVeldDefinitie.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.formulieren.model

--- a/src/main/kotlin/net/atos/zac/formulieren/model/FormulierVeldtype.kt
+++ b/src/main/kotlin/net/atos/zac/formulieren/model/FormulierVeldtype.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.formulieren.model

--- a/src/main/kotlin/nl/info/client/brp/BrpClientService.kt
+++ b/src/main/kotlin/nl/info/client/brp/BrpClientService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp

--- a/src/main/kotlin/nl/info/client/brp/PersonenApi.kt
+++ b/src/main/kotlin/nl/info/client/brp/PersonenApi.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp

--- a/src/main/kotlin/nl/info/client/brp/exception/BrpPersonNotFoundException.kt
+++ b/src/main/kotlin/nl/info/client/brp/exception/BrpPersonNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp.exception

--- a/src/main/kotlin/nl/info/client/brp/exception/BrpResponseExceptionMapper.kt
+++ b/src/main/kotlin/nl/info/client/brp/exception/BrpResponseExceptionMapper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp.exception

--- a/src/main/kotlin/nl/info/client/brp/exception/BrpRuntimeException.kt
+++ b/src/main/kotlin/nl/info/client/brp/exception/BrpRuntimeException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp.exception

--- a/src/main/kotlin/nl/info/client/brp/util/AbstractDatumJsonbDeserializer.kt
+++ b/src/main/kotlin/nl/info/client/brp/util/AbstractDatumJsonbDeserializer.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp.util

--- a/src/main/kotlin/nl/info/client/brp/util/AbstractVerblijfplaatsJsonbDeserializer.kt
+++ b/src/main/kotlin/nl/info/client/brp/util/AbstractVerblijfplaatsJsonbDeserializer.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp.util

--- a/src/main/kotlin/nl/info/client/brp/util/BRPClientHeadersFactory.kt
+++ b/src/main/kotlin/nl/info/client/brp/util/BRPClientHeadersFactory.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp.util

--- a/src/main/kotlin/nl/info/client/brp/util/FieldPropertyVisibilityStrategy.kt
+++ b/src/main/kotlin/nl/info/client/brp/util/FieldPropertyVisibilityStrategy.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp.util

--- a/src/main/kotlin/nl/info/client/brp/util/JsonbConfiguration.kt
+++ b/src/main/kotlin/nl/info/client/brp/util/JsonbConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp.util

--- a/src/main/kotlin/nl/info/client/brp/util/PersonenQueryResponseJsonbDeserializer.kt
+++ b/src/main/kotlin/nl/info/client/brp/util/PersonenQueryResponseJsonbDeserializer.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp.util

--- a/src/main/kotlin/nl/info/client/keycloak/KeycloakEmployeesAdminClientConfiguration.kt
+++ b/src/main/kotlin/nl/info/client/keycloak/KeycloakEmployeesAdminClientConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/client/kvk/KvkBasisprofielClient.kt
+++ b/src/main/kotlin/nl/info/client/kvk/KvkBasisprofielClient.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.kvk

--- a/src/main/kotlin/nl/info/client/kvk/KvkClientService.kt
+++ b/src/main/kotlin/nl/info/client/kvk/KvkClientService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.kvk

--- a/src/main/kotlin/nl/info/client/kvk/KvkSearchClient.kt
+++ b/src/main/kotlin/nl/info/client/kvk/KvkSearchClient.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.kvk

--- a/src/main/kotlin/nl/info/client/kvk/KvkVestigingsprofielClient.kt
+++ b/src/main/kotlin/nl/info/client/kvk/KvkVestigingsprofielClient.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.kvk

--- a/src/main/kotlin/nl/info/client/kvk/exception/KvkClientNoResultException.kt
+++ b/src/main/kotlin/nl/info/client/kvk/exception/KvkClientNoResultException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.kvk.exception

--- a/src/main/kotlin/nl/info/client/kvk/exception/KvkClientNoResultResponseExceptionMapper.kt
+++ b/src/main/kotlin/nl/info/client/kvk/exception/KvkClientNoResultResponseExceptionMapper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.kvk.exception

--- a/src/main/kotlin/nl/info/client/kvk/exception/KvkRuntimeExceptionMapper.kt
+++ b/src/main/kotlin/nl/info/client/kvk/exception/KvkRuntimeExceptionMapper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.kvk.exception

--- a/src/main/kotlin/nl/info/client/kvk/model/KvkSearchParameters.kt
+++ b/src/main/kotlin/nl/info/client/kvk/model/KvkSearchParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.kvk.model

--- a/src/main/kotlin/nl/info/client/kvk/util/KvkClientHeadersFactory.kt
+++ b/src/main/kotlin/nl/info/client/kvk/util/KvkClientHeadersFactory.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.kvk.util

--- a/src/main/kotlin/nl/info/client/smartdocuments/SmartDocumentsClient.kt
+++ b/src/main/kotlin/nl/info/client/smartdocuments/SmartDocumentsClient.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.smartdocuments

--- a/src/main/kotlin/nl/info/client/smartdocuments/exception/SmartDocumentsBadRequestException.kt
+++ b/src/main/kotlin/nl/info/client/smartdocuments/exception/SmartDocumentsBadRequestException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.smartdocuments.exception

--- a/src/main/kotlin/nl/info/client/smartdocuments/exception/SmartDocumentsBadRequestResponseExceptionMapper.kt
+++ b/src/main/kotlin/nl/info/client/smartdocuments/exception/SmartDocumentsBadRequestResponseExceptionMapper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.smartdocuments.exception

--- a/src/main/kotlin/nl/info/client/smartdocuments/exception/SmartDocumentsResponseExceptionMapper.kt
+++ b/src/main/kotlin/nl/info/client/smartdocuments/exception/SmartDocumentsResponseExceptionMapper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.smartdocuments.exception

--- a/src/main/kotlin/nl/info/client/smartdocuments/model/document/SmartDocumentsDocumentRequestDeclarations.kt
+++ b/src/main/kotlin/nl/info/client/smartdocuments/model/document/SmartDocumentsDocumentRequestDeclarations.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.smartdocuments.model.document

--- a/src/main/kotlin/nl/info/client/smartdocuments/model/document/SmartDocumentsDocumentResponseDeclarations.kt
+++ b/src/main/kotlin/nl/info/client/smartdocuments/model/document/SmartDocumentsDocumentResponseDeclarations.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.smartdocuments.model.document

--- a/src/main/kotlin/nl/info/client/smartdocuments/model/template/SmartDocumentsTemplateDeclarations.kt
+++ b/src/main/kotlin/nl/info/client/smartdocuments/model/template/SmartDocumentsTemplateDeclarations.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.smartdocuments.model.template

--- a/src/main/kotlin/nl/info/client/smartdocuments/rest/DownloadedFile.kt
+++ b/src/main/kotlin/nl/info/client/smartdocuments/rest/DownloadedFile.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.smartdocuments.rest

--- a/src/main/kotlin/nl/info/client/zgw/brc/BrcClient.kt
+++ b/src/main/kotlin/nl/info/client/zgw/brc/BrcClient.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.brc

--- a/src/main/kotlin/nl/info/client/zgw/brc/BrcClientService.kt
+++ b/src/main/kotlin/nl/info/client/zgw/brc/BrcClientService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.brc

--- a/src/main/kotlin/nl/info/client/zgw/brc/exception/BrcResponseExceptionMapper.kt
+++ b/src/main/kotlin/nl/info/client/zgw/brc/exception/BrcResponseExceptionMapper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.brc.exception

--- a/src/main/kotlin/nl/info/client/zgw/brc/exception/BrcRuntimeException.kt
+++ b/src/main/kotlin/nl/info/client/zgw/brc/exception/BrcRuntimeException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.brc.exception

--- a/src/main/kotlin/nl/info/client/zgw/brc/model/BesluitenListParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/brc/model/BesluitenListParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.brc.model

--- a/src/main/kotlin/nl/info/client/zgw/shared/ZGWApiService.kt
+++ b/src/main/kotlin/nl/info/client/zgw/shared/ZGWApiService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.shared

--- a/src/main/kotlin/nl/info/client/zgw/shared/exception/ResultTypeNotFoundException.kt
+++ b/src/main/kotlin/nl/info/client/zgw/shared/exception/ResultTypeNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.shared.exception

--- a/src/main/kotlin/nl/info/client/zgw/shared/exception/StatusTypeNotFoundException.kt
+++ b/src/main/kotlin/nl/info/client/zgw/shared/exception/StatusTypeNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.shared.exception

--- a/src/main/kotlin/nl/info/client/zgw/shared/exception/ZgwRuntimeException.kt
+++ b/src/main/kotlin/nl/info/client/zgw/shared/exception/ZgwRuntimeException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.shared.exception

--- a/src/main/kotlin/nl/info/client/zgw/shared/model/audit/ZRCAuditTrailRegel.kt
+++ b/src/main/kotlin/nl/info/client/zgw/shared/model/audit/ZRCAuditTrailRegel.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.shared.model.audit

--- a/src/main/kotlin/nl/info/client/zgw/util/ZgwUriUtils.kt
+++ b/src/main/kotlin/nl/info/client/zgw/util/ZgwUriUtils.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.util

--- a/src/main/kotlin/nl/info/client/zgw/zrc/jsonb/GeometryJsonbSerializer.kt
+++ b/src/main/kotlin/nl/info/client/zgw/zrc/jsonb/GeometryJsonbSerializer.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.zrc.jsonb

--- a/src/main/kotlin/nl/info/client/zgw/ztc/ZtcClient.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/ZtcClient.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc

--- a/src/main/kotlin/nl/info/client/zgw/ztc/ZtcClientService.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/ZtcClientService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc

--- a/src/main/kotlin/nl/info/client/zgw/ztc/exception/CatalogusNotFoundException.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/exception/CatalogusNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.exception

--- a/src/main/kotlin/nl/info/client/zgw/ztc/exception/RoltypeNotFoundException.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/exception/RoltypeNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.exception

--- a/src/main/kotlin/nl/info/client/zgw/ztc/exception/ZtcResponseExceptionMapper.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/exception/ZtcResponseExceptionMapper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.exception

--- a/src/main/kotlin/nl/info/client/zgw/ztc/exception/ZtcRuntimeException.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/exception/ZtcRuntimeException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/AbstractZtcListParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/AbstractZtcListParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/Afleidingswijze.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/Afleidingswijze.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/BesluittypeListParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/BesluittypeListParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/CatalogusListParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/CatalogusListParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/EigenschapListParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/EigenschapListParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/Formaat.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/Formaat.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/IndicatieInternExtern.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/IndicatieInternExtern.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/ObjectStatusFilter.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/ObjectStatusFilter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/Referentieproces.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/Referentieproces.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/ResultaattypeListParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/ResultaattypeListParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/Richting.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/Richting.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/RoltypeListGeneriekParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/RoltypeListGeneriekParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/RoltypeListParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/RoltypeListParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/StatustypeListParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/StatustypeListParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/ZaaktypeInformatieobjecttypeListParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/ZaaktypeInformatieobjecttypeListParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/ZaaktypeListParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/ZaaktypeListParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/extensions/InformatieObjectTypeExtensions.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/extensions/InformatieObjectTypeExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model.extensions

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/extensions/ZaakTypeExtensions.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/extensions/ZaakTypeExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model.extensions

--- a/src/main/kotlin/nl/info/zac/admin/ReferenceTableAdminService.kt
+++ b/src/main/kotlin/nl/info/zac/admin/ReferenceTableAdminService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.admin

--- a/src/main/kotlin/nl/info/zac/admin/ReferenceTableService.kt
+++ b/src/main/kotlin/nl/info/zac/admin/ReferenceTableService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.admin

--- a/src/main/kotlin/nl/info/zac/admin/ZaakafhandelParameterBeheerService.kt
+++ b/src/main/kotlin/nl/info/zac/admin/ZaakafhandelParameterBeheerService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.admin

--- a/src/main/kotlin/nl/info/zac/admin/exception/ReferenceTableNotFoundException.kt
+++ b/src/main/kotlin/nl/info/zac/admin/exception/ReferenceTableNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/admin/model/ReferenceTable.kt
+++ b/src/main/kotlin/nl/info/zac/admin/model/ReferenceTable.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.admin.model

--- a/src/main/kotlin/nl/info/zac/admin/model/ReferenceTableValue.kt
+++ b/src/main/kotlin/nl/info/zac/admin/model/ReferenceTableValue.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.admin.model

--- a/src/main/kotlin/nl/info/zac/app/admin/HealthCheckRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/HealthCheckRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin

--- a/src/main/kotlin/nl/info/zac/app/admin/ReferenceTableRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/ReferenceTableRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin

--- a/src/main/kotlin/nl/info/zac/app/admin/SignaleringAdminRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/SignaleringAdminRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin

--- a/src/main/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin

--- a/src/main/kotlin/nl/info/zac/app/admin/ZaaktypeBpmnProcessDefinitionRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/ZaaktypeBpmnProcessDefinitionRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin

--- a/src/main/kotlin/nl/info/zac/app/admin/converter/RestZaakafhandelParametersConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/converter/RestZaakafhandelParametersConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin.converter

--- a/src/main/kotlin/nl/info/zac/app/admin/flowable/cmmn/ZacCmmnAdminUtilRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/flowable/cmmn/ZacCmmnAdminUtilRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin.flowable.cmmn

--- a/src/main/kotlin/nl/info/zac/app/admin/model/RESTBuildInformation.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/model/RESTBuildInformation.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin.model

--- a/src/main/kotlin/nl/info/zac/app/admin/model/RESTDeletedSignaleringenResponse.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/model/RESTDeletedSignaleringenResponse.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin.model

--- a/src/main/kotlin/nl/info/zac/app/admin/model/RESTZaaktypeInrichtingscheck.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/model/RESTZaaktypeInrichtingscheck.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin.model

--- a/src/main/kotlin/nl/info/zac/app/admin/model/RestBetrokkeneKoppelingen.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/model/RestBetrokkeneKoppelingen.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/app/admin/model/RestReferenceTable.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/model/RestReferenceTable.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin.model

--- a/src/main/kotlin/nl/info/zac/app/admin/model/RestReferenceTableUpdate.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/model/RestReferenceTableUpdate.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin.model

--- a/src/main/kotlin/nl/info/zac/app/admin/model/RestReferenceTableValue.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/model/RestReferenceTableValue.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin.model

--- a/src/main/kotlin/nl/info/zac/app/admin/model/RestSmartDocuments.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/model/RestSmartDocuments.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin.model

--- a/src/main/kotlin/nl/info/zac/app/admin/model/RestZaaktypeBpmnProcessDefinition.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/model/RestZaaktypeBpmnProcessDefinition.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin.model

--- a/src/main/kotlin/nl/info/zac/app/configuratie/ConfiguratieRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/configuratie/ConfiguratieRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.configuratie

--- a/src/main/kotlin/nl/info/zac/app/configuratie/model/RestTaal.kt
+++ b/src/main/kotlin/nl/info/zac/app/configuratie/model/RestTaal.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.configuratie.model

--- a/src/main/kotlin/nl/info/zac/app/csv/CsvRESTService.kt
+++ b/src/main/kotlin/nl/info/zac/app/csv/CsvRESTService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.csv

--- a/src/main/kotlin/nl/info/zac/app/decision/DecisionPublicationDateMissingException.kt
+++ b/src/main/kotlin/nl/info/zac/app/decision/DecisionPublicationDateMissingException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/app/decision/DecisionPublicationDisabledException.kt
+++ b/src/main/kotlin/nl/info/zac/app/decision/DecisionPublicationDisabledException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/app/decision/DecisionResponseDateInvalidException.kt
+++ b/src/main/kotlin/nl/info/zac/app/decision/DecisionResponseDateInvalidException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/app/decision/DecisionResponseDateMissingException.kt
+++ b/src/main/kotlin/nl/info/zac/app/decision/DecisionResponseDateMissingException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/app/decision/DecisionService.kt
+++ b/src/main/kotlin/nl/info/zac/app/decision/DecisionService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.decision

--- a/src/main/kotlin/nl/info/zac/app/documentcreation/DocumentCreationRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/documentcreation/DocumentCreationRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/app/documentcreation/model/RestDocumentCreationAttendedData.kt
+++ b/src/main/kotlin/nl/info/zac/app/documentcreation/model/RestDocumentCreationAttendedData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.documentcreation.model

--- a/src/main/kotlin/nl/info/zac/app/documentcreation/model/RestDocumentCreationAttendedResponse.kt
+++ b/src/main/kotlin/nl/info/zac/app/documentcreation/model/RestDocumentCreationAttendedResponse.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.documentcreation.model

--- a/src/main/kotlin/nl/info/zac/app/exception/RestExceptionMapper.kt
+++ b/src/main/kotlin/nl/info/zac/app/exception/RestExceptionMapper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.exception

--- a/src/main/kotlin/nl/info/zac/app/identity/IdentityRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/identity/IdentityRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.identity

--- a/src/main/kotlin/nl/info/zac/app/identity/converter/RestGroupConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/identity/converter/RestGroupConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.identity.converter

--- a/src/main/kotlin/nl/info/zac/app/identity/converter/RestUserConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/identity/converter/RestUserConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.identity.converter

--- a/src/main/kotlin/nl/info/zac/app/identity/model/RestGroup.kt
+++ b/src/main/kotlin/nl/info/zac/app/identity/model/RestGroup.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.identity.model

--- a/src/main/kotlin/nl/info/zac/app/identity/model/RestLoggedInUser.kt
+++ b/src/main/kotlin/nl/info/zac/app/identity/model/RestLoggedInUser.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.identity.model

--- a/src/main/kotlin/nl/info/zac/app/identity/model/RestUser.kt
+++ b/src/main/kotlin/nl/info/zac/app/identity/model/RestUser.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.identity.model

--- a/src/main/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.informatieobjecten

--- a/src/main/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectUpdateService.kt
+++ b/src/main/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectUpdateService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.informatieobjecten

--- a/src/main/kotlin/nl/info/zac/app/informatieobjecten/model/InformatieobjectenFixtures.kt
+++ b/src/main/kotlin/nl/info/zac/app/informatieobjecten/model/InformatieobjectenFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.informatieobjecten.model

--- a/src/main/kotlin/nl/info/zac/app/klant/KlantRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/KlantRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant

--- a/src/main/kotlin/nl/info/zac/app/klant/exception/RechtspersoonNotFoundException.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/exception/RechtspersoonNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/app/klant/exception/VestigingNotFoundException.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/exception/VestigingNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/app/klant/model/bedrijven/BedrijfType.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/bedrijven/BedrijfType.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.bedrijven

--- a/src/main/kotlin/nl/info/zac/app/klant/model/bedrijven/RestBedrijf.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/bedrijven/RestBedrijf.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.bedrijven

--- a/src/main/kotlin/nl/info/zac/app/klant/model/bedrijven/RestKlantenAdres.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/bedrijven/RestKlantenAdres.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.bedrijven

--- a/src/main/kotlin/nl/info/zac/app/klant/model/bedrijven/RestListBedrijvenParameters.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/bedrijven/RestListBedrijvenParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.bedrijven

--- a/src/main/kotlin/nl/info/zac/app/klant/model/bedrijven/RestVestigingsprofiel.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/bedrijven/RestVestigingsprofiel.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.bedrijven

--- a/src/main/kotlin/nl/info/zac/app/klant/model/contactmoment/RestContactmoment.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/contactmoment/RestContactmoment.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.contactmoment

--- a/src/main/kotlin/nl/info/zac/app/klant/model/contactmoment/RestListContactmomentenParameters.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/contactmoment/RestListContactmomentenParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.contactmoment

--- a/src/main/kotlin/nl/info/zac/app/klant/model/klant/IdentificatieType.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/klant/IdentificatieType.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.klant

--- a/src/main/kotlin/nl/info/zac/app/klant/model/klant/RestContactGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/klant/RestContactGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.klant

--- a/src/main/kotlin/nl/info/zac/app/klant/model/klant/RestKlant.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/klant/RestKlant.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.klant

--- a/src/main/kotlin/nl/info/zac/app/klant/model/klant/RestRoltype.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/klant/RestRoltype.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.klant

--- a/src/main/kotlin/nl/info/zac/app/klant/model/personen/RestListPersonenParameters.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/personen/RestListPersonenParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.personen

--- a/src/main/kotlin/nl/info/zac/app/klant/model/personen/RestPersonenParameters.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/personen/RestPersonenParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.personen

--- a/src/main/kotlin/nl/info/zac/app/klant/model/personen/RestPersoon.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/personen/RestPersoon.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/app/klant/model/personen/RestPersoonIndicaties.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/model/personen/RestPersoonIndicaties.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.personen

--- a/src/main/kotlin/nl/info/zac/app/planitems/PlanItemsRESTService.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/PlanItemsRESTService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.planitems

--- a/src/main/kotlin/nl/info/zac/app/planitems/converter/FormulierKoppelingConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/converter/FormulierKoppelingConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.planitems.converter

--- a/src/main/kotlin/nl/info/zac/app/planitems/converter/RESTPlanItemConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/converter/RESTPlanItemConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.planitems.converter

--- a/src/main/kotlin/nl/info/zac/app/planitems/model/DefaultHumanTaskFormulierKoppeling.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/model/DefaultHumanTaskFormulierKoppeling.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.planitems.model

--- a/src/main/kotlin/nl/info/zac/app/planitems/model/PlanItemType.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/model/PlanItemType.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.planitems.model

--- a/src/main/kotlin/nl/info/zac/app/planitems/model/RESTHumanTaskData.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/model/RESTHumanTaskData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.planitems.model

--- a/src/main/kotlin/nl/info/zac/app/planitems/model/RESTProcessTaskData.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/model/RESTProcessTaskData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.planitems.model

--- a/src/main/kotlin/nl/info/zac/app/planitems/model/RESTTaakStuurGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/model/RESTTaakStuurGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.planitems.model

--- a/src/main/kotlin/nl/info/zac/app/planitems/model/RESTUserEventListenerData.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/model/RESTUserEventListenerData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.planitems.model

--- a/src/main/kotlin/nl/info/zac/app/planitems/model/UserEventListenerActie.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/model/UserEventListenerActie.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.planitems.model

--- a/src/main/kotlin/nl/info/zac/app/search/IndexingAdminRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/IndexingAdminRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.search

--- a/src/main/kotlin/nl/info/zac/app/search/IndexingRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/IndexingRestService.kt
@@ -1,5 +1,5 @@
 /*
- *  * SPDX-FileCopyrightText: 2025 Lifely
+ *  * SPDX-FileCopyrightText: 2025 INFO.nl
  *  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.search

--- a/src/main/kotlin/nl/info/zac/app/search/SearchRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/SearchRestService.kt
@@ -1,6 +1,6 @@
 /*
  *
- *  * SPDX-FileCopyrightText: 2025 Lifely
+ *  * SPDX-FileCopyrightText: 2025 INFO.nl
  *  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/kotlin/nl/info/zac/app/search/converter/RestZoekParametersConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/converter/RestZoekParametersConverter.kt
@@ -1,6 +1,6 @@
 /*
  *
- *  * SPDX-FileCopyrightText: 2025 Lifely
+ *  * SPDX-FileCopyrightText: 2025 INFO.nl
  *  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/kotlin/nl/info/zac/app/search/converter/RestZoekResultaatConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/converter/RestZoekResultaatConverter.kt
@@ -1,6 +1,6 @@
 /*
  *
- *  * SPDX-FileCopyrightText: 2025 Lifely
+ *  * SPDX-FileCopyrightText: 2025 INFO.nl
  *  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/kotlin/nl/info/zac/app/search/model/AbstractRestZoekObject.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/model/AbstractRestZoekObject.kt
@@ -1,6 +1,6 @@
 /*
  *
- *  * SPDX-FileCopyrightText: 2025 Lifely
+ *  * SPDX-FileCopyrightText: 2025 INFO.nl
  *  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/kotlin/nl/info/zac/app/search/model/RestDatumRange.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/model/RestDatumRange.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.search.model

--- a/src/main/kotlin/nl/info/zac/app/search/model/RestDocumentZoekObject.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/model/RestDocumentZoekObject.kt
@@ -1,5 +1,5 @@
 /*
- *  SPDX-FileCopyrightText: 2025 Lifely
+ *  SPDX-FileCopyrightText: 2025 INFO.nl
  *  SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.search.model

--- a/src/main/kotlin/nl/info/zac/app/search/model/RestTaakZoekObject.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/model/RestTaakZoekObject.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.search.model

--- a/src/main/kotlin/nl/info/zac/app/search/model/RestZaakKoppelenZoekObject.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/model/RestZaakKoppelenZoekObject.kt
@@ -1,5 +1,5 @@
 /*
- *  SPDX-FileCopyrightText: 2025 Lifely
+ *  SPDX-FileCopyrightText: 2025 INFO.nl
  *  SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.search.model

--- a/src/main/kotlin/nl/info/zac/app/search/model/RestZaakZoekObject.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/model/RestZaakZoekObject.kt
@@ -1,6 +1,6 @@
 /*
  *
- *  * SPDX-FileCopyrightText: 2025 Lifely
+ *  * SPDX-FileCopyrightText: 2025 INFO.nl
  *  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/kotlin/nl/info/zac/app/search/model/RestZoekKoppelenParameters.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/model/RestZoekKoppelenParameters.kt
@@ -1,6 +1,6 @@
 /*
  *
- *  * SPDX-FileCopyrightText: 2025 Lifely
+ *  * SPDX-FileCopyrightText: 2025 INFO.nl
  *  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/kotlin/nl/info/zac/app/search/model/RestZoekParameters.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/model/RestZoekParameters.kt
@@ -1,6 +1,6 @@
 /*
  *
- *  * SPDX-FileCopyrightText: 2025 Lifely
+ *  * SPDX-FileCopyrightText: 2025 INFO.nl
  *  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/kotlin/nl/info/zac/app/search/model/RestZoekResultaat.kt
+++ b/src/main/kotlin/nl/info/zac/app/search/model/RestZoekResultaat.kt
@@ -1,6 +1,6 @@
 /*
  *
- *  * SPDX-FileCopyrightText: 2025 Lifely
+ *  * SPDX-FileCopyrightText: 2025 INFO.nl
  *  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/kotlin/nl/info/zac/app/shared/RestPageParameters.kt
+++ b/src/main/kotlin/nl/info/zac/app/shared/RestPageParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.shared

--- a/src/main/kotlin/nl/info/zac/app/signalering/SignaleringRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/signalering/SignaleringRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.signalering

--- a/src/main/kotlin/nl/info/zac/app/signalering/converter/RestSignaleringInstellingenConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/signalering/converter/RestSignaleringInstellingenConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.signalering.converter

--- a/src/main/kotlin/nl/info/zac/app/signalering/converter/SignaleringTaskConverters.kt
+++ b/src/main/kotlin/nl/info/zac/app/signalering/converter/SignaleringTaskConverters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.signalering.converter

--- a/src/main/kotlin/nl/info/zac/app/signalering/exception/SignaleringException.kt
+++ b/src/main/kotlin/nl/info/zac/app/signalering/exception/SignaleringException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.signalering.exception

--- a/src/main/kotlin/nl/info/zac/app/signalering/model/RestSignaleringInstellingen.kt
+++ b/src/main/kotlin/nl/info/zac/app/signalering/model/RestSignaleringInstellingen.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.signalering.model

--- a/src/main/kotlin/nl/info/zac/app/signalering/model/RestSignaleringTaskSummary.kt
+++ b/src/main/kotlin/nl/info/zac/app/signalering/model/RestSignaleringTaskSummary.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.signalering.model

--- a/src/main/kotlin/nl/info/zac/app/task/TaskRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/TaskRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task

--- a/src/main/kotlin/nl/info/zac/app/task/converter/RestTaskConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/converter/RestTaskConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Dimpact, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Dimpact, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task.converter

--- a/src/main/kotlin/nl/info/zac/app/task/converter/RestTaskHistoryConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/converter/RestTaskHistoryConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task.converter

--- a/src/main/kotlin/nl/info/zac/app/task/model/RestTask.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/model/RestTask.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task.model

--- a/src/main/kotlin/nl/info/zac/app/task/model/RestTaskAssignData.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/model/RestTaskAssignData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task.model

--- a/src/main/kotlin/nl/info/zac/app/task/model/RestTaskDistributeData.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/model/RestTaskDistributeData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task.model

--- a/src/main/kotlin/nl/info/zac/app/task/model/RestTaskDistributeTask.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/model/RestTaskDistributeTask.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task.model

--- a/src/main/kotlin/nl/info/zac/app/task/model/RestTaskDocumentData.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/model/RestTaskDocumentData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task.model

--- a/src/main/kotlin/nl/info/zac/app/task/model/RestTaskHistoryLine.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/model/RestTaskHistoryLine.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task.model

--- a/src/main/kotlin/nl/info/zac/app/task/model/RestTaskReleaseData.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/model/RestTaskReleaseData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task.model

--- a/src/main/kotlin/nl/info/zac/app/task/model/TaakSortering.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/model/TaakSortering.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task.model

--- a/src/main/kotlin/nl/info/zac/app/task/model/TaakStatus.kt
+++ b/src/main/kotlin/nl/info/zac/app/task/model/TaakStatus.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task.model

--- a/src/main/kotlin/nl/info/zac/app/util/UtilRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/util/UtilRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.util

--- a/src/main/kotlin/nl/info/zac/app/util/filter/CharsetInterceptorFilter.kt
+++ b/src/main/kotlin/nl/info/zac/app/util/filter/CharsetInterceptorFilter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/app/zaak/ZaakKoppelenRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/ZaakKoppelenRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak

--- a/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely, 2024 Dimpact
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl, 2024 Dimpact
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak

--- a/src/main/kotlin/nl/info/zac/app/zaak/converter/RestDecisionConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/converter/RestDecisionConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.converter

--- a/src/main/kotlin/nl/info/zac/app/zaak/converter/RestGerelateerdeZaakConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/converter/RestGerelateerdeZaakConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.converter

--- a/src/main/kotlin/nl/info/zac/app/zaak/converter/RestOpenstaandeTakenConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/converter/RestOpenstaandeTakenConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.converter

--- a/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.converter

--- a/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakOverzichtConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakOverzichtConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.converter

--- a/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakResultaatConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakResultaatConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.converter

--- a/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaaktypeConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaaktypeConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.converter

--- a/src/main/kotlin/nl/info/zac/app/zaak/exception/BetrokkeneNotAllowed.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/exception/BetrokkeneNotAllowed.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.exception

--- a/src/main/kotlin/nl/info/zac/app/zaak/exception/CommunicationChannelNotFound.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/exception/CommunicationChannelNotFound.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.exception

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTDocumentOntkoppelGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTDocumentOntkoppelGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTReden.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTReden.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakAanmaakGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakAanmaakGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakAfbrekenGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakAfbrekenGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakAfsluitenGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakAfsluitenGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakBetrokkeneGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakBetrokkeneGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakEditMetRedenGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakEditMetRedenGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakHeropenenGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakHeropenenGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakKenmerk.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakKenmerk.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakOpschortGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakOpschortGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakOpschorting.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakOpschorting.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakStatusmailOptie.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakStatusmailOptie.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakVerlengGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakVerlengGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZakenVerdeelGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZakenVerdeelGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZakenVrijgevenGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZakenVrijgevenGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RelatieType.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RelatieType.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestCoordinates.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestCoordinates.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecision.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecision.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecisionChangeData.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecisionChangeData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecisionCreateData.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecisionCreateData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecisionType.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecisionType.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecisionTypePublication.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecisionTypePublication.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecisionWithdrawalData.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestDecisionWithdrawalData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestGeometry.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestGeometry.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestGerelateerdeZaak.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestGerelateerdeZaak.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestOpenstaandeTaken.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestOpenstaandeTaken.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestResultaattype.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestResultaattype.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaak.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaak.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakAssignmentData.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakAssignmentData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakAssignmentToLoggedInUserData.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakAssignmentToLoggedInUserData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakBetrokkene.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakBetrokkene.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakLinkData.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakLinkData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakLocatieGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakLocatieGegevens.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakOverzicht.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakOverzicht.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakResultaat.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakResultaat.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakStatus.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakStatus.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakUnlinkData.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakUnlinkData.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaaktype.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaaktype.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaaktypeRelatie.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaaktypeRelatie.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2023 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.model

--- a/src/main/kotlin/nl/info/zac/authentication/ActiveSession.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/ActiveSession.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.authentication

--- a/src/main/kotlin/nl/info/zac/authentication/InternalEndpoint.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/InternalEndpoint.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.authentication

--- a/src/main/kotlin/nl/info/zac/authentication/LoggedInUser.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/LoggedInUser.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.authentication

--- a/src/main/kotlin/nl/info/zac/authentication/SecurityUtil.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/SecurityUtil.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.authentication

--- a/src/main/kotlin/nl/info/zac/authentication/ServletRequestProducingListener.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/ServletRequestProducingListener.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.authentication

--- a/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.authentication

--- a/src/main/kotlin/nl/info/zac/authentication/ZacApiKeyAuthFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/ZacApiKeyAuthFilter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.authentication

--- a/src/main/kotlin/nl/info/zac/configuratie/ConfiguratieService.kt
+++ b/src/main/kotlin/nl/info/zac/configuratie/ConfiguratieService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.configuratie

--- a/src/main/kotlin/nl/info/zac/configuratie/model/Taal.kt
+++ b/src/main/kotlin/nl/info/zac/configuratie/model/Taal.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.configuratie.model

--- a/src/main/kotlin/nl/info/zac/documentcreation/DocumentCreationService.kt
+++ b/src/main/kotlin/nl/info/zac/documentcreation/DocumentCreationService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.documentcreation

--- a/src/main/kotlin/nl/info/zac/documentcreation/converter/DocumentCreationDataConverter.kt
+++ b/src/main/kotlin/nl/info/zac/documentcreation/converter/DocumentCreationDataConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.documentcreation.converter

--- a/src/main/kotlin/nl/info/zac/documentcreation/model/DocumentCreationAttendedResponse.kt
+++ b/src/main/kotlin/nl/info/zac/documentcreation/model/DocumentCreationAttendedResponse.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.documentcreation.model

--- a/src/main/kotlin/nl/info/zac/documentcreation/model/DocumentCreationDataAttended.kt
+++ b/src/main/kotlin/nl/info/zac/documentcreation/model/DocumentCreationDataAttended.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.documentcreation.model

--- a/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/EnkelvoudigInformatieObjectLockNotFoundException.kt
+++ b/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/EnkelvoudigInformatieObjectLockNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.enkelvoudiginformatieobject

--- a/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/EnkelvoudigInformatieObjectLockService.kt
+++ b/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/EnkelvoudigInformatieObjectLockService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.enkelvoudiginformatieobject

--- a/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/model/EnkelvoudigInformatieObjectLock.kt
+++ b/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/model/EnkelvoudigInformatieObjectLock.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.enkelvoudiginformatieobject.model

--- a/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/util/EnkelvoudigInformatieObjectCheckers.kt
+++ b/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/util/EnkelvoudigInformatieObjectCheckers.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.enkelvoudiginformatieobject.util

--- a/src/main/kotlin/nl/info/zac/exception/ErrorCode.kt
+++ b/src/main/kotlin/nl/info/zac/exception/ErrorCode.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/exception/InputValidationFailedException.kt
+++ b/src/main/kotlin/nl/info/zac/exception/InputValidationFailedException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.exception

--- a/src/main/kotlin/nl/info/zac/exception/ServerErrorException.kt
+++ b/src/main/kotlin/nl/info/zac/exception/ServerErrorException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.exception

--- a/src/main/kotlin/nl/info/zac/flowable/bpmn/ZaaktypeBpmnProcessDefinitionService.kt
+++ b/src/main/kotlin/nl/info/zac/flowable/bpmn/ZaaktypeBpmnProcessDefinitionService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.flowable.bpmn

--- a/src/main/kotlin/nl/info/zac/flowable/bpmn/exception/ProcessDefinitionNotFoundException.kt
+++ b/src/main/kotlin/nl/info/zac/flowable/bpmn/exception/ProcessDefinitionNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.flowable.bpmn.exception

--- a/src/main/kotlin/nl/info/zac/flowable/bpmn/model/ZaaktypeBpmnProcessDefinition.kt
+++ b/src/main/kotlin/nl/info/zac/flowable/bpmn/model/ZaaktypeBpmnProcessDefinition.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.flowable.bpmn.model

--- a/src/main/kotlin/nl/info/zac/formio/FormioService.kt
+++ b/src/main/kotlin/nl/info/zac/formio/FormioService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Dimpact, 2025 Lifely
+ * SPDX-FileCopyrightText: 2024 Dimpact, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.formio

--- a/src/main/kotlin/nl/info/zac/formio/model/FormioFormulier.kt
+++ b/src/main/kotlin/nl/info/zac/formio/model/FormioFormulier.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Dimpact, 2025 Lifely
+ * SPDX-FileCopyrightText: 2024 Dimpact, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.formio.model

--- a/src/main/kotlin/nl/info/zac/healthcheck/HealthCheckService.kt
+++ b/src/main/kotlin/nl/info/zac/healthcheck/HealthCheckService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.healthcheck

--- a/src/main/kotlin/nl/info/zac/healthcheck/exception/BuildInformationException.kt
+++ b/src/main/kotlin/nl/info/zac/healthcheck/exception/BuildInformationException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.healthcheck.exception

--- a/src/main/kotlin/nl/info/zac/healthcheck/model/ZaaktypeInrichtingscheck.kt
+++ b/src/main/kotlin/nl/info/zac/healthcheck/model/ZaaktypeInrichtingscheck.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.healthcheck.model

--- a/src/main/kotlin/nl/info/zac/history/ZaakHistoryService.kt
+++ b/src/main/kotlin/nl/info/zac/history/ZaakHistoryService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.history

--- a/src/main/kotlin/nl/info/zac/history/converter/AuditWijzigingAttributeHelpers.kt
+++ b/src/main/kotlin/nl/info/zac/history/converter/AuditWijzigingAttributeHelpers.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.history.converter

--- a/src/main/kotlin/nl/info/zac/history/converter/ZaakHistoryLineConverter.kt
+++ b/src/main/kotlin/nl/info/zac/history/converter/ZaakHistoryLineConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.history.converter

--- a/src/main/kotlin/nl/info/zac/history/converter/ZaakHistoryPartialUpdateConverter.kt
+++ b/src/main/kotlin/nl/info/zac/history/converter/ZaakHistoryPartialUpdateConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.history.converter

--- a/src/main/kotlin/nl/info/zac/history/converter/besluiten/AuditBesluitConverter.kt
+++ b/src/main/kotlin/nl/info/zac/history/converter/besluiten/AuditBesluitConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.history.converter.besluiten

--- a/src/main/kotlin/nl/info/zac/history/converter/documenten/AuditBesluitInformatieobjectConverter.kt
+++ b/src/main/kotlin/nl/info/zac/history/converter/documenten/AuditBesluitInformatieobjectConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/history/converter/documenten/AuditEnkelvoudigInformatieobjectConverter.kt
+++ b/src/main/kotlin/nl/info/zac/history/converter/documenten/AuditEnkelvoudigInformatieobjectConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/history/converter/documenten/AuditGebruiksrechtenWijzigingConverter.kt
+++ b/src/main/kotlin/nl/info/zac/history/converter/documenten/AuditGebruiksrechtenWijzigingConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.history.converter.documenten

--- a/src/main/kotlin/nl/info/zac/history/model/HistoryAction.kt
+++ b/src/main/kotlin/nl/info/zac/history/model/HistoryAction.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.history.model

--- a/src/main/kotlin/nl/info/zac/identity/IdentityService.kt
+++ b/src/main/kotlin/nl/info/zac/identity/IdentityService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.identity

--- a/src/main/kotlin/nl/info/zac/identity/exception/GroupNotFoundException.kt
+++ b/src/main/kotlin/nl/info/zac/identity/exception/GroupNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.identity.exception

--- a/src/main/kotlin/nl/info/zac/identity/exception/UserNotFoundException.kt
+++ b/src/main/kotlin/nl/info/zac/identity/exception/UserNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.identity.exception

--- a/src/main/kotlin/nl/info/zac/identity/exception/UserNotInGroupException.kt
+++ b/src/main/kotlin/nl/info/zac/identity/exception/UserNotInGroupException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.identity.exception

--- a/src/main/kotlin/nl/info/zac/identity/model/Group.kt
+++ b/src/main/kotlin/nl/info/zac/identity/model/Group.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.identity.model

--- a/src/main/kotlin/nl/info/zac/identity/model/User.kt
+++ b/src/main/kotlin/nl/info/zac/identity/model/User.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.identity.model

--- a/src/main/kotlin/nl/info/zac/log/LogUtils.kt
+++ b/src/main/kotlin/nl/info/zac/log/LogUtils.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/mail/MailMessageBuilder.kt
+++ b/src/main/kotlin/nl/info/zac/mail/MailMessageBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.mail

--- a/src/main/kotlin/nl/info/zac/mail/MailService.kt
+++ b/src/main/kotlin/nl/info/zac/mail/MailService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.mail

--- a/src/main/kotlin/nl/info/zac/mail/model/Attachment.kt
+++ b/src/main/kotlin/nl/info/zac/mail/model/Attachment.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.mail.model

--- a/src/main/kotlin/nl/info/zac/mail/model/Bronnen.kt
+++ b/src/main/kotlin/nl/info/zac/mail/model/Bronnen.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.mail.model

--- a/src/main/kotlin/nl/info/zac/mail/model/MailAdres.kt
+++ b/src/main/kotlin/nl/info/zac/mail/model/MailAdres.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.mail.model

--- a/src/main/kotlin/nl/info/zac/notification/Action.kt
+++ b/src/main/kotlin/nl/info/zac/notification/Action.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.notification

--- a/src/main/kotlin/nl/info/zac/notification/Channel.kt
+++ b/src/main/kotlin/nl/info/zac/notification/Channel.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.notification

--- a/src/main/kotlin/nl/info/zac/notification/Notification.kt
+++ b/src/main/kotlin/nl/info/zac/notification/Notification.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.notification

--- a/src/main/kotlin/nl/info/zac/notification/NotificationReceiver.kt
+++ b/src/main/kotlin/nl/info/zac/notification/NotificationReceiver.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.notification

--- a/src/main/kotlin/nl/info/zac/notification/Resource.kt
+++ b/src/main/kotlin/nl/info/zac/notification/Resource.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.notification

--- a/src/main/kotlin/nl/info/zac/persistence/EntityManagerProducer.kt
+++ b/src/main/kotlin/nl/info/zac/persistence/EntityManagerProducer.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.persistence

--- a/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely, 2024 Dimpact
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl, 2024 Dimpact
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.productaanvraag

--- a/src/main/kotlin/nl/info/zac/productaanvraag/util/AanvraagToZgwConverter.kt
+++ b/src/main/kotlin/nl/info/zac/productaanvraag/util/AanvraagToZgwConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.productaanvraag.util

--- a/src/main/kotlin/nl/info/zac/search/IndexingException.kt
+++ b/src/main/kotlin/nl/info/zac/search/IndexingException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search

--- a/src/main/kotlin/nl/info/zac/search/IndexingService.kt
+++ b/src/main/kotlin/nl/info/zac/search/IndexingService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search

--- a/src/main/kotlin/nl/info/zac/search/SearchException.kt
+++ b/src/main/kotlin/nl/info/zac/search/SearchException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search

--- a/src/main/kotlin/nl/info/zac/search/SearchService.kt
+++ b/src/main/kotlin/nl/info/zac/search/SearchService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search

--- a/src/main/kotlin/nl/info/zac/search/converter/AbstractZoekObjectConverter.kt
+++ b/src/main/kotlin/nl/info/zac/search/converter/AbstractZoekObjectConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.converter

--- a/src/main/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverter.kt
+++ b/src/main/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.converter

--- a/src/main/kotlin/nl/info/zac/search/converter/TaakZoekObjectConverter.kt
+++ b/src/main/kotlin/nl/info/zac/search/converter/TaakZoekObjectConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.converter

--- a/src/main/kotlin/nl/info/zac/search/converter/ZaakZoekObjectConverter.kt
+++ b/src/main/kotlin/nl/info/zac/search/converter/ZaakZoekObjectConverter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.converter

--- a/src/main/kotlin/nl/info/zac/search/model/DatumRange.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/DatumRange.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/DatumVeld.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/DatumVeld.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/DocumentIndicatie.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/DocumentIndicatie.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/FilterParameters.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/FilterParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/FilterResultaat.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/FilterResultaat.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/FilterVeld.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/FilterVeld.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/FilterWaarde.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/FilterWaarde.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/SorteerVeld.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/SorteerVeld.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/Sortering.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/Sortering.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/ZaakIndicatie.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/ZaakIndicatie.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/ZoekParameters.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/ZoekParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/ZoekResultaat.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/ZoekResultaat.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/ZoekVeld.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/ZoekVeld.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model

--- a/src/main/kotlin/nl/info/zac/search/model/zoekobject/DocumentZoekObject.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/zoekobject/DocumentZoekObject.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model.zoekobject

--- a/src/main/kotlin/nl/info/zac/search/model/zoekobject/TaakZoekObject.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/zoekobject/TaakZoekObject.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model.zoekobject

--- a/src/main/kotlin/nl/info/zac/search/model/zoekobject/ZaakZoekObject.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/zoekobject/ZaakZoekObject.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model.zoekobject

--- a/src/main/kotlin/nl/info/zac/search/model/zoekobject/ZoekObject.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/zoekobject/ZoekObject.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model.zoekobject

--- a/src/main/kotlin/nl/info/zac/search/model/zoekobject/ZoekObjectType.kt
+++ b/src/main/kotlin/nl/info/zac/search/model/zoekobject/ZoekObjectType.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2021 - 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.model.zoekobject

--- a/src/main/kotlin/nl/info/zac/shared/exception/ValidatieFoutExceptionMapper.kt
+++ b/src/main/kotlin/nl/info/zac/shared/exception/ValidatieFoutExceptionMapper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.shared.exception

--- a/src/main/kotlin/nl/info/zac/shared/helper/SuspensionZaakHelper.kt
+++ b/src/main/kotlin/nl/info/zac/shared/helper/SuspensionZaakHelper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.shared.helper

--- a/src/main/kotlin/nl/info/zac/shared/model/ListParameters.kt
+++ b/src/main/kotlin/nl/info/zac/shared/model/ListParameters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.shared.model

--- a/src/main/kotlin/nl/info/zac/shared/model/Paging.kt
+++ b/src/main/kotlin/nl/info/zac/shared/model/Paging.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.shared.model

--- a/src/main/kotlin/nl/info/zac/shared/model/Resultaat.kt
+++ b/src/main/kotlin/nl/info/zac/shared/model/Resultaat.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.shared.model

--- a/src/main/kotlin/nl/info/zac/shared/model/SorteerRichting.kt
+++ b/src/main/kotlin/nl/info/zac/shared/model/SorteerRichting.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.shared.model

--- a/src/main/kotlin/nl/info/zac/shared/model/Sorting.kt
+++ b/src/main/kotlin/nl/info/zac/shared/model/Sorting.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.shared.model

--- a/src/main/kotlin/nl/info/zac/signalering/SignaleringMailHelper.kt
+++ b/src/main/kotlin/nl/info/zac/signalering/SignaleringMailHelper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.signalering

--- a/src/main/kotlin/nl/info/zac/signalering/SignaleringPredicateHelper.kt
+++ b/src/main/kotlin/nl/info/zac/signalering/SignaleringPredicateHelper.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.signalering

--- a/src/main/kotlin/nl/info/zac/signalering/SignaleringService.kt
+++ b/src/main/kotlin/nl/info/zac/signalering/SignaleringService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2024 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.signalering

--- a/src/main/kotlin/nl/info/zac/signalering/ZaakTaskDueDateEmailNotificationService.kt
+++ b/src/main/kotlin/nl/info/zac/signalering/ZaakTaskDueDateEmailNotificationService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos, 2023 Lifely
+ * SPDX-FileCopyrightText: 2022 Atos, 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.signalering

--- a/src/main/kotlin/nl/info/zac/smartdocuments/SmartDocumentsService.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/SmartDocumentsService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.smartdocuments

--- a/src/main/kotlin/nl/info/zac/smartdocuments/SmartDocumentsTemplatesService.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/SmartDocumentsTemplatesService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.smartdocuments

--- a/src/main/kotlin/nl/info/zac/smartdocuments/exception/SmartDocumentsConfigurationException.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/exception/SmartDocumentsConfigurationException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.smartdocuments.exception

--- a/src/main/kotlin/nl/info/zac/smartdocuments/exception/SmartDocumentsDisabledException.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/exception/SmartDocumentsDisabledException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.smartdocuments.exception

--- a/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestMappedSmartDocumentsTemplate.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestMappedSmartDocumentsTemplate.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestMappedSmartDocumentsTemplateGroup.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestMappedSmartDocumentsTemplateGroup.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestSmartDocumentsPath.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestSmartDocumentsPath.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.smartdocuments.rest

--- a/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestSmartDocumentsTemplate.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestSmartDocumentsTemplate.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestSmartDocumentsTemplateGroup.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestSmartDocumentsTemplateGroup.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestSmartDocumentsValidator.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/rest/RestSmartDocumentsValidator.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.smartdocuments.rest

--- a/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplate.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplate.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplateGroup.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplateGroup.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/solr/SolrUtil.kt
+++ b/src/main/kotlin/nl/info/zac/solr/SolrUtil.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/kotlin/nl/info/zac/task/TaskService.kt
+++ b/src/main/kotlin/nl/info/zac/task/TaskService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.task

--- a/src/main/kotlin/nl/info/zac/util/AllOpen.kt
+++ b/src/main/kotlin/nl/info/zac/util/AllOpen.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.util

--- a/src/main/kotlin/nl/info/zac/util/BSNValidator.kt
+++ b/src/main/kotlin/nl/info/zac/util/BSNValidator.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.util

--- a/src/main/kotlin/nl/info/zac/util/Base64Converters.kt
+++ b/src/main/kotlin/nl/info/zac/util/Base64Converters.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.util

--- a/src/main/kotlin/nl/info/zac/util/CoroutineDispatcherProducer.kt
+++ b/src/main/kotlin/nl/info/zac/util/CoroutineDispatcherProducer.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.util

--- a/src/main/kotlin/nl/info/zac/util/MapUtils.kt
+++ b/src/main/kotlin/nl/info/zac/util/MapUtils.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.util

--- a/src/main/kotlin/nl/info/zac/util/NoArgConstructor.kt
+++ b/src/main/kotlin/nl/info/zac/util/NoArgConstructor.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.util

--- a/src/main/kotlin/nl/info/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/nl/info/zac/zaak/ZaakService.kt
@@ -1,5 +1,5 @@
 /*
-* SPDX-FileCopyrightText: 2024 Lifely
+* SPDX-FileCopyrightText: 2024 INFO.nl
 * SPDX-License-Identifier: EUPL-1.2+
 */
 package nl.info.zac.zaak

--- a/src/main/kotlin/nl/info/zac/zaak/exception/BetrokkeneIsAlreadyAddedToZaakException.kt
+++ b/src/main/kotlin/nl/info/zac/zaak/exception/BetrokkeneIsAlreadyAddedToZaakException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.zaak.exception

--- a/src/main/kotlin/nl/info/zac/zaak/exception/CaseHasLockedInformationObjectsException.kt
+++ b/src/main/kotlin/nl/info/zac/zaak/exception/CaseHasLockedInformationObjectsException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/kotlin/nl/info/zac/zaak/exception/CaseHasOpenSubcasesException.kt
+++ b/src/main/kotlin/nl/info/zac/zaak/exception/CaseHasOpenSubcasesException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/main/kotlin/nl/info/zac/zaak/model/Betrokkenen.kt
+++ b/src/main/kotlin/nl/info/zac/zaak/model/Betrokkenen.kt
@@ -1,5 +1,5 @@
 /*
-* SPDX-FileCopyrightText: 2024 Lifely
+* SPDX-FileCopyrightText: 2024 INFO.nl
 * SPDX-License-Identifier: EUPL-1.2+
 */
 package nl.info.zac.zaak.model

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2024 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2024 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/resources/META-INF/services/org.flowable.cdi.spi.CmmnEngineLookup
+++ b/src/main/resources/META-INF/services/org.flowable.cdi.spi.CmmnEngineLookup
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2021 Atos, 2025 Lifely
+# SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/src/main/resources/api-specs/README.md
+++ b/src/main/resources/api-specs/README.md
@@ -4,6 +4,6 @@ These OpenAPI specifications are used in the ZAC build process to automatically 
 
 ## Updating OpenAPI specifications
 
-Some of these API specs have been changed manually by Lifely to make them work with the OpenAPI Generator tool.
+Some of these API specs have been changed manually by INFO.nl to make them work with the OpenAPI Generator tool.
 Please read [updatingDependencies.md](../../../../docs/development/updatingDependencies.md) for more information on how to update these API specs.
 

--- a/src/main/resources/api-specs/klanten/klanten-openapi.yaml
+++ b/src/main/resources/api-specs/klanten/klanten-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
-# INFO/Lifely: we changed this OpenAPI spec in some places because when generating Java client code
+# INFO.nl: we changed this OpenAPI spec in some places because when generating Java client code
 # using the OpenAPI Generator framework this spec resulted in uncompilable code.
-# See the 'INFO/Lifely' comments in the spec below.
+# See the 'INFO.nl' comments in the spec below.
 info:
   title: klantinteracties
   version: 0.1.2 (1)
@@ -3234,7 +3234,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DigitaalAdresForeignKey'
-          # INFO/Lifely: nullable arrays result in uncompilable generated Java code so we uncomment this for now
+          # INFO.nl: nullable arrays result in uncompilable generated Java code so we uncomment this for now
           # nullable: true
           description: Digitaal adresen dat een partij verstrekte voor gebruik bij
             toekomstig contact met de gemeente.
@@ -3254,7 +3254,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RekeningnummerForeignKey'
-          # INFO/Lifely: nullable arrays result in uncompilable generated Java code so we uncomment this for now
+          # INFO.nl: nullable arrays result in uncompilable generated Java code so we uncomment this for now
           #nullable: true
           description: Rekeningnummers van een partij
         voorkeursRekeningnummer:

--- a/src/main/resources/api-specs/or/objects-openapi.yaml
+++ b/src/main/resources/api-specs/or/objects-openapi.yaml
@@ -1,5 +1,5 @@
 openapi: 3.0.3
-# Lifely: manually fixed an issue in this spec; see 'Lifely' below
+# INFO.nl: manually fixed an issue in this spec; see 'INFO.nl' below
 info:
   title: Objects API
   version: 2.4.4 (v2)
@@ -936,7 +936,7 @@ components:
           minimum: 0
           description: Version of the OBJECTTYPE for data in the object record
         data:
-          # Lifely: manually added missing attributes 'type' and 'additionalProperties'
+          # INFO.nl: manually added missing attributes 'type' and 'additionalProperties'
           type: object
           additionalProperties: {}
           description: Object data, based on OBJECTTYPE

--- a/src/main/resources/api-specs/zgw/brc-openapi.yaml
+++ b/src/main/resources/api-specs/zgw/brc-openapi.yaml
@@ -1,5 +1,5 @@
 openapi: 3.0.3
-# Lifely: renamed invalid minLength and maxLength properties to minLength and maxLength
+# INFO.nl: renamed invalid minLength and maxLength properties to minLength and maxLength
 info:
   title: Besluiten API
   version: 1.1.0 (1)
@@ -2276,7 +2276,7 @@ components:
             * `tijdelijk` - Besluit met tijdelijke werking
             * `ingetrokken_overheid` - Besluit ingetrokken door overheid
             * `ingetrokken_belanghebbende` - Besluit ingetrokken o.v.v. belanghebbende
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/VervalredenEnum'
@@ -2412,7 +2412,7 @@ components:
             * `tijdelijk` - Besluit met tijdelijke werking
             * `ingetrokken_overheid` - Besluit ingetrokken door overheid
             * `ingetrokken_belanghebbende` - Besluit ingetrokken o.v.v. belanghebbende
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/VervalredenEnum'
@@ -2584,7 +2584,7 @@ components:
             * `tijdelijk` - Besluit met tijdelijke werking
             * `ingetrokken_overheid` - Besluit ingetrokken door overheid
             * `ingetrokken_belanghebbende` - Besluit ingetrokken o.v.v. belanghebbende
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/VervalredenEnum'
@@ -2643,7 +2643,7 @@ components:
       - tijdelijk
       - ingetrokken_overheid
       - ingetrokken_belanghebbende
-      # manual changed by Lifely: need to allow for empty values returned by the API
+      # manual changed by INFO.nl: need to allow for empty values returned by the API
       - ''
       type: string
     Wijzigingen:

--- a/src/main/resources/api-specs/zgw/drc-openapi.yaml
+++ b/src/main/resources/api-specs/zgw/drc-openapi.yaml
@@ -6432,7 +6432,7 @@ components:
       - sha_256
       - sha_512
       - sha_3
-        # manual added by Lifely: need to allow for empty values returned by the API
+        # manual added by INFO.nl: need to allow for empty values returned by the API
       - ''
       type: string
     AuditTrail:
@@ -6848,7 +6848,7 @@ components:
             * `confidentieel` - Confidentieel
             * `geheim` - Geheim
             * `zeer_geheim` - Zeer geheim
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/VertrouwelijkheidaanduidingEnum'
@@ -6868,7 +6868,7 @@ components:
             * `ter_vaststelling` - (Ter vaststelling) Informatieobject gereed maar moet nog vastgesteld worden.
             * `definitief` - (Definitief) Informatieobject door bevoegd iets of iemand vastgesteld dan wel ontvangen.
             * `gearchiveerd` - (Gearchiveerd) Informatieobject duurzaam bewaarbaar gemaakt; een gearchiveerd informatie-element.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/StatusEnum'
@@ -7035,7 +7035,7 @@ components:
             * `confidentieel` - Confidentieel
             * `geheim` - Geheim
             * `zeer_geheim` - Zeer geheim
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/VertrouwelijkheidaanduidingEnum'
@@ -7056,7 +7056,7 @@ components:
             * `ter_vaststelling` - (Ter vaststelling) Informatieobject gereed maar moet nog vastgesteld worden.
             * `definitief` - (Definitief) Informatieobject door bevoegd iets of iemand vastgesteld dan wel ontvangen.
             * `gearchiveerd` - (Gearchiveerd) Informatieobject duurzaam bewaarbaar gemaakt; een gearchiveerd informatie-element.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/StatusEnum'
@@ -7080,7 +7080,7 @@ components:
           maxLength: 255
         inhoud:
           type: string
-          # manual changed by Lifely: `format: byte` results in errors when using the generated client code
+          # manual changed by INFO.nl: `format: byte` results in errors when using the generated client code
           format: bytes
           description: Minimal accepted size of uploaded file = 4294967296 bytes (or
             4.0 GiB)
@@ -7203,7 +7203,7 @@ components:
             * `confidentieel` - Confidentieel
             * `geheim` - Geheim
             * `zeer_geheim` - Zeer geheim
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/VertrouwelijkheidaanduidingEnum'
@@ -7224,7 +7224,7 @@ components:
             * `ter_vaststelling` - (Ter vaststelling) Informatieobject gereed maar moet nog vastgesteld worden.
             * `definitief` - (Definitief) Informatieobject door bevoegd iets of iemand vastgesteld dan wel ontvangen.
             * `gearchiveerd` - (Gearchiveerd) Informatieobject duurzaam bewaarbaar gemaakt; een gearchiveerd informatie-element.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/StatusEnum'
@@ -7248,7 +7248,7 @@ components:
           maxLength: 255
         inhoud:
           type: string
-          # Manually changed by Lifely: `format: byte` results in errors when using the generated client code
+          # Manually changed by INFO.nl: `format: byte` results in errors when using the generated client code
           format: bytes
           description: Minimal accepted size of uploaded file = 4294967296 bytes (or
             4.0 GiB)
@@ -7962,7 +7962,7 @@ components:
             * `confidentieel` - Confidentieel
             * `geheim` - Geheim
             * `zeer_geheim` - Zeer geheim
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/VertrouwelijkheidaanduidingEnum'
@@ -7983,7 +7983,7 @@ components:
             * `ter_vaststelling` - (Ter vaststelling) Informatieobject gereed maar moet nog vastgesteld worden.
             * `definitief` - (Definitief) Informatieobject door bevoegd iets of iemand vastgesteld dan wel ontvangen.
             * `gearchiveerd` - (Gearchiveerd) Informatieobject duurzaam bewaarbaar gemaakt; een gearchiveerd informatie-element.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/StatusEnum'
@@ -8007,7 +8007,7 @@ components:
           maxLength: 255
         inhoud:
           type: string
-          # Manually changed by Lifely: `format: byte` results in errors when using the generated client code
+          # Manually changed by INFO.nl: `format: byte` results in errors when using the generated client code
           format: bytes
           description: Minimal accepted size of uploaded file = 4294967296 bytes (or
             4.0 GiB)
@@ -8255,7 +8255,7 @@ components:
       - analoog
       - digitaal
       - pki
-      # manual added by Lifely: need to allow for empty values returned by the API
+      # manual added by INFO.nl: need to allow for empty values returned by the API
       - ''
       type: string
     StatusEnum:
@@ -8264,7 +8264,7 @@ components:
       - ter_vaststelling
       - definitief
       - gearchiveerd
-      # manual changed by Lifely: need to allow for empty values returned by the API
+      # manual changed by INFO.nl: need to allow for empty values returned by the API
       # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
       - ''
       type: string
@@ -8323,7 +8323,7 @@ components:
       - confidentieel
       - geheim
       - zeer_geheim
-      # manual changed by Lifely: need to allow for empty values returned by the API
+      # manual changed by INFO.nl: need to allow for empty values returned by the API
       # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
       - ''
       type: string

--- a/src/main/resources/api-specs/zgw/zrc-openapi.yaml
+++ b/src/main/resources/api-specs/zgw/zrc-openapi.yaml
@@ -1,5 +1,5 @@
 openapi: 3.0.3
-# Lifely: renamed invalid min_length and max_length properties to minLength and maxLength
+# INFO.nl: renamed invalid min_length and max_length properties to minLength and maxLength
 info:
   title: Zaken API
   version: 1.5.1 (1)
@@ -10663,7 +10663,7 @@ components:
       enum:
       - blijvend_bewaren
       - vernietigen
-      # manual changed by Lifely: need to allow for empty values returned by the API
+      # manual changed by INFO.nl: need to allow for empty values returned by the API
       # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
       - ''
       type: string
@@ -10864,7 +10864,7 @@ components:
 
             * `gemachtigde` - De betrokkene in de rol bij de zaak is door een andere betrokkene bij dezelfde zaak gemachtigd om namens hem of haar te handelen
             * `machtiginggever` - De betrokkene in de rol bij de zaak heeft een andere betrokkene bij dezelfde zaak gemachtigd om namens hem of haar te handelen
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/IndicatieMachtigingEnum'
@@ -10992,7 +10992,7 @@ components:
       - nog_niet
       - gedeeltelijk
       - geheel
-      # manual changed by Lifely: need to allow for empty values returned by the API
+      # manual changed by INFO.nl: need to allow for empty values returned by the API
       # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
       - ''
       type: string
@@ -11246,7 +11246,7 @@ components:
       - m
       - v
       - o
-      # manual changed by Lifely: need to allow for empty values returned by the API
+      # manual changed by INFO.nl: need to allow for empty values returned by the API
       # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
       - ''
       type: string
@@ -11254,7 +11254,7 @@ components:
       enum:
       - gemachtigde
       - machtiginggever
-      # manual changed by Lifely: need to allow for empty values returned by the API
+      # manual changed by INFO.nl: need to allow for empty values returned by the API
       # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
       - ''
       type: string
@@ -11279,7 +11279,7 @@ components:
       - kapitaalvennootschap_binnen_eer
       - overige_buitenlandse_rechtspersoon_vennootschap
       - kapitaalvennootschap_buiten_eer
-      # manual changed by Lifely: need to allow for empty values returned by the API
+      # manual changed by INFO.nl: need to allow for empty values returned by the API
       # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
       - ''
       type: string
@@ -11523,7 +11523,7 @@ components:
       - kanaal
       - resource
       - resourceUrl
-      # manual changed by Lifely: this causes corrupt uncompilable Java code with OpenAPI Generator 7.9.0
+      # manual changed by INFO.nl: this causes corrupt uncompilable Java code with OpenAPI Generator 7.9.0
       # NullEnum:
       #      enum:
       #      - null
@@ -12968,7 +12968,7 @@ components:
             * `nog_niet` - De met de zaak gemoeide kosten zijn (nog) niet betaald.
             * `gedeeltelijk` - De met de zaak gemoeide kosten zijn gedeeltelijk betaald.
             * `geheel` - De met de zaak gemoeide kosten zijn geheel betaald.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/BetalingsindicatieEnum'
@@ -13376,7 +13376,7 @@ components:
             * `m` - Man
             * `v` - Vrouw
             * `o` - Onbekend
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/GeslachtsaanduidingEnum'
@@ -13435,7 +13435,7 @@ components:
             * `m` - Man
             * `v` - Vrouw
             * `o` - Onbekend
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/GeslachtsaanduidingEnum'
@@ -13472,7 +13472,7 @@ components:
           maxLength: 500
         innRechtsvorm:
           description: De juridische vorm van de NIET-NATUURLIJK PERSOON.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/InnRechtsvormEnum'
@@ -13506,7 +13506,7 @@ components:
           maxLength: 500
         innRechtsvorm:
           description: De juridische vorm van de NIET-NATUURLIJK PERSOON.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/InnRechtsvormEnum'
@@ -14197,7 +14197,7 @@ components:
             * `nog_niet` - De met de zaak gemoeide kosten zijn (nog) niet betaald.
             * `gedeeltelijk` - De met de zaak gemoeide kosten zijn gedeeltelijk betaald.
             * `geheel` - De met de zaak gemoeide kosten zijn geheel betaald.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/BetalingsindicatieEnum'
@@ -14305,7 +14305,7 @@ components:
 
             * `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum overgedragen worden naar een archiefbewaarplaats.
             * `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd worden.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/ArchiefnominatieEnum'
@@ -14887,7 +14887,7 @@ components:
             * `nog_niet` - De met de zaak gemoeide kosten zijn (nog) niet betaald.
             * `gedeeltelijk` - De met de zaak gemoeide kosten zijn gedeeltelijk betaald.
             * `geheel` - De met de zaak gemoeide kosten zijn geheel betaald.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/BetalingsindicatieEnum'
@@ -14950,7 +14950,7 @@ components:
 
             * `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum overgedragen worden naar een archiefbewaarplaats.
             * `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd worden.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/ArchiefnominatieEnum'

--- a/src/main/resources/api-specs/zgw/ztc-openapi.yaml
+++ b/src/main/resources/api-specs/zgw/ztc-openapi.yaml
@@ -1,5 +1,5 @@
 openapi: 3.0.3
-# Lifely: renamed invalid min_length and max_length properties to minLength and maxLength
+# INFO.nl: renamed invalid min_length and max_length properties to minLength and maxLength
 info:
   title: Catalogi API
   version: 1.3.1 (1)
@@ -10286,7 +10286,7 @@ components:
       enum:
       - blijvend_bewaren
       - vernietigen
-      # manual added by Lifely: need to allow for empty values returned by the API
+      # manual added by INFO.nl: need to allow for empty values returned by the API
       # and unfortunately the OpenAPI Generator does not fully support the `oneOf` construct yet
       - ''
       type: string
@@ -10636,7 +10636,7 @@ components:
             * `woz_waarde` - Woz waarde
             * `zakelijk_recht` - Zakelijk recht
             * `overige` - Overige
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/ObjecttypeEnum'
@@ -10739,7 +10739,7 @@ components:
             * `woz_waarde` - Woz waarde
             * `zakelijk_recht` - Zakelijk recht
             * `overige` - Overige
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/ObjecttypeEnum'
@@ -11497,7 +11497,7 @@ components:
       - woz_waarde
       - zakelijk_recht
       - overige
-      # manual added by Lifely: need to allow for empty values returned by the API
+      # manual added by INFO.nl: need to allow for empty values returned by the API
       # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
       - ''
       type: string
@@ -12535,7 +12535,7 @@ components:
 
             * `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum overgedragen worden naar een archiefbewaarplaats.
             * `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd worden.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/ArchiefnominatieEnum'
@@ -12679,7 +12679,7 @@ components:
 
             * `blijvend_bewaren` - Het zaakdossier moet bewaard blijven en op de Archiefactiedatum overgedragen worden naar een archiefbewaarplaats.
             * `vernietigen` - Het zaakdossier moet op of na de Archiefactiedatum vernietigd worden.
-          # manual changed by Lifely: need to allow for empty values returned by the API
+          # manual changed by INFO.nl: need to allow for empty values returned by the API
           # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
           allOf:
           - $ref: '#/components/schemas/ArchiefnominatieEnum'

--- a/src/main/resources/openapi-generator-templates/pojo.mustache
+++ b/src/main/resources/openapi-generator-templates/pojo.mustache
@@ -1,4 +1,4 @@
-{{! Lifely/INFO temporary workaround for the issue where the OpenAPI Generator Gradle plugin }}
+{{! INFO.nl temporary workaround for the issue where the OpenAPI Generator Gradle plugin }}
 {{! incorrectly generates '@JsonbTransient' annotations for certain 'type' fields in polymorphic model classes }}
 {{! which has the result that these fields are not serialized and deserialized leading to errors in the various APIs we use. }}
 {{! For example in the generated BRP 'PersonenQuery.java' class the 'type' String field was given the '@JsonbTransient' annotation }}
@@ -57,21 +57,21 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensi
   */
 {{/description}}
   {{^withXml}}
-  {{! Lifely/INFO. Changed this line to prevent the generation of the @JsonbTransient annotation for polymorphism. See reasons above. }}
+  {{! INFO.nl. Changed this line to prevent the generation of the @JsonbTransient annotation for polymorphism. See reasons above. }}
   {{#jsonb}}@JsonbProperty("{{baseName}}"){{/jsonb}}
-  {{! Lifely/INFO. End of change. }}
+  {{! INFO.nl. End of change. }}
   {{/withXml}}
 {{#vendorExtensions.x-field-extra-annotation}}
 {{{vendorExtensions.x-field-extra-annotation}}}
 {{/vendorExtensions.x-field-extra-annotation}}
 {{#isContainer}}
-  {{! Lifely/INFO: the use of allOf in combination with readOnly fields in the parent class results in uncompilable code }}
+  {{! INFO.nl: the use of allOf in combination with readOnly fields in the parent class results in uncompilable code }}
   {{! see: https://github.com/OpenAPITools/openapi-generator/issues/16374 }}
   {{! as workaround we simply set the visibility of all fields in pojo's to 'protected' instead of 'private' }}
   protected {{{datatypeWithEnum}}} {{name}}{{#required}} = {{{defaultValue}}}{{/required}}{{^required}} = null{{/required}};
 {{/isContainer}}
 {{^isContainer}}
-  {{! Lifely/INFO: the use of allOf in combination with readOnly fields in the parent class results in uncompilable code }}
+  {{! INFO.nl: the use of allOf in combination with readOnly fields in the parent class results in uncompilable code }}
   {{! see: https://github.com/OpenAPITools/openapi-generator/issues/16374 }}
   {{! as workaround we simply set the visibility of all fields in pojo's to 'protected' instead of 'private' }}
   protected {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};

--- a/src/main/resources/openapi-generator-templates/typeInfoAnnotation.mustache
+++ b/src/main/resources/openapi-generator-templates/typeInfoAnnotation.mustache
@@ -1,4 +1,4 @@
-{{! Lifely/INFO temporary workaround for the issue where the OpenAPI Generator Gradle plugin }}
+{{! INFO.nl temporary workaround for the issue where the OpenAPI Generator Gradle plugin }}
 {{! generates '@JsonbTypeInfo(key = "type")' annotations in the generated model classes both for }}
 {{! parent and child polymorphic classes resulting in errors such as: }}
 {{! "Caused by: jakarta.json.bind.JsonbException: One polymorphic chain cannot have two conflicting property names. }}
@@ -27,5 +27,5 @@
 {{/discriminator.mappedModels}}
 {{/jackson}}
 {{#jsonbPolymorphism}}
-{{! Workaround Lifely/INFO: the original code has been removed for reasons see above }}
+{{! Workaround INFO.nl: the original code has been removed for reasons see above }}
 {{/jsonbPolymorphism}}

--- a/src/main/resources/policies/document-rechten.rego
+++ b/src/main/resources/policies/document-rechten.rego
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 # When updating this file, please make sure to also update the policy documentation

--- a/src/main/resources/policies/overige-rechten.rego
+++ b/src/main/resources/policies/overige-rechten.rego
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 # When updating this file, please make sure to also update the policy documentation

--- a/src/main/resources/policies/rollen.rego
+++ b/src/main/resources/policies/rollen.rego
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 # When updating this file, please make sure to also update the policy documentation

--- a/src/main/resources/policies/taak-rechten.rego
+++ b/src/main/resources/policies/taak-rechten.rego
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 # When updating this file, please make sure to also update the policy documentation

--- a/src/main/resources/policies/werklijst-rechten.rego
+++ b/src/main/resources/policies/werklijst-rechten.rego
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 # When updating this file, please make sure to also update the policy documentation

--- a/src/main/resources/policies/zaak-rechten.rego
+++ b/src/main/resources/policies/zaak-rechten.rego
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/src/main/resources/schemas/V55__drop_table_zoek_index.sql
+++ b/src/main/resources/schemas/V55__drop_table_zoek_index.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V56__smartdocuments_templates.sql
+++ b/src/main/resources/schemas/V56__smartdocuments_templates.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V57__smartdocuments_templates_zaakafhandelparameter.sql
+++ b/src/main/resources/schemas/V57__smartdocuments_templates_zaakafhandelparameter.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V58__smartdocuments_document_creation_templates.sql
+++ b/src/main/resources/schemas/V58__smartdocuments_document_creation_templates.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V59__referentie_tabel_server_error_pagina_tekst.sql
+++ b/src/main/resources/schemas/V59__referentie_tabel_server_error_pagina_tekst.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 INSERT INTO ${schema}.referentie_tabel(id_referentie_tabel, code, naam)

--- a/src/main/resources/schemas/V60__smartdocuments_informatie_object_type.sql
+++ b/src/main/resources/schemas/V60__smartdocuments_informatie_object_type.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 DROP TABLE IF EXISTS ${schema}.smartdocuments_document_creation_template_group CASCADE;

--- a/src/main/resources/schemas/V61__smartdocuments_remove_informatie_object_type_from_group.sql
+++ b/src/main/resources/schemas/V61__smartdocuments_remove_informatie_object_type_from_group.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V62__referentie_tabel_communicatiekanaal.sql
+++ b/src/main/resources/schemas/V62__referentie_tabel_communicatiekanaal.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 INSERT INTO ${schema}.referentie_tabel(id_referentie_tabel, code, naam)

--- a/src/main/resources/schemas/V63__referentie_waarde_systeem_column.sql
+++ b/src/main/resources/schemas/V63__referentie_waarde_systeem_column.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V64__referentie_tabel_systeem_column.sql
+++ b/src/main/resources/schemas/V64__referentie_tabel_systeem_column.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V65__referentie_tabel_constraint_upper_on_code.sql
+++ b/src/main/resources/schemas/V65__referentie_tabel_constraint_upper_on_code.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V67__zaakafhandelparameters_create_document_enable_column.sql
+++ b/src/main/resources/schemas/V67__zaakafhandelparameters_create_document_enable_column.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V68__zaaktype_bpmn_process_definition_table.sql
+++ b/src/main/resources/schemas/V68__zaaktype_bpmn_process_definition_table.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V69__delete_domein_overig_referentie_waarde.sql
+++ b/src/main/resources/schemas/V69__delete_domein_overig_referentie_waarde.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/wildfly/configure-wildfly.cli
+++ b/src/main/resources/wildfly/configure-wildfly.cli
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+# SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/src/main/resources/wildfly/deploy-zaakafhandelcomponent.cli
+++ b/src/main/resources/wildfly/deploy-zaakafhandelcomponent.cli
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/src/main/webapp/WEB-INF/beans.xml
+++ b/src/main/webapp/WEB-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 <!-- Note that currently ZAC requires the bean discovery mode to be set to 'all' even though this is generally not advised. -->

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ SPDX-FileCopyrightText: 2021 Atos, 2023 Lifely
+  ~ SPDX-FileCopyrightText: 2021 Atos, 2023 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 

--- a/src/main/webapp/error-403.html
+++ b/src/main/webapp/error-403.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2025 Lifely
+  ~ SPDX-FileCopyrightText: 2025 INFO.nl
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 <!doctype html>

--- a/src/test/kotlin/net/atos/client/bag/model/BagFixtures.kt
+++ b/src/test/kotlin/net/atos/client/bag/model/BagFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.client.bag.model

--- a/src/test/kotlin/net/atos/client/klant/KlantFixtures.kt
+++ b/src/test/kotlin/net/atos/client/klant/KlantFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/client/or/object/model/ObjectRegistratieFixtures.kt
+++ b/src/test/kotlin/net/atos/client/or/object/model/ObjectRegistratieFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/client/util/JWTTokenGeneratorTest.kt
+++ b/src/test/kotlin/net/atos/client/util/JWTTokenGeneratorTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/bag/BagFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/bag/BagFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/bag/BagRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/bag/BagRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.bag

--- a/src/test/kotlin/net/atos/zac/app/bag/converter/RESTAdresseerbaarObjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/bag/converter/RESTAdresseerbaarObjectConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/flowable/cmmn/ZacCmmnAdminUtilRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/flowable/cmmn/ZacCmmnAdminUtilRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.app.flowable.cmmn

--- a/src/test/kotlin/net/atos/zac/app/formulieren/converter/RESTFormulierDefinitieConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/formulieren/converter/RESTFormulierDefinitieConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/formulieren/model/FormulierFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/formulieren/model/FormulierFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/mail/model/MailFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/app/mail/model/MailFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/ontkoppeldedocumenten/OntkoppeldeDocumentenRESTServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/policy/model/AppPolicyFixtures.kt.kt
+++ b/src/test/kotlin/net/atos/zac/app/policy/model/AppPolicyFixtures.kt.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/util/EnkelvoudigInformatieObjectStatusEnumReaderTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/EnkelvoudigInformatieObjectStatusEnumReaderTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/util/LocalDateReaderTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/LocalDateReaderTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/util/RESTTaalReaderTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/RESTTaalReaderTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/util/UUIDReaderTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/UUIDReaderTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/util/ZonedDateTimeReaderTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/ZonedDateTimeReaderTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/util/exception/RestExceptionMapperTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/flowable/FlowableFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/FlowableFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable

--- a/src/test/kotlin/net/atos/zac/flowable/ZaakVariabelenServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/ZaakVariabelenServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable

--- a/src/test/kotlin/net/atos/zac/flowable/cmmn/CMMNServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/cmmn/CMMNServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.cmmn

--- a/src/test/kotlin/net/atos/zac/flowable/cmmn/UpdateZaakLifecycleListenerTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/cmmn/UpdateZaakLifecycleListenerTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.flowable.cmmn

--- a/src/test/kotlin/net/atos/zac/flowable/task/FlowableTaskServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/task/FlowableTaskServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/flowable/task/TaakVariabelenServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/task/TaakVariabelenServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/mailtemplates/MailTemplateHelperTest.kt
+++ b/src/test/kotlin/net/atos/zac/mailtemplates/MailTemplateHelperTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/mailtemplates/model/MailtemplatesFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/mailtemplates/model/MailtemplatesFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package net.atos.zac.mailtemplates.model

--- a/src/test/kotlin/net/atos/zac/policy/PolicyServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/policy/PolicyServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/policy/input/UserInputTest.kt
+++ b/src/test/kotlin/net/atos/zac/policy/input/UserInputTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/policy/output/PolicyOutputFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/policy/output/PolicyOutputFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/solr/SolrDeployerServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/solr/SolrDeployerServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/util/JsonbConfigurationTest.kt
+++ b/src/test/kotlin/net/atos/zac/util/JsonbConfigurationTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/util/time/ZonedDateTimeParamConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/util/time/ZonedDateTimeParamConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/websocket/SessionRegistryTest.kt
+++ b/src/test/kotlin/net/atos/zac/websocket/SessionRegistryTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/net/atos/zac/websocket/event/WebsocketFixtures.kt
+++ b/src/test/kotlin/net/atos/zac/websocket/event/WebsocketFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/client/brp/BrpClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/brp/BrpClientServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/client/brp/model/BrpFixtures.kt
+++ b/src/test/kotlin/nl/info/client/brp/model/BrpFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/client/brp/util/BRPClientHeadersFactoryTest.kt
+++ b/src/test/kotlin/nl/info/client/brp/util/BRPClientHeadersFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.brp.util

--- a/src/test/kotlin/nl/info/client/kvk/KvkClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/kvk/KvkClientServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.kvk

--- a/src/test/kotlin/nl/info/client/kvk/model/KvkZoekenFixtures.kt
+++ b/src/test/kotlin/nl/info/client/kvk/model/KvkZoekenFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.kvk.model

--- a/src/test/kotlin/nl/info/client/smartdocuments/model/SmartDocumentsResponseFixtures.kt
+++ b/src/test/kotlin/nl/info/client/smartdocuments/model/SmartDocumentsResponseFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/client/zgw/brc/BrcClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/brc/BrcClientServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/client/zgw/brc/model/BrcFixtures.kt
+++ b/src/test/kotlin/nl/info/client/zgw/brc/model/BrcFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/client/zgw/brc/model/generated/BesluitInformatieObjectFixtures.kt
+++ b/src/test/kotlin/nl/info/client/zgw/brc/model/generated/BesluitInformatieObjectFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/client/zgw/drc/model/DrcFixtures.kt
+++ b/src/test/kotlin/nl/info/client/zgw/drc/model/DrcFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/client/zgw/model/ZrcFixtures.kt
+++ b/src/test/kotlin/nl/info/client/zgw/model/ZrcFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.model

--- a/src/test/kotlin/nl/info/client/zgw/shared/ZGWApiServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/shared/ZGWApiServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.shared

--- a/src/test/kotlin/nl/info/client/zgw/shared/exception/ZgwErrorExceptionMapperTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/shared/exception/ZgwErrorExceptionMapperTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.shared.exception

--- a/src/test/kotlin/nl/info/client/zgw/shared/model/SharedFixtures.kt
+++ b/src/test/kotlin/nl/info/client/zgw/shared/model/SharedFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/client/zgw/shared/model/audit/AuditTrailRegelFixtures.kt
+++ b/src/test/kotlin/nl/info/client/zgw/shared/model/audit/AuditTrailRegelFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/client/zgw/zrc/jsonb/GeometryJsonbSerializerTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/zrc/jsonb/GeometryJsonbSerializerTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.zrc.jsonb

--- a/src/test/kotlin/nl/info/client/zgw/ztc/ZtcClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/ztc/ZtcClientServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc

--- a/src/test/kotlin/nl/info/client/zgw/ztc/model/ZtcFixtures.kt
+++ b/src/test/kotlin/nl/info/client/zgw/ztc/model/ZtcFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.client.zgw.ztc.model

--- a/src/test/kotlin/nl/info/test/org/flowable/engine/repository/FlowableEngineRepositoryFixtures.kt
+++ b/src/test/kotlin/nl/info/test/org/flowable/engine/repository/FlowableEngineRepositoryFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.test.org.flowable.engine.repository

--- a/src/test/kotlin/nl/info/test/org/flowable/task/service/impl/persistence/entity/PersistenceEntityFixtures.kt
+++ b/src/test/kotlin/nl/info/test/org/flowable/task/service/impl/persistence/entity/PersistenceEntityFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.test.org.flowable.task.service.impl.persistence.entity

--- a/src/test/kotlin/nl/info/test/org/keycloak/representations/idm/KeycloakRepresentationsIdmFixtures.kt
+++ b/src/test/kotlin/nl/info/test/org/keycloak/representations/idm/KeycloakRepresentationsIdmFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/admin/ReferenceTableAdminServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/admin/ReferenceTableAdminServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.admin

--- a/src/test/kotlin/nl/info/zac/admin/ReferenceTableServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/admin/ReferenceTableServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/admin/SignaleringAdminRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/admin/SignaleringAdminRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.admin

--- a/src/test/kotlin/nl/info/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/admin/ZaakafhandelParameterBeheerServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.admin

--- a/src/test/kotlin/nl/info/zac/admin/model/AdminFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/admin/model/AdminFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/admin/AppAdminFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/AppAdminFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin

--- a/src/test/kotlin/nl/info/zac/app/admin/FormioFormulierenRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/FormioFormulierenRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin

--- a/src/test/kotlin/nl/info/zac/app/admin/HealthCheckRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/HealthCheckRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.admin

--- a/src/test/kotlin/nl/info/zac/app/admin/ReferenceTableRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/ReferenceTableRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/admin/converter/RestZaakafhandelParametersConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/converter/RestZaakafhandelParametersConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/csv/CsvRESTServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/csv/CsvRESTServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.csv

--- a/src/test/kotlin/nl/info/zac/app/decision/DecisionServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/decision/DecisionServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.decision

--- a/src/test/kotlin/nl/info/zac/app/documentcreation/DocumentCreationRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/documentcreation/DocumentCreationRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/documentcreation/model/DocumentCreationFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/documentcreation/model/DocumentCreationFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.informatieobjecten

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectUpdateServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectUpdateServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.informatieobjecten

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/model/InformatieObjectenRestFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/model/InformatieObjectenRestFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieobjectFileUploadFormValidatorTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieobjectFileUploadFormValidatorTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/klant/KlantRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/klant/KlantRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/klant/model/personen/KlantModelFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/klant/model/personen/KlantModelFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.personen

--- a/src/test/kotlin/nl/info/zac/app/klant/model/personen/RestPersoonTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/klant/model/personen/RestPersoonTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.klant.model.personen

--- a/src/test/kotlin/nl/info/zac/app/model/IdentityFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/model/IdentityFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/planitems/PlanItemsRESTServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/planitems/PlanItemsRESTServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/planitems/model/PlanItemsFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/planitems/model/PlanItemsFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/search/SearchFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/search/SearchFixtures.kt
@@ -1,6 +1,6 @@
 /*
  *
- *  * SPDX-FileCopyrightText: 2025 Lifely
+ *  * SPDX-FileCopyrightText: 2025 INFO.nl
  *  * SPDX-License-Identifier: EUPL-1.2+
  *
  */

--- a/src/test/kotlin/nl/info/zac/app/signalering/SignaleringRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/signalering/SignaleringRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/signalering/converter/RESTSignaleringTaakConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/signalering/converter/RESTSignaleringTaakConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/signalering/model/SignaleringFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/signalering/model/SignaleringFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/task/TaskRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/task/TaskRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.task

--- a/src/test/kotlin/nl/info/zac/app/task/converter/RestTaskHistoryConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/task/converter/RestTaskHistoryConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/task/model/TaskRestFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/task/model/TaskRestFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/util/UtilRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/util/UtilRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.util

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakKoppelenRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakKoppelenRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely, 2025 Dimpact
+ * SPDX-FileCopyrightText: 2025 INFO.nl, 2025 Dimpact
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely, 2024 Dimpact
+ * SPDX-FileCopyrightText: 2023 INFO.nl, 2024 Dimpact
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak

--- a/src/test/kotlin/nl/info/zac/app/zaak/converter/RestDecisionConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/converter/RestDecisionConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakOverzichtConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakOverzichtConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakResultaatConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakResultaatConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.app.zaak.converter

--- a/src/test/kotlin/nl/info/zac/app/zaak/model/RestDecisionChangeDataTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/model/RestDecisionChangeDataTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/model/RestZakenFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/model/RestZakenFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/authentication/AuthenticationFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/AuthenticationFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/authentication/UserPrincipalFilterTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/UserPrincipalFilterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.authentication

--- a/src/test/kotlin/nl/info/zac/authentication/ZacApiKeyAuthFilterTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/ZacApiKeyAuthFilterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.authentication

--- a/src/test/kotlin/nl/info/zac/configuratie/ConfiguratieServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/configuratie/ConfiguratieServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/documentcreation/DocumentCreationServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/documentcreation/DocumentCreationServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/documentcreation/model/DocumentCreationFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/documentcreation/model/DocumentCreationFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/flowable/bpmn/BpmnServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/flowable/bpmn/BpmnServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.flowable.bpmn

--- a/src/test/kotlin/nl/info/zac/flowable/bpmn/ZaaktypeBpmnProcessDefinitionServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/flowable/bpmn/ZaaktypeBpmnProcessDefinitionServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.flowable.bpmn

--- a/src/test/kotlin/nl/info/zac/flowable/bpmn/model/FlowableBpmnFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/flowable/bpmn/model/FlowableBpmnFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.flowable.bpmn.model

--- a/src/test/kotlin/nl/info/zac/formio/FormioFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/formio/FormioFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.formio

--- a/src/test/kotlin/nl/info/zac/formio/FormioServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/formio/FormioServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.formio

--- a/src/test/kotlin/nl/info/zac/healthcheck/HealthcheckFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/healthcheck/HealthcheckFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/healthcheck/model/ZaaktypeInrichtingscheckTest.kt
+++ b/src/test/kotlin/nl/info/zac/healthcheck/model/ZaaktypeInrichtingscheckTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.healthcheck.model

--- a/src/test/kotlin/nl/info/zac/helper/SuspensionZaakHelperTest.kt
+++ b/src/test/kotlin/nl/info/zac/helper/SuspensionZaakHelperTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.identity

--- a/src/test/kotlin/nl/info/zac/identity/model/IdentityFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/identity/model/IdentityFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/mail/MailServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/mail/MailServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.mail

--- a/src/test/kotlin/nl/info/zac/mail/model/MailAdresTest.kt
+++ b/src/test/kotlin/nl/info/zac/mail/model/MailAdresTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/mail/model/MailFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/mail/model/MailFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.mail.model

--- a/src/test/kotlin/nl/info/zac/model/EnkelvoudigInformatieObjectFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/model/EnkelvoudigInformatieObjectFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/notification/NotificationFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/notification/NotificationFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/notification/NotificationReceiverTest.kt
+++ b/src/test/kotlin/nl/info/zac/notification/NotificationReceiverTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.notification

--- a/src/test/kotlin/nl/info/zac/productaanvraag/AanvraagFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/AanvraagFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Lifely
+ * SPDX-FileCopyrightText: 2023 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.productaanvraag

--- a/src/test/kotlin/nl/info/zac/search/IndexingServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/IndexingServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/search/SearchServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/SearchServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.converter

--- a/src/test/kotlin/nl/info/zac/search/converter/ZaakZoekObjectConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/converter/ZaakZoekObjectConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.search.converter

--- a/src/test/kotlin/nl/info/zac/search/converter/ZoekenConverterFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/search/converter/ZoekenConverterFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/search/model/ZoekenModelFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/search/model/ZoekenModelFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/signalering/SignaleringServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/signalering/SignaleringServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/signalering/ZaakTaskDueDateEmailNotificationServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/signalering/ZaakTaskDueDateEmailNotificationServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/signalering/model/SignaleringFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/signalering/model/SignaleringFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/smartdocuments/SmartDocumentsServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/smartdocuments/SmartDocumentsServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/smartdocuments/SmartDocumentsTemplatesServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/smartdocuments/SmartDocumentsTemplatesServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/smartdocuments/rest/RestSmartDocumentsTemplateGroupTest.kt
+++ b/src/test/kotlin/nl/info/zac/smartdocuments/rest/RestSmartDocumentsTemplateGroupTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/smartdocuments/rest/SmartDocumentsRestFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/smartdocuments/rest/SmartDocumentsRestFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/smartdocuments/rest/SmartDocumentsValidatorKtTest.kt
+++ b/src/test/kotlin/nl/info/zac/smartdocuments/rest/SmartDocumentsValidatorKtTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/smartdocuments/templates/SmartDocumentsTemplateConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/smartdocuments/templates/SmartDocumentsTemplateConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsModelFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsModelFixtures.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/task/TaskServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/task/TaskServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.task

--- a/src/test/kotlin/nl/info/zac/test/config/ZacTestConfig.kt
+++ b/src/test/kotlin/nl/info/zac/test/config/ZacTestConfig.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.test.config

--- a/src/test/kotlin/nl/info/zac/test/date/DateTestUtil.kt
+++ b/src/test/kotlin/nl/info/zac/test/date/DateTestUtil.kt
@@ -1,5 +1,5 @@
 /*
-* SPDX-FileCopyrightText: 2025 Lifely
+* SPDX-FileCopyrightText: 2025 INFO.nl
 * SPDX-License-Identifier: EUPL-1.2+
 */
 package nl.info.zac.test.date

--- a/src/test/kotlin/nl/info/zac/test/listener/MockkClearingTestListener.kt
+++ b/src/test/kotlin/nl/info/zac/test/listener/MockkClearingTestListener.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.test.listener

--- a/src/test/kotlin/nl/info/zac/test/util/Base64ConvertersTest.kt
+++ b/src/test/kotlin/nl/info/zac/test/util/Base64ConvertersTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.test.util

--- a/src/test/kotlin/nl/info/zac/test/util/TestStringUtils.kt
+++ b/src/test/kotlin/nl/info/zac/test/util/TestStringUtils.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/kotlin/nl/info/zac/util/BSNValidatorTest.kt
+++ b/src/test/kotlin/nl/info/zac/util/BSNValidatorTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Lifely
+ * SPDX-FileCopyrightText: 2025 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 package nl.info.zac.util

--- a/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Lifely
+ * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/test/resources/kotest.properties
+++ b/src/test/resources/kotest.properties
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/src/test/resources/policies/document-rechten_test.rego
+++ b/src/test/resources/policies/document-rechten_test.rego
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 package net.atos.zac.overig

--- a/src/test/resources/policies/overige-rechten_test.rego
+++ b/src/test/resources/policies/overige-rechten_test.rego
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 package net.atos.zac.overig

--- a/src/test/resources/policies/taak-rechten_test.rego
+++ b/src/test/resources/policies/taak-rechten_test.rego
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 package net.atos.zac.overig

--- a/src/test/resources/policies/werklijst-rechten_test.rego
+++ b/src/test/resources/policies/werklijst-rechten_test.rego
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 package net.atos.zac.overig

--- a/src/test/resources/policies/zaak-rechten_test.rego
+++ b/src/test/resources/policies/zaak-rechten_test.rego
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 package net.atos.zac.overig

--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -3,7 +3,7 @@
 set -e
 
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/start-e2e-with-local-env.sh
+++ b/start-e2e-with-local-env.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/start-e2e-with-test-env.sh
+++ b/start-e2e-with-test-env.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/start-e2e.sh
+++ b/start-e2e.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/start-it-with-local-env.sh
+++ b/start-it-with-local-env.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# SPDX-FileCopyrightText: 2024 Lifely
+# SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/startupwithenv.sh
+++ b/startupwithenv.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 

--- a/stop-docker-compose.sh
+++ b/stop-docker-compose.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# SPDX-FileCopyrightText: 2023 Lifely
+# SPDX-FileCopyrightText: 2023 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
 


### PR DESCRIPTION
Renamed all copyright statements from Lifely to INFO.nl since INFO.nl is the owner of the code, even while the Dimpact contract still is with Lifely.

Solves PZ-6823