### PR TITLE
fix: check if user and group match before starting zaak assign

### DIFF
--- a/src/main/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestService.kt
@@ -148,7 +148,7 @@ class ZaakafhandelParametersRestService @Inject constructor(
         }
         restZaakafhandelParameters.defaultBehandelaarId?.let { defaultBehandelaarId ->
             restZaakafhandelParameters.defaultGroepId?.let { defaultGroepId ->
-                identityService.checkIfUserIsInGroup(defaultBehandelaarId, defaultGroepId)
+                identityService.validateIfUserIsInGroup(defaultBehandelaarId, defaultGroepId)
             }
         }
         return zaakafhandelParametersConverter.toZaakafhandelParameters(

--- a/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
@@ -343,7 +343,7 @@ class ZaakRestService @Inject constructor(
         restZaakEditMetRedenGegevens.zaak.run {
             behandelaar?.id?.let { behandelaarId ->
                 groep?.id?.let { groepId ->
-                    identityService.checkIfUserIsInGroup(behandelaarId, groepId)
+                    identityService.validateIfUserIsInGroup(behandelaarId, groepId)
                 }
             }
         }
@@ -546,7 +546,7 @@ class ZaakRestService @Inject constructor(
         }
         toekennenGegevens.assigneeUserName?.let { behandelaarId ->
             toekennenGegevens.groupId.let { groepId ->
-                identityService.checkIfUserIsInGroup(behandelaarId, groepId)
+                identityService.validateIfUserIsInGroup(behandelaarId, groepId)
             }
         }
 
@@ -597,7 +597,7 @@ class ZaakRestService @Inject constructor(
     @Path("lijst/verdelen")
     fun assignFromList(@Valid restZakenVerdeelGegevens: RESTZakenVerdeelGegevens) {
         assertPolicy(policyService.readWerklijstRechten().zakenTakenVerdelen)
-        // this can be a long-running operation so run it asynchronously
+        // this can be a long-running operation, so run it asynchronously
         CoroutineScope(dispatcher).launch {
             zaakService.assignZaken(
                 zaakUUIDs = restZakenVerdeelGegevens.uuids,

--- a/src/main/kotlin/nl/info/zac/identity/IdentityService.kt
+++ b/src/main/kotlin/nl/info/zac/identity/IdentityService.kt
@@ -97,8 +97,11 @@ class IdentityService @Inject constructor(
             .map { it.name }
     }
 
-    fun checkIfUserIsInGroup(userId: String, groupId: String) {
-        if (!listGroupNamesForUser(userId).contains(groupId)) {
+    fun isUserInGroup(userId: String, groupId: String) =
+        listGroupNamesForUser(userId).contains(groupId)
+
+    fun validateIfUserIsInGroup(userId: String, groupId: String) {
+        if (!isUserInGroup(userId, groupId)) {
             throw UserNotInGroupException()
         }
     }

--- a/src/test/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestServiceTest.kt
@@ -245,7 +245,7 @@ class ZaakafhandelParametersRestServiceTest : BehaviorSpec({
         val behandelaarGroupId = "fakeBehandelaarGroupId"
         every { policyService.readOverigeRechten().beheren } returns true
         every {
-            identityService.checkIfUserIsInGroup(behandelaarId, behandelaarGroupId)
+            identityService.validateIfUserIsInGroup(behandelaarId, behandelaarGroupId)
         } throws UserNotInGroupException()
 
         When("zaakafhandelparameters are created") {

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
@@ -385,7 +385,7 @@ class ZaakRestServiceTest : BehaviorSpec({
         When("the zaak is assigned to a user and a group") {
             every { policyService.readZaakRechten(zaak) } returns createZaakRechtenAllDeny(toekennen = true)
             every {
-                identityService.checkIfUserIsInGroup(
+                identityService.validateIfUserIsInGroup(
                     restZaakToekennenGegevens.assigneeUserName!!,
                     restZaakToekennenGegevens.groupId
                 )
@@ -428,7 +428,7 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { zrcClientService.readZaak(restZaakToekennenGegevensUnknownGroup.zaakUUID) } returns zaak
         every { policyService.readZaakRechten(zaak) } returns createZaakRechtenAllDeny(toekennen = true)
         every {
-            identityService.checkIfUserIsInGroup(
+            identityService.validateIfUserIsInGroup(
                 restZaakToekennenGegevensUnknownGroup.assigneeUserName!!,
                 restZaakToekennenGegevensUnknownGroup.groupId
             )
@@ -476,7 +476,7 @@ class ZaakRestServiceTest : BehaviorSpec({
         When("the zaak is assigned to a user and a group") {
             every { policyService.readZaakRechten(zaak) } returns createZaakRechtenAllDeny(toekennen = true)
             every {
-                identityService.checkIfUserIsInGroup(
+                identityService.validateIfUserIsInGroup(
                     restZaakToekennenGegevens.assigneeUserName!!,
                     restZaakToekennenGegevens.groupId
                 )
@@ -707,7 +707,7 @@ class ZaakRestServiceTest : BehaviorSpec({
         every { task.id } returns "id"
         every { eventingService.send(any<ScreenEvent>()) } just runs
         every { restZaakConverter.toRestZaak(patchedZaak) } returns restZaak
-        every { identityService.checkIfUserIsInGroup(restZaak.behandelaar!!.id, restZaak.groep!!.id) } just runs
+        every { identityService.validateIfUserIsInGroup(restZaak.behandelaar!!.id, restZaak.groep!!.id) } just runs
         every { zaakafhandelParameterService.readZaakafhandelParameters(any()) } returns createZaakafhandelParameters()
 
         When("zaak final date is set to a later date") {
@@ -741,7 +741,7 @@ class ZaakRestServiceTest : BehaviorSpec({
 
         every { zrcClientService.readZaak(zaak.uuid) } returns zaak
         every { policyService.readZaakRechten(zaak) } returns createZaakRechten()
-        every { identityService.checkIfUserIsInGroup(any(), any()) } throws InputValidationFailedException()
+        every { identityService.validateIfUserIsInGroup(any(), any()) } throws InputValidationFailedException()
         every { zaakafhandelParameterService.readZaakafhandelParameters(any()) } returns createZaakafhandelParameters()
 
         When("zaak update is requested") {
@@ -775,7 +775,7 @@ class ZaakRestServiceTest : BehaviorSpec({
 
         When("zaak update is requested without a new final date") {
             val zaakWithoutDateChange = restZaak.copy(uiterlijkeEinddatumAfdoening = zaak.uiterlijkeEinddatumAfdoening)
-            every { identityService.checkIfUserIsInGroup(any(), any()) } just runs
+            every { identityService.validateIfUserIsInGroup(any(), any()) } just runs
             every { restZaakConverter.convertToPatch(zaakWithoutDateChange) } returns zaak
             every { restZaakConverter.toRestZaak(any()) } returns zaakWithoutDateChange
             every { zrcClientService.patchZaak(zaak.uuid, any(), any()) } returns zaak
@@ -813,7 +813,7 @@ class ZaakRestServiceTest : BehaviorSpec({
 
         When("zaak update is requested without a new final date") {
             val zaakWithoutDateChange = restZaak.copy(uiterlijkeEinddatumAfdoening = zaak.uiterlijkeEinddatumAfdoening)
-            every { identityService.checkIfUserIsInGroup(any(), any()) } just runs
+            every { identityService.validateIfUserIsInGroup(any(), any()) } just runs
             every { restZaakConverter.convertToPatch(zaakWithoutDateChange) } returns zaak
             every { restZaakConverter.toRestZaak(any()) } returns zaakWithoutDateChange
             every { zrcClientService.patchZaak(zaak.uuid, any(), any()) } returns zaak

--- a/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
@@ -194,7 +194,7 @@ class IdentityServiceTest : BehaviorSpec({
         }
 
         When("a check if an existing user is in a group is performed") {
-            identityService.checkIfUserIsInGroup(userName1, groupId)
+            identityService.validateIfUserIsInGroup(userName1, groupId)
 
             Then("the check succeeds") {}
         }
@@ -233,7 +233,7 @@ class IdentityServiceTest : BehaviorSpec({
 
         When("a check if a user is in an unknown group is performed") {
             shouldThrow<UserNotInGroupException> {
-                identityService.checkIfUserIsInGroup(userName1, unknownGroupName)
+                identityService.validateIfUserIsInGroup(userName1, unknownGroupName)
             }
 
             Then("an exception is thrown") {}
@@ -249,7 +249,7 @@ class IdentityServiceTest : BehaviorSpec({
 
         When("a check if an unknown user is in a group is performed") {
             shouldThrow<UserNotFoundException> {
-                identityService.checkIfUserIsInGroup(unknownUserName, groupId)
+                identityService.validateIfUserIsInGroup(unknownUserName, groupId)
             }
 
             Then("an exception is thrown") {}


### PR DESCRIPTION
Check if a user is part of the requested group before assigning user/group

Solves PZ-7085