### PR TITLE
fix(besluit-view): use correct translation string

### DIFF
--- a/src/main/app/src/app/zaken/besluit-view/besluit-view.component.ts
+++ b/src/main/app/src/app/zaken/besluit-view/besluit-view.component.ts
@@ -139,7 +139,7 @@ export class BesluitViewComponent implements OnInit, OnChanges {
         this.maakMessageField(besluit),
       ],
       callback: (results) => this.saveIntrekking(results),
-      melding: this.translate.instant("msg.besluit.intrekken.melding"),
+      melding: this.translate.instant("msg.besluit.intrekken"),
       confirmButtonActionKey: "actie.besluit.intrekken",
       icon: "stop_circle",
     });


### PR DESCRIPTION
This pull request makes a minor update to the confirmation dialog messaging in the `BesluitViewComponent`. Specifically, it changes the translation key used for the withdrawal message to simplify or correct the displayed text.

* Updated the `melding` property in the confirmation dialog configuration to use the `msg.besluit.intrekken` translation key instead of `msg.besluit.intrekken.melding` in `besluit-view.component.ts`.