### PR TITLE
fix: do not select SmartDocuments template in e2e

### DIFF
--- a/src/e2e/step-definitions/external-systems.ts
+++ b/src/e2e/step-definitions/external-systems.ts
@@ -47,8 +47,7 @@ When(
       .getByRole("option", { name: "Melding evenement organiseren behandelen" })
       .click();
 
-    await this.page.getByLabel("Sjabloon").last().click();
-    await this.page.getByRole("option", { name: "OpenZaakTest" }).click();
+    // The only existing template is selected by default, so no need to click on it.
 
     const inputTitle = this.page.getByLabel(/Titel/i);
     await inputTitle.fill(documentInput.title);


### PR DESCRIPTION
Template is already pre-selected as it is the only one in the group

Solves: PZ-7082