### PR TITLE
fix: support empty values in VervalredenEnum in ZGW BRC OpenAPI spec

### DIFF
--- a/src/main/resources/api-specs/zgw/brc-openapi.yaml
+++ b/src/main/resources/api-specs/zgw/brc-openapi.yaml
@@ -2654,7 +2654,7 @@ components:
         - tijdelijk
         - ingetrokken_overheid
         - ingetrokken_belanghebbende
-        # manual changed by INFO.nl: need to allow for empty values returned by the API
+        # manually changed by INFO.nl: need to allow for empty values returned by the API
         # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
         - ''
       type: string

--- a/src/main/resources/api-specs/zgw/brc-openapi.yaml
+++ b/src/main/resources/api-specs/zgw/brc-openapi.yaml
@@ -2654,6 +2654,9 @@ components:
         - tijdelijk
         - ingetrokken_overheid
         - ingetrokken_belanghebbende
+        # manual changed by INFO.nl: need to allow for empty values returned by the API
+        # and unfortunately OpenAPI Generator does not support the `oneOf` construct fully yet
+        - ''
       type: string
     Wijzigingen:
       type: object


### PR DESCRIPTION
Support empty values in VervalredenEnum in ZGW BRC OpenAPI spec.

Solves PZ-6957