### PR TITLE
fix(persoon-zoek.component): enable all fields for no filled fields

### DIFF
--- a/src/main/app/src/app/klanten/zoek/personen/persoon-zoek.component.ts
+++ b/src/main/app/src/app/klanten/zoek/personen/persoon-zoek.component.ts
@@ -203,7 +203,7 @@ export class PersoonZoekComponent implements OnInit, OnDestroy {
   }
 
   private updateControls(potential: GeneratedType<"RestPersonenParameters">[]) {
-    const hasValues = Object.values(potential).some((value) => value);
+    const hasValues = Object.values(potential).some(Boolean);
     for (const [key, control] of Object.entries(this.formGroup.controls)) {
       if (!hasValues) {
         this.enableField(control, true);


### PR DESCRIPTION
This pull request updates the `PersoonZoekComponent` to improve the way form value changes are handled and to enhance the logic for enabling/disabling form fields. The main changes involve adopting a more idiomatic Angular approach for subscription cleanup and refining the control update logic.

**Form value change handling and subscription management:**

* Replaced the manual `takeUntil(this.destroy$)` pattern with Angular's `takeUntilDestroyed()` for automatic subscription cleanup in the `valueChanges` observable. This makes the code cleaner and less error-prone. [[1]](diffhunk://#diff-1e1ba19c6ad9fb36d80181c90c9e76f970ec491599868f3234e17b8ff3bd8327R15) [[2]](diffhunk://#diff-1e1ba19c6ad9fb36d80181c90c9e76f970ec491599868f3234e17b8ff3bd8327L109-R115)
* Updated the `valueChanges` subscription to use the emitted `value` directly, simplifying the extraction and transformation of form values, especially for the `geboortedatum` field.

**Form control state logic:**

* Enhanced the `updateControls` method to check if any potential query values exist (`hasValues`). If no values are present, all fields are enabled, ensuring the form is fully interactive when empty.