### PR TITLE
feat: client code generation for pabc openapi spec

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -240,6 +240,7 @@ java {
         .srcDir(srcGenerated.dir("zgw/zrc/java"))
         .srcDir(srcGenerated.dir("zgw/ztc/java"))
         .srcDir(srcGenerated.dir("or/objects/java"))
+        .srcDir(srcGenerated.dir("pabc/java"))
 }
 
 jsonSchema2Pojo {
@@ -677,6 +678,13 @@ tasks {
         modelPackage.set("nl.info.client.or.objects.model.generated")
     }
 
+    register<GenerateTask>("generatePabcClient") {
+        description = "Generates Java client code for the Platform Autorisatie Beheer Component API"
+        inputSpec.set("$rootDir/src/main/resources/api-specs/pabc/pabc-openapi.json")
+        outputDir.set("$rootDir/src/generated/pabc/java")
+        modelPackage.set("nl.info.client.pabc.model.generated")
+    }
+
     register("generateJavaClients") {
         description = "Generates Java client code for the various REST APIs"
         dependsOn(
@@ -691,7 +699,8 @@ tasks {
             "generateZgwDrcClient",
             "generateZgwZrcClient",
             "generateZgwZtcClient",
-            "generateOrObjectsClient"
+            "generateOrObjectsClient",
+            "generatePabcClient"
         )
     }
 

--- a/src/main/resources/api-specs/pabc/pabc-openapi.json
+++ b/src/main/resources/api-specs/pabc/pabc-openapi.json
@@ -1,0 +1,241 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Platform Autorisatie Beheer Component API",
+    "description": "API for the Platform Autorisatie Beheer Component (PABC)",
+    "version": "v1"
+  },
+  "paths": {
+    "/api/v1/application-roles-per-entity-type": {
+      "post": {
+        "tags": ["GetApplicationRolesPerEntityType"],
+        "operationId": "Get application roles per entity type",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetApplicationRolesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetApplicationRolesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/seed": {
+      "get": {
+        "tags": ["Seed"],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApplicationRoleModel": {
+        "required": ["application", "name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the application role",
+            "example": "Behandelaar"
+          },
+          "application": {
+            "type": "string",
+            "description": "The application that this role applies to",
+            "example": "ZAC"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EntityTypeModel": {
+        "required": ["id", "name", "type"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier for the entity type",
+            "example": "melding-klein-kansspel"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the entity type",
+            "example": "Melding klein kansspel"
+          },
+          "type": {
+            "type": "string",
+            "description": "The kind of entity",
+            "example": "zaaktype"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetApplicationRolesRequest": {
+        "required": ["functionalRoleNames"],
+        "type": "object",
+        "properties": {
+          "functionalRoleNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The functional roles of the logged in user",
+            "example": ["GemeenteRol1", "GemeenteRol2"]
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetApplicationRolesResponse": {
+        "required": ["results"],
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GetApplicationRolesResponseModel"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetApplicationRolesResponseModel": {
+        "required": ["applicationRoles", "entityType"],
+        "type": "object",
+        "properties": {
+          "entityType": {
+            "$ref": "#/components/schemas/EntityTypeModel"
+          },
+          "applicationRoles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationRoleModel"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": {}
+      },
+      "ValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "additionalProperties": {}
+      }
+    },
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "name": "X-API-KEY",
+        "in": "header"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added generated Java client for PABC based on its OpenAPI spec. Included it in the generateJavaClients task and configured the output as a source directory.

Solves [PZ-7761]