### PR TITLE
chore: make EnkelvoudigInformatieObjectRestServiceHistorieTest more resilient for different ZonedDateTime serialised formats

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/EnkelvoudigInformatieObjectRestServiceHistorieTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/EnkelvoudigInformatieObjectRestServiceHistorieTest.kt
@@ -35,7 +35,7 @@ import nl.info.zac.itest.util.shouldEqualJsonIgnoringExtraneousFields
 
 @OptIn(ExperimentalKotest::class)
 @Order(TEST_SPEC_ORDER_AFTER_ZAAK_UPDATED)
-class InformatieobjectenHistorieTest : BehaviorSpec({
+class EnkelvoudigInformatieObjectRestServiceHistorieTest : BehaviorSpec({
     val logger = KotlinLogging.logger {}
     val itestHttpClient = ItestHttpClient()
 
@@ -160,8 +160,9 @@ class InformatieobjectenHistorieTest : BehaviorSpec({
                             string("applicatie")
                             string("attribuutLabel")
                             string("datumTijd") {
-                                // "2024-07-16T10:46:53.405553Z"
-                                match("""\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z""".toRegex())
+                                // accept formats "2024-07-16T10:46:53.405553Z" or "2024-07-16T10:46:53.405Z"
+                                // (if the nanoseconds are divisible by 1,000, they are truncated to milliseconds)
+                                match("""\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(\d{3})?Z""".toRegex())
                             }
                             string("door")
                             string("nieuweWaarde")

--- a/src/main/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectRestService.kt
@@ -393,17 +393,6 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
         return updateEnkelvoudigInformatieobject(enkelvoudigInformatieObjectVersieGegevens, document, updatedDocument)
     }
 
-    private fun updateEnkelvoudigInformatieobject(
-        enkelvoudigInformatieObjectVersieGegevens: RestEnkelvoudigInformatieObjectVersieGegevens,
-        enkelvoudigInformatieObject: EnkelvoudigInformatieObject,
-        enkelvoudigInformatieObjectWithLockRequest: EnkelvoudigInformatieObjectWithLockRequest
-    ): RestEnkelvoudigInformatieobject =
-        enkelvoudigInformatieObjectUpdateService.updateEnkelvoudigInformatieObjectWithLockData(
-            enkelvoudigInformatieObject.url.extractUuid(),
-            enkelvoudigInformatieObjectWithLockRequest,
-            enkelvoudigInformatieObjectVersieGegevens.toelichting
-        ).let(restInformatieobjectConverter::convertToREST)
-
     @POST
     @Path("/informatieobject/{uuid}/lock")
     fun lockDocument(@PathParam("uuid") uuid: UUID, @QueryParam("zaak") zaakUUID: UUID): Response {
@@ -559,4 +548,15 @@ class EnkelvoudigInformatieObjectRestService @Inject constructor(
                 )
             }
         }
+
+    private fun updateEnkelvoudigInformatieobject(
+        enkelvoudigInformatieObjectVersieGegevens: RestEnkelvoudigInformatieObjectVersieGegevens,
+        enkelvoudigInformatieObject: EnkelvoudigInformatieObject,
+        enkelvoudigInformatieObjectWithLockRequest: EnkelvoudigInformatieObjectWithLockRequest
+    ): RestEnkelvoudigInformatieobject =
+        enkelvoudigInformatieObjectUpdateService.updateEnkelvoudigInformatieObjectWithLockData(
+            enkelvoudigInformatieObject.url.extractUuid(),
+            enkelvoudigInformatieObjectWithLockRequest,
+            enkelvoudigInformatieObjectVersieGegevens.toelichting
+        ).let(restInformatieobjectConverter::convertToREST)
 }


### PR DESCRIPTION
Make EnkelvoudigInformatieObjectRestServiceHistorieTest more resilient for different ZonedDateTime serialised formats.

> This happens because the ZonedDateTime class in Java includes nanosecond precision, and when serialized to JSON, the formatting depends on the library or formatter used.
> - 3 digits: If the nanoseconds are divisible by 1,000, they are truncated to milliseconds (e.g., 2023-10-01T12:34:56.123Z).
> - 6 digits: If the nanoseconds are not divisible by 1,000, the formatter may include microseconds (e.g., 2023-10-01T12:34:56.123456Z).

Solves PZ-8210