### PR TITLE
chore(zaak-view): put all `indicaties` on a separate row

### DIFF
--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -178,18 +178,23 @@
         </zac-bedrijfsgegevens>
       </section>
       <mat-card class="zaken-card w50 flex-1">
-        <mat-card-header class="flex-row space-between">
-          <mat-card-title>{{ zaak.identificatie }}</mat-card-title>
-          <mat-card-subtitle>{{
-            zaak.zaaktype.omschrijving
-          }}</mat-card-subtitle>
+        <mat-card-header class="flex-col gap-8 space-between">
           <div class="flex-row">
             <zac-zaak-indicaties
               [layout]="indicatiesLayout.VIEW"
               [zaak]="zaak"
             ></zac-zaak-indicaties>
+          </div>
+          <section class="flex-row space-between items-center">
+            <div>
+              <mat-card-title>
+                {{ zaak.identificatie }}
+              </mat-card-title>
+              <mat-card-subtitle>{{
+                zaak.zaaktype.omschrijving
+              }}</mat-card-subtitle>
+            </div>
             <button
-              *ngIf="zaak.isProcesGestuurd && zaak.isOpen && !zaak.isHeropend"
               class="proces-button"
               (click)="showProces()"
               [title]="'actie.proces.bekijken' | translate"
@@ -197,7 +202,7 @@
             >
               <mat-icon> play_shapes </mat-icon>
             </button>
-          </div>
+          </section>
         </mat-card-header>
         <mat-card-content>
           <mat-tab-group mat-stretch-tabs="false">


### PR DESCRIPTION
This pull request modifies the layout and structure of the `zaak-view.component.html` file to improve the visual organization of the `mat-card-header` section. The changes primarily focus on restructuring the header content and adjusting its styling.

### Layout improvements:

* [`src/main/app/src/app/zaken/zaak-view/zaak-view.component.html`](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL181-R205): Changed the `mat-card-header` layout from a `flex-row space-between` structure to a `flex-col gap-8 space-between` structure. This improves spacing and alignment for the case `indicaties`.

Solves PZ-6806