### PR TITLE
fix(dialog): when no data is returned, return `true` as a fallback

### DIFF
--- a/src/main/app/src/app/shared/dialog/dialog.component.ts
+++ b/src/main/app/src/app/shared/dialog/dialog.component.ts
@@ -47,7 +47,7 @@ export class DialogComponent implements OnInit {
       }
     }
     this.data.options.callback(results).subscribe({
-      next: (data) => this.dialogRef.close(data),
+      next: (data) => this.dialogRef.close(data ?? true),
       error: () => this.dialogRef.close(false),
     });
   }


### PR DESCRIPTION
This pull request updates the behavior of the `DialogComponent` to ensure a default value is provided when closing the dialog. 

* [`src/main/app/src/app/shared/dialog/dialog.component.ts`](diffhunk://#diff-4f20afbe11ed85afd69c572c6d9a3b3a1452832cafd17a97c26861bb39216627L50-R50): Modified the `next` callback in the `callback(results).subscribe` method to close the dialog with `true` as the default value if `data` is null or undefined.

Solves [PZ-6903](https://dimpact.atlassian.net/browse/PZ-6903)