### PR TITLE
fix(lint-changed-files): only validate the actual changed files

### DIFF
--- a/.github/workflows/lint-changed-files.yml
+++ b/.github/workflows/lint-changed-files.yml
@@ -97,18 +97,7 @@ jobs:
         if: steps.changed-files.outputs.files_to_lint != ''
         working-directory: src/main/app
         run: |
-          # Create a temporary tsconfig that extends the base strict config,
-          # but only includes the changed TS files
-          cat > tsconfig.changed-files.json << 'EOF'
-          {
-            "extends": "./tsconfig.json",
-            "compilerOptions": {},
-            "include": [],
-            "exclude": []
-          }
-          EOF
-
-          # Add changed files to the include array
+          # Get changed TypeScript files
           FILES_TO_CHECK="${{ steps.changed-files.outputs.files_to_lint }}"
           if [ -n "$FILES_TO_CHECK" ]; then
             # Convert file paths to be relative to the app directory
@@ -122,15 +111,59 @@ jobs:
               exit 0
             fi
             
-            # Convert to JSON array format
-            FILES_JSON=$(echo "$RELATIVE_TS_FILES" | jq -R -s -c 'split("\n") | map(select(length>0))')
+            echo "🔍 Running strict TypeScript checking on changed files..."
+            echo "TypeScript files to check:"
+            echo "$RELATIVE_TS_FILES"
+            echo ""
             
-            # Update tsconfig to include only changed files
-            jq --argjson files "$FILES_JSON" '.include = $files' tsconfig.changed-files.json > tsconfig.changed-files.tmp.json
-            mv tsconfig.changed-files.tmp.json tsconfig.changed-files.json
+            # Run TypeScript compilation for the entire project and filter for changed files
+            echo "Running TypeScript compilation check..."
+            TSC_TEMP_FILE=$(mktemp)
+            if timeout 60s npx tsc --noEmit --project . > "$TSC_TEMP_FILE" 2>&1; then
+              TSC_EXIT_CODE=0
+            else
+              TSC_EXIT_CODE=$?
+            fi
             
-            echo "Running TypeScript check on changed files..."
-            npx tsc --project tsconfig.changed-files.json
+            # Check if timeout occurred
+            if [ $TSC_EXIT_CODE -eq 124 ]; then
+              echo "⚠️  TypeScript check timed out (60s)"
+              rm -f "$TSC_TEMP_FILE"
+              exit 1
+            fi
+            
+            FAILED_FILES=""
+            # Check each changed TypeScript file for errors
+            for file in $RELATIVE_TS_FILES; do
+              echo ""
+              echo "👀 Checking: $file"
+              # Filter output to only show errors from the current file being checked
+              # TypeScript error format: "src/app/file.ts(line,col): error message"
+              FILTERED_ERRORS=$(grep "^$file(" "$TSC_TEMP_FILE" || true)
+              
+              if [ -n "$FILTERED_ERRORS" ]; then
+                echo "❌ TypeScript errors found in $file:"
+                echo "$FILTERED_ERRORS"
+                FAILED_FILES="$FAILED_FILES$file"$'\n'
+              else
+                echo "✅ $file passed TypeScript check"
+              fi
+            done
+            
+            # Clean up temp file
+            rm -f "$TSC_TEMP_FILE"
+            
+            if [ -n "$FAILED_FILES" ]; then
+              echo ""
+              echo "❌ TypeScript check failed for changed files with errors in the files themselves"
+              echo "💡 Changed files must follow strict TypeScript standards"
+              echo "💡 Files with errors:"
+              echo "$FAILED_FILES"
+              exit 1
+            fi
+            
+            echo ""
+            echo "✅ All TypeScript files passed strict checking"
           fi
 
       - name: Comment on PR if linting failed


### PR DESCRIPTION
This pull request updates the strict TypeScript checking process for changed files in both the GitHub Actions workflow and the associated shell script. The new approach removes the creation of temporary `tsconfig` files and instead runs a full project TypeScript compilation, filtering errors to only those in changed files. This simplifies the logic, improves reliability, and provides clearer feedback on which files have issues.

**TypeScript strict checking improvements:**

* Replaced the logic that generated a temporary `tsconfig.changed-files.json` (including only changed files) with a process that runs `tsc` on the entire project, then filters the output to report errors only for changed TypeScript files. This change applies to both `.github/workflows/lint-changed-files.yml` and `scripts/lint-changed-files.sh`. [[1]](diffhunk://#diff-b8de1babd0bc1b43204b13418820bb1943f143bf75ae179c8ae7ec14ce9eb858L100-R100) [[2]](diffhunk://#diff-b8de1babd0bc1b43204b13418820bb1943f143bf75ae179c8ae7ec14ce9eb858L125-R166) [[3]](diffhunk://#diff-8bb2c4f79b63f3bebd4e5be3e91b131ebcbb4409abad558fcc27d8dfe94d5767L121-R197)
* Improved error reporting: the scripts now output which changed files have TypeScript errors, with clearer messaging and summaries for the developer. [[1]](diffhunk://#diff-b8de1babd0bc1b43204b13418820bb1943f143bf75ae179c8ae7ec14ce9eb858L125-R166) [[2]](diffhunk://#diff-8bb2c4f79b63f3bebd4e5be3e91b131ebcbb4409abad558fcc27d8dfe94d5767L121-R197)
* Added a timeout (60 seconds) to the TypeScript check to prevent CI from hanging indefinitely if compilation takes too long. [[1]](diffhunk://#diff-b8de1babd0bc1b43204b13418820bb1943f143bf75ae179c8ae7ec14ce9eb858L125-R166) [[2]](diffhunk://#diff-8bb2c4f79b63f3bebd4e5be3e91b131ebcbb4409abad558fcc27d8dfe94d5767L121-R197)

**Code and workflow simplification:**

* Removed all logic related to dynamically generating and updating a temporary `tsconfig` file for changed files, reducing complexity and potential for errors. [[1]](diffhunk://#diff-b8de1babd0bc1b43204b13418820bb1943f143bf75ae179c8ae7ec14ce9eb858L100-R100) [[2]](diffhunk://#diff-b8de1babd0bc1b43204b13418820bb1943f143bf75ae179c8ae7ec14ce9eb858L125-R166) [[3]](diffhunk://#diff-8bb2c4f79b63f3bebd4e5be3e91b131ebcbb4409abad558fcc27d8dfe94d5767L121-R197)
* Updated script comments and output to reflect the new approach and clarify that ESLint covers most linting requirements, with strict TypeScript checking now handled in a more robust way.
