### PR TITLE
feat: add SmartDocuments aanvrager data for initiator of type niet-natuurlijk persoon with a vestigingsnummer

### DIFF
--- a/src/main/java/net/atos/client/zgw/zrc/model/Rol.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Rol.java
@@ -195,7 +195,7 @@ public abstract class Rol<T> {
     }
 
     /**
-     * Can be null according to the ZGW API and this does occur in practice in certain circumstances.
+     * Can be null, according to the ZGW API, and this does occur in practice in certain circumstances.
      *
      * @return the betrokkene identificatie; or null if there is none
      */

--- a/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverter.kt
@@ -140,7 +140,7 @@ class RestZaakConverter @Inject constructor(
                 // niet_natuurlijk_persoon rol type is used for 'RSIN-type' niet-natuurlijke personen but also for vestigingen
                 NIET_NATUURLIJK_PERSOON -> (initiator.betrokkeneIdentificatie as NietNatuurlijkPersoonIdentificatie).let {
                     when {
-                        it.annIdentificatie?.isNotBlank() == true -> IdentificatieType.RSIN
+                        it.innNnpId?.isNotBlank() == true -> IdentificatieType.RSIN
                         it.vestigingsNummer?.isNotBlank() == true -> IdentificatieType.VN
                         else -> null
                     }


### PR DESCRIPTION
Add SmartDocuments aanvrager data for initiator of type niet-natuurlijk persoon with a vestigingsnummer. Fixed a bug in converting niet-natuurlijk persoon betrokkene with RSIN identification.

Solves PZ-7529