### PR TITLE
feat(EIGENSCHAP): also handle the `datumkenmerk` for reopened cases

### DIFF
--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
@@ -5,8 +5,11 @@
 
 <mat-toolbar role="heading" class="gap-16" mat-dialog-title>
   <mat-icon>thumb_up_alt</mat-icon>
-  <span class="flex-grow-1">
-    {{ "planitem." + data.planItem.userEventListenerActie | translate }}
+  <span class="flex-grow-1" *ngIf="data.planItem">
+    {{ "planitem." + data.planItem?.userEventListenerActie | translate }}
+  </span>
+  <span class="flex-grow-1" *ngIf="!data.planItem">
+    {{ "actie.zaak.afsluiten" | translate }}
   </span>
   <button mat-icon-button (click)="close()">
     <mat-icon>close</mat-icon>
@@ -17,9 +20,9 @@
 <form [formGroup]="formGroup" (submit)="afhandelen()">
   <mat-dialog-content>
     <p
-      *ngIf="data.planItem.toelichting"
+      *ngIf="data.planItem?.toelichting"
       class="readonly"
-      [innerHTML]="planItem.toelichting"
+      [innerHTML]="data.planItem?.toelichting"
     ></p>
     <p
       *ngIf="besluitVastleggen"
@@ -49,11 +52,13 @@
       [form]="formGroup"
       key="brondatumEigenschap"
       *ngIf="formGroup.controls.resultaattype.value?.datumKenmerkVerplicht"
-    />
+    >
+      <mat-label>{{ "zaak.brondatum" | translate }}</mat-label>
+    </zac-date>
     <div
       *ngIf="
         data.zaak.zaaktype.zaakafhandelparameters?.afrondenMail !==
-        'NIET_BESCHIKBAAR'
+          'NIET_BESCHIKBAAR' && !!data.planItem
       "
     >
       <mat-checkbox id="sendMail" formControlName="sendMail">

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -799,54 +799,21 @@ export class ZaakViewComponent
 
   private openZaakAfsluitenDialog() {
     void this.actionsSidenav.close();
-    const dialogData = new DialogData<
-      unknown,
-      { toelichting: string; resultaattype: { id: string } }
-    >({
-      formFields: [
-        new SelectFormFieldBuilder()
-          .id("resultaattype")
-          .label("resultaat")
-          .optionLabel("naam")
-          .options(
-            this.zakenService.listResultaattypes(this.zaak.zaaktype.uuid),
-          )
-          .validators(Validators.required)
-          .build(),
-        new InputFormFieldBuilder()
-          .id("toelichting")
-          .label("toelichting")
-          .maxlength(80)
-          .build(),
-      ],
-      callback: ({ toelichting, resultaattype: { id } }) =>
-        this.zakenService
-          .afsluiten(this.zaak.uuid, {
-            reden: toelichting,
-            resultaattypeUuid: id,
-          })
-          .pipe(
-            tap(() => this.websocketService.suspendListener(this.zaakListener)),
-          ),
-      confirmButtonActionKey: "actie.zaak.afsluiten",
-      icon: "thumb_up_alt",
-    });
 
     this.dialog
-      .open(DialogComponent, { data: dialogData })
+      .open(ZaakAfhandelenDialogComponent, { data: { zaak: this.zaak } })
       .afterClosed()
       .subscribe((result) => {
         this.activeSideAction = null;
-        if (result) {
-          this.updateZaak();
-          this.loadTaken();
-          this.utilService.openSnackbar("msg.zaak.afgesloten");
-        }
+        if (!result) return;
+        this.updateZaak();
+        this.loadTaken();
+        this.utilService.openSnackbar("msg.zaak.afgesloten");
       });
   }
 
   private openZaakOpschortenDialog() {
-    this.actionsSidenav.close();
+    void this.actionsSidenav.close();
     this.dialog
       .open(ZaakOpschortenDialogComponent, {
         data: { zaak: this.zaak },

--- a/src/main/app/src/assets/i18n/en.json
+++ b/src/main/app/src/assets/i18n/en.json
@@ -88,6 +88,7 @@
   "uiterlijkereactiedatum": "Final response date",
   "einddatum": "End date",
   "zaak.einddatum": "Case end date",
+  "zaak.brondatum": "Case archiving source date",
   "streefdatum": "Due date",
   "einddatumGepland": "Due date",
   "einddatumGeplandWaarschuwing": "Due date warning window",

--- a/src/main/app/src/assets/i18n/nl.json
+++ b/src/main/app/src/assets/i18n/nl.json
@@ -88,6 +88,7 @@
   "uiterlijkereactiedatum": "Uiterlijke reactiedatum",
   "einddatum": "Einddatum",
   "zaak.einddatum": "Zaak einddatum",
+  "zaak.brondatum": "Zaak archievering brondatum",
   "streefdatum": "Streefdatum",
   "einddatumGepland": "Streefdatum",
   "einddatumGeplandWaarschuwing": "Streefdatum waarschuwingsvenster",

--- a/src/main/kotlin/nl/info/client/zgw/zrc/ZrcClient.kt
+++ b/src/main/kotlin/nl/info/client/zgw/zrc/ZrcClient.kt
@@ -153,6 +153,14 @@ interface ZrcClient {
     @Path("zaken/{zaak_uuid}/zaakeigenschappen")
     fun zaakeigenschapList(@PathParam("zaak_uuid") zaakUUID: UUID): List<ZaakEigenschap>
 
+    @PUT
+    @Path("zaken/{zaak_uuid}/zaakeigenschappen/{uuid}")
+    fun zaakEigenschapUpdate(
+        @PathParam("zaak_uuid") zaakUUID: UUID,
+        @PathParam("uuid") uuid: UUID,
+        zaakeigenschap: ZaakEigenschap
+    ): ZaakEigenschap
+
     @POST
     @Path("zaken/{zaak_uuid}/zaakeigenschappen")
     fun zaakeigenschapCreate(@PathParam("zaak_uuid") zaakUUID: UUID, zaakeigenschap: ZaakEigenschap): ZaakEigenschap

--- a/src/main/kotlin/nl/info/client/zgw/zrc/ZrcClientService.kt
+++ b/src/main/kotlin/nl/info/client/zgw/zrc/ZrcClientService.kt
@@ -244,6 +244,18 @@ class ZrcClientService @Inject constructor(
         return zrcClient.zaakeigenschapCreate(zaakUUID, zaakEigenschap)
     }
 
+    fun listZaakeigenschappen(zaakUUID: UUID): List<ZaakEigenschap> {
+        return zrcClient.zaakeigenschapList(zaakUUID)
+    }
+
+    fun updateZaakeigenschap(
+        zaakUUID: UUID,
+        uuid: UUID,
+        zaakEigenschap: ZaakEigenschap
+    ): ZaakEigenschap {
+        return zrcClient.zaakEigenschapUpdate(zaakUUID, uuid, zaakEigenschap)
+    }
+
     private fun deleteDeletedRollen(
         currentRoles: List<Rol<*>>,
         rolesToBeDeleted: List<Rol<*>>,

--- a/src/main/kotlin/nl/info/zac/app/planitems/model/RESTUserEventListenerData.kt
+++ b/src/main/kotlin/nl/info/zac/app/planitems/model/RESTUserEventListenerData.kt
@@ -24,5 +24,9 @@ data class RESTUserEventListenerData(
 
     var restMailGegevens: RESTMailGegevens? = null,
 
+    /**
+     * De einddatum van het processtermijn voor de zaak.
+     * Ook wel de 'brondatum' genoemd.
+     */
     var brondatumEigenschap: String? = null
 )

--- a/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
@@ -63,6 +63,7 @@ import nl.info.client.zgw.zrc.util.isHeropend
 import nl.info.client.zgw.zrc.util.isOpen
 import nl.info.client.zgw.ztc.ZtcClientService
 import nl.info.client.zgw.ztc.model.extensions.isNuGeldig
+import nl.info.client.zgw.ztc.model.generated.BrondatumArchiefprocedure
 import nl.info.zac.app.decision.DecisionService
 import nl.info.zac.app.klant.model.klant.IdentificatieType
 import nl.info.zac.app.zaak.converter.RestDecisionConverter
@@ -755,11 +756,21 @@ class ZaakRestService @Inject constructor(
     ) {
         val (zaak, zaakType) = zaakService.readZaakAndZaakTypeByZaakUUID(zaakUUID)
         assertPolicy(zaak.isOpen() && policyService.readZaakRechten(zaak, zaakType).behandelen)
+
+        zaakService.processSpecialBrondatumProcedure(
+            zaak,
+            afsluitenGegevens.resultaattypeUuid,
+            BrondatumArchiefprocedure().apply {
+                datumkenmerk = afsluitenGegevens.brondatumEigenschap
+            }
+        )
+
         zgwApiService.updateResultaatForZaak(
             zaak,
             afsluitenGegevens.resultaattypeUuid,
             afsluitenGegevens.reden
         )
+
         zgwApiService.closeZaak(zaak, afsluitenGegevens.reden)
     }
 

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakAfsluitenGegevens.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RESTZaakAfsluitenGegevens.kt
@@ -13,5 +13,11 @@ import java.util.UUID
 data class RESTZaakAfsluitenGegevens(
     var reden: String? = null,
 
-    var resultaattypeUuid: UUID
+    var resultaattypeUuid: UUID,
+
+    /**
+     * De einddatum van het processtermijn voor de zaak.
+     * Ook wel de 'brondatum' genoemd.
+     */
+    var brondatumEigenschap: String? = null
 )

--- a/src/test/kotlin/nl/info/client/zgw/ztc/model/ZtcFixtures.kt
+++ b/src/test/kotlin/nl/info/client/zgw/ztc/model/ZtcFixtures.kt
@@ -58,9 +58,11 @@ fun createBesluitType(
     }
 
 fun createBrondatumArchiefprocedure(
-    afleidingswijze: AfleidingswijzeEnum? = AfleidingswijzeEnum.VERVALDATUM_BESLUIT
+    afleidingswijze: AfleidingswijzeEnum? = AfleidingswijzeEnum.VERVALDATUM_BESLUIT,
+    datumkenmerk: String = "fakeDatumkenmerk",
 ) = BrondatumArchiefprocedure().apply {
     this.afleidingswijze = afleidingswijze
+    this.datumkenmerk = datumkenmerk
 }
 
 fun createCatalogus(

--- a/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
@@ -38,10 +38,15 @@ import nl.info.client.zgw.zrc.ZrcClientService
 import nl.info.client.zgw.zrc.model.generated.ArchiefnominatieEnum
 import nl.info.client.zgw.zrc.model.generated.BetrokkeneTypeEnum
 import nl.info.client.zgw.zrc.model.generated.Zaak
+import nl.info.client.zgw.zrc.model.generated.ZaakEigenschap
 import nl.info.client.zgw.ztc.ZtcClientService
+import nl.info.client.zgw.ztc.model.createBrondatumArchiefprocedure
+import nl.info.client.zgw.ztc.model.createResultaatType
 import nl.info.client.zgw.ztc.model.createRolType
 import nl.info.client.zgw.ztc.model.createStatusType
 import nl.info.client.zgw.ztc.model.createZaakType
+import nl.info.client.zgw.ztc.model.generated.AfleidingswijzeEnum
+import nl.info.client.zgw.ztc.model.generated.Eigenschap
 import nl.info.client.zgw.ztc.model.generated.OmschrijvingGeneriekEnum
 import nl.info.zac.admin.model.createZaakafhandelParameters
 import nl.info.zac.app.klant.model.klant.IdentificatieType
@@ -956,6 +961,75 @@ class ZaakServiceTest : BehaviorSpec({
 
                 Then("it should return the correct zaaktype") {
                     result shouldBe zaakType
+                }
+            }
+        }
+    }
+
+    Context("Process special brondatum procedure") {
+        Given("A zaak and resultaattype with EIGENSCHAP afleidingswijze and existing zaakeigenschap") {
+            val zaak = createZaak()
+            val resultaatTypeUUID = UUID.randomUUID()
+            val resultaatType = createResultaatType(
+                brondatumArchiefprocedure = createBrondatumArchiefprocedure(
+                    afleidingswijze = AfleidingswijzeEnum.EIGENSCHAP
+                )
+            )
+            val brondatumArchiefprocedure = createBrondatumArchiefprocedure(
+                afleidingswijze = AfleidingswijzeEnum.EIGENSCHAP,
+            )
+
+            val existingZaakEigenschap = ZaakEigenschap(
+                URI(""),
+                UUID.randomUUID(),
+                brondatumArchiefprocedure.datumkenmerk
+            ).apply {
+                waarde = "testWaarde"
+            }
+
+            every { ztcClientService.readResultaattype(resultaatTypeUUID) } returns resultaatType
+            every { zrcClientService.listZaakeigenschappen(zaak.uuid) } returns listOf(existingZaakEigenschap)
+            every { zrcClientService.updateZaakeigenschap(any(), any(), any()) } returns existingZaakEigenschap
+
+            When("processSpecialBrondatumProcedure is called with existing zaakeigenschap") {
+                zaakService.processSpecialBrondatumProcedure(zaak, resultaatTypeUUID, brondatumArchiefprocedure)
+
+                Then("it should update the existing zaakeigenschap") {
+                    verify { zrcClientService.updateZaakeigenschap(zaak.uuid, existingZaakEigenschap.uuid, any()) }
+                }
+
+                And("it should not create a new zaakeigenschap") {
+                    verify(exactly = 0) { zrcClientService.createEigenschap(zaak.uuid, any()) }
+                }
+            }
+        }
+
+        Given("A zaak and resultaattype with EIGENSCHAP afleidingswijze and non-existing zaakeigenschap") {
+            val zaak = createZaak()
+            val resultaatTypeUUID = UUID.randomUUID()
+            val resultaatType = createResultaatType(
+                brondatumArchiefprocedure = createBrondatumArchiefprocedure(
+                    afleidingswijze = AfleidingswijzeEnum.EIGENSCHAP
+                )
+            )
+            val brondatumArchiefprocedure = createBrondatumArchiefprocedure(
+                afleidingswijze = AfleidingswijzeEnum.EIGENSCHAP
+            )
+            val eigenschap = Eigenschap()
+            every { ztcClientService.readResultaattype(resultaatTypeUUID) } returns resultaatType
+            every { zrcClientService.listZaakeigenschappen(zaak.uuid) } returns emptyList()
+            every { ztcClientService.readEigenschap(zaak.zaaktype, brondatumArchiefprocedure.datumkenmerk) } returns eigenschap
+            every { zrcClientService.createEigenschap(any(), any()) } returns mockk()
+
+            When("processSpecialBrondatumProcedure is called with non-existing zaakeigenschap") {
+                zaakService.processSpecialBrondatumProcedure(zaak, resultaatTypeUUID, brondatumArchiefprocedure)
+
+                Then("it should create a new zaakeigenschap") {
+                    verify { zrcClientService.createEigenschap(zaak.uuid, any()) }
+                }
+
+                And("it should not update any existing zaakeigenschap") {
+                    verify(exactly = 0) { zrcClientService.updateZaakeigenschap(zaak.uuid, any(), any()) }
                 }
             }
         }


### PR DESCRIPTION
This pull request introduces support for handling the "brondatum" (source date for archiving) when closing or finalizing a case ("zaak"), ensuring the correct property is set or updated as required by the selected result type. It also improves the user interface and validation around this process. The most important changes are grouped below:

**Frontend: Enhanced Dialog and Brondatum Support**
* The `ZaakAfhandelenDialogComponent` now supports cases both with and without a `planItem`, adjusts UI labels accordingly, and displays the "brondatum" field with proper translation. The dialog now handles the closing of a case directly if no `planItem` is present. [[1]](diffhunk://#diff-772747fe6884c601d31ee05fbb41a22908a725ec8d6926331b2e8d0682cfe65bL8-R12) [[2]](diffhunk://#diff-772747fe6884c601d31ee05fbb41a22908a725ec8d6926331b2e8d0682cfe65bL20-R25) [[3]](diffhunk://#diff-772747fe6884c601d31ee05fbb41a22908a725ec8d6926331b2e8d0682cfe65bL52-R61) [[4]](diffhunk://#diff-124658cc57edeb6e71ca4021cc6e1a4a24c8ade62e4269525e1c0d17584e9a6cL29) [[5]](diffhunk://#diff-124658cc57edeb6e71ca4021cc6e1a4a24c8ade62e4269525e1c0d17584e9a6cL51-R50) [[6]](diffhunk://#diff-124658cc57edeb6e71ca4021cc6e1a4a24c8ade62e4269525e1c0d17584e9a6cL60) [[7]](diffhunk://#diff-124658cc57edeb6e71ca4021cc6e1a4a24c8ade62e4269525e1c0d17584e9a6cR139-R169)
* The `ZaakViewComponent` now opens the improved `ZaakAfhandelenDialogComponent` for case closure, replacing the previous generic dialog, and updates the UI flow accordingly.
* Added translations for the new "zaak.brondatum" label in both Dutch and English. [[1]](diffhunk://#diff-57e9586bcf4390dd074ebbbbae39d448f1c5c2329c0c31c51e87645a819cc9dcR91) [[2]](diffhunk://#diff-75c15ffb62a2f759f0dd674475297f30f2dd58275cae67261c41e896b806e173R91)

**Backend: Brondatum Archiefprocedure Processing**
* Added logic in `ZaakService` to process the special "brondatum" procedure: if the result type requires a brondatum based on an "eigenschap" (property), it validates and upserts the property value on the case, updating it if it already exists. [[1]](diffhunk://#diff-be5defe1d03970f7d9a75bde0946aa490b49ec541ef7b3bb490019f72a5d148cR27-R40) [[2]](diffhunk://#diff-be5defe1d03970f7d9a75bde0946aa490b49ec541ef7b3bb490019f72a5d148cR366-R409)
* The `PlanItemsRestService` and `ZaakRestService` now invoke the new brondatum processing logic before closing a case or handling a plan item, ensuring the property is set as required. [[1]](diffhunk://#diff-5d21fccb2e561d2f55c1b010d9356cd23b4f1b55df103ccf7be246a4957d4c9eR265-L313) [[2]](diffhunk://#diff-ee1ff4793bc36d23bf497c590a29424b56c1874f97f93483732fd7eaa21f31f3R66) [[3]](diffhunk://#diff-ee1ff4793bc36d23bf497c590a29424b56c1874f97f93483732fd7eaa21f31f3R759-R773)
* The data models (`RESTZaakAfsluitenGegevens` and `RESTUserEventListenerData`) have been extended to include the optional `brondatumEigenschap` field, and relevant documentation has been added. [[1]](diffhunk://#diff-5acc01314d29207e27aa96077b2590d86c37fdb9c4c4cc525bb629b118b64aa5L16-R22) [[2]](diffhunk://#diff-78ec7b1640872f0dcff413bbc5d0f86ed372297e062b3e795ccfeb8859e9b4cfR27-R30)

**API and Service Layer Extensions**
* The ZRC client and service have been extended with support for updating an existing "ZaakEigenschap" and listing all properties for a case, enabling the upsert logic for the brondatum. [[1]](diffhunk://#diff-782aad8a94fd6ab2d3525a955d6b37eb0bff1459a59e99618c7709271c0603b3R156-R163) [[2]](diffhunk://#diff-5b39372d524cdcfc76c3b3562e22f05bb4a5158f844e2d4659feb40fe6fd3210R247-R258)

**Test Improvements**
* The test fixture for `BrondatumArchiefprocedure` now supports specifying a `datumkenmerk`, allowing for more flexible test scenarios.

These changes together ensure that the correct archiving source date is handled according to the business rules, improving both backend consistency and frontend user experience.

Solves PZ-7555