### PR TITLE
feat: added supporting text on automatic mail reply

### DIFF
--- a/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.html
+++ b/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.html
@@ -574,13 +574,18 @@
             </mat-card>
             <mat-card>
               <form [formGroup]="automatischeOntvangstbevestigingFormGroup">
-                <mat-card-header>
-                  <zac-toggle
-                    label="gegevens.mail.ontvangstbevestiging"
-                    labelPosition="before"
-                    [form]="automatischeOntvangstbevestigingFormGroup"
-                    key="enabled"
-                  ></zac-toggle>
+                <mat-card-header class="mb-2">
+                  <mat-card-title>
+                    <zac-toggle
+                      label="gegevens.mail.ontvangstbevestiging"
+                      labelPosition="before"
+                      [form]="automatischeOntvangstbevestigingFormGroup"
+                      key="enabled"
+                    ></zac-toggle>
+                  </mat-card-title>
+                  <mat-card-subtitle>
+                    {{ "gegevens.mail.ontvangstbevestiging.hint" | translate }}
+                  </mat-card-subtitle>
                 </mat-card-header>
                 <mat-card-content
                   *ngIf="

--- a/src/main/app/src/assets/i18n/en.json
+++ b/src/main/app/src/assets/i18n/en.json
@@ -213,6 +213,7 @@
   "gegevens.mail.afzenders": "Mail senders",
   "gegevens.mail.templates": "Mail templates",
   "gegevens.mail.ontvangstbevestiging": "Automatic receipt confirmation",
+  "gegevens.mail.ontvangstbevestiging.hint": "An automatic receipt can only be sent for cases created directly from a form, and where the initiator's e-mail address is known.",
   "goedkeuren": "Approve",
   "geldig": "Valid",
   "begin.geldigheid": "Start validity",

--- a/src/main/app/src/assets/i18n/nl.json
+++ b/src/main/app/src/assets/i18n/nl.json
@@ -213,6 +213,7 @@
   "gegevens.mail.afzenders": "Mailafzenders",
   "gegevens.mail.templates": "Mailtemplates",
   "gegevens.mail.ontvangstbevestiging": "Automatische ontvangstbevestiging",
+  "gegevens.mail.ontvangstbevestiging.hint": "Een automatische ontvangstbevestiging kan alleen verstuurd worden bij zaken die direct vanuit een formulier zijn aangemaakt, én waarbij het e-mailadres van de initiator bekend is.",
   "goedkeuren": "Goedkeuren",
   "geldig": "Geldig",
   "begin.geldigheid": "Begin geldigheid",

--- a/src/main/app/src/styles.less
+++ b/src/main/app/src/styles.less
@@ -478,6 +478,10 @@ mat-hint {
   content: none;
 }
 
+.mat-mdc-card-header .mat-mdc-card-header-text {
+  width: 100%;
+}
+
 h1 {
   font-size: 18px;
   font-weight: 600;


### PR DESCRIPTION
This pull request introduces enhancements to the `parameter-edit` component's UI and adds new localization strings for better user guidance. Additionally, it includes a minor CSS update to improve layout styling for card headers.

### UI Enhancements:
* Updated `parameter-edit.component.html` to include a `mat-card-title` and `mat-card-subtitle` within the `mat-card-header`, providing a title and translated hint for the "Automatic receipt confirmation" toggle.

### Localization Updates:
* Added a new key, `gegevens.mail.ontvangstbevestiging.hint`, to the English translation file (`en.json`) with an explanation of when automatic receipt confirmation is applicable.
* Added the same key to the Dutch translation file (`nl.json`) with the corresponding Dutch translation.

### Styling Improvements:
* Adjusted `.mat-mdc-card-header-text` in `styles.less` to ensure the card header text spans the full width of the header.

Solves PZ-7704