### PR TITLE
test(zaak-view-component): validate the `openPlanItemStartenDialog`

### DIFF
--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -662,17 +662,18 @@ export class ZaakViewComponent
       .afterClosed()
       .subscribe((result) => {
         this.activeSideAction = null;
-        if (result) {
-          if (result === "openBesluitVastleggen") {
-            this.activeSideAction = "actie.besluit.vastleggen";
-            this.actionsSidenav.open();
-          } else {
-            this.utilService.openSnackbar(
-              "msg.planitem.uitgevoerd." + planItem.userEventListenerActie,
-            );
-            this.updateZaak();
-          }
+        if (!result) return;
+
+        if (result === "openBesluitVastleggen") {
+          this.activeSideAction = "actie.besluit.vastleggen";
+          this.actionsSidenav.open();
+          return;
         }
+
+        this.utilService.openSnackbar(
+          `msg.planitem.uitgevoerd.${planItem.userEventListenerActie}`,
+        );
+        this.updateZaak();
       });
   }
 


### PR DESCRIPTION
This pull request enhances the test coverage and robustness of the `ZaakViewComponent` by adding new unit tests for dialog interactions and improving the setup of related services and mocks. It also refines the logic in the component to handle dialog results more clearly and concisely.

### Test suite improvements

* Added new tests for the `openPlanItemStartenDialog` method in `zaak-view.component.spec.ts`, verifying that the correct side action is triggered or a snackbar is shown based on the dialog result.
* Improved test setup by injecting and mocking dependencies such as `MatDialog`, `TakenService`, `IdentityService`, `WebsocketService`, `ZaakafhandelParametersService`, and others, ensuring more reliable and isolated tests. [[1]](diffhunk://#diff-f07ef4c4248b3e9a9e99f86c4d93da4961620f2863391d167a217f48ad50d260R12-R38) [[2]](diffhunk://#diff-f07ef4c4248b3e9a9e99f86c4d93da4961620f2863391d167a217f48ad50d260R52-R56) [[3]](diffhunk://#diff-f07ef4c4248b3e9a9e99f86c4d93da4961620f2863391d167a217f48ad50d260R76-R83) [[4]](diffhunk://#diff-f07ef4c4248b3e9a9e99f86c4d93da4961620f2863391d167a217f48ad50d260R109-R112) [[5]](diffhunk://#diff-f07ef4c4248b3e9a9e99f86c4d93da4961620f2863391d167a217f48ad50d260R143-R180)

### Component logic refinement

* Simplified the `openPlanItemStartenDialog` method in `zaak-view.component.ts` to return early if the dialog result is empty, and to use clearer conditional logic for handling specific dialog outcomes.

Solves PZ-7911