### PR TITLE
chore: use latest version of Azure CLI in e2e tests GitHub pipeline

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -34,7 +34,7 @@ jobs:
       - name: add ip to nsg
         uses: azure/CLI@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
         with:
-          azcliversion: "latest"
+          azcliversion: latest
           inlineScript: |
             az network nsg rule create -g zac-infra --nsg-name k8s-test-nsg -n allow_github_runner --priority 295 --source-address-prefixes ${{ env.my_ip }} --destination-port-ranges '*' --direction Inbound --access allow --protocol '*' --destination-address-prefixes '*'
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -155,6 +155,6 @@ jobs:
         if: always()
         uses: azure/CLI@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
         with:
-          azcliversion: "latest"
+          azcliversion: latest
           inlineScript: |
             az network nsg rule delete -g zac-infra --nsg-name k8s-test-nsg -n allow_github_runner


### PR DESCRIPTION
Use latest version of Azure CLI in e2e tests GitHub pipeline. See: https://github.com/marketplace/actions/azure-cli-action

This will hopefully fix the warnings we see: `WARNING: You're using Az version 12.5.0. The latest version of Az is 14.2.0.` 

Solves PZ-7930