### PR TITLE
feat(zaak-afhandelen-dialoog): require `brondatumEigenschap`

### DIFF
--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
@@ -25,7 +25,7 @@
       [innerHTML]="data.planItem?.toelichting"
     ></p>
     <p
-      *ngIf="besluitVastleggen"
+      *ngIf="formGroup.controls.resultaattype.value?.besluitVerplicht"
       class="readonly error"
       [innerHTML]="'msg.besluit.verplicht' | translate"
     ></p>
@@ -100,7 +100,7 @@
   </mat-dialog-content>
   <mat-dialog-actions>
     <button
-      *ngIf="!besluitVastleggen"
+      *ngIf="!formGroup.controls.resultaattype.value?.besluitVerplicht"
       mat-raised-button
       color="primary"
       type="submit"
@@ -112,7 +112,7 @@
       {{ "actie.zaak.afhandelen" | translate }}
     </button>
     <button
-      *ngIf="besluitVastleggen"
+      *ngIf="formGroup.controls.resultaattype.value?.besluitVerplicht"
       mat-raised-button
       color="primary"
       (click)="openBesluitVastleggen()"

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.spec.ts
@@ -297,6 +297,21 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
         }),
       );
     });
+
+    it("should not allow the form to be submitted when a brondatumEigenschap is required", async () => {
+      const resultaattypeSelect = await loader.getHarness(MatSelectHarness);
+      await resultaattypeSelect.open();
+
+      const options = await resultaattypeSelect.getOptions();
+      await options[0]?.click();
+
+      const submitButton = await loader.getHarness(
+        MatButtonHarness.with({ text: /actie\.zaak\.afhandelen/ }),
+      );
+      const isDisabled = await submitButton.isDisabled();
+
+      expect(isDisabled).toBe(true);
+    });
   });
 
   describe("mail expansion panel", () => {

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
@@ -24,7 +24,6 @@ import { ZakenService } from "../zaken.service";
 export class ZaakAfhandelenDialogComponent {
   loading = false;
   sendMailDefault = false;
-  besluitVastleggen = false;
   mailtemplate?: GeneratedType<"RESTMailtemplate">;
   initiatorEmail?: string;
 
@@ -113,19 +112,27 @@ export class ZaakAfhandelenDialogComponent {
     this.formGroup.controls.resultaattype.valueChanges
       .pipe(takeUntilDestroyed())
       .subscribe((value) => {
-        this.besluitVastleggen = value?.besluitVerplicht ?? false;
-        if (this.besluitVastleggen) {
+        if (value?.besluitVerplicht) {
           this.formGroup.controls.toelichting.disable();
           this.formGroup.controls.sendMail.disable();
           this.formGroup.controls.verzender.disable();
           this.formGroup.controls.ontvanger.disable();
-          return;
+        } else {
+          this.formGroup.controls.toelichting.enable();
+          this.formGroup.controls.sendMail.enable();
+          this.formGroup.controls.verzender.enable();
+          this.formGroup.controls.ontvanger.enable();
         }
 
-        this.formGroup.controls.toelichting.enable();
-        this.formGroup.controls.sendMail.enable();
-        this.formGroup.controls.verzender.enable();
-        this.formGroup.controls.ontvanger.enable();
+        if (value?.datumKenmerkVerplicht) {
+          this.formGroup.controls.brondatumEigenschap.addValidators([
+            Validators.required,
+          ]);
+        } else {
+          this.formGroup.controls.brondatumEigenschap.removeValidators([
+            Validators.required,
+          ]);
+        }
       });
   }
 
@@ -174,15 +181,15 @@ export class ZaakAfhandelenDialogComponent {
         resultaatToelichting: values.toelichting,
         restMailGegevens:
           values.sendMail && this.mailtemplate
-            ? {
-                verzender: values.verzender?.mail,
-                replyTo: values.verzender?.replyTo,
+            ? ({
+                verzender: values.verzender?.mail ?? undefined,
+                replyTo: values.verzender?.replyTo ?? undefined,
                 ontvanger: values.ontvanger ?? undefined,
                 onderwerp: this.mailtemplate.onderwerp,
                 body: this.mailtemplate.body,
                 createDocumentFromMail: true,
-              }
-            : null,
+              } satisfies GeneratedType<"RESTMailGegevens">)
+            : undefined,
         brondatumEigenschap: values.brondatumEigenschap?.toISOString() ?? null,
       })
       .subscribe({


### PR DESCRIPTION
When the result-type has the `datumKenmerkVerplicht` flag, it should require the `brondatumEigenschap` field and the form should not be submit-able

This pull request refactors how the `ZaakAfhandelenDialogComponent` determines when to show or enable certain UI elements and adds validation for required fields based on the selected `resultaattype`. The main improvement is removing the `besluitVastleggen` property in favor of directly referencing form control values, and adding logic to require the `brondatumEigenschap` field when needed. Additionally, the form submission logic and related tests are updated accordingly.

**Form logic and validation improvements:**

* Removed the `besluitVastleggen` property and now use `formGroup.controls.resultaattype.value?.besluitVerplicht` directly in the template and component logic, simplifying state management. [[1]](diffhunk://#diff-124658cc57edeb6e71ca4021cc6e1a4a24c8ade62e4269525e1c0d17584e9a6cL27) [[2]](diffhunk://#diff-772747fe6884c601d31ee05fbb41a22908a725ec8d6926331b2e8d0682cfe65bL28-R28) [[3]](diffhunk://#diff-772747fe6884c601d31ee05fbb41a22908a725ec8d6926331b2e8d0682cfe65bL103-R103) [[4]](diffhunk://#diff-772747fe6884c601d31ee05fbb41a22908a725ec8d6926331b2e8d0682cfe65bL115-R115)
* Added dynamic validation for the `brondatumEigenschap` field: it is now required if `datumKenmerkVerplicht` is true in the selected `resultaattype`.

**Form submission and data handling:**

* Updated the submission logic to use `undefined` instead of `null` for optional mail fields, and to only include `restMailGegevens` when appropriate, ensuring type correctness with `satisfies GeneratedType<"RESTMailGegevens">`.

**Testing:**

* Added a test to ensure the form cannot be submitted when `brondatumEigenschap` is required but not filled in.

Solves PZ-7555