### PR TITLE
feat: save vestiging initiator and betrokkene in productaanvraag as niet-natuurlijk persoon role

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceHistoryTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceHistoryTest.kt
@@ -156,20 +156,20 @@ class ZaakRestServiceHistoryTest : BehaviorSpec({
                     "door": "Functionele gebruiker",
                     "nieuweWaarde": "$TEST_PERSON_HENDRIKA_JANSE_BSN",
                     "toelichting": ""
-                  },
-                  {
-                    "actie": "GEKOPPELD",
-                    "attribuutLabel": "zaakinformatieobject",
-                    "door": "Functionele gebruiker",
-                    "nieuweWaarde": "Aanvraag PDF",
-                    "toelichting": "Document toegevoegd tijdens het starten van de van de zaak vanuit een product aanvraag"
-                  },
+                  },          
                   {
                     "actie": "GEKOPPELD",
                     "attribuutLabel": "Behandelaar",
                     "door": "Functionele gebruiker",
                     "nieuweWaarde": "$TEST_GROUP_A_DESCRIPTION",
                     "toelichting": ""
+                  },
+                 {
+                    "actie": "GEKOPPELD",
+                    "attribuutLabel": "zaakinformatieobject",
+                    "door": "Functionele gebruiker",
+                    "nieuweWaarde": "Aanvraag PDF",
+                    "toelichting": "Document toegevoegd tijdens het starten van de van de zaak vanuit een product aanvraag"
                   },
                   {
                     "actie": "AANGEMAAKT",

--- a/src/main/kotlin/nl/info/zac/notification/NotificationReceiver.kt
+++ b/src/main/kotlin/nl/info/zac/notification/NotificationReceiver.kt
@@ -160,10 +160,14 @@ class NotificationReceiver @Inject constructor(
         }
     }
 
+    /**
+     * Determines whether the notification is a Dimpact productaanvraag notification and if so,
+     * handles it accordingly by creating a zaak and starting a zaakafhandel process.
+     * Only attempts to handle a productaanvraag if the notification resource is an object with 'CREATE' action
+     * and has an object type defined.
+     */
     private fun handleProductaanvraag(notification: Notification) {
         val objecttypeUri = notification.properties?.let { it[OBJECTTYPE_KENMERK] }
-        // only attempt to handle productaanvraag if the notification resource is an object with 'CREATE' action
-        // and has an object type defined
         if (notification.resource == Resource.OBJECT && notification.action == Action.CREATE && objecttypeUri?.isNotEmpty() == true) {
             productaanvraagService.handleProductaanvraag(notification.resourceUrl.extractUuid())
         }


### PR DESCRIPTION
Save vestiging initiator and betrokkene in productaanvraag as niet-natuurlijk persoon role and no longer as vestiging role since the vestiging role is deprecated in Open Zaak. See: https://github.com/open-zaak/open-zaak/issues/1935

Solves PZ-71515