### PR TITLE
fix: support not configured template and sender

### DIFF
--- a/src/main/java/net/atos/zac/admin/model/AutomaticEmailConfirmation.java
+++ b/src/main/java/net/atos/zac/admin/model/AutomaticEmailConfirmation.java
@@ -38,11 +38,9 @@ public class AutomaticEmailConfirmation {
     private boolean enabled = false;
 
     @Column(name = "template_name")
-    @NotNull
     private String templateName;
 
     @Column(name = "email_sender")
-    @NotNull
     private String emailSender;
 
     @Column(name = "email_reply")


### PR DESCRIPTION
Template name or sender can be missing (not configured yet) We still want to save what's configured by the user.

Solves PZ-7769