### PR TITLE
fix: truncate basename zaakafhandelcomponent.solrcloud.fullname in helm

### DIFF
--- a/charts/zac/Chart.yaml
+++ b/charts/zac/Chart.yaml
@@ -6,7 +6,7 @@
 apiVersion: v2
 name: zaakafhandelcomponent
 description: A Helm chart for installing Zaakafhandelcomponent
-version: 1.0.69
+version: 1.0.70
 appVersion: '3.6'
 icon: https://raw.githubusercontent.com/infonl/dimpact-zaakafhandelcomponent/49f8dee60948282b546ebdfdc5cff6f8bbef0305/docs/manuals/ZAC-gebruikershandleiding/images/pic.svg
 dependencies:

--- a/charts/zac/README.md
+++ b/charts/zac/README.md
@@ -1,6 +1,6 @@
 # zaakafhandelcomponent
 
-![Version: 1.0.69](https://img.shields.io/badge/Version-1.0.69-informational?style=flat-square) ![AppVersion: 3.6](https://img.shields.io/badge/AppVersion-3.6-informational?style=flat-square)
+![Version: 1.0.70](https://img.shields.io/badge/Version-1.0.70-informational?style=flat-square) ![AppVersion: 3.6](https://img.shields.io/badge/AppVersion-3.6-informational?style=flat-square)
 
 A Helm chart for installing Zaakafhandelcomponent
 

--- a/charts/zac/templates/_helpers.tpl
+++ b/charts/zac/templates/_helpers.tpl
@@ -48,10 +48,10 @@ We truncate at 57 chars in order to provide space for the suffix
 
 {{/*
 Create a default fully qualified name for solrcloud.
-We truncate at 57 chars in order to provide space for the suffix
+We truncate at 25 chars in order to provide space for the suffixes set by the solr-operator and zookeeper
 */}}
 {{- define "zaakafhandelcomponent.solrcloud.fullname" -}}
-{{ include "zaakafhandelcomponent.fullname" . | trunc 57 | trimSuffix "-" }}-solr
+{{ include "zaakafhandelcomponent.fullname" . | trunc 25 | trimSuffix "-" }}-solr
 {{- end }}
 
 {{/*


### PR DESCRIPTION
truncate the name used for zaakafhandelcomponent.solrcloud.fullname quite a bit, to allow solr-operator and zookeeper suffixes

Solves PZ-6967