### PR TITLE
chore: no longer use the annIdentificatie field when retrieving the identification for a niet-natuurlijk persoon

### DIFF
--- a/src/main/java/net/atos/client/zgw/zrc/model/RolNietNatuurlijkPersoon.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/RolNietNatuurlijkPersoon.java
@@ -56,14 +56,14 @@ public class RolNietNatuurlijkPersoon extends Rol<NietNatuurlijkPersoonIdentific
         if (identificatie == null || betrokkeneIdentificatie == null) {
             return false;
         }
-        if (betrokkeneIdentificatie.getAnnIdentificatie() != null || identificatie.getAnnIdentificatie() != null) {
-            return Objects.equals(betrokkeneIdentificatie.getAnnIdentificatie(), identificatie.getAnnIdentificatie());
-        }
         if (betrokkeneIdentificatie.getInnNnpId() != null || identificatie.getInnNnpId() != null) {
             return Objects.equals(betrokkeneIdentificatie.getInnNnpId(), identificatie.getInnNnpId());
         }
         if (betrokkeneIdentificatie.getVestigingsNummer() != null || identificatie.getVestigingsNummer() != null) {
             return Objects.equals(betrokkeneIdentificatie.getVestigingsNummer(), identificatie.getVestigingsNummer());
+        }
+        if (betrokkeneIdentificatie.getAnnIdentificatie() != null || identificatie.getAnnIdentificatie() != null) {
+            return Objects.equals(betrokkeneIdentificatie.getAnnIdentificatie(), identificatie.getAnnIdentificatie());
         }
         return true;
     }
@@ -83,9 +83,6 @@ public class RolNietNatuurlijkPersoon extends Rol<NietNatuurlijkPersoonIdentific
         if (identificatie == null) {
             return null;
         }
-        if (StringUtils.isNotEmpty(identificatie.getAnnIdentificatie())) {
-            return identificatie.getAnnIdentificatie();
-        }
         if (StringUtils.isNotEmpty(identificatie.getInnNnpId())) {
             return identificatie.getInnNnpId();
         }
@@ -98,14 +95,14 @@ public class RolNietNatuurlijkPersoon extends Rol<NietNatuurlijkPersoonIdentific
         if (identificatie == null) {
             return 0;
         }
-        if (identificatie.getAnnIdentificatie() != null) {
-            return Objects.hash(getBetrokkeneIdentificatie().getAnnIdentificatie());
-        }
         if (identificatie.getInnNnpId() != null) {
             return Objects.hash(getBetrokkeneIdentificatie().getInnNnpId());
         }
         if (identificatie.getVestigingsNummer() != null) {
             return Objects.hash(getBetrokkeneIdentificatie().getVestigingsNummer());
+        }
+        if (identificatie.getAnnIdentificatie() != null) {
+            return Objects.hash(getBetrokkeneIdentificatie().getAnnIdentificatie());
         }
         return 0;
     }


### PR DESCRIPTION
No longer use the `annIdentificatie` field when retrieving the identification for a niet-natuurlijk persoon because we do not use this field in ZAC/PodiumD. Also see: https://dimpact.atlassian.net/wiki/spaces/PZW/pages/453542005/20250707+-+ZAC+Architecture+meeting

Solves PZ-7548