### PR TITLE
chore: allow small drop in Codecov test coverage before failing Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,10 @@
 # SPDX-FileCopyrightText: 2024 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
+# When modifying this file, please check if it is valid using the following command:
+# `curl --data-binary @codecov.yml https://codecov.io/validate`
+# See: https://docs.codecov.com/docs/codecov-yaml
 codecov:
   notify:
     # only notify Codecov after two builds because we want to make sure
@@ -9,6 +13,7 @@ codecov:
     # our unit test and integration test coverage
     after_n_builds: 2
   max_report_age: off
+coverage:
   status:
     project:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,10 @@ codecov:
     # our unit test and integration test coverage
     after_n_builds: 2
   max_report_age: off
+  status:
+    project:
+      default:
+        # Allow the coverage to drop a little bit before failing the Codecov check.
+        # This to avoid failing Codecov checks when the coverage drops with e.g. 0.01%
+        # even when there are no changes made to the code.
+        threshold: 1


### PR DESCRIPTION
Allow small drop in Codecov test coverage before failing the Codecov check to avoid false positives where the test coverage sometimes drops by 0.01% without any code changes. See e.g.: https://github.com/codecov/codecov-ruby/issues/62

Solves PZ-7808