### PR TITLE
fix: set sslRequired to none in our ZAC Keycloak realm

### DIFF
--- a/scripts/docker-compose/imports/keycloak/zaakafhandelcomponent-realm.json
+++ b/scripts/docker-compose/imports/keycloak/zaakafhandelcomponent-realm.json
@@ -27,7 +27,7 @@
   "oauth2DeviceCodeLifespan": 600,
   "oauth2DevicePollingInterval": 5,
   "enabled": true,
-  "sslRequired": "external",
+  "sslRequired": "none",
   "registrationAllowed": false,
   "registrationEmailAsUsername": false,
   "rememberMe": false,


### PR DESCRIPTION
Set sslRequired to none in our ZAC Keycloak realm since we never require SSL in our local Docker Compose setup. Note that the `sslRequired` in the Keycloak master realm is still set to the default value: `external`. It is not trivial to change that so that is maybe for another PR. For details see: https://smartling.github.io/keycloak/docs/1.2.1.Smartling-SNAPSHOT/reference/en-US/html_single/#ssl_modes

This solves the intermittent issue that I have on my local machine where ZAC can no longer access our ZAC Keycloak realm because it suddently requires SSL for some reason. ZAC then fails to start up with the following error:
`11:04:24,175 WARN  [org.wildfly.security.http.oidc] (default task-1) ELY23005: Unable to load OpenID provider metadata from http://localhost:8081/realms/zaakafhandelcomponent/.well-known/openid-configuration`

Solves PZ-7576