### PR TITLE
fix: fallback for empty observable

### DIFF
--- a/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
+++ b/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
@@ -8,7 +8,7 @@ import { Injectable, isDevMode } from "@angular/core";
 import { MatDialog } from "@angular/material/dialog";
 import { Router } from "@angular/router";
 import { TranslateService } from "@ngx-translate/core";
-import { EMPTY, Observable, throwError } from "rxjs";
+import { Observable, of, throwError } from "rxjs";
 import { P, match } from "ts-pattern";
 import { UtilService } from "../core/service/util.service";
 import { HttpParamsError } from "../shared/http/zac-http-client";
@@ -139,7 +139,7 @@ export class FoutAfhandelingService {
       );
       this.bericht = err.error.message;
       void this.router.navigate(["/fout-pagina"]);
-      return EMPTY;
+      return of();
     }
 
     if (err.status === 0 && err.url?.startsWith("/rest/")) {
@@ -153,7 +153,7 @@ export class FoutAfhandelingService {
       );
       this.bericht = "";
       void this.router.navigate(["/fout-pagina"]);
-      return EMPTY;
+      return of();
     }
 
     // only show server error texts in case of a server error (500 family of errors)

--- a/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
+++ b/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
@@ -7,7 +7,7 @@ import { Component, Input, OnInit } from "@angular/core";
 import { FormBuilder, Validators } from "@angular/forms";
 import { MatDrawer } from "@angular/material/sidenav";
 import moment, { Moment } from "moment";
-import { EMPTY, firstValueFrom, Observable, of } from "rxjs";
+import { defaultIfEmpty, EMPTY, firstValueFrom, Observable, of } from "rxjs";
 import { ReferentieTabelService } from "src/app/admin/referentie-tabel.service";
 import { UtilService } from "src/app/core/service/util.service";
 import { Vertrouwelijkheidaanduiding } from "src/app/informatie-objecten/model/vertrouwelijkheidaanduiding.enum";
@@ -250,7 +250,11 @@ export class CaseDetailsEditComponent implements OnInit {
       omschrijving,
     } = data;
 
-    await firstValueFrom(this.patchBehandelaar(data, reden ?? undefined));
+    await firstValueFrom(
+      this.patchBehandelaar(data, reden ?? undefined).pipe(
+        defaultIfEmpty(null),
+      ),
+    );
 
     this.zakenService
       .updateZaak(this.zaak.uuid, {
@@ -281,10 +285,11 @@ export class CaseDetailsEditComponent implements OnInit {
   ) {
     const isSameBehandelaar =
       zaak.behandelaar?.id === this.zaak.behandelaar?.id;
+
     const isSameGroup = zaak.groep?.id === this.zaak.groep?.id;
     if (isSameBehandelaar && isSameGroup) return EMPTY;
 
-    if (zaak.behandelaar?.id && zaak.behandelaar.id === this.loggedInUser.id) {
+    if (zaak.behandelaar?.id === this.loggedInUser.id) {
       return this.zakenService.toekennenAanIngelogdeMedewerker(
         this.zaak.uuid,
         reason,


### PR DESCRIPTION
Added fallback for empty observable in `zaak-edit` form, do not use `EMPTY` in fout-service as we do not want a default `null` value
