### PR TITLE
chore: small translation improvement

### DIFF
--- a/src/main/app/src/assets/i18n/nl.json
+++ b/src/main/app/src/assets/i18n/nl.json
@@ -841,7 +841,7 @@
   "msg.initiator.ontkoppelen.bevestigen": "De initiator ontkoppelen van de zaak?",
   "msg.initiator.ontkoppelen.uitgevoerd": "De initiator is ontkoppeld van de zaak",
   "msg.initiator.toegevoegd": "De initiator {{naam}} is toegevoegd",
-  "msg.initiator.bevestigen": "{{naam}} wordt de behandelaar van de zaak",
+  "msg.initiator.bevestigen": "{{naam}} wordt de initiator van de zaak",
   "msg.initiator.gewijzigd": "De initiator is gewijzigd",
   "msg.loading": "Bezig met het ophalen van de gegevens",
   "msg.mailtemplate.opgeslagen": "Mailtemplate opgeslagen",


### PR DESCRIPTION
This pull request includes a small change to the Dutch translations in the `src/main/app/src/assets/i18n/nl.json` file. The update corrects the wording in a message to reflect that `{{naam}}` becomes the "initiator" of the case instead of the "handler."

Solves PZ-1734