### PR TITLE
refactor(signaleringen): make use of the `ZacHttpClient`

### DIFF
--- a/src/main/app/src/app/signaleringen/signaleringen-settings.service.ts
+++ b/src/main/app/src/app/signaleringen/signaleringen-settings.service.ts
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { catchError } from "rxjs/operators";
-import { FoutAfhandelingService } from "../fout-afhandeling/fout-afhandeling.service";
-import { GeneratedType } from "../shared/utils/generated-types";
+import { PutBody, ZacHttpClient } from "../shared/http/zac-http-client";
 
 @Injectable({
   providedIn: "root",
@@ -15,26 +12,13 @@ import { GeneratedType } from "../shared/utils/generated-types";
 export class SignaleringenSettingsService {
   private basepath = "/rest/signaleringen";
 
-  constructor(
-    private http: HttpClient,
-    private foutAfhandelingService: FoutAfhandelingService,
-  ) {}
+  constructor(private readonly zacHttpClient: ZacHttpClient) {}
 
   list() {
-    return this.http
-      .get<
-        GeneratedType<"RestSignaleringInstellingen">[]
-      >(`${this.basepath}/instellingen`)
-      .pipe(
-        catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
-      );
+    return this.zacHttpClient.GET("/rest/signaleringen/instellingen");
   }
 
-  put(instellingen: GeneratedType<"RestSignaleringInstellingen">) {
-    return this.http
-      .put<void>(`${this.basepath}/instellingen`, instellingen)
-      .pipe(
-        catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
-      );
+  put(body: PutBody<"/rest/signaleringen/instellingen">) {
+    return this.zacHttpClient.PUT("/rest/signaleringen/instellingen", body);
   }
 }

--- a/src/main/app/src/app/signaleringen/signaleringen-settings/signaleringen-settings.component.ts
+++ b/src/main/app/src/app/signaleringen/signaleringen-settings/signaleringen-settings.component.ts
@@ -15,7 +15,7 @@ import { SignaleringenSettingsService } from "../signaleringen-settings.service"
 })
 export class SignaleringenSettingsComponent implements OnInit, AfterViewInit {
   isLoadingResults = true;
-  columns: string[] = ["subjecttype", "type", "dashboard", "mail"];
+  columns = ["subjecttype", "type", "dashboard", "mail"] as const;
   dataSource = new MatTableDataSource<
     GeneratedType<"RestSignaleringInstellingen">
   >();
@@ -25,11 +25,11 @@ export class SignaleringenSettingsComponent implements OnInit, AfterViewInit {
     private utilService: UtilService,
   ) {}
 
-  ngOnInit(): void {
+  ngOnInit() {
     this.utilService.setTitle("title.signaleringen.settings");
   }
 
-  ngAfterViewInit(): void {
+  ngAfterViewInit() {
     this.service.list().subscribe((instellingen) => {
       this.dataSource.data = instellingen;
       this.isLoadingResults = false;
@@ -38,9 +38,12 @@ export class SignaleringenSettingsComponent implements OnInit, AfterViewInit {
 
   changed(
     row: GeneratedType<"RestSignaleringInstellingen">,
-    column: string,
+    column: keyof Pick<
+      GeneratedType<"RestSignaleringInstellingen">,
+      "dashboard" | "mail"
+    >,
     checked: boolean,
-  ): void {
+  ) {
     this.utilService.setLoading(true);
     row[column] = checked;
     this.service.put(row).subscribe(() => {


### PR DESCRIPTION
This pull request refactors the `SignaleringenSettingsService` to use a standardized HTTP client (`ZacHttpClient`) and streamlines related code in the `SignaleringenSettingsComponent`. The changes improve type safety, code consistency, and error handling by centralizing HTTP logic.

**Refactor to standardized HTTP client:**

* Replaced usage of `HttpClient` and custom error handling in `SignaleringenSettingsService` with the shared `ZacHttpClient`, simplifying HTTP calls and removing redundant dependencies. (`src/main/app/src/app/signaleringen/signaleringen-settings.service.ts`)

**Type safety and code consistency improvements:**

* Changed the `columns` property in `SignaleringenSettingsComponent` to use a `const` assertion for stronger type safety. (`src/main/app/src/app/signaleringen/signaleringen-settings/signaleringen-settings.component.ts`)
* Updated the `changed` method to use a stricter `keyof Pick<...>` type for the `column` parameter, ensuring only valid columns can be changed. (`src/main/app/src/app/signaleringen/signaleringen-settings/signaleringen-settings.component.ts`)
* Removed explicit return types (`: void`) from lifecycle hooks for consistency and conciseness. (`src/main/app/src/app/signaleringen/signaleringen-settings/signaleringen-settings.component.ts`)

Solves PZ-7675