### PR TITLE
chore: added margins to the zaak view page

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-create-attended/informatie-object-create-attended.component.ts
@@ -37,7 +37,7 @@ export class InformatieObjectCreateAttendedComponent
   implements OnInit, OnDestroy
 {
   @Input({ required: true }) zaak!: GeneratedType<"RestZaak">;
-  @Input({ required: true }) taak!: GeneratedType<"RestTask">;
+  @Input() taak?: GeneratedType<"RestTask">;
   @Input({ required: true }) sideNav!: MatDrawer;
   @Input({ required: false }) smartDocumentsGroupPath: string[] = [];
   @Input({ required: false }) smartDocumentsTemplateName?: string;

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -145,7 +145,7 @@
     ></zac-zaakdata>
   </mat-drawer>
   <mat-drawer-content>
-    <div class="flex-row flex-wrap gap-10">
+    <div class="flex-row flex-wrap gap-12">
       <section class="w100 flex-1" *ngIf="showInitiator()">
         <zac-zaak-initiator-toevoegen
           class="w100 flex-1"
@@ -178,7 +178,7 @@
         >
         </zac-bedrijfsgegevens>
       </section>
-      <mat-card class="zaken-card w50 flex-1">
+      <mat-card class="w50 flex-1">
         <mat-card-header class="flex-col gap-8 space-between">
           <div class="flex-row">
             <zac-zaak-indicaties
@@ -213,7 +213,7 @@
                 <mat-icon>topic</mat-icon>
                 {{ "gegevens.algemeen" | translate }}</ng-template
               >
-              <div id="algemeneGegevens_tab" class="content">
+              <div class="content">
                 <div class="flex flex-row flex-wrap justify-start gap-10">
                   <zac-static-text
                     [label]="'status' | translate"
@@ -268,7 +268,7 @@
 
                   <zac-static-text
                     [label]="'groep' | translate"
-                    [value]="zaak.groep.naam | empty"
+                    [value]="zaak.groep?.naam | empty"
                     class="flex-item"
                   ></zac-static-text>
                   <zac-static-text
@@ -365,7 +365,7 @@
                 <mat-icon>place</mat-icon>
                 {{ "locatie" | translate }}</ng-template
               >
-              <div id="locatie_tab" class="table-wrapper">
+              <div class="table-wrapper">
                 <div class="flex flex-col gap-10 editable">
                   <button
                     *ngIf="zaak.rechten.wijzigenLocatie"
@@ -393,7 +393,7 @@
                 <mat-icon>account_tree</mat-icon>
                 {{ "gerelateerdeZaken" | translate }}</ng-template
               >
-              <div id="gerelateerdeZaken_tab" class="table-wrapper">
+              <div class="table-wrapper">
                 <table mat-table [dataSource]="zaak.gerelateerdeZaken">
                   <ng-container
                     *ngFor="let column of gerelateerdeZaakColumns"
@@ -406,7 +406,7 @@
                       {{ row[column] | empty | datum }}
                     </td>
                   </ng-container>
-                  <ng-container matColumnDef="url" stickyEnd>
+                  <ng-container matColumnDef="actions" stickyEnd>
                     <th mat-header-cell *matHeaderCellDef></th>
                     <td mat-cell *matCellDef="let row">
                       <a
@@ -434,13 +434,13 @@
                   </ng-container>
                   <tr
                     mat-header-row
-                    *matHeaderRowDef="gerelateerdeZaakColumns.concat(['url'])"
+                    *matHeaderRowDef="gerelateerdeZaakColumnsWithAction"
                   ></tr>
                   <tr
                     mat-row
                     *matRowDef="
                       let row;
-                      columns: gerelateerdeZaakColumns.concat(['url'])
+                      columns: gerelateerdeZaakColumnsWithAction
                     "
                   ></tr>
                 </table>
@@ -452,7 +452,7 @@
                 <mat-icon>history</mat-icon>
                 {{ "historie" | translate }}
               </ng-template>
-              <div id="historie_tab" class="table-wrapper historie-table">
+              <div class="table-wrapper">
                 <table
                   mat-table
                   matSort
@@ -571,7 +571,7 @@
                 <mat-icon>groups</mat-icon>
                 {{ "betrokkenen" | translate }}
               </ng-template>
-              <div id="betrokkenen_tab" class="table-wrapper betrokkenen-table">
+              <div class="table-wrapper">
                 <table mat-table [dataSource]="betrokkenen" matSort>
                   <ng-container matColumnDef="roltype">
                     <th mat-header-cell *matHeaderCellDef>
@@ -729,7 +729,7 @@
                 <mat-icon>gps_fixed</mat-icon>
                 {{ "bagObjecten" | translate }}
               </ng-template>
-              <div id="bagobjecten_tab" class="table-wrapper bagobjecten-table">
+              <div class="table-wrapper">
                 <table mat-table [dataSource]="bagObjectenDataSource" matSort>
                   <ng-container matColumnDef="identificatie">
                     <th mat-header-cell *matHeaderCellDef>
@@ -806,25 +806,22 @@
           </mat-tab-group>
         </mat-card-content>
       </mat-card>
-
-      <div class="w50 flex-1 flex-col">
+      <div class="w50 flex-1 flex-col gap-12">
         <zac-besluit-view
-          class="besluiten"
-          *ngIf="zaak.besluiten"
-          [besluiten]="zaak.besluiten"
+          *ngIf="zaak.besluiten?.length"
+          [besluiten]="zaak.besluiten ?? []"
           [result]="zaak.resultaat"
           [readonly]="!zaak.isOpen || !zaak.rechten.behandelen"
           (besluitWijzigen)="besluitWijzigen($event)"
           (doIntrekking)="doIntrekking($event)"
         ></zac-besluit-view>
 
-        <mat-card class="taken-card">
+        <mat-card class="flex-grow-1">
           <mat-card-header>
             <mat-card-title>{{ "taken" | translate }}</mat-card-title>
             <mat-slide-toggle
               [formControl]="toonAfgerondeTaken"
               color="primary"
-              id="takenAfgerondeToon_toggle"
               (change)="filterTakenOpStatus()"
               >{{ "toonAfgerondeTaken" | translate }}</mat-slide-toggle
             >
@@ -924,7 +921,7 @@
                     {{ taak.data.behandelaar | empty: "naam" }}
                   </td>
                 </ng-container>
-                <ng-container matColumnDef="id" stickyEnd id="taakButtons">
+                <ng-container matColumnDef="id" stickyEnd>
                   <th mat-header-cell *matHeaderCellDef></th>
                   <td mat-cell *matCellDef="let row">
                     <div class="flex-row">
@@ -1007,18 +1004,18 @@
           </mat-card-content>
         </mat-card>
       </div>
+      <zac-zaak-documenten
+        #zaakDocumentenComponent
+        class="w100"
+        [zaak]="zaak"
+        (documentMoveToCase)="documentMoveToCase($event)"
+      ></zac-zaak-documenten>
     </div>
-    <zac-zaak-documenten
-      #zaakDocumentenComponent
-      class="w100"
-      [zaak]="zaak"
-      (documentMoveToCase)="documentMoveToCase($event)"
-    ></zac-zaak-documenten>
-
-    <zac-notities
-      *ngIf="notitieRechten?.lezen || notitieRechten?.wijzigen"
-      [zaakUuid]="zaak.uuid"
-      [notitieRechten]="notitieRechten"
-    ></zac-notities>
   </mat-drawer-content>
 </mat-drawer-container>
+
+<zac-notities
+  *ngIf="notitieRechten?.lezen || notitieRechten?.wijzigen"
+  [zaakUuid]="zaak.uuid"
+  [notitieRechten]="notitieRechten"
+></zac-notities>

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
@@ -10,33 +10,8 @@ mat-slide-toggle {
   position: absolute;
 }
 
-.taken-card {
-  height: 100%;
-  margin-bottom: 10px;
-}
-
-.zaken-card {
-  min-width: 620px;
-  margin-bottom: 10px;
-}
-
-.besluiten {
-  margin-bottom: 10px;
-}
-
-.historie-table {
-  height: 400px;
-  overflow: auto;
-}
-
-.betrokkenen-table {
-  height: 400px;
-  overflow: auto;
-}
-
-.bagobjecten-table {
-  height: 400px;
-  overflow: auto;
+.table-wrapper {
+  max-height: 400px;
 }
 
 .mat-mdc-column-betrokkenegegevens span {

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -133,6 +133,11 @@ export class ZaakViewComponent
     "startdatum",
     "relatieType",
   ] as const;
+  gerelateerdeZaakColumnsWithAction = [
+    ...this.gerelateerdeZaakColumns,
+    "actions",
+  ];
+
   notitieRechten!: GeneratedType<"RestNotitieRechten">;
   dateFieldIconMap = new Map<string, TextIcon>();
   viewInitialized = false;

--- a/src/main/app/src/styles.less
+++ b/src/main/app/src/styles.less
@@ -97,7 +97,7 @@ mat-drawer-container {
   height: calc(100% - 68px);
 
   .mat-drawer-content {
-    padding: 16px 0;
+    padding: 12px;
   }
 }
 


### PR DESCRIPTION
This pull request makes several improvements and refactors to the `zaak-view` component and related files, focusing on UI consistency, code maintainability, and improved handling of optional data. The most significant changes include refactoring table wrappers and actions, updating input handling for optional data, and streamlining styles.

**UI and Table Structure Improvements:**

* Refactored all tab content wrappers in `zaak-view.component.html` to use a unified `.table-wrapper` class, removing individual table-specific classes and associated IDs for a more consistent and maintainable layout. The `.table-wrapper` class now enforces a `max-height` of 400px for scrollable tables. [[1]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL368-R368) [[2]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL396-R396) [[3]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL455-R455) [[4]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL574-R574) [[5]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL732-R732) [[6]](diffhunk://#diff-b56a7de812e2b10c8105f1daff6dc290cd0ed7cd70d21775631054cacb27864cL13-R14)
* Updated the "Gerelateerde Zaken" table to use a new `actions` column instead of `url`, and introduced a new `gerelateerdeZaakColumnsWithAction` array (as per the [docs](https://material.angular.dev/components/table/examples#table-expandable-rows)) in the component TypeScript to manage columns more flexibly. [[1]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL409-R409) [[2]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL437-R443) [[3]](diffhunk://#diff-14b5c3c4e0d3f425036177305b195cf3a0676481590bebf604ceba13ae75ecbdR136-R140)

**Optional Data Handling and Input Improvements:**

* Made the `taak` input property in `InformatieObjectCreateAttendedComponent` optional to better handle cases where a task may not be present.
* Updated template bindings to safely access nested optional properties, such as using `zaak.groep?.naam` instead of `zaak.groep.naam`.
* Improved the display logic for `zac-besluit-view` to only render when `zaak.besluiten` has items and to safely handle cases where it may be undefined.

**Styling and Layout Adjustments:**

* Increased the gap between flex items from `gap-10` to `gap-12` for better spacing and visual clarity. [[1]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL148-R148) [[2]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL809-L827)
* Removed redundant or unnecessary CSS classes and margins from cards and sections, consolidating layout logic. [[1]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL181-R181) [[2]](diffhunk://#diff-b56a7de812e2b10c8105f1daff6dc290cd0ed7cd70d21775631054cacb27864cL13-R14)
* Adjusted padding for `.mat-drawer-content` for improved alignment.

**Minor Template Cleanups:**

* Removed unused or redundant attributes (such as `id="takenAfgerondeToon_toggle"`), and cleaned up misplaced closing tags to improve template readability and maintainability. [[1]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL809-L827) [[2]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL927-R924) [[3]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL1010-L1024)

These changes collectively enhance the maintainability, consistency, and robustness of the `zaak-view` UI and its related components.

Solves PZ-7979