### PR TITLE
chore: generate constants for annotation validations in generated Java code using the OpenAPI Generator framework

### DIFF
--- a/src/main/kotlin/nl/info/zac/app/identity/model/RestGroup.kt
+++ b/src/main/kotlin/nl/info/zac/app/identity/model/RestGroup.kt
@@ -5,6 +5,8 @@
 package nl.info.zac.app.identity.model
 
 import jakarta.validation.constraints.Size
+import nl.info.client.zgw.zrc.model.generated.OrganisatorischeEenheidIdentificatie.IDENTIFICATIE_MAX_LENGTH
+import nl.info.client.zgw.zrc.model.generated.OrganisatorischeEenheidIdentificatie.NAAM_MAX_LENGTH
 import nl.info.zac.identity.model.Group
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
@@ -14,18 +16,18 @@ import nl.info.zac.util.NoArgConstructor
 data class RestGroup(
     /**
      * Since this is used for the 'identificatie' field in
-     * [net.atos.client.zgw.zrc.model.OrganisatorischeEenheid]
+     * [nl.info.client.zgw.zrc.model.generated.OrganisatorischeEenheidIdentificatie],
      * we need to make sure it adheres to the same constraints.
      */
-    @field:Size(max = 24)
+    @field:Size(max = IDENTIFICATIE_MAX_LENGTH)
     var id: String,
 
     /**
      * Since this is used for the 'naam' field in
-     * [net.atos.client.zgw.zrc.model.OrganisatorischeEenheid]
+     * [nl.info.client.zgw.zrc.model.generated.OrganisatorischeEenheidIdentificatie],
      * we need to make sure it adheres to the same constraints.
      */
-    @field:Size(max = 50)
+    @field:Size(max = NAAM_MAX_LENGTH)
     var naam: String
 )
 

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaak.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaak.kt
@@ -7,6 +7,8 @@ package nl.info.zac.app.zaak.model
 import jakarta.json.bind.annotation.JsonbProperty
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
+import nl.info.client.zgw.zrc.model.generated.Zaak.OMSCHRIJVING_MAX_LENGTH
+import nl.info.client.zgw.zrc.model.generated.Zaak.TOELICHTING_MAX_LENGTH
 import nl.info.zac.app.identity.model.RestGroup
 import nl.info.zac.app.identity.model.RestUser
 import nl.info.zac.app.klant.model.klant.IdentificatieType
@@ -18,15 +20,6 @@ import java.time.LocalDate
 import java.util.EnumSet
 import java.util.UUID
 
-/**
- * Maximum length of the zaak 'omschrijving' field as defined by the ZGW ZRC API specification.
- */
-const val OMSCHRIJVING_MAX_LENGTH = 80
-
-/**
- * Maximum length of the zaak 'toelichting' field as defined by the ZGW ZRC API specification.
- */
-const val TOELICHTING_MAX_LENGTH = 1000
 
 @NoArgConstructor
 @AllOpen
@@ -74,7 +67,7 @@ data class RestZaak(
 
     /**
      * Indicates whether the case is driven using a BPMN process or not.
-     * If not it is in most cases driven by the ZAC CMMN model.
+     * If not, it is in most cases driven by the ZAC CMMN model.
      */
     @get:JsonbProperty("isProcesGestuurd")
     var isProcesGestuurd: Boolean,

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaak.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaak.kt
@@ -20,7 +20,6 @@ import java.time.LocalDate
 import java.util.EnumSet
 import java.util.UUID
 
-
 @NoArgConstructor
 @AllOpen
 data class RestZaak(

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakAssignmentData.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakAssignmentData.kt
@@ -6,6 +6,7 @@ package nl.info.zac.app.zaak.model
 
 import jakarta.json.bind.annotation.JsonbProperty
 import jakarta.validation.constraints.Size
+import nl.info.client.zgw.zrc.model.generated.OrganisatorischeEenheidIdentificatie.IDENTIFICATIE_MAX_LENGTH
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
 import java.util.UUID
@@ -17,10 +18,10 @@ data class RestZaakAssignmentData(
 
     /**
      * Since this is used for the 'identificatie' field in
-     * [net.atos.client.zgw.zrc.model.OrganisatorischeEenheid]
+     * [nl.info.client.zgw.zrc.model.generated.OrganisatorischeEenheidIdentificatie]
      * we need to make sure it adheres to the same constraints.
      */
-    @field:Size(max = 24)
+    @field:Size(max = IDENTIFICATIE_MAX_LENGTH)
     @field:JsonbProperty("groepId")
     var groupId: String,
 

--- a/src/main/resources/openapi-generator-templates/beanValidationCore.mustache
+++ b/src/main/resources/openapi-generator-templates/beanValidationCore.mustache
@@ -1,0 +1,22 @@
+{{! INFO.nl - manually changed in order to use custom generated Java constants for validation annotation values }}
+{{! see `infonlBeanValidationConstants.mustache` for details }}
+{{#pattern}}{{^isByteArray}} @Pattern(regexp="{{{pattern}}}"){{/isByteArray}}{{/pattern}}{{!
+minLength && maxLength set
+}}{{#minLength}}{{#maxLength}}  @Size(min={{nameInSnakeCase}}_MIN_LENGTH,max={{nameInSnakeCase}}_MAX_LENGTH){{/maxLength}}{{/minLength}}{{!
+minLength set, maxLength not
+}}{{#minLength}}{{^maxLength}}  @Size(min={{nameInSnakeCase}}_MIN_LENGTH){{/maxLength}}{{/minLength}}{{!
+minLength not set, maxLength set
+}}{{^minLength}}{{#maxLength}}  @Size(max={{nameInSnakeCase}}_MAX_LENGTH){{/maxLength}}{{/minLength}}{{!
+@Size: minItems && maxItems set
+}}{{#minItems}}{{#maxItems}} @Size(min={{minItems}},max={{maxItems}}){{/maxItems}}{{/minItems}}{{!
+@Size: minItems set, maxItems not
+}}{{#minItems}}{{^maxItems}} @Size(min={{minItems}}){{/maxItems}}{{/minItems}}{{!
+@Size: minItems not set && maxItems set
+}}{{^minItems}}{{#maxItems}} @Size(max={{.}}){{/maxItems}}{{/minItems}}{{!
+check for integer or long / all others=decimal type with @Decimal*
+isInteger set
+}}{{#isInteger}}{{#minimum}} @Min({{.}}){{/minimum}}{{#maximum}} @Max({{.}}){{/maximum}}{{/isInteger}}{{!
+isLong set
+}}{{#isLong}}{{#minimum}} @Min({{.}}L){{/minimum}}{{#maximum}} @Max({{.}}L){{/maximum}}{{/isLong}}{{!
+Not Integer, not Long => we have a decimal value!
+}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{minimum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/minimum}}{{#maximum}} @DecimalMax({{#exclusiveMaximum}}value={{/exclusiveMaximum}}"{{maximum}}"{{#exclusiveMaximum}},inclusive=false{{/exclusiveMaximum}}){{/maximum}}{{/isLong}}{{/isInteger}}

--- a/src/main/resources/openapi-generator-templates/infonlBeanValidationConstants.mustache
+++ b/src/main/resources/openapi-generator-templates/infonlBeanValidationConstants.mustache
@@ -1,0 +1,12 @@
+{{! INFO.nl - add custom Java constants for values used in bean validation annotations }}
+{{! so that we can use these in our own code as well. }}
+{{#useBeanValidation}}
+{{#vars}}
+{{#minLength}}
+  public static final int {{nameInSnakeCase}}_MIN_LENGTH = {{minLength}};
+{{/minLength}}
+{{#maxLength}}
+  public static final int {{nameInSnakeCase}}_MAX_LENGTH = {{maxLength}};
+{{/maxLength}}
+{{/vars}}
+{{/useBeanValidation}}

--- a/src/main/resources/openapi-generator-templates/pojo.mustache
+++ b/src/main/resources/openapi-generator-templates/pojo.mustache
@@ -1,4 +1,5 @@
-{{! INFO.nl temporary workaround for the issue where the OpenAPI Generator Gradle plugin }}
+{{! INFO.nl - manual changes made to the original OpenAPI Generator template }}
+{{! 1. temporary workaround for the issue where the OpenAPI Generator Gradle plugin }}
 {{! incorrectly generates '@JsonbTransient' annotations for certain 'type' fields in polymorphic model classes }}
 {{! which has the result that these fields are not serialized and deserialized leading to errors in the various APIs we use. }}
 {{! For example in the generated BRP 'PersonenQuery.java' class the 'type' String field was given the '@JsonbTransient' annotation }}
@@ -6,10 +7,8 @@
 {{! This was most likely introduced by: https://github.com/OpenAPITools/openapi-generator/pull/20164 }}
 {{! It may also be that the BRP OpenAPI spec does not use the discriminator keyword correctly since these 'type' fields are simple strings. }}
 {{! and not polymorphic structures. Also see: https://apidog.com/blog/openapi-discriminator-guide/ }}
-
 {{! This template is based on a copy of the Java Mustache model template of the main branch of https://github.com/OpenAPITools/openapi-generator }}
-{{! This workaround can be removed once we have migrated to a version of the OpenAPI Generator Gradle plugin that has solved this issue. }}
-
+{{! 2. Added custom Java constants for values used in bean validation annotations }}
 {{#withXml}}
 {{#hasVars}}@XmlType(name = "{{classname}}", propOrder =
     { {{#vars}}"{{name}}"{{^-last}}, {{/-last}}{{/vars}} }
@@ -39,6 +38,9 @@
 {{{vendorExtensions.x-class-extra-annotation}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+{{! INFO.nl }}
+{{>infonlBeanValidationConstants}}
+{{! /INFO.nl }}
   {{#vars}}{{#isEnum}}{{^isContainer}}
 {{>enumClass}}{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}
 {{>enumClass}}{{/mostInnerItems}}{{/isContainer}}{{/isEnum}}
@@ -59,7 +61,7 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensi
   {{^withXml}}
   {{! INFO.nl. Changed this line to prevent the generation of the @JsonbTransient annotation for polymorphism. See reasons above. }}
   {{#jsonb}}@JsonbProperty("{{baseName}}"){{/jsonb}}
-  {{! INFO.nl. End of change. }}
+  {{! /INFO.nl}}
   {{/withXml}}
 {{#vendorExtensions.x-field-extra-annotation}}
 {{{vendorExtensions.x-field-extra-annotation}}}


### PR DESCRIPTION
Generate constants for annotation validations in generated Java code using the OpenAPI Generator framework and use those in our own code.

Solves PZ-7198