### PR TITLE
fix(informatie-object-create-attended): set available `templates`

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
@@ -124,6 +124,8 @@ export class InformatieObjectCreateAttendedComponent implements OnInit {
     });
 
     this.form.controls.templateGroup.valueChanges.subscribe((value) => {
+      this.templates = value?.templates ?? [];
+
       if (!value?.templates) {
         this.form.controls.template.setValue(null);
         this.form.controls.template.disable();


### PR DESCRIPTION
templates are set based on the selected `templateGroup`

This pull request introduces a small enhancement to the `InformatieObjectCreateAttendedComponent` class. The change ensures that the `templates` property is updated with the correct value when the `templateGroup` form control's value changes.

Solves PZ-7081