### PR TITLE
refactor(health-check.service): make use of the `ZacHttpClient`

### DIFF
--- a/src/main/app/src/app/admin/health-check.service.ts
+++ b/src/main/app/src/app/admin/health-check.service.ts
@@ -3,60 +3,32 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Observable } from "rxjs";
-import { catchError } from "rxjs/operators";
-import { FoutAfhandelingService } from "../fout-afhandeling/fout-afhandeling.service";
 import { ZacHttpClient } from "../shared/http/zac-http-client";
-import { GeneratedType } from "../shared/utils/generated-types";
 
 @Injectable({
   providedIn: "root",
 })
 export class HealthCheckService {
-  constructor(
-    private readonly http: HttpClient,
-    private readonly foutAfhandelingService: FoutAfhandelingService,
-    private readonly zacHttpClient: ZacHttpClient,
-  ) {}
+  constructor(private readonly zacHttpClient: ZacHttpClient) {}
 
-  private basepath = "/rest/health-check";
-
-  listZaaktypeInrichtingschecks(): Observable<
-    GeneratedType<"RESTZaaktypeInrichtingscheck">[]
-  > {
-    return this.http
-      .get<
-        GeneratedType<"RESTZaaktypeInrichtingscheck">[]
-      >(`${this.basepath}/zaaktypes`)
-      .pipe(
-        catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
-      );
+  listZaaktypeInrichtingschecks() {
+    return this.zacHttpClient.GET("/rest/health-check/zaaktypes");
   }
 
-  readBestaatCommunicatiekanaalEformulier(): Observable<boolean> {
-    return this.http
-      .get<boolean>(`${this.basepath}/bestaat-communicatiekanaal-eformulier`)
-      .pipe(
-        catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
-      );
+  readBestaatCommunicatiekanaalEformulier() {
+    return this.zacHttpClient.GET(
+      "/rest/health-check/bestaat-communicatiekanaal-eformulier",
+    );
   }
 
-  clearZTCCaches(): Observable<string> {
-    return this.http
-      .delete<string>(`${this.basepath}/ztc-cache`)
-      .pipe(
-        catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
-      );
+  clearZTCCaches() {
+    return this.zacHttpClient.DELETE("/rest/health-check/ztc-cache");
   }
 
   readZTCCacheTime(): Observable<string> {
-    return this.http
-      .get<string>(`${this.basepath}/ztc-cache`)
-      .pipe(
-        catchError((err) => this.foutAfhandelingService.foutAfhandelen(err)),
-      );
+    return this.zacHttpClient.GET("/rest/health-check/ztc-cache");
   }
 
   readBuildInformatie() {


### PR DESCRIPTION
This pull request refactors the `HealthCheckService` to simplify its implementation by removing redundant dependencies and centralizing HTTP requests through the `ZacHttpClient`. Error handling is now managed within `ZacHttpClient`, resulting in cleaner and more maintainable code.

Refactoring and simplification:

* Replaced direct usage of `HttpClient` and manual error handling with `ZacHttpClient` for all HTTP requests, removing the need for `FoutAfhandelingService` and related imports. (`src/main/app/src/app/admin/health-check.service.ts`, [src/main/app/src/app/admin/health-check.service.tsL6-R31](diffhunk://#diff-8f4d711b6a291e6ad92b02a2e0799215ba02a386e916552c25981dd2cca174d6L6-R31))
* Simplified method implementations (`listZaaktypeInrichtingschecks`, `readBestaatCommunicatiekanaalEformulier`, `clearZTCCaches`, and `readZTCCacheTime`) to directly call the corresponding `ZacHttpClient` methods, reducing boilerplate code. (`src/main/app/src/app/admin/health-check.service.ts`, [src/main/app/src/app/admin/health-check.service.tsL6-R31](diffhunk://#diff-8f4d711b6a291e6ad92b02a2e0799215ba02a386e916552c25981dd2cca174d6L6-R31))

Solves PZ-7675