### PR TITLE
fix(zaak-details-wijzigen): use the `uiterlijkeEinddatumAfdoening`

### DIFF
--- a/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
+++ b/src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.ts
@@ -247,6 +247,7 @@ export class CaseDetailsEditComponent implements OnInit {
       vertrouwelijkheidaanduiding,
       startdatum,
       einddatumGepland,
+      uiterlijkeEinddatumAfdoening,
       omschrijving,
     } = data;
 
@@ -264,7 +265,7 @@ export class CaseDetailsEditComponent implements OnInit {
           startdatum: startdatum?.toISOString(),
           einddatumGepland: einddatumGepland?.toISOString(),
           uiterlijkeEinddatumAfdoening:
-            form.value.einddatumGepland?.toISOString(),
+            uiterlijkeEinddatumAfdoening?.toISOString(),
           omschrijving: omschrijving ?? "",
         },
         reden: reden ?? "",


### PR DESCRIPTION
This pull request introduces changes to the `CaseDetailsEditComponent` class in the `zaak-details-wijzigen.component.ts` file to ensure proper handling of the `uiterlijkeEinddatumAfdoening` property. The updates aim to improve data mapping and consistency in the component.

### Updates to data mapping:

* Added `uiterlijkeEinddatumAfdoening` to the destructured properties from `data`, ensuring it is explicitly included for processing. (`[src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.tsR250](diffhunk://#diff-a7b8de2b20ec5a86f971410a498af5df82b22e82a60b4b31b5e78495abba3e0aR250)`)
* Updated the mapping logic to correctly assign `uiterlijkeEinddatumAfdoening` using its own value instead of incorrectly referencing `form.value.einddatumGepland`. (`[src/main/app/src/app/zaken/zaak-details-wijzigen/zaak-details-wijzigen.component.tsL267-R268](diffhunk://#diff-a7b8de2b20ec5a86f971410a498af5df82b22e82a60b4b31b5e78495abba3e0aL267-R268)`)


Solves PZ-XXXX