### PR TITLE
feat(PlanItemsRestService): create `eigenshap` for `EIGENSCHAP` result

### DIFF
--- a/src/main/app/package.json
+++ b/src/main/app/package.json
@@ -11,7 +11,7 @@
     "start": "npm run generate:types:zac-openapi && ng serve --proxy-config proxy.conf.json",
     "build": "npm run generate:types:zac-openapi && ng build --configuration=production --base-href=/",
     "test": "ng test",
-    "test:watch": "ng test --watch",
+    "test:watch": "ng test --watch --verbose",
     "test:ci": "npx jest -t",
     "test:report": "ng test --coverage",
     "lint": "ng lint",

--- a/src/main/app/setupJest.ts
+++ b/src/main/app/setupJest.ts
@@ -5,3 +5,7 @@
  */
 
 import "whatwg-fetch";
+
+afterEach(() => {
+  jest.clearAllMocks();
+});

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
@@ -50,7 +50,12 @@
       key="brondatumEigenschap"
       *ngIf="formGroup.controls.resultaattype.value?.datumKenmerkVerplicht"
     />
-    <div *ngIf="mailBeschikbaar">
+    <div
+      *ngIf="
+        data.zaak.zaaktype.zaakafhandelparameters?.afrondenMail !==
+        'NIET_BESCHIKBAAR'
+      "
+    >
       <mat-checkbox id="sendMail" formControlName="sendMail">
         {{ "sendMail" | translate }}
       </mat-checkbox>

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
@@ -14,152 +14,103 @@
 </mat-toolbar>
 <mat-divider></mat-divider>
 
-<mat-dialog-content [formGroup]="formGroup">
-  <p
-    *ngIf="data.planItem.toelichting"
-    class="readonly"
-    [innerHTML]="planItem.toelichting"
-  ></p>
-  <p
-    *ngIf="besluitVastleggen"
-    class="readonly error"
-    [innerHTML]="'msg.besluit.verplicht' | translate"
-  ></p>
-  <zac-static-text
-    *ngIf="data.zaak.resultaat"
-    [label]="'resultaat' | translate"
-    [value]="data.zaak.resultaat.resultaattype?.naam"
-  ></zac-static-text>
-  <zac-static-text
-    *ngFor="let besluit of data.zaak.besluiten"
-    [label]="besluit.identificatie | empty"
-    [value]="besluit.besluittype?.naam"
-  ></zac-static-text>
-  <div *ngIf="!data.zaak.resultaat">
-    <mat-form-field appearance="fill" floatLabel="always" class="full-width">
-      <mat-label>{{ "resultaat" | translate }}</mat-label>
-      <mat-select
-        placeholder="{{ 'resultaat.-kies-' | translate }}"
-        formControlName="resultaattype"
-      >
-        <mat-option
-          *ngFor="let resultaattype of resultaattypes | async"
-          [value]="resultaattype"
-          >{{ resultaattype.naam }}</mat-option
-        >
-      </mat-select>
-      <mat-error>{{
-        getError(formGroup.get("resultaattype")!, "resultaattype")
-      }}</mat-error>
-    </mat-form-field>
-  </div>
-  <div>
-    <mat-form-field appearance="fill" class="full-width">
-      <mat-label>{{ "toelichting" | translate }}</mat-label>
-      <input
-        id="toelichting"
-        formControlName="toelichting"
-        maxlength="80"
-        matInput
-      />
-      <mat-hint align="end"
-        >{{ formGroup.get("toelichting")!.value.length }}/80</mat-hint
-      >
-    </mat-form-field>
-  </div>
-  <div *ngIf="mailBeschikbaar">
-    <mat-checkbox id="sendMail" formControlName="sendMail">
-      {{ "sendMail" | translate }}
-    </mat-checkbox>
-  </div>
-  <div *ngIf="formGroup.get('sendMail')!.value">
-    <mat-form-field appearance="fill" class="full-width">
-      <mat-label>{{ "verzender" | translate }}</mat-label>
-      <mat-select
-        placeholder="{{ 'verzender.-kies-' | translate }}"
-        formControlName="verzender"
-        [compareWith]="compareObject"
-      >
-        <mat-select-trigger>
-          {{ formGroup.get("verzender")!.value?.mail }}
-        </mat-select-trigger>
-        <mat-option
-          *ngFor="let afzender of afzenders | async"
-          [value]="afzender"
-        >
-          {{ afzender.mail }}
-          <div class="suffix" *ngIf="afzender.suffix">
-            {{ afzender.suffix | translate }}
-          </div>
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-  </div>
-  <div *ngIf="formGroup.get('sendMail')!.value">
-    <mat-form-field appearance="fill" class="full-width">
+<form [formGroup]="formGroup" (submit)="afhandelen()">
+  <mat-dialog-content>
+    <p
+      *ngIf="data.planItem.toelichting"
+      class="readonly"
+      [innerHTML]="planItem.toelichting"
+    ></p>
+    <p
+      *ngIf="besluitVastleggen"
+      class="readonly error"
+      [innerHTML]="'msg.besluit.verplicht' | translate"
+    ></p>
+    <zac-static-text
+      *ngIf="data.zaak.resultaat"
+      [label]="'resultaat' | translate"
+      [value]="data.zaak.resultaat.resultaattype?.naam"
+    ></zac-static-text>
+    <zac-static-text
+      *ngFor="let besluit of data.zaak.besluiten"
+      [label]="besluit.identificatie | empty"
+      [value]="besluit.besluittype?.naam"
+    ></zac-static-text>
+    <zac-select
+      [form]="formGroup"
+      key="resultaattype"
+      label="resultaat"
+      *ngIf="!data.zaak.resultaat"
+      [options]="resultaattypes"
+      optionDisplayValue="naam"
+    />
+    <zac-input [form]="formGroup" key="toelichting" />
+    <zac-date
+      [form]="formGroup"
+      key="brondatumEigenschap"
+      *ngIf="formGroup.controls.resultaattype.value?.datumKenmerkVerplicht"
+    />
+    <div *ngIf="mailBeschikbaar">
+      <mat-checkbox id="sendMail" formControlName="sendMail">
+        {{ "sendMail" | translate }}
+      </mat-checkbox>
+    </div>
+    <zac-select
+      [form]="formGroup"
+      key="verzender"
+      *ngIf="formGroup.controls.sendMail.value"
+      [options]="afzenders"
+      [optionDisplayValue]="afzenderOptionDisplayValue"
+    />
+    <zac-input
+      [form]="formGroup"
+      key="ontvanger"
+      *ngIf="formGroup.controls.sendMail.value"
+    >
       <button
         *ngIf="initiatorEmail"
         mat-icon-button
         type="button"
         matSuffix
-        title="{{ initiatorToevoegenIcon.title | translate }}"
+        title="{{ 'actie.initiator.email.toevoegen' | translate }}"
         (click)="setInitiatorEmail()"
       >
-        <mat-icon>{{ initiatorToevoegenIcon.icon }}</mat-icon>
+        <mat-icon>person</mat-icon>
       </button>
-
-      <mat-label>{{ "ontvanger" | translate }}</mat-label>
-      <input
-        matInput
-        id="ontvanger"
-        maxlength="200"
-        formControlName="ontvanger"
-      />
-      <mat-hint align="end"
-        >{{ formGroup.get("ontvanger")!.value.length }}/200</mat-hint
-      >
-      <mat-error>{{
-        getError(formGroup.get("ontvanger")!, "ontvanger")
-      }}</mat-error>
-    </mat-form-field>
-  </div>
-
-  <mat-expansion-panel
-    class="mat-elevation-z0"
-    *ngIf="formGroup.get('sendMail')!.value"
-  >
-    <mat-expansion-panel-header>
-      {{ "body" | translate }}
-    </mat-expansion-panel-header>
-    <p class="readonly" [innerHTML]="mailtemplate?.body"></p>
-  </mat-expansion-panel>
-</mat-dialog-content>
-<mat-dialog-actions>
-  <button
-    *ngIf="!besluitVastleggen"
-    mat-raised-button
-    color="primary"
-    id="zaakAfhandelen_button"
-    [disabled]="loading || formGroup.invalid"
-    (click)="afhandelen()"
-  >
-    <mat-icon *ngIf="loading">
-      <mat-spinner diameter="18"></mat-spinner>
-    </mat-icon>
-    {{ "actie.zaak.afhandelen" | translate }}
-  </button>
-
-  <button
-    *ngIf="besluitVastleggen"
-    mat-raised-button
-    color="primary"
-    id="besluitVastleggen_button"
-    (click)="openBesluitVastleggen()"
-  >
-    {{ "actie.besluit.vastleggen" | translate }}
-  </button>
-
-  <button mat-raised-button [disabled]="loading" (click)="close()">
-    {{ "actie.annuleren" | translate }}
-  </button>
-</mat-dialog-actions>
+    </zac-input>
+    <mat-expansion-panel
+      class="mat-elevation-z0"
+      *ngIf="formGroup.controls.sendMail.value"
+    >
+      <mat-expansion-panel-header>
+        {{ "body" | translate }}
+      </mat-expansion-panel-header>
+      <p class="readonly" [innerHTML]="mailtemplate?.body"></p>
+    </mat-expansion-panel>
+  </mat-dialog-content>
+  <mat-dialog-actions>
+    <button
+      *ngIf="!besluitVastleggen"
+      mat-raised-button
+      color="primary"
+      type="submit"
+      [disabled]="loading || formGroup.invalid"
+    >
+      <mat-icon *ngIf="loading">
+        <mat-spinner diameter="18"></mat-spinner>
+      </mat-icon>
+      {{ "actie.zaak.afhandelen" | translate }}
+    </button>
+    <button
+      *ngIf="besluitVastleggen"
+      mat-raised-button
+      color="primary"
+      (click)="openBesluitVastleggen()"
+    >
+      {{ "actie.besluit.vastleggen" | translate }}
+    </button>
+    <button mat-raised-button [disabled]="loading" (click)="close()">
+      {{ "actie.annuleren" | translate }}
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.spec.ts
@@ -1,0 +1,315 @@
+/*
+ * SPDX-FileCopyrightText: 2025 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import { HarnessLoader } from "@angular/cdk/testing";
+import { TestbedHarnessEnvironment } from "@angular/cdk/testing/testbed";
+import { provideHttpClient } from "@angular/common/http";
+import { provideHttpClientTesting } from "@angular/common/http/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ReactiveFormsModule } from "@angular/forms";
+import { MatButtonHarness } from "@angular/material/button/testing";
+import { MatCheckboxHarness } from "@angular/material/checkbox/testing";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { MatExpansionPanelHarness } from "@angular/material/expansion/testing";
+import { MatInputHarness } from "@angular/material/input/testing";
+import { MatSelectHarness } from "@angular/material/select/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { TranslateModule } from "@ngx-translate/core";
+import { fromPartial } from "@total-typescript/shoehorn";
+import { EMPTY, of } from "rxjs";
+import { KlantenService } from "../../klanten/klanten.service";
+import { MailtemplateService } from "../../mailtemplate/mailtemplate.service";
+import { PlanItemsService } from "../../plan-items/plan-items.service";
+import { MaterialFormBuilderModule } from "../../shared/material-form-builder/material-form-builder.module";
+import { MaterialModule } from "../../shared/material/material.module";
+import { PipesModule } from "../../shared/pipes/pipes.module";
+import { StaticTextComponent } from "../../shared/static-text/static-text.component";
+import { GeneratedType } from "../../shared/utils/generated-types";
+import { CustomValidators } from "../../shared/validators/customValidators";
+import { ZakenService } from "../zaken.service";
+import { ZaakAfhandelenDialogComponent } from "./zaak-afhandelen-dialog.component";
+
+describe(ZaakAfhandelenDialogComponent.name, () => {
+  let fixture: ComponentFixture<ZaakAfhandelenDialogComponent>;
+  let loader: HarnessLoader;
+
+  let dialogRef: MatDialogRef<ZaakAfhandelenDialogComponent>;
+  let zakenService: ZakenService;
+  let planItemsService: PlanItemsService;
+  let mailtemplateService: MailtemplateService;
+  let klantenService: KlantenService;
+
+  const mockDialogRef = {
+    close: jest.fn(),
+    disableClose: false,
+  };
+
+  const mockZaak = fromPartial<GeneratedType<"RestZaak">>({
+    uuid: "test-zaak-uuid",
+    zaaktype: fromPartial<GeneratedType<"RestZaaktype">>({
+      uuid: "test-zaaktype-uuid",
+      omschrijving: "Test Zaaktype",
+      zaakafhandelparameters: {
+        afrondenMail: "BESCHIKBAAR_AAN",
+      },
+    }),
+    initiatorIdentificatieType: "BSN",
+    initiatorIdentificatie: "123456789",
+    resultaat: null,
+    besluiten: [],
+  });
+
+  const mockPlanItem = fromPartial<GeneratedType<"RESTPlanItem">>({
+    id: "test-plan-item-id",
+    userEventListenerActie: "ZAAK_AFHANDELEN",
+    toelichting: "Test toelichting",
+  });
+
+  const mockResultaattypes = [
+    fromPartial<GeneratedType<"RestResultaattype">>({
+      id: "resultaat-1",
+      naam: "Test Resultaat 1",
+      besluitVerplicht: false,
+      datumKenmerkVerplicht: true,
+    }),
+    fromPartial<GeneratedType<"RestResultaattype">>({
+      id: "resultaat-2",
+      naam: "Test Resultaat 2",
+      besluitVerplicht: true,
+      datumKenmerkVerplicht: false,
+    }),
+    fromPartial<GeneratedType<"RestResultaattype">>({
+      id: "resultaat-2",
+      naam: "Test Resultaat 3",
+      besluitVerplicht: false,
+      datumKenmerkVerplicht: false,
+    }),
+  ];
+
+  const mockAfzenders = [
+    fromPartial<GeneratedType<"RESTZaakAfzender">>({
+      mail: "test@example.com",
+      suffix: "Test Afzender",
+      replyTo: "reply@example.com",
+    }),
+  ];
+
+  const mockMailtemplate = fromPartial<GeneratedType<"RESTMailtemplate">>({
+    onderwerp: "Test Onderwerp",
+    body: "Test Body",
+  });
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ZaakAfhandelenDialogComponent, StaticTextComponent],
+      imports: [
+        ReactiveFormsModule,
+        TranslateModule.forRoot(),
+        PipesModule,
+        MaterialModule,
+        MaterialFormBuilderModule,
+        NoopAnimationsModule,
+      ],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: MatDialogRef,
+          useValue: mockDialogRef,
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            zaak: mockZaak,
+            planItem: mockPlanItem,
+          },
+        },
+        CustomValidators,
+      ],
+    }).compileComponents();
+
+    dialogRef = TestBed.inject(MatDialogRef);
+    zakenService = TestBed.inject(ZakenService);
+    planItemsService = TestBed.inject(PlanItemsService);
+    mailtemplateService = TestBed.inject(MailtemplateService);
+    klantenService = TestBed.inject(KlantenService);
+
+    jest
+      .spyOn(zakenService, "listResultaattypes")
+      .mockReturnValue(of(mockResultaattypes));
+    jest
+      .spyOn(zakenService, "listAfzendersVoorZaak")
+      .mockReturnValue(of(mockAfzenders));
+    jest
+      .spyOn(zakenService, "readDefaultAfzenderVoorZaak")
+      .mockReturnValue(of(mockAfzenders[0]));
+    jest
+      .spyOn(mailtemplateService, "findMailtemplate")
+      .mockReturnValue(of(mockMailtemplate));
+    jest
+      .spyOn(klantenService, "ophalenContactGegevens")
+      .mockReturnValue(of({ emailadres: "initiator@example.com" }));
+    jest
+      .spyOn(planItemsService, "doUserEventListenerPlanItem")
+      .mockReturnValue(EMPTY);
+
+    fixture = TestBed.createComponent(ZaakAfhandelenDialogComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  describe("sendMail checkbox", () => {
+    it("should show mail fields when sendMail is checked", async () => {
+      const sendMailCheckbox = await loader.getHarness(MatCheckboxHarness);
+      await sendMailCheckbox.check();
+
+      const fields = await loader.getAllHarnesses(MatSelectHarness);
+      const verzenderField = fields[1];
+
+      expect(verzenderField).toBeTruthy();
+    });
+
+    it("should hide mail fields when sendMail is unchecked", async () => {
+      const sendMailCheckbox = await loader.getHarness(MatCheckboxHarness);
+      await sendMailCheckbox.uncheck();
+
+      const fields = await loader.getAllHarnesses(MatSelectHarness);
+      const verzenderField = fields[1];
+
+      expect(verzenderField).toBeFalsy();
+    });
+  });
+
+  describe("resultaattype selection", () => {
+    it("should show besluitVastleggen button when resultaattype requires besluit", async () => {
+      const resultaattypeSelect = await loader.getHarness(MatSelectHarness);
+      await resultaattypeSelect.open();
+
+      const options = await resultaattypeSelect.getOptions();
+      await options[2]?.click();
+
+      const besluitButton = await loader.getHarnessOrNull(
+        MatButtonHarness.with({ text: /actie\.besluit\.vastleggen/ }),
+      );
+      const isDisabled = await besluitButton?.isDisabled();
+      expect(isDisabled).toBeFalsy();
+    });
+
+    it("should open besluit vastleggen when besluit button is clicked", async () => {
+      const resultaattypeSelect = await loader.getHarness(MatSelectHarness);
+      await resultaattypeSelect.open();
+
+      const options = await resultaattypeSelect.getOptions();
+
+      await options[2]?.click();
+
+      const button = await loader.getHarness(
+        MatButtonHarness.with({
+          text: /actie\.besluit\.vastleggen/,
+        }),
+      );
+      await button.click();
+
+      expect(dialogRef.close).toHaveBeenCalledWith("openBesluitVastleggen");
+    });
+  });
+
+  describe("actions", () => {
+    it("should close dialog when close button is clicked", async () => {
+      const closeButton = await loader.getHarness(
+        MatButtonHarness.with({ text: /actie\.annuleren/ }),
+      );
+      await closeButton.click();
+
+      expect(dialogRef.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("form validation", () => {
+    it("should disable submit button when form is invalid", async () => {
+      const submitButton = await loader.getHarness(
+        MatButtonHarness.with({ text: /actie\.zaak\.afhandelen/ }),
+      );
+      const isDisabled = await submitButton.isDisabled();
+
+      expect(isDisabled).toBe(true);
+    });
+
+    it("should enable submit button when form is valid", async () => {
+      const resultaattypeSelect = await loader.getHarness(MatSelectHarness);
+      await resultaattypeSelect.open();
+
+      const options = await resultaattypeSelect.getOptions();
+
+      await options[3]?.click();
+
+      await fixture.whenStable();
+
+      const submitButton = await loader.getHarness(
+        MatButtonHarness.with({ text: /actie\.zaak\.afhandelen/ }),
+      );
+
+      const isDisabled = await submitButton.isDisabled();
+
+      expect(isDisabled).toBe(false);
+    });
+  });
+
+  describe("form submission", () => {
+    it(`should call ${PlanItemsService.prototype.doUserEventListenerPlanItem.name} on submit`, async () => {
+      const resultaattypeSelect = await loader.getHarness(MatSelectHarness);
+      await resultaattypeSelect.open();
+
+      const options = await resultaattypeSelect.getOptions();
+      await options[3]?.click();
+
+      const submitButton = await loader.getHarness(
+        MatButtonHarness.with({ text: /actie\.zaak\.afhandelen/ }),
+      );
+
+      await submitButton.click();
+
+      expect(planItemsService.doUserEventListenerPlanItem).toHaveBeenCalled();
+    });
+
+    it("should send over a 'brondatumEigenschap' when a brondatumEigenschap is required", async () => {
+      const resultaattypeSelect = await loader.getHarness(MatSelectHarness);
+      await resultaattypeSelect.open();
+
+      const options = await resultaattypeSelect.getOptions();
+      await options[1]?.click(); // Select a type that requires brondatumEigenschap
+
+      const inputs = await loader.getAllHarnesses(MatInputHarness);
+
+      await inputs[1].setValue("2022-01-01");
+
+      const submitButton = await loader.getHarness(
+        MatButtonHarness.with({ text: /actie\.zaak\.afhandelen/ }),
+      );
+
+      await submitButton.click();
+
+      expect(planItemsService.doUserEventListenerPlanItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          brondatumEigenschap: "2021-12-31T23:00:00.000Z", // ISO 8601 format
+        }),
+      );
+    });
+  });
+
+  describe("mail expansion panel", () => {
+    it("should show mail body in expansion panel when sendMail is checked", async () => {
+      const sendMailCheckbox = await loader.getHarness(MatCheckboxHarness);
+      await sendMailCheckbox.check();
+      fixture.detectChanges();
+
+      const expansionPanel = await loader.getHarness(MatExpansionPanelHarness);
+      expect(expansionPanel).toBeTruthy();
+
+      const panelText = await expansionPanel.getTextContent();
+      expect(panelText).toContain("Test Body");
+    });
+  });
+});

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
@@ -3,22 +3,16 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import { Component, Inject, OnDestroy } from "@angular/core";
-import {
-  AbstractControl,
-  FormBuilder,
-  FormGroup,
-  Validators,
-} from "@angular/forms";
+import { Component, Inject } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { FormBuilder, Validators } from "@angular/forms";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { TranslateService } from "@ngx-translate/core";
-import { Observable, Subject } from "rxjs";
-import { takeUntil } from "rxjs/operators";
-import { UtilService } from "../../core/service/util.service";
+import { Moment } from "moment";
+import { Observable } from "rxjs";
 import { KlantenService } from "../../klanten/klanten.service";
 import { MailtemplateService } from "../../mailtemplate/mailtemplate.service";
 import { PlanItemsService } from "../../plan-items/plan-items.service";
-import { ActionIcon } from "../../shared/edit/action-icon";
 import { GeneratedType } from "../../shared/utils/generated-types";
 import { CustomValidators } from "../../shared/validators/customValidators";
 import { ZakenService } from "../zaken.service";
@@ -27,38 +21,42 @@ import { ZakenService } from "../zaken.service";
   templateUrl: "zaak-afhandelen-dialog.component.html",
   styleUrls: ["./zaak-afhandelen-dialog.component.less"],
 })
-export class ZaakAfhandelenDialogComponent implements OnDestroy {
+export class ZaakAfhandelenDialogComponent {
   loading = false;
   mailBeschikbaar = false;
   sendMailDefault = false;
-  formGroup: FormGroup;
   besluitVastleggen = false;
   mailtemplate?: GeneratedType<"RESTMailtemplate">;
   planItem: GeneratedType<"RESTPlanItem">;
   initiatorEmail?: string;
-  initiatorToevoegenIcon = new ActionIcon(
-    "person",
-    "actie.initiator.email.toevoegen",
-    new Subject<void>(),
-  );
+
   resultaattypes: Observable<GeneratedType<"RestResultaattype">[]>;
   afzenders: Observable<GeneratedType<"RESTZaakAfzender">[]>;
-  private ngDestroy = new Subject<void>();
+
+  formGroup = this.formBuilder.group({
+    resultaattype:
+      this.formBuilder.control<GeneratedType<"RestResultaattype"> | null>(null),
+    toelichting: this.formBuilder.control<string>(""),
+    sendMail: this.formBuilder.control<boolean>(false),
+    verzender:
+      this.formBuilder.control<GeneratedType<"RESTZaakAfzender"> | null>(null),
+    ontvanger: this.formBuilder.control<string>("", [CustomValidators.email]),
+    brondatumEigenschap: this.formBuilder.control<Moment | null>(null),
+  });
 
   constructor(
-    public dialogRef: MatDialogRef<ZaakAfhandelenDialogComponent>,
+    public readonly dialogRef: MatDialogRef<ZaakAfhandelenDialogComponent>,
     @Inject(MAT_DIALOG_DATA)
-    public data: {
+    public readonly data: {
       zaak: GeneratedType<"RestZaak">;
       planItem: GeneratedType<"RESTPlanItem">;
     },
-    private formBuilder: FormBuilder,
-    private translateService: TranslateService,
-    private zakenService: ZakenService,
-    private planItemsService: PlanItemsService,
-    private mailtemplateService: MailtemplateService,
-    private klantenService: KlantenService,
-    private utilService: UtilService,
+    private readonly formBuilder: FormBuilder,
+    private readonly translateService: TranslateService,
+    private readonly zakenService: ZakenService,
+    private readonly planItemsService: PlanItemsService,
+    private readonly mailtemplateService: MailtemplateService,
+    private readonly klantenService: KlantenService,
   ) {
     this.planItem = data.planItem;
     this.resultaattypes = this.zakenService.listResultaattypes(
@@ -72,9 +70,12 @@ export class ZaakAfhandelenDialogComponent implements OnDestroy {
       .subscribe((mailtemplate) => {
         this.mailtemplate = mailtemplate;
       });
-    const zap = this.data.zaak.zaaktype.zaakafhandelparameters;
-    this.mailBeschikbaar = zap?.afrondenMail !== "NIET_BESCHIKBAAR";
-    this.sendMailDefault = zap?.afrondenMail === "BESCHIKBAAR_AAN";
+    const zaakafhandelparameters =
+      this.data.zaak.zaaktype.zaakafhandelparameters;
+    this.mailBeschikbaar =
+      zaakafhandelparameters?.afrondenMail !== "NIET_BESCHIKBAAR";
+    this.sendMailDefault =
+      zaakafhandelparameters?.afrondenMail === "BESCHIKBAAR_AAN";
 
     if (
       this.data.zaak.initiatorIdentificatieType &&
@@ -82,75 +83,62 @@ export class ZaakAfhandelenDialogComponent implements OnDestroy {
     ) {
       this.klantenService
         .ophalenContactGegevens(this.data.zaak.initiatorIdentificatie)
-        .subscribe((gegevens) => {
-          if (gegevens.emailadres) {
-            this.initiatorEmail = gegevens.emailadres;
-          }
+        .subscribe(({ emailadres }) => {
+          if (!emailadres) return;
+          this.initiatorEmail = emailadres;
         });
     }
 
-    this.formGroup = this.formBuilder.group({
-      resultaattype: [
-        null,
-        this.data.zaak.resultaat ? null : [Validators.required],
-      ],
-      toelichting: "",
-      sendMail: this.sendMailDefault,
-      verzender: [null, this.sendMailDefault ? [Validators.required] : null],
-      ontvanger: [
-        "",
-        this.sendMailDefault
-          ? [Validators.required, CustomValidators.email]
-          : null,
-      ],
-    });
+    if (this.data.zaak.resultaat) {
+      this.formGroup.controls.resultaattype.addValidators(Validators.required);
+    }
+    if (this.sendMailDefault) {
+      this.formGroup.controls.verzender.addValidators(Validators.required);
+      this.formGroup.controls.ontvanger.addValidators([Validators.required]);
+    }
 
     this.zakenService
       .readDefaultAfzenderVoorZaak(this.data.zaak.uuid)
       .subscribe((afzender) => {
-        this.formGroup.get("verzender")?.setValue(afzender);
+        this.formGroup.controls.verzender.setValue(afzender);
       });
 
-    this.formGroup
-      .get("sendMail")
-      ?.valueChanges.pipe(takeUntil(this.ngDestroy))
+    this.formGroup.controls.sendMail.valueChanges
+      .pipe(takeUntilDestroyed())
       .subscribe((value) => {
-        this.formGroup
-          ?.get("verzender")
-          ?.setValidators(value ? [Validators.required] : null);
-        this.formGroup?.get("verzender")?.updateValueAndValidity();
-        this.formGroup
-          ?.get("ontvanger")
-          ?.setValidators(
-            value ? [Validators.required, CustomValidators.email] : null,
-          );
-        this.formGroup?.get("ontvanger")?.updateValueAndValidity();
+        this.formGroup.controls.verzender.setValidators(
+          value ? [Validators.required] : null,
+        );
+        this.formGroup.controls.ontvanger.setValidators(
+          value ? [Validators.required, CustomValidators.email] : null,
+        );
+        this.formGroup.updateValueAndValidity();
       });
 
-    this.formGroup
-      ?.get("resultaattype")
-      ?.valueChanges.pipe(takeUntil(this.ngDestroy))
-      .subscribe((value: GeneratedType<"RestResultaattype">) => {
-        this.besluitVastleggen = !!value.besluitVerplicht;
+    this.formGroup.controls.resultaattype.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe((value) => {
+        this.besluitVastleggen = value?.besluitVerplicht ?? false;
         if (this.besluitVastleggen) {
-          this.formGroup?.get("toelichting")?.disable();
-          this.formGroup?.get("sendMail")?.disable();
-          this.formGroup?.get("verzender")?.disable();
-          this.formGroup?.get("ontvanger")?.disable();
-        } else {
-          this.formGroup?.get("toelichting")?.enable();
-          this.formGroup?.get("sendMail")?.enable();
-          this.formGroup?.get("verzender")?.enable();
-          this.formGroup?.get("ontvanger")?.enable();
+          this.formGroup.controls.toelichting.disable();
+          this.formGroup.controls.sendMail.disable();
+          this.formGroup.controls.verzender.disable();
+          this.formGroup.controls.ontvanger.disable();
+          return;
         }
+
+        this.formGroup.controls.toelichting.enable();
+        this.formGroup.controls.sendMail.enable();
+        this.formGroup.controls.verzender.enable();
+        this.formGroup.controls.ontvanger.enable();
       });
   }
 
-  protected close(): void {
+  protected close() {
     this.dialogRef.close();
   }
 
-  protected afhandelen(): void {
+  protected afhandelen() {
     this.dialogRef.disableClose = true;
     this.loading = true;
     const values = this.formGroup.value;
@@ -162,19 +150,20 @@ export class ZaakAfhandelenDialogComponent implements OnDestroy {
         zaakUuid: this.data.zaak.uuid,
         resultaattypeUuid:
           this.data.zaak.resultaat?.resultaattype?.id ??
-          values.resultaattype.id,
+          values.resultaattype?.id,
         resultaatToelichting: values.toelichting,
         restMailGegevens:
           values.sendMail && this.mailtemplate
             ? {
-                verzender: values.verzender.mail,
-                replyTo: values.verzender.replyTo,
-                ontvanger: values.ontvanger,
+                verzender: values.verzender?.mail,
+                replyTo: values.verzender?.replyTo,
+                ontvanger: values.ontvanger ?? undefined,
                 onderwerp: this.mailtemplate.onderwerp,
                 body: this.mailtemplate.body,
                 createDocumentFromMail: true,
               }
             : null,
+        brondatumEigenschap: values.brondatumEigenschap?.toISOString() ?? null,
       })
       .subscribe({
         next: () => {
@@ -185,22 +174,19 @@ export class ZaakAfhandelenDialogComponent implements OnDestroy {
   }
 
   protected setInitiatorEmail() {
-    this.formGroup.get("ontvanger")?.setValue(this.initiatorEmail);
+    this.formGroup.controls.ontvanger.setValue(this.initiatorEmail ?? null);
   }
 
-  protected getError(fc: AbstractControl, label: string) {
-    return CustomValidators.getErrorMessage(fc, label, this.translateService);
+  protected afzenderOptionDisplayValue(
+    afzender: GeneratedType<"RESTZaakAfzender">,
+  ) {
+    const suffix = afzender.suffix
+      ? ` ${this.translateService.instant(afzender.suffix)}`
+      : "";
+    return `${afzender.mail}${suffix}`;
   }
 
-  ngOnDestroy(): void {
-    this.ngDestroy.next();
-    this.ngDestroy.complete();
-  }
-
-  protected openBesluitVastleggen(): void {
+  protected openBesluitVastleggen() {
     this.dialogRef.close("openBesluitVastleggen");
   }
-
-  protected compareObject = (a: unknown, b: unknown) =>
-    this.utilService.compare(a, b);
 }

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
@@ -23,7 +23,6 @@ import { ZakenService } from "../zaken.service";
 })
 export class ZaakAfhandelenDialogComponent {
   loading = false;
-  mailBeschikbaar = false;
   sendMailDefault = false;
   besluitVastleggen = false;
   mailtemplate?: GeneratedType<"RESTMailtemplate">;
@@ -72,8 +71,6 @@ export class ZaakAfhandelenDialogComponent {
       });
     const zaakafhandelparameters =
       this.data.zaak.zaaktype.zaakafhandelparameters;
-    this.mailBeschikbaar =
-      zaakafhandelparameters?.afrondenMail !== "NIET_BESCHIKBAAR";
     this.sendMailDefault =
       zaakafhandelparameters?.afrondenMail === "BESCHIKBAAR_AAN";
 

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -665,7 +665,7 @@ export class ZaakViewComponent
         if (result) {
           if (result === "openBesluitVastleggen") {
             this.activeSideAction = "actie.besluit.vastleggen";
-            this.actionsSidenav.open();
+            void this.actionsSidenav.open();
           } else {
             this.utilService.openSnackbar(
               "msg.planitem.uitgevoerd." + planItem.userEventListenerActie,
@@ -716,7 +716,7 @@ export class ZaakViewComponent
   }
 
   private openZaakAfbrekenDialog() {
-    this.actionsSidenav.close();
+    void this.actionsSidenav.close();
 
     if (this.zaak.isOpgeschort) {
       this.dialog.open(ActieOnmogelijkDialogComponent);
@@ -797,7 +797,7 @@ export class ZaakViewComponent
   }
 
   private openZaakAfsluitenDialog() {
-    this.actionsSidenav.close();
+    void this.actionsSidenav.close();
     const dialogData = new DialogData<
       unknown,
       { toelichting: string; resultaattype: { id: string } }

--- a/src/main/kotlin/nl/info/client/zgw/zrc/ZrcClientService.kt
+++ b/src/main/kotlin/nl/info/client/zgw/zrc/ZrcClientService.kt
@@ -25,6 +25,7 @@ import nl.info.client.zgw.zrc.model.generated.BetrokkeneTypeEnum
 import nl.info.client.zgw.zrc.model.generated.Resultaat
 import nl.info.client.zgw.zrc.model.generated.Status
 import nl.info.client.zgw.zrc.model.generated.Zaak
+import nl.info.client.zgw.zrc.model.generated.ZaakEigenschap
 import nl.info.zac.configuratie.ConfiguratieService
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
@@ -237,6 +238,10 @@ class ZrcClientService @Inject constructor(
     fun createStatus(status: Status): Status {
         status.statustoelichting?.let { zgwClientHeadersFactory.setAuditToelichting(it) }
         return zrcClient.statusCreate(status)
+    }
+
+    fun createEigenschap(zaakUUID: UUID, zaakEigenschap: ZaakEigenschap): ZaakEigenschap {
+        return zrcClient.zaakeigenschapCreate(zaakUUID, zaakEigenschap)
     }
 
     private fun deleteDeletedRollen(

--- a/src/main/kotlin/nl/info/client/zgw/ztc/ZtcClient.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/ZtcClient.kt
@@ -6,6 +6,7 @@ package nl.info.client.zgw.ztc
 
 import jakarta.ws.rs.BeanParam
 import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
@@ -62,6 +63,10 @@ interface ZtcClient {
     @GET
     @Path("eigenschappen")
     fun eigenschapList(@BeanParam parameters: EigenschapListParameters): Results<Eigenschap>
+
+    @POST
+    @Path("eigenschappen")
+    fun createEigenschap(eigenschap: Eigenschap): Eigenschap
 
     @GET
     @Path("informatieobjecttypen")

--- a/src/main/kotlin/nl/info/client/zgw/ztc/ZtcClientService.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/ZtcClientService.kt
@@ -371,7 +371,7 @@ class ZtcClientService @Inject constructor(
         uriToEigenschappenCache.get(zaaktype) {
             val response = ztcClient.eigenschapList(
                 EigenschapListParameters().apply {
-//                    this.zaaktype = zaaktype
+                    this.zaaktype = zaaktype
                     status = EigenschapListParametersStatus.alles
                 }
             )

--- a/src/main/kotlin/nl/info/client/zgw/ztc/exception/EigenschapNotFoundException.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/exception/EigenschapNotFoundException.kt
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package nl.info.client.zgw.ztc.exception
+
+import jakarta.ws.rs.NotFoundException
+
+class EigenschapNotFoundException(message: String) : NotFoundException(message)

--- a/src/main/kotlin/nl/info/client/zgw/ztc/model/EigenschapListParameters.kt
+++ b/src/main/kotlin/nl/info/client/zgw/ztc/model/EigenschapListParameters.kt
@@ -7,7 +7,19 @@ package nl.info.client.zgw.ztc.model
 import jakarta.ws.rs.QueryParam
 import java.net.URI
 
+enum class EigenschapListParametersStatus(val value: String) {
+    concept("concept"),
+    definitief("definitief"),
+    alles("alles")
+}
+
 class EigenschapListParameters {
     @field:QueryParam("zaaktype")
     var zaaktype: URI? = null
+
+    @field:QueryParam("zaaktypeIdentificatie")
+    var zaaktypeIdentificatie: String? = null
+
+    @field:QueryParam("status")
+    var status: EigenschapListParametersStatus? = null
 }

--- a/src/main/kotlin/nl/info/zac/app/planitems/model/RESTUserEventListenerData.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/model/RESTUserEventListenerData.kt
@@ -22,5 +22,7 @@ data class RESTUserEventListenerData(
 
     var resultaattypeUuid: UUID? = null,
 
-    var restMailGegevens: RESTMailGegevens? = null
+    var restMailGegevens: RESTMailGegevens? = null,
+
+    var brondatumEigenschap: String? = null
 )

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestResultaattype.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestResultaattype.kt
@@ -7,6 +7,7 @@ package nl.info.zac.app.zaak.model
 import net.atos.zac.util.time.PeriodUtil
 import nl.info.client.zgw.util.extractUuid
 import nl.info.client.zgw.ztc.model.generated.AfleidingswijzeEnum
+import nl.info.client.zgw.ztc.model.generated.BrondatumArchiefprocedure
 import nl.info.client.zgw.ztc.model.generated.ResultaatType
 import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
@@ -20,11 +21,13 @@ data class RestResultaattype(
     var naam: String? = null,
     var naamGeneriek: String? = null,
     var vervaldatumBesluitVerplicht: Boolean,
+    var datumKenmerkVerplicht: Boolean,
     var besluitVerplicht: Boolean,
     var toelichting: String? = null,
     var archiefNominatie: String? = null,
     var archiefTermijn: String? = null,
     var selectielijst: String? = null,
+    var bronArchiefprocedure: BrondatumArchiefprocedure? = null,
 )
 
 fun ResultaatType.toRestResultaatType() = RestResultaattype(
@@ -36,8 +39,10 @@ fun ResultaatType.toRestResultaatType() = RestResultaattype(
     archiefTermijn = this.archiefactietermijn?.let {
         PeriodUtil.format(Period.parse(it))
     },
+    bronArchiefprocedure = this.brondatumArchiefprocedure,
     besluitVerplicht = this.isBesluitVerplicht(),
-    vervaldatumBesluitVerplicht = this.isVervaldatumBesluitVerplicht()
+    vervaldatumBesluitVerplicht = this.isVervaldatumBesluitVerplicht(),
+    datumKenmerkVerplicht = this.isDatumKenmerkVerplicht()
 )
 
 fun List<ResultaatType>.toRestResultaatTypes(): List<RestResultaattype> = this.map { it.toRestResultaatType() }
@@ -48,4 +53,8 @@ fun ResultaatType.isBesluitVerplicht() = brondatumArchiefprocedure?.afleidingswi
 
 fun ResultaatType.isVervaldatumBesluitVerplicht() = brondatumArchiefprocedure?.afleidingswijze?.let {
     it == AfleidingswijzeEnum.VERVALDATUM_BESLUIT
+} == true
+
+fun ResultaatType.isDatumKenmerkVerplicht() = brondatumArchiefprocedure?.afleidingswijze?.let {
+    it == AfleidingswijzeEnum.EIGENSCHAP
 } == true

--- a/src/test/kotlin/nl/info/zac/app/planitems/model/PlanItemsFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/planitems/model/PlanItemsFixtures.kt
@@ -42,11 +42,13 @@ fun createRESTTaakStuurGegevens(
 fun createRESTUserEventListenerData(
     zaakUuid: UUID,
     actie: UserEventListenerActie,
-    restMailGegevens: RESTMailGegevens,
-    resultaattypeUuid: UUID = UUID.randomUUID()
+    restMailGegevens: RESTMailGegevens? = null,
+    resultaattypeUuid: UUID = UUID.randomUUID(),
+    brondatumEigenschap: String? = null
 ) = RESTUserEventListenerData(
     zaakUuid = zaakUuid,
     actie = actie,
     restMailGegevens = restMailGegevens,
-    resultaattypeUuid = resultaattypeUuid
+    resultaattypeUuid = resultaattypeUuid,
+    brondatumEigenschap = brondatumEigenschap
 )


### PR DESCRIPTION
This pull request refactors the `zaak-afhandelen-dialog` feature to modernize the form implementation, improve test coverage, and enhance maintainability. The main changes include replacing legacy Angular Material form controls with reusable custom components, introducing a comprehensive new test suite, and simplifying component logic.

**Component and Form Refactor:**

* Refactored `zaak-afhandelen-dialog.component.html` to use custom form components (`zac-select`, `zac-input`, `zac-date`) instead of direct Angular Material form controls, reducing template complexity and improving consistency. The form is now wrapped in a `<form>` element with native submission handling. [[1]](diffhunk://#diff-772747fe6884c601d31ee05fbb41a22908a725ec8d6926331b2e8d0682cfe65bL17-R18) [[2]](diffhunk://#diff-772747fe6884c601d31ee05fbb41a22908a725ec8d6926331b2e8d0682cfe65bL38-R88) [[3]](diffhunk://#diff-772747fe6884c601d31ee05fbb41a22908a725ec8d6926331b2e8d0682cfe65bL142-R121)
* Updated the component class (`zaak-afhandelen-dialog.component.ts`) to simplify form initialization, remove unused properties, and leverage modern Angular patterns such as `takeUntilDestroyed`. The form group is now defined with strong typing and validators. [[1]](diffhunk://#diff-124658cc57edeb6e71ca4021cc6e1a4a24c8ade62e4269525e1c0d17584e9a6cL6-L21) [[2]](diffhunk://#diff-124658cc57edeb6e71ca4021cc6e1a4a24c8ade62e4269525e1c0d17584e9a6cL30-R58)

**Testing Improvements:**

* Added a comprehensive new test suite in `zaak-afhandelen-dialog.component.spec.ts` that covers UI interactions, form validation, conditional rendering, and service calls, significantly increasing test coverage and reliability.

**Developer Experience:**

* Enhanced the `test:watch` npm script to include verbose output, providing more detailed feedback during test runs.
* Ensured all Jest mocks are cleared after each test run to prevent test interference.

Solves PZ-7555