### PR TITLE
chore: use custom Renovate versioning scheme for BRP Personen Mock Docker Image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -260,10 +260,9 @@ services:
       brp-personen-mock:
         condition: service_started
 
-
   brp-personen-mock:
-    # We use the 'latest' tag here because an unconventional versioning scheme is used for these Docker images which Renovate does not support
-    image: ghcr.io/brp-api/personen-mock:2.7.0-latest@sha256:761df5c1cc8745abc19f9edd91bc5f3302af548fd5c6839eaf847a9887290f0a
+    image: ghcr.io/brp-api/personen-mock:2.7.0-202507011650@sha256:5c8006ac4e4b7e96a32a7a1a42cab43f74ca95f0174cdb6b40dece2e717f8df4
+    platform: linux/amd64
     environment:
       - ASPNETCORE_ENVIRONMENT=Release
       - ASPNETCORE_URLS=http://+:5010

--- a/renovate.json
+++ b/renovate.json
@@ -270,6 +270,18 @@
         "docker"
       ],
       "versioning": "semver"
+    },
+    {
+      "matchPackageNames": [
+        "ghcr.io/brp-api/personen-mock"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d{12})$",
+      "description": [
+        "The BRP API Personen Mock Docker image uses a custom versioning scheme that Renovate does not support by default. Example: '2.7.0-202506301511'"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Use custom Renovate versioning scheme for BRP Personen Mock Docker Image.

Solves PZ-7938