### PR TITLE
chore: use the same Kotest version for the kotest-runner-junit5 and kotest-assertions-json dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,8 +60,7 @@ wildfly-security-elytron-http-oidc = "2.6.4.Final"
 
 eclipse-yasson = "3.0.4"
 
-kotest-runner-junit5 = "5.9.1"
-kotest-assertions-json = "5.9.1"
+kotest = "5.9.1"
 mockk = "1.14.5"
 
 testcontainers = "1.21.3"
@@ -142,8 +141,8 @@ wildfly-security-elytron-http-oidc = { group = "org.wildfly.security", name = "w
 # where we do not have the WildFly runtime environment available
 eclipse-yasson = { group = "org.eclipse", name = "yasson", version.ref = "eclipse-yasson" }
 
-kotest-runner-junit5 = { group = "io.kotest", name = "kotest-runner-junit5", version.ref = "kotest-runner-junit5" }
-kotest-assertions-json = { group = "io.kotest", name = "kotest-assertions-json", version.ref = "kotest-assertions-json" }
+kotest-runner-junit5 = { group = "io.kotest", name = "kotest-runner-junit5", version.ref = "kotest" }
+kotest-assertions-json = { group = "io.kotest", name = "kotest-assertions-json", version.ref = "kotest" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 json = { group = "org.json", name = "json", version.ref = "json-json" }
 


### PR DESCRIPTION
Use the same Kotest version for the kotest-runner-junit5 and kotest-assertions-json dependencies since they are always released under the same version.

Solves PZ-8144