### PR TITLE
refactor(zoeken.service): make use of the `ZacHttpClient`

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.ts
@@ -115,23 +115,22 @@ export class InformatieObjectLinkComponent
     if (!this.infoObject.informatieobjectTypeUUID) return;
 
     this.zoekenService
-      .listDocumentKoppelbareZaken(
-        this.caseSearchField?.formControl.value,
-        this.infoObject.informatieobjectTypeUUID,
-      )
-      .subscribe(
-        (result) => {
+      .listDocumentKoppelbareZaken({
+        zaakIdentificator: this.caseSearchField.formControl.value!,
+        informationObjectTypeUuid: this.infoObject.informatieobjectTypeUUID,
+      })
+      .subscribe({
+        next: (result) => {
           this.cases.data = result.resultaten;
-          this.totalCases = result.totaal;
+          this.totalCases = result.totaal ?? 0;
           this.loading = false;
           this.utilService.setLoading(false);
         },
-        () => {
-          // error handling
+        error: () => {
           this.loading = false;
           this.utilService.setLoading(false);
         },
-      );
+      });
   }
 
   selectCase(row: GeneratedType<"RestZaakKoppelenZoekObject">) {

--- a/src/main/app/src/app/zoeken/zoeken.service.ts
+++ b/src/main/app/src/app/zoeken/zoeken.service.ts
@@ -3,51 +3,31 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { Observable, Subject } from "rxjs";
-import { catchError } from "rxjs/operators";
-import { FoutAfhandelingService } from "../fout-afhandeling/fout-afhandeling.service";
+import { Subject } from "rxjs";
 import { PutBody, ZacHttpClient } from "../shared/http/zac-http-client";
-import { Resultaat } from "../shared/model/resultaat";
 import { GeneratedType } from "../shared/utils/generated-types";
 
 @Injectable({
   providedIn: "root",
 })
 export class ZoekenService {
-  private basepath = "/rest/zoeken";
   public trefwoorden$ = new Subject<string>();
   public hasSearched$ = new Subject<boolean>();
   public reset$ = new Subject<void>();
 
-  constructor(
-    private readonly http: HttpClient,
-    private readonly zacHttpClient: ZacHttpClient,
-    private readonly foutAfhandelingService: FoutAfhandelingService,
-  ) {}
+  constructor(private readonly zacHttpClient: ZacHttpClient) {}
 
   list(body: PutBody<"/rest/zoeken/list">) {
     return this.zacHttpClient.PUT("/rest/zoeken/list", body, {});
   }
 
-  listDocumentKoppelbareZaken(
-    zaakIdentificator: string,
-    informationObjectTypeUuid: string,
-  ): Observable<Resultaat<GeneratedType<"RestZaakKoppelenZoekObject">>> {
-    return this.http
-      .put<Resultaat<GeneratedType<"RestZaakKoppelenZoekObject">>>(
-        `${this.basepath}/zaken`,
-        {
-          zaakIdentificator,
-          informationObjectTypeUuid,
-          page: 0,
-          rows: 10,
-        },
-      )
-      .pipe(
-        catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
-      );
+  listDocumentKoppelbareZaken(body: PutBody<"/rest/zoeken/zaken">) {
+    return this.zacHttpClient.PUT(
+      "/rest/zoeken/zaken",
+      { page: 0, rows: 10, ...body },
+      {},
+    );
   }
 
   findLinkableZaken(


### PR DESCRIPTION
This pull request refactors the `ZoekenService` and updates the `InformatieObjectLinkComponent` to streamline the handling of linked document cases and improve code maintainability. The changes include simplifying method signatures, removing unused dependencies, and enhancing error handling.

### Refactoring of `ZoekenService`:

* Simplified the `listDocumentKoppelbareZaken` method to accept a single parameter object (`PutBody`) instead of multiple arguments, making the method more flexible and easier to maintain.
* Removed unused imports (`HttpClient`, `Observable`, `catchError`, and `FoutAfhandelingService`) and refactored the constructor to only include `ZacHttpClient`. This reduces dependency clutter and simplifies the service.

### Updates to `InformatieObjectLinkComponent`:

* Updated the call to `listDocumentKoppelbareZaken` to use the new parameter object structure, improving readability and aligning with the refactored service method.
* Enhanced error handling in the `subscribe` method by explicitly naming the `error` handler, improving clarity and consistency.
* Added a fallback value (`0`) for `result.totaal` to handle cases where `totaal` is undefined, ensuring robustness.
