### PR TITLE
feat(date): added clear button

### DIFF
--- a/src/main/app/src/app/shared/form/date/date.html
+++ b/src/main/app/src/app/shared/form/date/date.html
@@ -20,6 +20,15 @@
     [matDatepicker]="date"
   />
   <span *ngIf="showAmountOfDays" matSuffix>{{ control?.value | dagen }}</span>
+  <button
+    *ngIf="!control?.disabled && control?.value"
+    matSuffix
+    mat-icon-button
+    type="button"
+    (click)="control?.reset(undefined)"
+  >
+    <mat-icon>clear</mat-icon>
+  </button>
   <mat-datepicker-toggle matSuffix [for]="date"></mat-datepicker-toggle>
   <mat-datepicker #date></mat-datepicker>
   <mat-error *ngIf="getErrorMessage()">{{ getErrorMessage() }}</mat-error>

--- a/src/main/app/src/app/shared/form/date/date.less
+++ b/src/main/app/src/app/shared/form/date/date.less
@@ -1,24 +1,3 @@
-/*
- * SPDX-FileCopyrightText: 2021 Atos, 2025 INFO.nl
- * SPDX-License-Identifier: EUPL-1.2+
- */
-
-mat-datepicker-toggle {
-  &:hover {
-    color: inherit;
-  }
-}
-
-.daysSuffix {
-  color: #808080;
-  position: relative;
-  bottom: 7px;
-}
-
-::ng-deep .mat-mdc-form-field.mat-form-field-invalid .mat-mdc-icon-button {
-  color: var(--mat-form-field-error-text-color);
-}
-
 :host {
   ::ng-deep .mat-mdc-text-field-wrapper:has(input[type="date"]) {
     .mat-mdc-form-field-infix::after {

--- a/src/main/app/src/app/shared/form/date/date.ts
+++ b/src/main/app/src/app/shared/form/date/date.ts
@@ -13,6 +13,7 @@ import { FormHelper } from "../helpers";
 @Component({
   selector: "zac-date",
   templateUrl: "./date.html",
+  styleUrls: ["./date.less"],
 })
 export class ZacDate<
   Form extends Record<string, AbstractControl>,

--- a/src/main/app/src/app/shared/material-form-builder/form-components/date/date.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/date/date.component.html
@@ -18,8 +18,16 @@
   <span *ngIf="data.showDays" class="daysSuffix" matSuffix>{{
     data.formControl.value | dagen
   }}</span>
+  <button
+    *ngIf="!data.formControl?.disabled && data.formControl?.value"
+    matSuffix
+    mat-icon-button
+    type="button"
+    (click)="data.formControl?.reset(null)"
+  >
+    <mat-icon>clear</mat-icon>
+  </button>
   <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-
   <mat-datepicker #picker></mat-datepicker>
   <mat-hint *ngIf="data.hint">{{ data.hint.label | translate }}</mat-hint>
   <mat-error *ngIf="data.formControl.invalid">{{

--- a/src/main/app/src/variables.less
+++ b/src/main/app/src/variables.less
@@ -48,6 +48,9 @@
   --mat-dialog-headline-padding: 0 24px;
   --mat-dialog-actions-padding: 20px 24px;
 
+  --mdc-filled-text-field-container-color-hover: #ececec;
+  --mdc-filled-text-field-container-color-active: #e4e4e4;
+
   .mat-mdc-standard-chip {
     --mdc-chip-container-shape-radius: 4px 4px 4px 4px;
   }


### PR DESCRIPTION
This pull request introduces enhancements to date picker components, including the addition of a clear button for resetting date fields and styling updates for better user experience. The changes span multiple files to ensure consistent behavior and appearance across different components.

### Functional Enhancements:
* Added a clear button to reset the date field value in `zac-date` and material form builder date components. The button is conditionally displayed when the field is enabled and has a value. (`src/main/app/src/app/shared/form/date/date.html`, [[1]](diffhunk://#diff-891ddf9ec7dbf7871ead5054bc8ac2c5901ba7d77d639d1940dbac88391748ecR23-R31); `src/main/app/src/app/shared/material-form-builder/form-components/date/date.component.html`, [[2]](diffhunk://#diff-ec8af36c0895e77340fd5b1303970c8c878d461fa735d6402ab52c5831955faeR21-L22)

### Styling Updates:
* Fixes issue on having two date-picker fields in Firefox-browsers. `::-webkit-calendar-picker-indicator` does not Work anymore -- fallback to _just_ overlay the element.


Solves https://dimpact.atlassian.net/browse/PZ-7517?atlOrigin=eyJpIjoiNzY0MjIwYTI4NWFhNDkzYmEwNTFkOWMxZmU5Nzk5OWMiLCJwIjoiaiJ9