### PR TITLE
fix: regular group cannot be assigned to zaaktype without domein

### DIFF
--- a/src/main/kotlin/nl/info/zac/zaak/ZaakService.kt
+++ b/src/main/kotlin/nl/info/zac/zaak/ZaakService.kt
@@ -200,7 +200,7 @@ class ZaakService @Inject constructor(
                 this.zacClientRoles.contains(UserPrincipalFilter.ROL_DOMEIN_ELK_ZAAKTYPE) ||
                 params.domein?.let {
                     this.zacClientRoles.contains(it)
-                } ?: true
+                } ?: false
             if (!hasAccess) {
                 LOG.fine(
                     "Zaak with UUID '${zaak.uuid}' is skipped and not assigned. Group '${this.name}' " +

--- a/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
@@ -466,7 +466,7 @@ class ZaakServiceTest : BehaviorSpec({
             every { eventingService.send(capture(screenEventSlot)) } just Runs
             every {
                 zaakafhandelParameterService.readZaakafhandelParameters(it.zaaktype.extractUuid())
-            } returns createZaakafhandelParameters()
+            } returns createZaakafhandelParameters(domein = null)
         }
         val groupWithNoDomain = createGroup(zacClientRoles = emptyList())
         every { identityService.isUserInGroup(user.id, groupWithNoDomain.id) } returns true


### PR DESCRIPTION
Zaaktype wihtout domain should not be a valid assign target for group that has no DOMEIN_ELK_ZAAKTYPE

Solves PZ-7337