### PR TITLE
feat: add identification type to restzaakbetrokkene class for future use in frontend

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaakRestServiceTest.kt
@@ -628,6 +628,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                         getString("roltoelichting") shouldBe "fakeToelichting"
                         getString("type") shouldBe BETROKKENE_TYPE_NATUURLIJK_PERSOON
                         getString("identificatie") shouldBe TEST_PERSON_HENDRIKA_JANSE_BSN
+                        getString("identificatieType") shouldBe "BSN"
                     }
                     getJSONObject(1).apply {
                         getString("rolid") shouldNotBe null
@@ -636,6 +637,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                         getString("roltoelichting") shouldBe BETROKKENE_ROL_TOEVOEGEN_REDEN
                         getString("type") shouldBe BETROKKENE_TYPE_NATUURLIJK_PERSOON
                         getString("identificatie") shouldBe TEST_PERSON_HENDRIKA_JANSE_BSN
+                        getString("identificatieType") shouldBe "BSN"
                         zaakProductaanvraag1Betrokkene1Uuid = getString("rolid").let(UUID::fromString)
                     }
                 }

--- a/src/itest/kotlin/nl/info/zac/itest/config/ProjectConfig.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ProjectConfig.kt
@@ -119,6 +119,7 @@ class ProjectConfig : AbstractProjectConfig() {
         }
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
     override suspend fun afterProject() {
         // stop ZAC Docker Container gracefully to give JaCoCo a change to generate the code coverage report
         dockerComposeContainer.getContainerByServiceName(ZAC_CONTAINER_SERVICE_NAME).getOrNull()?.let { zacContaner ->

--- a/src/itest/kotlin/nl/info/zac/itest/config/ProjectConfig.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ProjectConfig.kt
@@ -119,7 +119,6 @@ class ProjectConfig : AbstractProjectConfig() {
         }
     }
 
-    @OptIn(ExperimentalStdlibApi::class)
     override suspend fun afterProject() {
         // stop ZAC Docker Container gracefully to give JaCoCo a change to generate the code coverage report
         dockerComposeContainer.getContainerByServiceName(ZAC_CONTAINER_SERVICE_NAME).getOrNull()?.let { zacContaner ->

--- a/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
@@ -807,12 +807,20 @@ class ZaakRestService @Inject constructor(
         return zaakHistoryService.getZaakHistory(zaakUUID)
     }
 
+    /**
+     * Returns the list of betrokkenen for a given zaak.
+     *
+     * We do filter out roles that do not have a [Rol.betrokkeneIdentificatie], which is technically possible in the ZGW API
+     * but for our purposes are invalid/incomplete roles.
+     */
     @GET
     @Path("zaak/{uuid}/betrokkene")
     fun listBetrokkenenVoorZaak(@PathParam("uuid") zaakUUID: UUID): List<RestZaakBetrokkene> {
         val zaak = zrcClientService.readZaak(zaakUUID)
         assertPolicy(policyService.readZaakRechten(zaak).lezen)
-        return zaakService.listBetrokkenenforZaak(zaak).toRestZaakBetrokkenen()
+        return zaakService.listBetrokkenenforZaak(zaak)
+            .toRestZaakBetrokkenen()
+            .filterNotNull()
     }
 
     /**

--- a/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
@@ -818,9 +818,7 @@ class ZaakRestService @Inject constructor(
     fun listBetrokkenenVoorZaak(@PathParam("uuid") zaakUUID: UUID): List<RestZaakBetrokkene> {
         val zaak = zrcClientService.readZaak(zaakUUID)
         assertPolicy(policyService.readZaakRechten(zaak).lezen)
-        return zaakService.listBetrokkenenforZaak(zaak)
-            .toRestZaakBetrokkenen()
-            .filterNotNull()
+        return zaakService.listBetrokkenenforZaak(zaak).toRestZaakBetrokkenen()
     }
 
     /**

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakBetrokkene.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakBetrokkene.kt
@@ -102,4 +102,4 @@ fun Rol<*>.toRestZaakBetrokkene(): RestZaakBetrokkene? {
     )
 }
 
-fun List<Rol<*>>.toRestZaakBetrokkenen(): List<RestZaakBetrokkene?> = map { it.toRestZaakBetrokkene() }
+fun List<Rol<*>>.toRestZaakBetrokkenen(): List<RestZaakBetrokkene> = mapNotNull { it.toRestZaakBetrokkene() }

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakBetrokkene.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaakBetrokkene.kt
@@ -39,7 +39,7 @@ data class RestZaakBetrokkene(
 
     /**
      * The identificatieType indicating what the type is of the [identificatie] field.
-     * Not that this is only set for certain betrokkene types, specifically for betrokkene types which support
+     * This is only set for certain betrokkene types, specifically for betrokkene types which support
      * multiple identificatie types like BetrokkeneTypeEnum.NIET_NATUURLIJK_PERSOON.
      */
     var identificatieType: IdentificatieType?

--- a/src/test/kotlin/nl/info/client/zgw/model/ZrcFixtures.kt
+++ b/src/test/kotlin/nl/info/client/zgw/model/ZrcFixtures.kt
@@ -150,7 +150,7 @@ fun createRolNatuurlijkPersoon(
     zaakURI: URI = URI("https://example.com/${UUID.randomUUID()}"),
     rolType: RolType = createRolType(zaakTypeUri = zaakURI),
     toelichting: String = "fakeToelichting",
-    natuurlijkPersoonIdentificatie: NatuurlijkPersoonIdentificatie = createNatuurlijkPersoonIdentificatie()
+    natuurlijkPersoonIdentificatie: NatuurlijkPersoonIdentificatie? = createNatuurlijkPersoonIdentificatie()
 ) = RolNatuurlijkPersoon(
     zaakURI,
     rolType,
@@ -162,7 +162,7 @@ fun createRolNatuurlijkPersoonForReads(
     uuid: UUID = UUID.randomUUID(),
     rolType: RolType = createRolType(),
     toelichting: String = "fakeToelichting",
-    natuurlijkPersoonIdentificatie: NatuurlijkPersoonIdentificatie = createNatuurlijkPersoonIdentificatie()
+    natuurlijkPersoonIdentificatie: NatuurlijkPersoonIdentificatie? = createNatuurlijkPersoonIdentificatie()
 ) = RolNatuurlijkPersoon(
     uuid,
     rolType,
@@ -186,7 +186,7 @@ fun createRolNietNatuurlijkPersoonForReads(
     uuid: UUID = UUID.randomUUID(),
     rolType: RolType = createRolType(),
     toelichting: String = "fakeToelichting",
-    nietNatuurlijkPersoonIdentificatie: NietNatuurlijkPersoonIdentificatie = createNietNatuurlijkPersoonIdentificatie()
+    nietNatuurlijkPersoonIdentificatie: NietNatuurlijkPersoonIdentificatie? = createNietNatuurlijkPersoonIdentificatie()
 ) = RolNietNatuurlijkPersoon(
     uuid,
     rolType,
@@ -210,7 +210,7 @@ fun createRolOrganisatorischeEenheidForReads(
     uuid: UUID = UUID.randomUUID(),
     rolType: RolType = createRolType(),
     roltoelichting: String = "fakeToelichting",
-    organisatorischeEenheidIdentificatie: OrganisatorischeEenheidIdentificatie =
+    organisatorischeEenheidIdentificatie: OrganisatorischeEenheidIdentificatie? =
         createOrganisatorischeEenheidIdentificatie()
 ) = RolOrganisatorischeEenheid(
     uuid,

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
@@ -1383,8 +1383,9 @@ class ZaakRestServiceTest : BehaviorSpec({
 
     Given(
         """
-            A zaak with a betrokkene of type natuurlijk persoon and of type niet-natuurlijk persoon
-            with a vestigingsnummer, and of type niet-natuurlijk persoon with a RSIN (=INN NNP ID)
+            A zaak with a betrokkene of type natuurlijk persoon, a betrokkene of type niet-natuurlijk persoon
+            with a vestigingsnummer, a betrokkene of type niet-natuurlijk persoon with a RSIN (=INN NNP ID),
+            and a betrokkene without a betrokkene identification.
             """
     ) {
         val zaak = createZaak()
@@ -1399,10 +1400,14 @@ class ZaakRestServiceTest : BehaviorSpec({
                 innNnpId = "fakeInnNnpId"
             )
         )
+        val rolNatuurlijkPersoonWithoutIdentificatie = createRolNatuurlijkPersoonForReads(
+            natuurlijkPersoonIdentificatie = null
+        )
         val betrokkeneRoles = listOf(
             rolNatuurlijkPersoon,
             rolNietNatuurlijkPersoonWithVestigingsnummer,
-            rolNietNatuurlijkPersoonWithRSIN
+            rolNietNatuurlijkPersoonWithRSIN,
+            rolNatuurlijkPersoonWithoutIdentificatie
         )
         every { zrcClientService.readZaak(zaak.uuid) } returns zaak
         every { policyService.readZaakRechten(zaak) } returns createZaakRechten()
@@ -1411,9 +1416,9 @@ class ZaakRestServiceTest : BehaviorSpec({
         When("the betrokkenen are retrieved") {
             val returnedBetrokkenen = zaakRestService.listBetrokkenenVoorZaak(zaak.uuid)
 
-            Then("the betrokkenen are returned") {
+            Then("the betrokkenen are correctly returned except the betrokkene without identification") {
                 with(returnedBetrokkenen) {
-                    size shouldBe betrokkeneRoles.size
+                    size shouldBe 3
                     with(first()) {
                         rolid shouldBe rolNatuurlijkPersoon.uuid.toString()
                         roltype shouldBe rolNatuurlijkPersoon.omschrijving

--- a/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
@@ -849,7 +849,7 @@ class ZaakServiceTest : BehaviorSpec({
                     roltoelichting shouldBe explanation
                     omschrijving shouldBe zaak.omschrijving
                     omschrijvingGeneriek shouldBe OmschrijvingGeneriekEnum.INITIATOR.toString()
-                    (this as RolNietNatuurlijkPersoon).betrokkeneIdentificatie.vestigingsNummer shouldBe vestingsnummer
+                    (this as RolNietNatuurlijkPersoon).betrokkeneIdentificatie?.vestigingsNummer shouldBe vestingsnummer
                 }
             }
         }


### PR DESCRIPTION
Added identification type to restzaakbetrokkene class for future use in frontend. Also filter out betrokkenen without an identification when retrieving betrokkenen since for us these are invalid/incomplete betrokkenen and the frontend breaks for such roles anyway.

Solves PZ-7535