### PR TITLE
fix: do not check policy for SmartDocuments template group names

### DIFF
--- a/src/itest/resources/bpmn/summaryForm.json
+++ b/src/itest/resources/bpmn/summaryForm.json
@@ -58,9 +58,6 @@
           "label": "Mail reciever",
           "labelPosition": "left-left",
           "disabled": true,
-          "validate": {
-            "required": true
-          },
           "key": "TF_EMAIL_TO",
           "type": "textfield",
           "input": true,

--- a/src/main/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/ZaakafhandelParametersRestService.kt
@@ -273,7 +273,8 @@ class ZaakafhandelParametersRestService @Inject constructor(
     fun getSmartDocumentsGroup(
         group: RestSmartDocumentsPath
     ): RestSmartDocumentsTemplateGroup {
-        assertPolicy(policyService.readOverigeRechten().beheren)
+        // No authorization to allow BPMN tasks (form.io) to read template group names and display them
+        // We should consider a proper authorization with PABC
         return smartDocumentsTemplatesService.getTemplateGroup(group.path)
     }
 


### PR DESCRIPTION
BPMN forms open Create Document side-panel which needs the group names

Solves PZ-7890