### PR TITLE
chore: no longer log ZGW validation errors inside a Flowable context as exceptions with log level ERROR

### DIFF
--- a/docs/development/fontCachingProcedures.md
+++ b/docs/development/fontCachingProcedures.md
@@ -5,7 +5,7 @@ Zac implements font caching strategy to enhance performance and user experience.
 
 ## Caching Strategy
 - all .woff2 files on *.dimpact.lifely.nl are cached for 30 days
-- backend Expires/Cache-Control replies are overriden and expires is set to 30 days
+- backend Expires/Cache-Control replies are overridden and expires is set to 30 days
 - the first hit once the local cache expires returns the old cache entry and the server refreshes the cached file from the backend, all other requests after this wait until the refresh has finished
 - the files are cached locally in the nginx container in /tmp and do not persist on restarts
 

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/EndCaseLifecycleListener.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/EndCaseLifecycleListener.kt
@@ -37,7 +37,7 @@ class EndCaseLifecycleListener(
                 FlowableHelper.getInstance().zgwApiService.endZaak(zaakUUID, EINDSTATUS_TOELICHTING)
             } catch (zgwValidationErrorException: ZgwValidationErrorException) {
                 // rethrow as an FlowableException, just to ensure that it is logged in [CommandContext] at log level INFO instead of ERROR
-                throw(FlowableZgwValidationErrorException("Failed to end zaak", zgwValidationErrorException))
+                throw FlowableZgwValidationErrorException("Failed to end zaak", zgwValidationErrorException)
             }
         }
     }

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/EndCaseLifecycleListener.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/EndCaseLifecycleListener.kt
@@ -4,7 +4,9 @@
  */
 package net.atos.zac.flowable.cmmn
 
+import net.atos.client.zgw.shared.exception.ZgwValidationErrorException
 import net.atos.zac.flowable.FlowableHelper
+import net.atos.zac.flowable.cmmn.exception.FlowableZgwValidationErrorException
 import nl.info.client.zgw.zrc.util.isOpen
 import org.flowable.cmmn.api.listener.CaseInstanceLifecycleListener
 import org.flowable.cmmn.api.runtime.CaseInstance
@@ -31,7 +33,12 @@ class EndCaseLifecycleListener(
         val zaakUUID = UUID.fromString(caseInstance.businessKey)
         if (FlowableHelper.getInstance().zrcClientService.readZaak(zaakUUID).isOpen()) {
             LOG.info("Zaak %${caseInstance.businessKey}: End Zaak")
-            FlowableHelper.getInstance().zgwApiService.endZaak(zaakUUID, EINDSTATUS_TOELICHTING)
+            try {
+                FlowableHelper.getInstance().zgwApiService.endZaak(zaakUUID, EINDSTATUS_TOELICHTING)
+            } catch (zgwValidationErrorException: ZgwValidationErrorException) {
+                // rethrow as an FlowableException, just to ensure that it is logged in [CommandContext] at log level INFO instead of ERROR
+                throw(FlowableZgwValidationErrorException("Failed to end zaak", zgwValidationErrorException))
+            }
         }
     }
 }

--- a/src/main/kotlin/net/atos/zac/flowable/cmmn/exception/CmmnExceptions.kt
+++ b/src/main/kotlin/net/atos/zac/flowable/cmmn/exception/CmmnExceptions.kt
@@ -4,6 +4,20 @@
  */
 package net.atos.zac.flowable.cmmn.exception
 
+import net.atos.client.zgw.shared.exception.ZgwValidationErrorException
+import org.flowable.common.engine.api.FlowableException
+
 class OpenTaskItemNotFoundException(override val message: String) : RuntimeException(message)
 
 class CaseDefinitionNotFoundException(override val message: String) : RuntimeException(message)
+
+/**
+ * Custom Flowable exception that wraps ZGW validation errors. It is used to throw ZGW validation errors from inside
+ * a Flowable context so that for these exceptions the Flowable command context will log them at INFO log level
+ * instead of the default ERROR log level.
+ */
+class FlowableZgwValidationErrorException(
+    override val message: String,
+    override val cause: ZgwValidationErrorException
+) :
+    FlowableException(message, cause)

--- a/src/main/kotlin/nl/info/zac/app/exception/RestExceptionMapper.kt
+++ b/src/main/kotlin/nl/info/zac/app/exception/RestExceptionMapper.kt
@@ -18,6 +18,7 @@ import net.atos.client.or.`object`.ObjectsClientService
 import net.atos.client.zgw.drc.DrcClientService
 import net.atos.client.zgw.drc.exception.DrcRuntimeException
 import net.atos.client.zgw.shared.exception.ZgwValidationErrorException
+import net.atos.zac.flowable.cmmn.exception.FlowableZgwValidationErrorException
 import nl.info.client.brp.BrpClientService
 import nl.info.client.zgw.brc.BrcClientService
 import nl.info.client.zgw.brc.exception.BrcRuntimeException
@@ -94,6 +95,7 @@ class RestExceptionMapper : ExceptionMapper<Exception> {
             }
             is ZgwRuntimeException -> handleZgwRuntimeException(exception)
             is ZgwValidationErrorException -> handleZgwValidationErrorException(exception)
+            is FlowableZgwValidationErrorException -> handleZgwValidationErrorException(exception.cause)
             is ProcessingException if (exception.cause is ConnectException || exception.cause is UnknownHostException) -> {
                 handleProcessingException(exception)
             }

--- a/src/main/resources/wildfly/configure-wildfly.cli
+++ b/src/main/resources/wildfly/configure-wildfly.cli
@@ -5,7 +5,9 @@
 
 # WildFly configuration script to configure WildFly for the Zaakafhandelcomponent
 
-# Add zaakafhandelcomponent datasource
+# Datasource configuration
+
+## Add zaakafhandelcomponent datasource
 data-source add \
     --name=ZaakafhandelcomponentDS \
     --jndi-name=java:jboss/datasources/ZaakafhandelcomponentDS \
@@ -14,7 +16,7 @@ data-source add \
     --use-java-context=true \
     --statistics-enabled=${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
 
-# Add flowable datasource
+## Add flowable datasource
 data-source add \
     --name=FlowableDS \
     --jndi-name=java:jboss/datasources/FlowableDS \
@@ -46,13 +48,17 @@ data-source add \
     "otel.service.name" = "zac" \
 })
 
-# Create custom ZAC mail session
+# Mail configuration
+
+## Create custom ZAC mail session
 /subsystem=mail/mail-session=zac:add(jndi-name=java:jboss/mail/zac,debug=false)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=zac-smtp-binding:add(host=${env.SMTP_SERVER},port=${env.SMTP_PORT})
 # Use fake credentials as defaults, to properly configure the mail session. Without credentials (or with empty string for user/password):
 #    - Weld fails to instantiate the mail session and satisfy the @Resource dependency in MailService
 #    - mail Transport we use throws AuthenticationFailedException because of insufficient configuration
 /subsystem=mail/mail-session=zac/server=smtp:add(outbound-socket-binding-ref=zac-smtp-binding,username=${env.SMTP_USERNAME:fakeDefaultUsername},password=${env.SMTP_PASSWORD:fakeDefaultPassword})
+
+# Logging configuration
 
 # To set the log level to DEBUG (default is INFO) uncomment the following lines.
 # Note that this will result in _a lot_ of logging including SessionRegistry sessionRegistry security sensitive data


### PR DESCRIPTION
No longer log ZGW validation errors inside a Flowable context as exceptions with log level ERROR.

Solves PZ-8163