### PR TITLE
chore: always show the zaakafhandelparameters koppeling tab

### DIFF
--- a/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.html
+++ b/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.html
@@ -750,7 +750,6 @@
         </ng-template>
       </mat-step>
       <mat-step
-        *ngIf="parameters.smartDocuments.enabledGlobally"
         [stepControl]="smartDocumentsEnabledForm"
         [hasError]="
           !isSmartDocumentsStepValid || !brpDoelbindingFormGroup.valid
@@ -840,7 +839,7 @@
               </form>
             </mat-card-content>
           </mat-card>
-          <mat-card>
+          <mat-card *ngIf="parameters.smartDocuments.enabledGlobally">
             <mat-card-content>
               <form [formGroup]="smartDocumentsEnabledForm" class="flex-col">
                 <div class="flex-row items-center">


### PR DESCRIPTION
Always show the zaakafhandelparameters koppeling tab so that the KVK and BRP koppelingen can be managed also if SmartDocuments is disabled globally.

Solves PZ-8094