### PR TITLE
chore(taken-werkvoorraad): extend timeout before refreshing data

### DIFF
--- a/src/main/app/src/app/taken/taken-werkvoorraad/taken-werkvoorraad.component.ts
+++ b/src/main/app/src/app/taken/taken-werkvoorraad/taken-werkvoorraad.component.ts
@@ -262,7 +262,7 @@ export class TakenWerkvoorraadComponent
       },
       finally: () => {
         this.selection.clear();
-        this.dataSource.load(1_000);
+        this.dataSource.load(5_000); // We need to give the indexing service some time to finish
         this.takenLoading.set(false);
         this.batchProcessService.stop();
       },


### PR DESCRIPTION
This pull request modifies the `TakenWerkvoorraadComponent` to improve the handling of data loading after batch processing. The key change increases the timeout before the items are loaded by the data source to provide additional time for the indexing service to complete its work.

### Changes to data loading:

* [`src/main/app/src/app/taken/taken-werkvoorraad/taken-werkvoorraad.component.ts`](diffhunk://#diff-e5fa18fbbabc6d05049b9bbd6d27c0dc10cbc35c4c120778c9a7d2c5b53b61b0L265-R265): Updated the `dataSource.load` method to load after 5_000ms instead of 1000ms, ensuring sufficient time for the indexing service to finish processing.

Solves PZ-7686