### PR TITLE
fix(zaak-opschorten): cast dates `toISOString` instead of `String`

### DIFF
--- a/src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.ts
@@ -160,10 +160,14 @@ export class ZaakOpschortenDialogComponent implements OnDestroy {
     const zaakOpschortGegevens: GeneratedType<"RESTZaakOpschortGegevens"> = {
       indicatieOpschorting: true,
       duurDagen: this.duurDagenField.formControl.value ?? undefined,
-      einddatumGepland: String(this.einddatumGeplandField.formControl.value),
+      einddatumGepland: moment(
+        this.einddatumGeplandField.formControl.value,
+      ).toISOString(),
       uiterlijkeEinddatumAfdoening: this.uiterlijkeEinddatumAfdoeningField
         .formControl.value
-        ? String(this.uiterlijkeEinddatumAfdoeningField.formControl.value)
+        ? moment(
+            this.uiterlijkeEinddatumAfdoeningField.formControl.value,
+          ).toISOString()
         : undefined,
       redenOpschorting: this.redenOpschortingField.formControl.value,
     };


### PR DESCRIPTION
This pull request updates the handling of date fields in the `ZaakOpschortenDialogComponent` to ensure proper formatting by converting them to ISO 8601 strings using the `moment` library.

### Changes to date handling:

* Updated the `einddatumGepland` field to use `moment` for converting the date value to an ISO 8601 string instead of using `String`. (`[src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.tsL163-R170](diffhunk://#diff-444941fae3c8adbd1fa9a464935d719e2108d0f5d882522292c959aaaacc8b8dL163-R170)`)
* Updated the `uiterlijkeEinddatumAfdoening` field to conditionally use `moment` for ISO 8601 conversion when a value is present, replacing the previous `String` conversion. (`[src/main/app/src/app/zaken/zaak-opschorten-dialog/zaak-opschorten-dialog.component.tsL163-R170](diffhunk://#diff-444941fae3c8adbd1fa9a464935d719e2108d0f5d882522292c959aaaacc8b8dL163-R170)`)

Solves bug introduced by https://github.com/infonl/dimpact-zaakafhandelcomponent/pull/3394