### PR TITLE
fix: do not make `null` and `undefined` into strings

### DIFF
--- a/src/main/app/src/app/formulieren/taken/abstract-taak-formulier.ts
+++ b/src/main/app/src/app/formulieren/taken/abstract-taak-formulier.ts
@@ -172,7 +172,7 @@ export abstract class AbstractTaakFormulier {
         if (typeof this.dataElementen[key] === "boolean") {
           this.dataElementen[key] = `${this.dataElementen[key]}`;
         } else {
-          this.dataElementen[key] = value as string; // TODO better define `dataElementen` type
+          this.dataElementen[key] = value as string; // TODO better define `dataElementen` type -- fixed in https://dimpact.atlassian.net/browse/PZ-6901
         }
       });
     return this.dataElementen;

--- a/src/main/app/src/app/formulieren/taken/abstract-taak-formulier.ts
+++ b/src/main/app/src/app/formulieren/taken/abstract-taak-formulier.ts
@@ -172,7 +172,7 @@ export abstract class AbstractTaakFormulier {
         if (typeof this.dataElementen[key] === "boolean") {
           this.dataElementen[key] = `${this.dataElementen[key]}`;
         } else {
-          this.dataElementen[key] = String(value);
+          this.dataElementen[key] = value as string; // TODO better define `dataElementen` type
         }
       });
     return this.dataElementen;

--- a/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie.ts
+++ b/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie.ts
@@ -153,7 +153,7 @@ export class AanvullendeInformatie extends AbstractTaakFormulier {
       .readDefaultAfzenderVoorZaak(this.zaak.uuid)
       .subscribe((defaultMail) => {
         this.getFormField(fields.VERZENDER).formControl.setValue(
-          defaultMail.mail,
+          defaultMail?.mail,
         );
       });
 

--- a/src/main/app/src/app/shared/material-form-builder/model/abstract-form-control-field.ts
+++ b/src/main/app/src/app/shared/material-form-builder/model/abstract-form-control-field.ts
@@ -16,6 +16,6 @@ export abstract class AbstractFormControlField<
   }
 
   initControl(value?: T | null) {
-    this.formControl = AbstractFormField.formControlInstance<T | null>(value);
+    this.formControl = AbstractFormField.formControlInstance<T | null>(value ?? null);
   }
 }

--- a/src/main/app/src/app/shared/material-form-builder/model/abstract-form-control-field.ts
+++ b/src/main/app/src/app/shared/material-form-builder/model/abstract-form-control-field.ts
@@ -16,6 +16,8 @@ export abstract class AbstractFormControlField<
   }
 
   initControl(value?: T | null) {
-    this.formControl = AbstractFormField.formControlInstance<T | null>(value ?? null);
+    this.formControl = AbstractFormField.formControlInstance<T | null>(
+      value ?? null,
+    );
   }
 }


### PR DESCRIPTION
### Fix form:
* [`src/main/app/src/app/formulieren/taken/abstract-taak-formulier.ts`](diffhunk://#diff-4a3ad7d21d1c797f4bbdf7d0317153b59d7fb9c0496a5f92dda9d0cae260041aL175-R175): Updated the assignment of `dataElementen[key]` to use `value as string` instead of `String(value)`, which broke the _taak_-form

Solves a bug introduced in https://github.com/infonl/dimpact-zaakafhandelcomponent/pull/3394

### Null/Undefined Handling:
* [`src/main/app/src/app/formulieren/taken/model/aanvullende-informatie.ts`](diffhunk://#diff-5c13e0919f777cd9b77d0b89e2f426924d5b42d95574a83d31b2e4bce177a46eL156-R156): Added optional chaining (`defaultMail?.mail`) to handle cases where `defaultMail` might be null or undefined.
* [`src/main/app/src/app/shared/material-form-builder/model/abstract-form-control-field.ts`](diffhunk://#diff-e9a6824655cb7dee9ec2e967e1b58d28f52847603a0d56649a08102c4c3f120aL19-R19): Ensured that a default value (`null`) is provided when initializing `formControl` using the nullish coalescing operator (`value ?? null`) to adhere to the Angular default value of a `formControl`.

Solves findings when debugging