### PR TITLE
feat(app): Fix unlink location - prevent disabling reason field

### DIFF
--- a/src/main/app/src/app/zaken/zaak-locatie-wijzigen/zaak-locatie-wijzigen.component.ts
+++ b/src/main/app/src/app/zaken/zaak-locatie-wijzigen/zaak-locatie-wijzigen.component.ts
@@ -249,7 +249,6 @@ export class CaseLocationEditComponent
     this.view.setZoom(this.DEFAULT_ZOOM);
     this.view.setCenter(this.DEFAULT_CENTER);
     this.nearestAddress = {} as AddressResult;
-    this.disableReasonControl();
   }
 
   private disableReasonControl() {


### PR DESCRIPTION
FE - Fix unlink location - prevent disabling reason field

Unlinked location could not be saved since Reason field was set to disabled; disabling now determined bij the subscription/compare of original value and new value. The way it should be.

Solves PZ-7011