### PR TITLE
chore: use SemVer versioning for PABC Renovate Docker image updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -252,6 +252,24 @@
       ],
       "versioning": "loose",
       "allowedVersions": "/jre-ubi9-minimal$/"
+    },
+    {
+      "matchPackageNames": [
+        "ghcr.io/platform-autorisatie-beheer-component/pabc-api"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "versioning": "semver"
+    },
+    {
+      "matchPackageNames": [
+        "ghcr.io/platform-autorisatie-beheer-component/pabc-migrations"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "versioning": "semver"
     }
   ]
 }


### PR DESCRIPTION
Use SemVer versioning for PABC Renovate Docker image updates because now Renovate does not upgrade PABC pre-release versions. See: https://github.com/Platform-Autorisatie-Beheer-Component/PABC-API/pkgs/container/pabc-api/versions

Solves PZ-7935