### PR TITLE
fix: brpKoppelen and kvkKoppelen zaakafhandelparameters default to true

### DIFF
--- a/src/main/resources/schemas/V75__update_brp_kvk_koppeling_defaults_to_true.sql
+++ b/src/main/resources/schemas/V75__update_brp_kvk_koppeling_defaults_to_true.sql
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2025 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+ALTER TABLE ${schema}.betrokkene_koppelingen
+ALTER COLUMN brpKoppelen SET DEFAULT TRUE;
+
+ALTER TABLE ${schema}.betrokkene_koppelingen
+ALTER COLUMN kvkKoppelen SET DEFAULT TRUE;


### PR DESCRIPTION
Zaakafhandelparameter columns brpKoppelen and kvkKoppelen should default to true to reflect most cases will be making use of these systems.

Solves PZ-8137
