### PR TITLE
chore: removed obsolete ZGW_API_URL_EXTERN environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,8 +120,6 @@ ZGW_API_CLIENT_MP_REST_URL=http://openzaak.local:8000/
 ZGW_API_CLIENTID=zac_client
 # Open Zaak API ZAC client secret
 ZGW_API_SECRET=openzaakZaakafhandelcomponentClientSecret
-# External Open Zaak API URL. Needs to be externally accessible to be able to use the Smart Documents SaaS service with ZAC.
-ZGW_API_URL_EXTERN=http://localhost:8001/
 
 # -----------------------------------------
 # Docker Compose only environment variables

--- a/.env.tpl
+++ b/.env.tpl
@@ -60,7 +60,6 @@ ZAC_INTERNAL_ENDPOINTS_API_KEY=fakeZacInternalEndpointsApiKey
 ZGW_API_CLIENT_MP_REST_URL=http://localhost:8001/
 ZGW_API_CLIENTID=zac_client
 ZGW_API_SECRET=openzaakZaakafhandelcomponentClientSecret
-ZGW_API_URL_EXTERN=http://localhost:8001/
 
 # -----------------------------------------
 # e2e only environment variables

--- a/charts/zac/templates/config.yaml
+++ b/charts/zac/templates/config.yaml
@@ -76,4 +76,3 @@ data:
   ZAC_INTERNAL_ENDPOINTS_API_KEY: {{ required "Valid .Values.zacInternalEndpointsApiKey entry required!" .Values.zacInternalEndpointsApiKey }}
   ZGW_API_CLIENT_MP_REST_URL: {{ required "Valid .Values.zgwApis.url entry required!" .Values.zgwApis.url }}
   ZGW_API_CLIENTID: {{ required "Valid .Values.zgwApis.clientId entry required!" .Values.zgwApis.clientId }}
-  ZGW_API_URL_EXTERN: {{ required "Valid .Values.zgwApis.urlExtern entry required!" .Values.zgwApis.urlExtern }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -721,7 +721,6 @@ services:
       - ZGW_API_CLIENT_MP_REST_URL=http://openzaak.local:8000/
       - ZGW_API_CLIENTID=zac_client
       - ZGW_API_SECRET=openzaakZaakafhandelcomponentClientSecret
-      - ZGW_API_URL_EXTERN=http://localhost:8001/
     ports:
       - "8080:8080"
       - "9990:9990"


### PR DESCRIPTION
Removed obsolete ZGW_API_URL_EXTERN environment variable. This was used by the SmartDocuments integration back in the day when SmartDocuments had a direct integration with OpenZaak. This is no longer the case.

Solves PZ-7607