### PR TITLE
feat: validate vestigingsnummer in productaanvraag flow

### DIFF
--- a/src/main/kotlin/nl/info/client/kvk/util/KvkValidators.kt
+++ b/src/main/kotlin/nl/info/client/kvk/util/KvkValidators.kt
@@ -4,6 +4,8 @@
  */
 package nl.info.client.kvk.util
 
+import java.lang.Character.isDigit
+
 const val KVK_VESTIGINGSNUMMER_LENGTH = 12
 
-fun String.isValidKvkVestigingsnummer() = this.length == KVK_VESTIGINGSNUMMER_LENGTH && this.all { it.isDigit() }
+fun String.isValidKvkVestigingsnummer() = this.length == KVK_VESTIGINGSNUMMER_LENGTH && this.all(::isDigit)

--- a/src/main/kotlin/nl/info/client/kvk/util/KvkValidators.kt
+++ b/src/main/kotlin/nl/info/client/kvk/util/KvkValidators.kt
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package nl.info.client.kvk.util
+
+const val KVK_VESTIGINGSNUMMER_LENGTH = 12
+
+fun String.isValidKvkVestigingsnummer() = this.length == KVK_VESTIGINGSNUMMER_LENGTH && this.all { it.isDigit() }

--- a/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
@@ -28,6 +28,7 @@ import net.atos.zac.productaanvraag.util.GeometryTypeEnumJsonAdapter
 import net.atos.zac.productaanvraag.util.IndicatieMachtigingEnumJsonAdapter
 import net.atos.zac.productaanvraag.util.RolOmschrijvingGeneriekEnumJsonAdapter
 import net.atos.zac.util.JsonbUtil
+import nl.info.client.kvk.util.KVK_VESTIGINGSNUMMER_LENGTH
 import nl.info.client.kvk.util.isValidKvkVestigingsnummer
 import nl.info.client.or.objects.model.generated.ModelObject
 import nl.info.client.zgw.shared.ZGWApiService
@@ -362,7 +363,7 @@ class ProductaanvraagService @Inject constructor(
         if (!vestigingsNummer.isValidKvkVestigingsnummer()) {
             throw ProductaanvraagNotSupportedException(
                 "Invalid KVK vestigingsnummer: '$vestigingsNummer'. " +
-                    "It should be a 12-digit number."
+                    "It should be a $KVK_VESTIGINGSNUMMER_LENGTH-digit number."
             )
         }
         return zrcClientService.createRol(

--- a/src/test/kotlin/nl/info/client/kvk/model/KvkZoekenFixtures.kt
+++ b/src/test/kotlin/nl/info/client/kvk/model/KvkZoekenFixtures.kt
@@ -10,6 +10,7 @@ import nl.info.client.kvk.zoeken.model.generated.Adres
 import nl.info.client.kvk.zoeken.model.generated.AdresType
 import nl.info.client.kvk.zoeken.model.generated.BinnenlandsAdres
 import nl.info.client.kvk.zoeken.model.generated.ResultaatItem
+import kotlin.random.Random
 
 @Suppress("LongParameterList")
 fun createAdresWithBinnenlandsAdres(
@@ -99,4 +100,10 @@ fun createVestigingsAdres(
     this.type = type
     this.indAfgeschermd = indAfgeschermd
     this.volledigAdres = volledigAdres
+}
+
+fun createRandomVestigingsNumber() = createRandomDigitsString(12)
+
+fun createRandomDigitsString(length: Int): String {
+    return (1..length).map { Random.nextInt(0, 10) }.joinToString("")
 }

--- a/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -397,7 +397,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             )
         )
         val formulierBron = createBron()
-        val vestigingsNummer = "123456" // invalid vestigingsnummer
+        val invalidVestigingsNummer = "123456"
         val productAanvraagORObject = createORObject(
             record = createObjectRecord(
                 data = mapOf(

--- a/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -407,7 +407,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                     "aanvraaggegevens" to mapOf("fakeKey" to mapOf("fakeSubKey" to "fakeValue")),
                     "betrokkenen" to listOf(
                         mapOf(
-                            "vestigingsNummer" to vestigingsNummer,
+                            "vestigingsNummer" to invalidVestigingsNummer,
                             "rolOmschrijvingGeneriek" to "initiator"
                         )
                     )

--- a/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -25,6 +25,7 @@ import net.atos.zac.documenten.InboxDocumentenService
 import net.atos.zac.flowable.cmmn.CMMNService
 import net.atos.zac.productaanvraag.InboxProductaanvraagService
 import net.atos.zac.productaanvraag.model.InboxProductaanvraag
+import nl.info.client.kvk.model.createRandomVestigingsNumber
 import nl.info.client.zgw.drc.model.createEnkelvoudigInformatieObject
 import nl.info.client.zgw.model.createZaak
 import nl.info.client.zgw.model.createZaakInformatieobjectForCreatesAndUpdates
@@ -337,7 +338,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             )
         )
         val formulierBron = createBron()
-        val vestigingsNummer = "fakeVestigingsNummer"
+        val vestigingsNummer = createRandomVestigingsNumber()
         val productAanvraagORObject = createORObject(
             record = createObjectRecord(
                 data = mapOf(
@@ -381,6 +382,65 @@ class ProductaanvraagServiceTest : BehaviorSpec({
     Given(
         """
         a productaanvraag-dimpact object registration object for which zaakafhandelparameters exist
+        containing a betrokkene with role initiator and type vestiging with an invalid vestigingsnummer
+        and zaakafhandelparameters that have the KVK koppeling enabled 
+        """
+    ) {
+        val productAanvraagObjectUUID = UUID.randomUUID()
+        val zaakTypeUUID = UUID.randomUUID()
+        val productAanvraagType = "productaanvraag"
+        val zaakafhandelParameters = createZaakafhandelParameters(
+            zaaktypeUUID = zaakTypeUUID,
+            betrokkeneKoppelingen = createBetrokkeneKoppelingen(
+                brpKoppelen = false,
+                kvkKoppelen = true
+            )
+        )
+        val formulierBron = createBron()
+        val vestigingsNummer = "123456" // invalid vestigingsnummer
+        val productAanvraagORObject = createORObject(
+            record = createObjectRecord(
+                data = mapOf(
+                    "bron" to formulierBron,
+                    "type" to productAanvraagType,
+                    // aanvraaggegevens must contain at least one key with a map value
+                    "aanvraaggegevens" to mapOf("fakeKey" to mapOf("fakeSubKey" to "fakeValue")),
+                    "betrokkenen" to listOf(
+                        mapOf(
+                            "vestigingsNummer" to vestigingsNummer,
+                            "rolOmschrijvingGeneriek" to "initiator"
+                        )
+                    )
+                )
+            )
+        )
+        every { objectsClientService.readObject(productAanvraagObjectUUID) } returns productAanvraagORObject
+        every {
+            zaakafhandelParameterBeheerService.findActiveZaakafhandelparametersByProductaanvraagtype(
+                productAanvraagType
+            )
+        } returns listOf(zaakafhandelParameters)
+
+        When("the productaanvraag is handled") {
+            productaanvraagService.handleProductaanvraag(productAanvraagObjectUUID)
+
+            Then(
+                """
+                    no zaak should be created and no CMMN case process should be started
+                    """
+            ) {
+                verify(exactly = 0) {
+                    zgwApiService.createZaak(any())
+                    zrcClientService.createZaakobject(any())
+                    cmmnService.startCase(any(), any(), any(), any())
+                }
+            }
+        }
+    }
+
+    Given(
+        """
+        a productaanvraag-dimpact object registration object for which zaakafhandelparameters exist
         containing a betrokkene with role initiator and type vestiging and zaakafhandelparameters
         that have the BRP koppeling enabled
         """
@@ -396,7 +456,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             zaaktypeUUID = zaakTypeUUID,
         )
         val formulierBron = createBron()
-        val vestigingsNummer = "fakeVestigingsNummer"
+        val vestigingsNummer = createRandomVestigingsNumber()
         val productAanvraagORObject = createORObject(
             record = createObjectRecord(
                 data = mapOf(
@@ -649,10 +709,10 @@ class ProductaanvraagServiceTest : BehaviorSpec({
         val beslisserBsn = "fakeBsn4"
         val klantcontacterBsn = "fakeBsn5"
         val medeInitiatorBsn = "fakeBsn6"
-        val belanghebbendeVestigingsnummer1 = "fakeVestigingsNummer1"
-        val belanghebbendeVestigingsnummer2 = "fakeVestigingsNummer2"
-        val beslisserVestigingsnummer = "fakeVestigingsNummer3"
-        val zaakcoordinatorVestigingsnummer = "fakeVestigingsNummer4"
+        val belanghebbendeVestigingsnummer1 = createRandomVestigingsNumber()
+        val belanghebbendeVestigingsnummer2 = createRandomVestigingsNumber()
+        val beslisserVestigingsnummer = createRandomVestigingsNumber()
+        val zaakcoordinatorVestigingsnummer = createRandomVestigingsNumber()
         val rolTypeBelanghebbende = createRolType(
             zaakTypeUri = zaakType.url,
             omschrijvingGeneriek = OmschrijvingGeneriekEnum.BELANGHEBBENDE


### PR DESCRIPTION
Validate vestigingsnummer in productaanvraag flow so that we no longer accept invalid KVK vestingingsnummers in the productaanvraag flow. PS: OpenZaak does no validation on vestigingsnummer.

Solves PZ-7271