### PR TITLE
fix: updated doelbinding header to use raadpleegmet instead of zoekmet for BSN lookup

### DIFF
--- a/src/main/kotlin/nl/info/client/brp/BrpClientService.kt
+++ b/src/main/kotlin/nl/info/client/brp/BrpClientService.kt
@@ -73,17 +73,21 @@ class BrpClientService @Inject constructor(
         private val FIELDS_PERSOON_BEPERKT = listOf(BURGERSERVICENUMMER, GESLACHT, NAAM, GEBOORTE, ADRESSERING)
     }
 
-    fun queryPersonen(personenQuery: PersonenQuery, auditEvent: String): PersonenQueryResponse =
-        updateQuery(personenQuery).let { updatedQuery ->
-            personenApi.personen(
-                personenQuery = updatedQuery,
-                purpose = resolvePurposeFromContext(
-                    auditEvent,
-                    queryPersonenDefaultPurpose.getOrNull()
-                ) { it.brpDoelbindingen?.zoekWaarde },
-                auditEvent = auditEvent
-            )
+    fun queryPersonen(personenQuery: PersonenQuery, isBsnQuery: Boolean, auditEvent: String): PersonenQueryResponse {
+        val updatedQuery = updateQuery(personenQuery)
+        val purpose = resolvePurposeFromContext(
+            auditEvent,
+            if (isBsnQuery) { retrievePersoonDefaultPurpose.getOrNull() } else { queryPersonenDefaultPurpose.getOrNull() }
+        ) {
+            if (isBsnQuery) { it.brpDoelbindingen?.raadpleegWaarde } else { it.brpDoelbindingen?.zoekWaarde }
         }
+        LOG.info("Resolved purpose: '$purpose' for auditEvent: '$auditEvent' (isBsnQuery=$isBsnQuery)")
+        return personenApi.personen(
+            personenQuery = updatedQuery,
+            purpose = purpose,
+            auditEvent = auditEvent
+        )
+    }
 
     /**
      * Retrieves a person by burgerservicenummer from the BRP Personen API.

--- a/src/main/kotlin/nl/info/zac/app/klant/KlantRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/KlantRestService.kt
@@ -146,10 +146,12 @@ class KlantRestService @Inject constructor(
     fun listPersonen(
         @HeaderParam(HEADER_VERWERKING) auditEvent: String,
         restListPersonenParameters: RestListPersonenParameters
-    ): RESTResultaat<RestPersoon> =
-        brpClientService.queryPersonen(restListPersonenParameters.toPersonenQuery(), auditEvent)
+    ): RESTResultaat<RestPersoon> {
+        val isBsnQuery = !restListPersonenParameters.bsn.isNullOrBlank()
+        return brpClientService.queryPersonen(restListPersonenParameters.toPersonenQuery(), isBsnQuery, auditEvent)
             .toRechtsPersonen()
             .toRestResultaat()
+    }
 
     @PUT
     @Path("bedrijven")

--- a/src/test/kotlin/nl/info/client/brp/BrpClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/brp/BrpClientServiceTest.kt
@@ -148,6 +148,7 @@ class BrpClientServiceTest : BehaviorSpec({
         When("a query is run on personen for this BSN") {
             val personResponse = configuredBrpClientService.queryPersonen(
                 createRaadpleegMetBurgerservicenummer(listOf(bsn)),
+                false,
                 REQUEST_CONTEXT
             )
 
@@ -180,6 +181,40 @@ class BrpClientServiceTest : BehaviorSpec({
         When("queryPersonen is called") {
             val personResponse = brpClientService.queryPersonen(
                 createRaadpleegMetBurgerservicenummer(listOf(bsn)),
+                false,
+                REQUEST_CONTEXT
+            )
+
+            Then("it should return the person") {
+                personResponse shouldBe raadpleegMetBurgerservicenummerResponse
+            }
+        }
+    }
+
+    Given("a BSN lookup is performed, the 'raadpleegWaarde' purpose is used") {
+        val bsn = "123456789"
+        val person = createPersoon(
+            bsn = bsn
+        )
+        val raadpleegMetBurgerservicenummerResponse = createRaadpleegMetBurgerservicenummerResponse(
+            persons = listOf(person)
+        )
+        val brpClientService = BrpClientService(
+            personenApi = personenApi,
+            queryPersonenDefaultPurpose = Optional.empty(),
+            retrievePersoonDefaultPurpose = Optional.of(RETRIEVE_PERSOON_PURPOSE),
+            zrcClientService = zrcClientService,
+            zaakafhandelParameterService = zaakafhandelParameterService
+        )
+
+        every {
+            personenApi.personen(any(), RETRIEVE_PERSOON_PURPOSE, REQUEST_CONTEXT)
+        } returns raadpleegMetBurgerservicenummerResponse
+
+        When("queryPersonen is called") {
+            val personResponse = brpClientService.queryPersonen(
+                createRaadpleegMetBurgerservicenummer(listOf(bsn)),
+                true,
                 REQUEST_CONTEXT
             )
 


### PR DESCRIPTION
In this PR when we perform a BSN lookup doelbinding header will use raadpleegment header value
Solves [PZ-7290]