### PR TITLE
fix: add null handling for retrieving the identificatienummer for an OpenZaak role to avoid nullpointers

### DIFF
--- a/src/main/java/net/atos/client/zgw/zrc/model/Rol.java
+++ b/src/main/java/net/atos/client/zgw/zrc/model/Rol.java
@@ -232,5 +232,11 @@ public abstract class Rol<T> {
 
     public abstract String getNaam();
 
+    /**
+     * Can be null, according to the ZGW API, and this does occur in practice in certain circumstances.
+     *
+     * @return the betrokkene identification number; or null if there is none
+     */
+    @Nullable
     public abstract String getIdentificatienummer();
 }

--- a/src/main/kotlin/nl/info/zac/documentcreation/converter/DocumentCreationDataConverter.kt
+++ b/src/main/kotlin/nl/info/zac/documentcreation/converter/DocumentCreationDataConverter.kt
@@ -123,11 +123,15 @@ class DocumentCreationDataConverter @Inject constructor(
 
     private fun convertToAanvragerData(initiator: Rol<*>, zaakNummer: String): AanvragerData? =
         when (initiator.betrokkeneType) {
-            NATUURLIJK_PERSOON -> createAanvragerDataNatuurlijkPersoon(
-                initiator.identificatienummer,
-                "$zaakNummer@$ACTION"
-            )
-            VESTIGING -> createAanvragerDataVestiging(initiator.identificatienummer)
+            NATUURLIJK_PERSOON -> initiator.identificatienummer?.run {
+                createAanvragerDataNatuurlijkPersoon(
+                    bsn = this,
+                    auditEvent = "$zaakNummer@$ACTION"
+                )
+            }
+            VESTIGING -> initiator.identificatienummer?.run {
+                createAanvragerDataVestiging(this)
+            }
             NIET_NATUURLIJK_PERSOON -> createAanvragerDataNietNatuurlijkPersoon(initiator)
             else -> error("Initiator of type '${initiator.betrokkeneType}' is not supported")
         }
@@ -162,13 +166,13 @@ class DocumentCreationDataConverter @Inject constructor(
      * as well as for KVK vestigingen.
      */
     private fun createAanvragerDataNietNatuurlijkPersoon(initiator: Rol<*>): AanvragerData? {
-        val nietNatuurlijkPersoonIdentificatie = (initiator.betrokkeneIdentificatie as NietNatuurlijkPersoonIdentificatie)
-        val kvkResultaat = if (nietNatuurlijkPersoonIdentificatie.innNnpId?.isNotBlank() == true) {
-            kvkClientService.findRechtspersoon(nietNatuurlijkPersoonIdentificatie.innNnpId)
-        } else if (nietNatuurlijkPersoonIdentificatie.vestigingsNummer?.isNotBlank() == true) {
-            kvkClientService.findVestiging(nietNatuurlijkPersoonIdentificatie.vestigingsNummer)
-        } else {
-            error(
+        val nietNatuurlijkPersoonIdentificatie = (initiator.betrokkeneIdentificatie as NietNatuurlijkPersoonIdentificatie?)
+        val kvkResultaat = when {
+            nietNatuurlijkPersoonIdentificatie?.innNnpId?.isNotBlank() == true ->
+                kvkClientService.findRechtspersoon(nietNatuurlijkPersoonIdentificatie.innNnpId)
+            nietNatuurlijkPersoonIdentificatie?.vestigingsNummer?.isNotBlank() == true ->
+                kvkClientService.findVestiging(nietNatuurlijkPersoonIdentificatie.vestigingsNummer)
+            else -> error(
                 "Niet-natuurlijke persoon initiator role '$initiator' with neither INN NNP ID (RSIN) " +
                     "nor vestigingsnummer is not supported"
             )

--- a/src/main/kotlin/nl/info/zac/search/converter/ZaakZoekObjectConverter.kt
+++ b/src/main/kotlin/nl/info/zac/search/converter/ZaakZoekObjectConverter.kt
@@ -117,8 +117,16 @@ class ZaakZoekObjectConverter @Inject constructor(
     }
 
     private fun addBetrokkenen(zaak: Zaak, zaakZoekObject: ZaakZoekObject) {
-        for (rol in zrcClientService.listRollen(zaak)) {
-            zaakZoekObject.addBetrokkene(rol.omschrijving, rol.identificatienummer)
+        for (role in zrcClientService.listRollen(zaak)) {
+            // It is possible for a role in the ZGW zaakregister to not have an identification number.
+            // This can happen when a rol for some reason no longer has an underlying 'identity' object (like a Natuurlijk Persoon etc.).
+            // In this case, we treat the rol as an empty 'orphaned' role and ignore it here.
+            role.identificatienummer?.run {
+                zaakZoekObject.addBetrokkene(
+                    rol = role.omschrijving,
+                    identificatie = this
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Added null handling for retrieving the identificatienummer for an OpenZaak role to avoid nullpointers.

Solves PZ-7871