### PR TITLE
fix(locatie-zoek): emit empty (`null`) location on save

### DIFF
--- a/src/main/app/src/app/zaken/zoek/locatie-zoek/locatie-zoek.component.ts
+++ b/src/main/app/src/app/zaken/zoek/locatie-zoek/locatie-zoek.component.ts
@@ -52,7 +52,7 @@ export class LocatieZoekComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() readonly = false;
   @Input({ required: true }) sideNav!: MatDrawer;
   @Input({ required: true }) reasonControl!: FormControl<string>;
-  @Output() locatie = new EventEmitter<GeometryGegevens>();
+  @Output() locatie = new EventEmitter<GeometryGegevens | null>();
   @Output() locationChanged = new EventEmitter<
     GeneratedType<"RestGeometry"> | undefined
   >();
@@ -305,10 +305,11 @@ export class LocatieZoekComponent implements OnInit, AfterViewInit, OnDestroy {
 
   save(): void {
     this.initialLocation = this.currentLocation;
-    if (!this.markerLocatie) return;
 
     this.locatie.next(
-      new GeometryGegevens(this.markerLocatie, this.reasonControl.value),
+      this.markerLocatie
+        ? new GeometryGegevens(this.markerLocatie, this.reasonControl.value)
+        : null,
     );
   }
 }


### PR DESCRIPTION
This pull request updates the `LocatieZoekComponent` to enhance type safety and handle null values more gracefully. The changes primarily affect the `@Output` property and the `save` method.

### Updates to `LocatieZoekComponent`:

* Modified the `@Output` property `locatie` to emit `GeometryGegevens | null` instead of just `GeometryGegevens`, allowing it to handle cases where no location is selected.
* Updated the `save` method to emit `null` for the `locatie` event when `markerLocatie` is undefined

Solves PZ-6940