### PR TITLE
chore: removed obsolete @PersistenceContext annotations

### DIFF
--- a/src/main/java/net/atos/zac/admin/MailTemplateKoppelingenService.java
+++ b/src/main/java/net/atos/zac/admin/MailTemplateKoppelingenService.java
@@ -11,8 +11,8 @@ import java.util.List;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
@@ -23,9 +23,18 @@ import net.atos.zac.admin.model.MailtemplateKoppeling;
 @ApplicationScoped
 @Transactional
 public class MailTemplateKoppelingenService {
-
-    @PersistenceContext(unitName = "ZaakafhandelcomponentPU")
     private EntityManager entityManager;
+
+    /**
+     * Default no-arg constructor, required by Weld.
+     */
+    public MailTemplateKoppelingenService() {
+    }
+
+    @Inject
+    public MailTemplateKoppelingenService(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
 
     public Optional<MailtemplateKoppeling> find(final long id) {
         final var mailtemplateKoppeling = entityManager.find(MailtemplateKoppeling.class, id);

--- a/src/main/java/net/atos/zac/gebruikersvoorkeuren/GebruikersvoorkeurenService.java
+++ b/src/main/java/net/atos/zac/gebruikersvoorkeuren/GebruikersvoorkeurenService.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -35,12 +34,23 @@ import nl.info.zac.signalering.SignaleringService;
 @ApplicationScoped
 @Transactional
 public class GebruikersvoorkeurenService {
-
-    @PersistenceContext(unitName = "ZaakafhandelcomponentPU")
     private EntityManager entityManager;
+    private SignaleringService signaleringService;
+
+    /**
+     * Default no-arg constructor, required by Weld.
+     */
+    public GebruikersvoorkeurenService() {
+    }
 
     @Inject
-    private SignaleringService signaleringService;
+    public GebruikersvoorkeurenService(
+            EntityManager entityManager,
+            SignaleringService signaleringService
+    ) {
+        this.entityManager = entityManager;
+        this.signaleringService = signaleringService;
+    }
 
     public Zoekopdracht createZoekopdracht(final Zoekopdracht zoekopdracht) {
         if (zoekopdracht.getId() != null) {

--- a/src/main/java/net/atos/zac/mailtemplates/MailTemplateService.java
+++ b/src/main/java/net/atos/zac/mailtemplates/MailTemplateService.java
@@ -11,8 +11,8 @@ import java.util.List;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
@@ -25,9 +25,18 @@ import net.atos.zac.mailtemplates.model.MailTemplate;
 @ApplicationScoped
 @Transactional
 public class MailTemplateService {
-
-    @PersistenceContext(unitName = "ZaakafhandelcomponentPU")
     private EntityManager entityManager;
+
+    /**
+     * Default no-arg constructor, required by Weld.
+     */
+    public MailTemplateService() {
+    }
+
+    @Inject
+    public MailTemplateService(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
 
     public Optional<MailTemplate> findMailtemplate(final long id) {
         final var mailTemplate = entityManager.find(MailTemplate.class, id);

--- a/src/main/java/net/atos/zac/productaanvraag/InboxProductaanvraagService.java
+++ b/src/main/java/net/atos/zac/productaanvraag/InboxProductaanvraagService.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -29,11 +29,20 @@ import nl.info.zac.shared.model.SorteerRichting;
 @ApplicationScoped
 @Transactional
 public class InboxProductaanvraagService {
-
     private static final String LIKE = "%%%s%%";
 
-    @PersistenceContext(unitName = "ZaakafhandelcomponentPU")
     private EntityManager entityManager;
+
+    /**
+     * Default no-arg constructor, required by Weld.
+     */
+    public InboxProductaanvraagService() {
+    }
+
+    @Inject
+    public InboxProductaanvraagService(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
 
     public void create(final InboxProductaanvraag inboxProductaanvraag) {
         entityManager.persist(inboxProductaanvraag);

--- a/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/EnkelvoudigInformatieObjectLockService.kt
+++ b/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/EnkelvoudigInformatieObjectLockService.kt
@@ -7,7 +7,6 @@ package nl.info.zac.enkelvoudiginformatieobject
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.persistence.EntityManager
-import jakarta.persistence.PersistenceContext
 import jakarta.transaction.Transactional
 import jakarta.transaction.Transactional.TxType.REQUIRED
 import jakarta.transaction.Transactional.TxType.SUPPORTS
@@ -25,12 +24,10 @@ import java.util.UUID
 @AllOpen
 @NoArgConstructor
 class EnkelvoudigInformatieObjectLockService @Inject constructor(
+    private val entityManager: EntityManager,
     private val drcClientService: DrcClientService,
     private val zrcClientService: ZrcClientService
 ) {
-    @PersistenceContext(unitName = "ZaakafhandelcomponentPU")
-    private lateinit var entityManager: EntityManager
-
     @Transactional(REQUIRED)
     fun createLock(informationObjectUUID: UUID, userID: String): EnkelvoudigInformatieObjectLock =
         EnkelvoudigInformatieObjectLock().apply {

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
@@ -78,7 +78,6 @@ class RestInformatieobjectConverterTest : BehaviorSpec({
         every {
             ztcClientService.readInformatieobjecttype(restTaakDocumentData.documentType.uuid)
         } returns providedInformatieObjectType
-
         every { configuratieService.readBronOrganisatie() } returns "123443210"
 
         When("convert is invoked") {
@@ -88,7 +87,6 @@ class RestInformatieobjectConverterTest : BehaviorSpec({
             )
             Then("the provided data is converted correctly") {
                 with(enkelvoudigInformatieObjectData) {
-                    // currently hardcoded
                     bronorganisatie shouldBe "123443210"
                     creatiedatum shouldHaveSameDayAs LocalDate.now()
                     titel shouldBe restTaakDocumentData.documentTitel
@@ -118,7 +116,6 @@ class RestInformatieobjectConverterTest : BehaviorSpec({
         every {
             ztcClientService.readInformatieobjecttype(restEnkelvoudigInformatieobject.informatieobjectTypeUUID)
         } returns providedInformatieObjectType
-
         every { configuratieService.readBronOrganisatie() } returns "123443210"
 
         When("convert taak object is invoked") {
@@ -127,7 +124,6 @@ class RestInformatieobjectConverterTest : BehaviorSpec({
             )
             Then("the provided data is converted correctly") {
                 with(enkelvoudigInformatieObjectData) {
-                    // currently hardcoded
                     bronorganisatie shouldBe "123443210"
                     creatiedatum shouldHaveSameDayAs LocalDate.now()
                     titel shouldBe restEnkelvoudigInformatieobject.titel
@@ -164,7 +160,6 @@ class RestInformatieobjectConverterTest : BehaviorSpec({
         every {
             ztcClientService.readInformatieobjecttype(restEnkelvoudigInformatieobject.informatieobjectTypeUUID)
         } returns providedInformatieObjectType
-
         every { configuratieService.readBronOrganisatie() } returns "123443210"
 
         When("convert zaak object is invoked") {
@@ -173,7 +168,6 @@ class RestInformatieobjectConverterTest : BehaviorSpec({
             )
             Then("the provided data is converted correctly") {
                 with(enkelvoudigInformatieObjectData) {
-                    // currently hardcoded
                     bronorganisatie shouldBe "123443210"
                     creatiedatum shouldHaveSameDayAs LocalDate.now()
                     titel shouldBe restEnkelvoudigInformatieobject.titel


### PR DESCRIPTION
Removed obsolete @PersistenceContext annotations. Unneeded because we have EntityManagerProducer.

Solves PZ-7264