### PR TITLE
feat: update docs for BPMN reference tables

### DIFF
--- a/docs/manuals/bpmn-guide/README.md
+++ b/docs/manuals/bpmn-guide/README.md
@@ -260,8 +260,9 @@ Example:
       ]
     }
 
-
 ```
+:warning: prefixing the reference table with 'BPMN_' is recommended to avoid conflicts with other ZAAK types and reference tables.
+
 ### Available documents section
 To display linked documents of a zaak you can use:
 * a fieldset with type `documentsFieldset`


### PR DESCRIPTION
BPMN specific reference tables should follow a naming convention as described in the docs.

Solves [PZ-7284]