### PR TITLE
refactor(column-picker): fixed lint issues

### DIFF
--- a/src/main/app/src/app/shared/dynamic-table/column-picker/column-picker.component.ts
+++ b/src/main/app/src/app/shared/dynamic-table/column-picker/column-picker.component.ts
@@ -31,18 +31,18 @@ export class ColumnPickerComponent {
 
   @Output() columnsChanged = new EventEmitter<Map<string, ColumnPickerValue>>();
 
-  private _columnSrc: Map<string, ColumnPickerValue>;
-  private _columns: Map<string, string>;
-  private _selection: string[];
+  private _columnSrc = new Map<string, ColumnPickerValue>();
+  private _columns = new Map<string, string>();
+  private _selection: string[] = [];
   private changed = false;
 
-  constructor(private translate: TranslateService) {}
+  constructor(private readonly translate: TranslateService) {}
 
-  menuOpened(): void {
+  menuOpened() {
     this.changed = false;
   }
 
-  selectionChanged($event: MatSelectionListChange): void {
+  selectionChanged($event: MatSelectionListChange) {
     this.changed = true;
     $event.options.forEach((option) =>
       this._columnSrc.set(
@@ -54,17 +54,17 @@ export class ColumnPickerComponent {
     );
   }
 
-  updateColumns(): void {
+  updateColumns() {
     if (this.changed) {
       this.columnsChanged.emit(this._columnSrc);
     }
   }
 
-  get columns(): Map<string, string> {
+  get columns() {
     return this._columns;
   }
 
-  isSelected(column: string): boolean {
+  isSelected(column: string) {
     return this._selection.includes(column);
   }
 }


### PR DESCRIPTION
This pull request refactors the `ColumnPickerComponent` class in `column-picker.component.ts` to simplify the initialization of private properties and streamline method definitions by removing redundant type annotations.

### Refactoring of `ColumnPickerComponent`:

* Initialized private properties (`_columnSrc`, `_columns`, `_selection`) directly with default values, removing the need for separate initialization elsewhere.
* Removed explicit return type annotations (`: void`, `: Map<string, string>`, etc.) from methods and getters, simplifying the method definitions.

Solves PZ-7675