### PR TITLE
fix: send over `bagObject` as the `zaakObject`

### DIFF
--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -1191,7 +1191,7 @@ export class ZaakViewComponent
     this.bagService
       .create({
         zaakUuid: this.zaak.uuid,
-        bagObject,
+        zaakobject: bagObject,
       })
       .subscribe(() => {
         this.utilService.openSnackbar("msg.bagObject.gekoppeld");


### PR DESCRIPTION
This pull request includes a small change to the `ZaakViewComponent` class in `zaak-view.component.ts`. The change updates the parameter name from `bagObject` to `zaakobject` when creating a new object with `bagService`.

Solves PZ-7078 

Which is a bug introduced by https://github.com/infonl/dimpact-zaakafhandelcomponent/pull/3463