### PR TITLE
chore: enable bean validation in OpenAPI Generator generated client code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -563,7 +563,8 @@ tasks {
                 "sourceFolder" to "",
                 "dateLibrary" to "java8",
                 "disallowAdditionalPropertiesIfNotPresent" to "false",
-                "useJakartaEe" to "true"
+                "useJakartaEe" to "true",
+                "useBeanValidation" to "true"
             )
         )
         // Specify custom Mustache template dir as temporary workaround for issues we have with the OpenAPI Generator.
@@ -617,7 +618,8 @@ tasks {
                 "sourceFolder" to "",
                 "dateLibrary" to "java8-localdatetime",
                 "disallowAdditionalPropertiesIfNotPresent" to "false",
-                "useJakartaEe" to "true"
+                "useJakartaEe" to "true",
+                "useBeanValidation" to "true"
             )
         )
     }

--- a/src/main/kotlin/nl/info/client/zgw/zrc/model/NillableHoofdzaakZaakPatch.kt
+++ b/src/main/kotlin/nl/info/client/zgw/zrc/model/NillableHoofdzaakZaakPatch.kt
@@ -12,7 +12,7 @@ import java.net.URI
  * Extension of [nl.info.client.zgw.zrc.model.generated.Zaak] to be able to delete the hoofdzaak of a zaak
  * in ZGW JSON requests.
  */
-class NillableHoofdzaakZaakPatch(
+open class NillableHoofdzaakZaakPatch(
     /**
      * As per the ZGW ZRC API, to remove the hoofdzaak from a zaak, the hoofdzaak needs to be set to `null`
      * in the ZGW API JSON request body.

--- a/src/main/kotlin/nl/info/client/zgw/zrc/model/NillableRelevanteZakenZaakPatch.kt
+++ b/src/main/kotlin/nl/info/client/zgw/zrc/model/NillableRelevanteZakenZaakPatch.kt
@@ -12,7 +12,7 @@ import nl.info.client.zgw.zrc.model.generated.Zaak
  * Extension of [nl.info.client.zgw.zrc.model.generated.Zaak] to be able to delete the 'relevante zaken' of a zaak
  * in ZGW JSON requests.
  */
-class NillableRelevanteZakenZaakPatch(
+open class NillableRelevanteZakenZaakPatch(
     /**
      * As per the ZGW ZRC API, to remove the relevante zaken from a zaak, the relevante zaken list needs to be set to `null`
      * in the ZGW API JSON request body.


### PR DESCRIPTION
Enable bean validation in OpenAPI Generator generated client code. With this at least we can see these annotations in the generated classes. In future we could even read the values from them and use then elsewhere.

Solves PZ-7181