### PR TITLE
chore: no longer create the zgw-referentielijsten-database-data

### DIFF
--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -127,7 +127,6 @@ mkdir -p $volumeDataFolder/zac-keycloak-database-data
 mkdir -p $volumeDataFolder/solr-data
 mkdir -p $volumeDataFolder/zac-database-data
 mkdir -p $volumeDataFolder/zac-keycloak-database-data
-mkdir -p $volumeDataFolder/zgw-referentielijsten-database-data
 
 # Build comma separated profile list
 profilesList=""


### PR DESCRIPTION
No longer create the zgw-referentielijsten-database-data in our Docker Compose because it is obsolete.

Solves PZ-8147