### PR TITLE
fix(build): clean build output for non patch version

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -89,7 +89,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: paths-filter
+    needs: [paths-filter, validate-input]
     if: ${{ needs.paths-filter.outputs.changes-requiring-build == 'true' || github.ref == 'refs/heads/main'}}
     outputs:
       branch_name: ${{ steps.gen_branch_name.outputs.BRANCH_NAME }}
@@ -129,7 +129,12 @@ jobs:
       # https://github.com/diffplug/spotless/issues/651
       - name: Gradle build
         run: |
-          ./gradlew build -x test --info --no-configuration-cache --rerun-tasks
+          if [ "${{ needs.validate-input.outputs.version-bump }}" != "patch" ]; then
+            ./gradlew clean build -x test --info --no-configuration-cache
+          else
+            ./gradlew build -x test --info --no-configuration-cache
+          fi
+  
 
       - name: Cache Gradle build artefacts
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3


### PR DESCRIPTION
Using clean build for non-patch updates will ensure the application is rebuilt correctly and can still use cached libraries, as these tasks can still report up-to-date. The patch updates will therefore run as they did before, and non-patch updates will be a bit faster than when using rerun-tasks.

Solves PZ-7624