### PR TITLE
feat: show open zaak validation errors on UI

### DIFF
--- a/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.spec.ts
+++ b/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.spec.ts
@@ -81,4 +81,23 @@ describe("FoutAfhandelingService", () => {
 
     expect(errorMessage).toEqual(`${translatedErrorMessage}`);
   });
+
+  it("should return an observable error message with details when httpErrorAfhandelen is called with a 400 error with exception details", async () => {
+    const message = "fakeBadRequestMessage";
+    const exceptionDetail = "fakeBadRequestExceptionDetail";
+    const errorResponse = new HttpErrorResponse({
+      error: {
+        message: message,
+        exception: exceptionDetail,
+      },
+      status: 400,
+    });
+
+    const error$ = service.httpErrorAfhandelen(errorResponse);
+    const errorMessage = await firstValueFrom(error$).catch((r) => r);
+
+    expect(errorMessage).toEqual(
+      `${translatedErrorMessage}: ${exceptionDetail}`,
+    );
+  });
 });

--- a/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
+++ b/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
@@ -120,13 +120,14 @@ export class FoutAfhandelingService {
       return throwError(() => err.message);
     }
 
-    const errorDetail =
-      err.error?.message || err.message || err?.error?.exception;
+    const errorMessage = err.error?.message || err.message;
 
-    if (err.status === 400) {
+    const errorDetail = err?.error?.exception;
+
+    if (err.status === 400 && !errorDetail) {
       return this.openFoutDialog(
         this.translateService.instant(
-          errorDetail || "dialoog.error.body.technisch",
+          errorMessage || "dialoog.error.body.technisch",
         ),
       );
     }
@@ -163,10 +164,9 @@ export class FoutAfhandelingService {
     // show error in context and do not redirect to error-page
     return this.openFoutDetailedDialog(
       this.translateService.instant(
-        errorDetail || "dialoog.error.body.technisch",
+        errorMessage || "dialoog.error.body.technisch",
       ),
-      err.error?.exception ??
-        this.translateService.instant("dialoog.error.body.fout"),
+      errorDetail ?? this.translateService.instant("dialoog.error.body.fout"),
       showServerErrorTexts,
     );
   }

--- a/src/main/kotlin/nl/info/zac/app/exception/RestExceptionResponseBuilder.kt
+++ b/src/main/kotlin/nl/info/zac/app/exception/RestExceptionResponseBuilder.kt
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2025 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
 package nl.info.zac.app.exception
 
 import com.fasterxml.jackson.core.JsonProcessingException

--- a/src/main/kotlin/nl/info/zac/app/exception/RestExceptionResponseBuilder.kt
+++ b/src/main/kotlin/nl/info/zac/app/exception/RestExceptionResponseBuilder.kt
@@ -1,0 +1,68 @@
+package nl.info.zac.app.exception
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.ws.rs.WebApplicationException
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import nl.info.zac.exception.ErrorCode
+import nl.info.zac.exception.ErrorCode.ERROR_CODE_SERVER_GENERIC
+import nl.info.zac.log.log
+import java.util.logging.Level
+import java.util.logging.Logger
+
+object RestExceptionResponseBuilder {
+
+    private val LOG = Logger.getLogger(RestExceptionResponseBuilder::class.java.name)
+    const val JSON_CONVERSION_ERROR_MESSAGE = "Failed to convert exception to JSON"
+
+    fun createResponse(exception: WebApplicationException): Response =
+        Response.status(exception.response.status)
+            .type(MediaType.APPLICATION_JSON)
+            .entity(getJSONMessage(errorMessage = exception.message ?: ERROR_CODE_SERVER_GENERIC.value))
+            .build()
+
+    fun generateResponse(
+        responseStatus: Response.Status,
+        errorCode: ErrorCode,
+        exception: Exception,
+        exceptionMessage: String? = null
+    ): Response = Response.status(responseStatus)
+        .type(MediaType.APPLICATION_JSON)
+        .entity(
+            getJSONMessage(
+                errorMessage = errorCode.value,
+                exceptionMessage = exceptionMessage
+            )
+        )
+        .build().also {
+            log(
+                logger = LOG,
+                level = if (responseStatus == Response.Status.INTERNAL_SERVER_ERROR) Level.SEVERE else Level.FINE,
+                message = exception.message
+                    ?: "Exception was thrown. Returning response with error message: '${errorCode.value}'.",
+                throwable = exception
+            )
+        }
+
+    fun generateServerErrorResponse(
+        exception: Exception,
+        errorCode: ErrorCode? = null,
+        exceptionMessage: String? = null
+    ) = generateResponse(
+        responseStatus = Response.Status.INTERNAL_SERVER_ERROR,
+        errorCode = errorCode ?: ERROR_CODE_SERVER_GENERIC,
+        exception = exception,
+        exceptionMessage = exceptionMessage
+    )
+
+    private fun getJSONMessage(errorMessage: String, exceptionMessage: String? = null) =
+        try {
+            val errorJsonHashMap = mutableMapOf("message" to errorMessage)
+            exceptionMessage?.let { errorJsonHashMap["exception"] = it }
+            ObjectMapper().writeValueAsString(errorJsonHashMap)
+        } catch (jsonProcessingException: JsonProcessingException) {
+            log(LOG, Level.SEVERE, JSON_CONVERSION_ERROR_MESSAGE, jsonProcessingException)
+            JSON_CONVERSION_ERROR_MESSAGE
+        }
+}

--- a/src/main/kotlin/nl/info/zac/shared/exception/ValidatieFoutExceptionMapper.kt
+++ b/src/main/kotlin/nl/info/zac/shared/exception/ValidatieFoutExceptionMapper.kt
@@ -8,6 +8,8 @@ import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.ExceptionMapper
 import jakarta.ws.rs.ext.Provider
 import net.atos.client.zgw.shared.exception.ValidationErrorException
+import nl.info.zac.app.exception.RestExceptionResponseBuilder.generateResponse
+import nl.info.zac.exception.ErrorCode
 
 /**
  * Exception mapper to catch [ValidationErrorException] thrown and convert them to a [Response] which is returned to
@@ -15,8 +17,12 @@ import net.atos.client.zgw.shared.exception.ValidationErrorException
  */
 @Provider
 class ValidatieFoutExceptionMapper : ExceptionMapper<ValidationErrorException> {
-    override fun toResponse(validationErrorException: ValidationErrorException): Response =
-        validationErrorException.validatieFout.toString().let {
-            Response.status(Response.Status.BAD_REQUEST).entity(it).build()
-        }
+    override fun toResponse(validationErrorException: ValidationErrorException): Response {
+        return generateResponse(
+            responseStatus = Response.Status.BAD_REQUEST,
+            errorCode = ErrorCode.ERROR_CODE_VALIDATION_GENERIC,
+            exception = validationErrorException,
+            exceptionMessage = validationErrorException.validatieFout.invalidParams.toString()
+        )
+    }
 }


### PR DESCRIPTION
Handle `net.atos.client.zgw.shared.exception.ValidationErrorException` to propagate OpenZaak input validation errors to frontend

Solves [PZ-7314]