### PR TITLE
fix: revert copyright changes in flyway db migrations

### DIFF
--- a/src/main/resources/schemas/V55__drop_table_zoek_index.sql
+++ b/src/main/resources/schemas/V55__drop_table_zoek_index.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V56__smartdocuments_templates.sql
+++ b/src/main/resources/schemas/V56__smartdocuments_templates.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V57__smartdocuments_templates_zaakafhandelparameter.sql
+++ b/src/main/resources/schemas/V57__smartdocuments_templates_zaakafhandelparameter.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V58__smartdocuments_document_creation_templates.sql
+++ b/src/main/resources/schemas/V58__smartdocuments_document_creation_templates.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V59__referentie_tabel_server_error_pagina_tekst.sql
+++ b/src/main/resources/schemas/V59__referentie_tabel_server_error_pagina_tekst.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 INSERT INTO ${schema}.referentie_tabel(id_referentie_tabel, code, naam)

--- a/src/main/resources/schemas/V60__smartdocuments_informatie_object_type.sql
+++ b/src/main/resources/schemas/V60__smartdocuments_informatie_object_type.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 DROP TABLE IF EXISTS ${schema}.smartdocuments_document_creation_template_group CASCADE;

--- a/src/main/resources/schemas/V61__smartdocuments_remove_informatie_object_type_from_group.sql
+++ b/src/main/resources/schemas/V61__smartdocuments_remove_informatie_object_type_from_group.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V62__referentie_tabel_communicatiekanaal.sql
+++ b/src/main/resources/schemas/V62__referentie_tabel_communicatiekanaal.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 INSERT INTO ${schema}.referentie_tabel(id_referentie_tabel, code, naam)

--- a/src/main/resources/schemas/V63__referentie_waarde_systeem_column.sql
+++ b/src/main/resources/schemas/V63__referentie_waarde_systeem_column.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V64__referentie_tabel_systeem_column.sql
+++ b/src/main/resources/schemas/V64__referentie_tabel_systeem_column.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V65__referentie_tabel_constraint_upper_on_code.sql
+++ b/src/main/resources/schemas/V65__referentie_tabel_constraint_upper_on_code.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V67__zaakafhandelparameters_create_document_enable_column.sql
+++ b/src/main/resources/schemas/V67__zaakafhandelparameters_create_document_enable_column.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-FileCopyrightText: 2024 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V68__zaaktype_bpmn_process_definition_table.sql
+++ b/src/main/resources/schemas/V68__zaaktype_bpmn_process_definition_table.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 INFO.nl
+ * SPDX-FileCopyrightText: 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/resources/schemas/V69__delete_domein_overig_referentie_waarde.sql
+++ b/src/main/resources/schemas/V69__delete_domein_overig_referentie_waarde.sql
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 INFO.nl
+ * SPDX-FileCopyrightText: 2025 Lifely
  * SPDX-License-Identifier: EUPL-1.2+
  */
 


### PR DESCRIPTION
Reverted copyright changes in flyway db migrations since this breaks the deployment on environments where these migrations have been run.

Solves PZ-6826