### PR TITLE
fix: change domain match rules

### DIFF
--- a/src/main/kotlin/nl/info/zac/identity/IdentityService.kt
+++ b/src/main/kotlin/nl/info/zac/identity/IdentityService.kt
@@ -8,13 +8,13 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.inject.Named
 import net.atos.zac.admin.ZaakafhandelParameterService
+import nl.info.zac.authentication.UserPrincipalFilter.Companion.ROL_DOMEIN_ELK_ZAAKTYPE
 import nl.info.zac.identity.exception.GroupNotFoundException
 import nl.info.zac.identity.exception.UserNotFoundException
 import nl.info.zac.identity.exception.UserNotInGroupException
 import nl.info.zac.identity.model.Group
 import nl.info.zac.identity.model.User
 import nl.info.zac.identity.model.getFullName
-import nl.info.zac.identity.model.hasAccessTo
 import nl.info.zac.identity.model.toGroup
 import nl.info.zac.identity.model.toUser
 import nl.info.zac.util.AllOpen
@@ -58,7 +58,7 @@ class IdentityService @Inject constructor(
             .map { it.toGroup(zacKeycloakClientId) }
         val domein = zaakafhandelParameterService.readZaakafhandelParameters(zaaktypeUuid).domein
         return groups
-            .filter { it.hasAccessTo(domein) }
+            .filter { (domein == null || domein == ROL_DOMEIN_ELK_ZAAKTYPE) || it.zacClientRoles.contains(domein) }
             .sortedBy { it.name }
     }
 

--- a/src/main/kotlin/nl/info/zac/identity/model/Group.kt
+++ b/src/main/kotlin/nl/info/zac/identity/model/Group.kt
@@ -4,7 +4,6 @@
  */
 package nl.info.zac.identity.model
 
-import nl.info.zac.authentication.UserPrincipalFilter.Companion.ROL_DOMEIN_ELK_ZAAKTYPE
 import org.keycloak.representations.idm.GroupRepresentation
 
 data class Group(
@@ -46,17 +45,3 @@ fun GroupRepresentation.toGroup(keycloakClientId: String): Group =
         email = attributes?.get("email")?.singleOrNull(),
         zacClientRoles = clientRoles[keycloakClientId].orEmpty()
     )
-
-/**
- * Checks if the group has access to the specified domain.
- *
- * Access is granted if any of these conditions are met:
- * - The domain parameter is null
- * - The domain equals the default domain [ROL_DOMEIN_ELK_ZAAKTYPE]
- * - The group's [zacClientRoles] contains the specified domain
- *
- * @param domain The domain to check access for
- * @return true if the group has access to the domain, false otherwise
- */
-fun Group.hasAccessTo(domain: String?) =
-    (domain == null || domain == ROL_DOMEIN_ELK_ZAAKTYPE) || this.zacClientRoles.contains(domain)

--- a/src/main/kotlin/nl/info/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/nl/info/zac/zaak/ZaakService.kt
@@ -32,11 +32,11 @@ import nl.info.client.zgw.ztc.ZtcClientService
 import nl.info.client.zgw.ztc.model.generated.OmschrijvingGeneriekEnum
 import nl.info.client.zgw.ztc.model.generated.RolType
 import nl.info.zac.app.klant.model.klant.IdentificatieType
+import nl.info.zac.authentication.UserPrincipalFilter
 import nl.info.zac.enkelvoudiginformatieobject.EnkelvoudigInformatieObjectLockService
 import nl.info.zac.identity.IdentityService
 import nl.info.zac.identity.model.Group
 import nl.info.zac.identity.model.User
-import nl.info.zac.identity.model.hasAccessTo
 import nl.info.zac.util.AllOpen
 import nl.info.zac.zaak.exception.BetrokkeneIsAlreadyAddedToZaakException
 import nl.info.zac.zaak.exception.CaseHasLockedInformationObjectsException
@@ -126,7 +126,7 @@ class ZaakService @Inject constructor(
             zaakUUIDs
                 .map(zrcClientService::readZaak)
                 .filter { isZaakOpen(it) }
-                .filter { domainAccess(it, group) }
+                .filter { group.hasDomainAccess(it) }
                 .map { zaak ->
                     zrcClientService.updateRol(
                         zaak,
@@ -182,13 +182,17 @@ class ZaakService @Inject constructor(
             it.isOpen()
         }
 
-    private fun domainAccess(zaak: Zaak, group: Group) =
+    private fun Group.hasDomainAccess(zaak: Zaak) =
         zaakafhandelParameterService.readZaakafhandelParameters(zaak.zaaktype.extractUuid()).let { params ->
-            val hasAccess = group.hasAccessTo(params.domein)
+            val hasAccess = params.domein == UserPrincipalFilter.ROL_DOMEIN_ELK_ZAAKTYPE ||
+                this.zacClientRoles.contains(UserPrincipalFilter.ROL_DOMEIN_ELK_ZAAKTYPE) ||
+                params.domein?.let {
+                    this.zacClientRoles.contains(it)
+                } ?: false
             if (!hasAccess) {
                 LOG.fine(
-                    "Zaak with UUID '${zaak.uuid}' is skipped and not assigned. Group '${group.name}' " +
-                        "with roles '${group.zacClientRoles}' has no access to domain '${params.domein}'"
+                    "Zaak with UUID '${zaak.uuid}' is skipped and not assigned. Group '${this.name}' " +
+                        "with roles '${this.zacClientRoles}' has no access to domain '${params.domein}'"
                 )
                 eventingService.send(ScreenEventType.ZAAK_ROLLEN.skipped(zaak))
             }

--- a/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
@@ -18,6 +18,7 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import net.atos.client.zgw.zrc.model.Rol
+import net.atos.client.zgw.zrc.model.RolMedewerker
 import net.atos.zac.admin.ZaakafhandelParameterService
 import net.atos.zac.event.EventingService
 import net.atos.zac.event.Opcode
@@ -33,13 +34,14 @@ import nl.info.client.zgw.util.extractUuid
 import nl.info.client.zgw.zrc.ZrcClientService
 import nl.info.client.zgw.zrc.model.generated.ArchiefnominatieEnum
 import nl.info.client.zgw.zrc.model.generated.BetrokkeneTypeEnum
+import nl.info.client.zgw.zrc.model.generated.Zaak
 import nl.info.client.zgw.ztc.ZtcClientService
 import nl.info.client.zgw.ztc.model.createRolType
 import nl.info.client.zgw.ztc.model.createStatusType
 import nl.info.client.zgw.ztc.model.generated.OmschrijvingGeneriekEnum
 import nl.info.zac.admin.model.createZaakafhandelParameters
 import nl.info.zac.app.klant.model.klant.IdentificatieType
-import nl.info.zac.authentication.UserPrincipalFilter
+import nl.info.zac.authentication.UserPrincipalFilter.Companion.ROL_DOMEIN_ELK_ZAAKTYPE
 import nl.info.zac.configuratie.ConfiguratieService
 import nl.info.zac.enkelvoudiginformatieobject.EnkelvoudigInformatieObjectLockService
 import nl.info.zac.exception.ErrorCode.ERROR_CODE_CASE_HAS_LOCKED_INFORMATION_OBJECTS
@@ -369,11 +371,14 @@ class ZaakServiceTest : BehaviorSpec({
         }
     }
 
-    Given("A list of zaken with no domain") {
+    Given("A list of zaken with no domain and a group with ROL_DOMEIN_ELK_ZAAKTYPE") {
         val screenEventSlot = slot<ScreenEvent>()
         zaken.map {
             every { zrcClientService.readZaak(it.uuid) } returns it
             every { eventingService.send(capture(screenEventSlot)) } just Runs
+            every {
+                zaakafhandelParameterService.readZaakafhandelParameters(it.zaaktype.extractUuid())
+            } returns createZaakafhandelParameters()
             every {
                 ztcClientService.readRoltype(
                     it.zaaktype,
@@ -381,17 +386,15 @@ class ZaakServiceTest : BehaviorSpec({
                 )
             } returns rolTypeBehandelaar
             every { zrcClientService.updateRol(it, any(), explanation) } just Runs
-            every {
-                zaakafhandelParameterService.readZaakafhandelParameters(it.zaaktype.extractUuid())
-            } returns createZaakafhandelParameters(domein = UserPrincipalFilter.ROL_DOMEIN_ELK_ZAAKTYPE)
         }
-        every { identityService.isUserInGroup(user.id, group.id) } returns true
+        val groupWithAllDomains = createGroup(zacClientRoles = listOf(ROL_DOMEIN_ELK_ZAAKTYPE))
+        every { identityService.isUserInGroup(user.id, groupWithAllDomains.id) } returns true
 
         When("the assign zaken function is called") {
             zaakService.assignZaken(
                 zaakUUIDs = zaken.map { it.uuid },
                 explanation = explanation,
-                group = group,
+                group = groupWithAllDomains,
                 user = user,
                 screenEventResourceId = screenEventResourceId
             )
@@ -419,14 +422,49 @@ class ZaakServiceTest : BehaviorSpec({
         }
     }
 
-    Given("A list of zaken and the second one has a group not matching the requested one") {
+    Given("A list of zaken with no domain and a group with domain") {
+        val screenEventSlot = slot<ScreenEvent>()
+        zaken.map {
+            every { zrcClientService.readZaak(it.uuid) } returns it
+            every { eventingService.send(capture(screenEventSlot)) } just Runs
+            every {
+                zaakafhandelParameterService.readZaakafhandelParameters(it.zaaktype.extractUuid())
+            } returns createZaakafhandelParameters()
+        }
+        val groupWithDomain = createGroup(zacClientRoles = listOf("another_domain"))
+        every { identityService.isUserInGroup(user.id, groupWithDomain.id) } returns true
+
+        When("the assign zaken function is called") {
+            zaakService.assignZaken(
+                zaakUUIDs = zaken.map { it.uuid },
+                explanation = explanation,
+                group = groupWithDomain,
+                user = user,
+                screenEventResourceId = screenEventResourceId
+            )
+
+            Then("no roles are updated") {
+                verify(exactly = 0) {
+                    zrcClientService.updateRol(any<Zaak>(), any<RolMedewerker>(), explanation)
+                }
+            }
+
+            And("a final screen event of type 'zaken verdelen' is sent") {
+                with(screenEventSlot.captured) {
+                    opcode shouldBe Opcode.UPDATED
+                    objectType shouldBe ScreenEventType.ZAKEN_VERDELEN
+                    objectId.resource shouldBe screenEventResourceId
+                }
+            }
+        }
+    }
+
+    Given("A list of two zaken and the second one has a group not matching the requested one") {
         val screenEventSlot = slot<ScreenEvent>()
         zaken.map {
             every { zrcClientService.readZaak(it.uuid) } returns it
             every { eventingService.send(capture(screenEventSlot)) } just Runs
         }
-        every { identityService.isUserInGroup(user.id, group.id) } returns true
-
         zaken[0].let {
             every {
                 ztcClientService.readRoltype(
@@ -437,12 +475,15 @@ class ZaakServiceTest : BehaviorSpec({
             every { zrcClientService.updateRol(it, any(), explanation) } just Runs
             every {
                 zaakafhandelParameterService.readZaakafhandelParameters(it.zaaktype.extractUuid())
-            } returns zaakafhandelParameters
+            } returns createZaakafhandelParameters(domein = "zaaktype_domain")
         }
-
-        every {
-            zaakafhandelParameterService.readZaakafhandelParameters(zaken[1].zaaktype.extractUuid())
-        } returns createZaakafhandelParameters(domein = "another_domein")
+        zaken[1].let {
+            every {
+                zaakafhandelParameterService.readZaakafhandelParameters(it.zaaktype.extractUuid())
+            } returns createZaakafhandelParameters(domein = "another_domein")
+        }
+        val group = createGroup(zacClientRoles = listOf("zaaktype_domain"))
+        every { identityService.isUserInGroup(user.id, group.id) } returns true
 
         When("the assign zaken function is called") {
             zaakService.assignZaken(
@@ -453,7 +494,7 @@ class ZaakServiceTest : BehaviorSpec({
                 screenEventResourceId = screenEventResourceId
             )
 
-            Then("group and user roles are updated") {
+            Then("group and user roles of the first zaak are updated") {
                 verify(exactly = 2) {
                     zrcClientService.updateRol(zaken[0], any(), explanation)
                 }


### PR DESCRIPTION
group with regular domain can be assigned only to a zaaktype with domain group with domein_elk_zaaktype can be assigned to any zaaktype

Solves: PZ-7332