### PR TITLE
fix: fixed issue with e-mail sending when an empty attachment string was provided

### DIFF
--- a/src/test/kotlin/nl/info/zac/mail/MailServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/mail/MailServiceTest.kt
@@ -147,10 +147,12 @@ class MailServiceTest : BehaviorSpec({
         }
     }
 
-    Given("a task") {
+    Given("A task and mail gegevens with an attachment UUID array string consisting of an empty string") {
         val task = mockk<Task>()
         val mailGegevens = createMailGegevens(
-            createDocumentFromMail = true
+            createDocumentFromMail = true,
+            // test if we can correctly handle an attachment UUID array string consisting of an empty string
+            attachments = ""
         )
         val bronnen = Bronnen.Builder().add(task).build()
         val resolvedSubject = "resolvedSubject"


### PR DESCRIPTION
Fixed issue with e-mail sending when an empty attachment string was provided. In the long run we should improve the ZAC endpoint in question and we should make sure our frontend no longer sends empty strings when no input is provided.

Solves PZ-6983