### PR TITLE
fix: when pabc is disabled do not call policyService with zaaktypeOmschrijving

### DIFF
--- a/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
@@ -295,8 +295,7 @@ class ZaakRestService @Inject constructor(
             assertPolicy(
                 policyService.readOverigeRechten().startenZaak &&
                     loggedInUser.isAuthorisedForZaaktype(
-                        zaakType.omschrijving,
-                        false
+                        zaakType.omschrijving
                     )
             )
         }
@@ -578,11 +577,12 @@ class ZaakRestService @Inject constructor(
         ztcClientService.listZaaktypen(configuratieService.readDefaultCatalogusURI())
             // After PABC is fully integrated, `isAuthorisedForZaaktype` will be decommissioned
             // (to be replaced by PolicyService)
-            .filter {
-                loggedInUserInstance.get().isAuthorisedForZaaktype(
-                    it.omschrijving,
-                    configuratieService.featureFlagPabcIntegration()
-                )
+            .filter { zt ->
+                if (configuratieService.featureFlagPabcIntegration()) {
+                    loggedInUserInstance.get().isAuthorisedForZaaktypePabc(zt.omschrijving)
+                } else {
+                    loggedInUserInstance.get().isAuthorisedForZaaktype(zt.omschrijving)
+                }
             }
             .filter { !it.concept }
             .filter { it.isNuGeldig() }

--- a/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
@@ -296,7 +296,7 @@ class ZaakRestService @Inject constructor(
                 policyService.readOverigeRechten().startenZaak &&
                     loggedInUser.isAuthorisedForZaaktype(
                         zaakType.omschrijving,
-                        configuratieService.featureFlagPabcIntegration()
+                        false
                     )
             )
         }

--- a/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
@@ -289,7 +289,7 @@ class ZaakRestService @Inject constructor(
         val loggedInUser = loggedInUserInstance.get()
         // for PABC-based IAM integration, check if the user has the right to start a zaak
         if (loggedInUser.pabcIntegrationEnabled) {
-            policyService.readOverigeRechten(restZaak.zaaktype.omschrijving).startenZaak
+            assertPolicy(policyService.readOverigeRechten(zaakType.omschrijving).startenZaak)
         } else {
             // make sure to use the omschrijving of the zaaktype that was retrieved to perform authorization on zaaktype
             assertPolicy(

--- a/src/main/kotlin/nl/info/zac/authentication/LoggedInUser.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/LoggedInUser.kt
@@ -26,8 +26,6 @@ class LoggedInUser(
      */
     val applicationRolesPerZaaktype: Map<String, Set<String>> = emptyMap(),
 
-    val pabcIntegrationEnabled: Boolean
-
 ) : User(id, firstName, lastName, displayName, email) {
     fun isAuthorisedForAllZaaktypen(): Boolean = geautoriseerdeZaaktypen == null
 
@@ -35,7 +33,7 @@ class LoggedInUser(
      * If PABC-based authorization is active, use the map of application roles per zaaktype.
      * Otherwise, legacy functional (Keycloak) role-based authorization is used.
      */
-    fun isAuthorisedForZaaktype(zaaktypeOmschrijving: String) =
+    fun isAuthorisedForZaaktype(zaaktypeOmschrijving: String, pabcIntegrationEnabled: Boolean) =
         if (pabcIntegrationEnabled) {
             applicationRolesPerZaaktype[zaaktypeOmschrijving]?.isNotEmpty() == true
         } else {

--- a/src/main/kotlin/nl/info/zac/authentication/LoggedInUser.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/LoggedInUser.kt
@@ -33,10 +33,9 @@ class LoggedInUser(
      * If PABC-based authorization is active, use the map of application roles per zaaktype.
      * Otherwise, legacy functional (Keycloak) role-based authorization is used.
      */
-    fun isAuthorisedForZaaktype(zaaktypeOmschrijving: String, pabcIntegrationEnabled: Boolean) =
-        if (pabcIntegrationEnabled) {
-            applicationRolesPerZaaktype[zaaktypeOmschrijving]?.isNotEmpty() == true
-        } else {
-            geautoriseerdeZaaktypen?.contains(zaaktypeOmschrijving) ?: true
-        }
+    fun isAuthorisedForZaaktype(zaaktypeOmschrijving: String) =
+        geautoriseerdeZaaktypen?.contains(zaaktypeOmschrijving) ?: true
+
+    fun isAuthorisedForZaaktypePabc(zaaktypeOmschrijving: String) =
+        applicationRolesPerZaaktype[zaaktypeOmschrijving]?.isNotEmpty() == true
 }

--- a/src/main/kotlin/nl/info/zac/authentication/SecurityUtil.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/SecurityUtil.kt
@@ -37,8 +37,7 @@ class SecurityUtil @Inject constructor(
             "Functionele gebruiker",
             null,
             emptySet(),
-            emptySet(),
-            pabcIntegrationEnabled = false,
+            emptySet()
         )
 
         val systemUser: ThreadLocal<Boolean> = ThreadLocal.withInitial { false }

--- a/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
@@ -131,8 +131,7 @@ constructor(
                     .getStringListClaimValue(GROUP_MEMBERSHIP_CLAIM_NAME)
                     .toSet(),
                 geautoriseerdeZaaktypen = getAuthorisedZaaktypen(functionalRoles),
-                applicationRolesPerZaaktype = applicationRolesPerZaaktype,
-                pabcIntegrationEnabled = pabcIntegrationEnabled
+                applicationRolesPerZaaktype = applicationRolesPerZaaktype
             )
         }
 

--- a/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
@@ -45,7 +45,7 @@ constructor(
     companion object {
         private val LOG = Logger.getLogger(UserPrincipalFilter::class.java.name)
         private const val GROUP_MEMBERSHIP_CLAIM_NAME = "group_membership"
-        val pabcDefinedRoles: Set<String> = setOf(
+        val SUPPORTED_PABC_FUNCTIONAL_ROLES: Set<String> = setOf(
             "behandelaar",
             "coordinator",
             "beheerder",
@@ -153,7 +153,7 @@ constructor(
         // Filter out roles we shouldn't send to PABC
         // Currently PABC has only the following roles defined
         val filteredFunctionalRoles = functionalRoles.filter {
-            it in pabcDefinedRoles
+            it in SUPPORTED_PABC_FUNCTIONAL_ROLES
         }
 
         if (filteredFunctionalRoles.isEmpty()) {

--- a/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
@@ -40,7 +40,7 @@ constructor(
     private val zaakafhandelParameterService: ZaakafhandelParameterService,
     private val pabcClientService: PabcClientService,
     @ConfigProperty(name = "FEATURE_FLAG_PABC_INTEGRATION", defaultValue = "false")
-    private val pabcIntegrationEnabled: Boolean,
+    private val pabcIntegrationEnabled: Boolean
 ) : Filter {
     companion object {
         private val LOG = Logger.getLogger(UserPrincipalFilter::class.java.name)

--- a/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
@@ -45,13 +45,6 @@ constructor(
     companion object {
         private val LOG = Logger.getLogger(UserPrincipalFilter::class.java.name)
         private const val GROUP_MEMBERSHIP_CLAIM_NAME = "group_membership"
-        val SUPPORTED_PABC_FUNCTIONAL_ROLES: Set<String> = setOf(
-            "behandelaar",
-            "coordinator",
-            "beheerder",
-            "recordmanager",
-            "raadpleger"
-        )
     }
 
     override fun doFilter(
@@ -151,9 +144,10 @@ constructor(
     @Suppress("TooGenericExceptionCaught")
     private fun buildApplicationRoleMappingsFromPabc(functionalRoles: Set<String>): Map<String, Set<String>> {
         // Filter out roles we shouldn't send to PABC
-        // Currently PABC has only the following roles defined
-        val filteredFunctionalRoles = functionalRoles.filter {
-            it in SUPPORTED_PABC_FUNCTIONAL_ROLES
+        val filteredFunctionalRoles = functionalRoles.filterNot {
+            it in setOf(
+                ZACRole.DOMEIN_ELK_ZAAKTYPE.value
+            )
         }
 
         if (filteredFunctionalRoles.isEmpty()) {

--- a/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
@@ -40,11 +40,18 @@ constructor(
     private val zaakafhandelParameterService: ZaakafhandelParameterService,
     private val pabcClientService: PabcClientService,
     @ConfigProperty(name = "FEATURE_FLAG_PABC_INTEGRATION", defaultValue = "false")
-    private val pabcIntegrationEnabled: Boolean
+    private val pabcIntegrationEnabled: Boolean,
 ) : Filter {
     companion object {
         private val LOG = Logger.getLogger(UserPrincipalFilter::class.java.name)
         private const val GROUP_MEMBERSHIP_CLAIM_NAME = "group_membership"
+        val pabcDefinedRoles: Set<String> = setOf(
+            "behandelaar",
+            "coordinator",
+            "beheerder",
+            "recordmanager",
+            "raadpleger"
+        )
     }
 
     override fun doFilter(
@@ -144,10 +151,9 @@ constructor(
     @Suppress("TooGenericExceptionCaught")
     private fun buildApplicationRoleMappingsFromPabc(functionalRoles: Set<String>): Map<String, Set<String>> {
         // Filter out roles we shouldn't send to PABC
-        val filteredFunctionalRoles = functionalRoles.filterNot {
-            it in setOf(
-                ZACRole.DOMEIN_ELK_ZAAKTYPE.value
-            )
+        // Currently PABC has only the following roles defined
+        val filteredFunctionalRoles = functionalRoles.filter {
+            it in pabcDefinedRoles
         }
 
         if (filteredFunctionalRoles.isEmpty()) {

--- a/src/main/kotlin/nl/info/zac/configuratie/ConfiguratieService.kt
+++ b/src/main/kotlin/nl/info/zac/configuratie/ConfiguratieService.kt
@@ -54,6 +54,9 @@ class ConfiguratieService @Inject constructor(
     @ConfigProperty(name = "FEATURE_FLAG_BPMN_SUPPORT")
     private val bpmnSupport: Boolean,
 
+    @ConfigProperty(name = "FEATURE_FLAG_PABC_INTEGRATION")
+    private val pabcIntegration: Boolean,
+
     @ConfigProperty(name = "BRON_ORGANISATIE_RSIN")
     private val bronOrganisatie: String,
 
@@ -124,6 +127,8 @@ class ConfiguratieService @Inject constructor(
     }
 
     fun featureFlagBpmnSupport(): Boolean = bpmnSupport
+
+    fun featureFlagPabcIntegration(): Boolean = pabcIntegration
 
     fun readMaxFileSizeMB() = MAX_FILE_SIZE_MB.toLong()
 

--- a/src/main/kotlin/nl/info/zac/search/SearchService.kt
+++ b/src/main/kotlin/nl/info/zac/search/SearchService.kt
@@ -8,6 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Instance
 import jakarta.inject.Inject
 import nl.info.zac.authentication.LoggedInUser
+import nl.info.zac.configuratie.ConfiguratieService
 import nl.info.zac.search.IndexingService.Companion.SOLR_CORE
 import nl.info.zac.search.model.FilterParameters
 import nl.info.zac.search.model.FilterResultaat
@@ -38,7 +39,8 @@ import java.time.format.DateTimeFormatter.ISO_INSTANT
 @AllOpen
 @NoArgConstructor
 class SearchService @Inject constructor(
-    private val loggedInUserInstance: Instance<LoggedInUser>
+    private val loggedInUserInstance: Instance<LoggedInUser>,
+    private val configuratieService: ConfiguratieService
 ) {
     companion object {
         private lateinit var solrClient: SolrClient
@@ -172,7 +174,7 @@ class SearchService @Inject constructor(
     private fun applyAllowedZaaktypenPolicy(query: SolrQuery) {
         // signaleringen job does not have a logged-in user so check if logged-in user is present
         loggedInUserInstance.get()?.let { loggedInUser ->
-            if (loggedInUser.pabcIntegrationEnabled) {
+            if (configuratieService.featureFlagPabcIntegration()) {
                 // PABC enabled: build the filterQuery from per‑zaaktype mappings (keys)
                 val allowedZaaktypen = loggedInUser.applicationRolesPerZaaktype.keys
                 val filterQuery = if (allowedZaaktypen.isEmpty()) {

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
@@ -256,6 +256,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                 objectsClientService
                     .readObject(restZaakAanmaakGegevens.inboxProductaanvraag?.productaanvraagObjectUUID)
             } returns objectRegistratieObject
+            every { loggedInUserInstance.get() } returns createLoggedInUser()
             every { productaanvraagService.getAanvraaggegevens(objectRegistratieObject) } returns formulierData
             every {
                 productaanvraagService.getProductaanvraag(objectRegistratieObject)
@@ -301,7 +302,7 @@ class ZaakRestServiceTest : BehaviorSpec({
             When("a zaaktype is created for which the user has permissions and no BPMN process definition is found") {
                 every { identityService.readGroup(restZaakAanmaakGegevens.zaak.groep!!.id) } returns group
                 every { identityService.readUser(restZaakAanmaakGegevens.zaak.behandelaar!!.id) } returns user
-                every { policyService.readOverigeRechten(null) } returns createOverigeRechtenAllDeny(startenZaak = true)
+                every { policyService.readOverigeRechten() } returns createOverigeRechtenAllDeny(startenZaak = true)
                 every {
                     policyService.readZaakRechten(zaak, zaakType)
                 } returns createZaakRechtenAllDeny(toevoegenInitiatorPersoon = true)
@@ -345,9 +346,8 @@ class ZaakRestServiceTest : BehaviorSpec({
                 zaak = createRestZaak(communicatiekanaal = null)
             )
             every { zaakService.readZaakTypeByUUID(any()) } returns zaakType
-            every {
-                policyService.readOverigeRechten(zaakType.omschrijving)
-            } returns createOverigeRechtenAllDeny(startenZaak = true)
+            every { policyService.readOverigeRechten() } returns createOverigeRechtenAllDeny(startenZaak = true)
+            every { loggedInUserInstance.get() } returns createLoggedInUser()
             every { zaakafhandelParameterService.readZaakafhandelParameters(any()) } returns createZaakafhandelParameters()
 
             When("zaak creation is attempted") {
@@ -367,9 +367,8 @@ class ZaakRestServiceTest : BehaviorSpec({
                 zaak = createRestZaak(communicatiekanaal = "      ")
             )
             every { zaakService.readZaakTypeByUUID(any<UUID>()) } returns zaakType
-            every {
-                policyService.readOverigeRechten(zaakType.omschrijving)
-            } returns createOverigeRechtenAllDeny(startenZaak = true)
+            every { policyService.readOverigeRechten() } returns createOverigeRechtenAllDeny(startenZaak = true)
+            every { loggedInUserInstance.get() } returns createLoggedInUser()
             every { zaakafhandelParameterService.readZaakafhandelParameters(any()) } returns createZaakafhandelParameters()
 
             When("zaak creation is attempted") {

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceTest.kt
@@ -246,6 +246,7 @@ class ZaakRestServiceTest : BehaviorSpec({
             val updatedRolesSlot = mutableListOf<Rol<*>>()
 
             every { configuratieService.featureFlagBpmnSupport() } returns false
+            every { configuratieService.featureFlagPabcIntegration() } returns false
             every { configuratieService.readBronOrganisatie() } returns bronOrganisatie
             every { configuratieService.readVerantwoordelijkeOrganisatie() } returns verantwoordelijkeOrganisatie
             every { cmmnService.startCase(zaak, zaakType, zaakAfhandelParameters, null) } just runs
@@ -1485,6 +1486,7 @@ class ZaakRestServiceTest : BehaviorSpec({
             )
             val zaaktypeInrichtingscheck = createZaaktypeInrichtingscheck()
             every { configuratieService.readDefaultCatalogusURI() } returns defaultCatalogueURI
+            every { configuratieService.featureFlagPabcIntegration() } returns false
             every { ztcClientService.listZaaktypen(defaultCatalogueURI) } returns zaaktypes
             every { loggedInUserInstance.get() } returns loggedInUser
             zaaktypes.forEach {
@@ -1551,6 +1553,7 @@ class ZaakRestServiceTest : BehaviorSpec({
                 "BPMN support is enabled and a BPMN process definition exists for the second but not for the first zaaktype"
             ) {
                 every { configuratieService.featureFlagBpmnSupport() } returns true
+                every { configuratieService.featureFlagPabcIntegration() } returns false
                 every { bpmnService.findProcessDefinitionForZaaktype(zaakType1UUID) } returns null
                 every { bpmnService.findProcessDefinitionForZaaktype(zaakType2UUID) } returns createZaaktypeBpmnProcessDefinition()
 

--- a/src/test/kotlin/nl/info/zac/authentication/AuthenticationFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/AuthenticationFixtures.kt
@@ -18,8 +18,7 @@ fun createLoggedInUser(
     roles: Set<String> = setOf("fakeRole1", "fakeRole2"),
     groups: Set<String> = setOf("fakeGroup1", "fakeGroup2"),
     zaakTypes: Set<String>? = setOf(ZAAK_TYPE_1_OMSCHRIJVING, ZAAK_TYPE_2_OMSCHRIJVING),
-    pabcMappings: Map<String, Set<String>> = emptyMap(),
-    pabcIntegrationEnabled: Boolean = false
+    pabcMappings: Map<String, Set<String>> = emptyMap()
 ) = LoggedInUser(
     id,
     firstName,
@@ -29,6 +28,5 @@ fun createLoggedInUser(
     roles,
     groups,
     zaakTypes,
-    pabcMappings,
-    pabcIntegrationEnabled
+    pabcMappings
 )

--- a/src/test/kotlin/nl/info/zac/authentication/LoggedInUserAuthorisationTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/LoggedInUserAuthorisationTest.kt
@@ -28,15 +28,15 @@ class LoggedInUserAuthorisationTest : BehaviorSpec({
         When("authorisation is checked for various zaaktypen") {
 
             Then("authorised for ZAAK_TYPE_1_OMSCHRIJVING (mapped with roles)") {
-                userAuthorizedWithPabc.isAuthorisedForZaaktype(ZAAK_TYPE_1_OMSCHRIJVING, true) shouldBe true
+                userAuthorizedWithPabc.isAuthorisedForZaaktypePabc(ZAAK_TYPE_1_OMSCHRIJVING) shouldBe true
             }
 
             Then("not authorised for ZAAK_TYPE_2_OMSCHRIJVING (mapped but no roles)") {
-                userAuthorizedWithPabc.isAuthorisedForZaaktype(ZAAK_TYPE_2_OMSCHRIJVING, true) shouldBe false
+                userAuthorizedWithPabc.isAuthorisedForZaaktypePabc(ZAAK_TYPE_2_OMSCHRIJVING) shouldBe false
             }
 
             Then("not authorised for zaaktype not present in mappings") {
-                userAuthorizedWithPabc.isAuthorisedForZaaktype("zaaktype3", true) shouldBe false
+                userAuthorizedWithPabc.isAuthorisedForZaaktypePabc("zaaktype3") shouldBe false
             }
         }
     }
@@ -55,14 +55,14 @@ class LoggedInUserAuthorisationTest : BehaviorSpec({
         When("authorisation is evaluated without PABC mappings") {
 
             Then("all zaaktypen: authorised for any zaaktype") {
-                userAuthorizedForAllWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_1_OMSCHRIJVING, false) shouldBe true
-                userAuthorizedForAllWithPabcDisabled.isAuthorisedForZaaktype("zaaktype3", false) shouldBe true
+                userAuthorizedForAllWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_1_OMSCHRIJVING) shouldBe true
+                userAuthorizedForAllWithPabcDisabled.isAuthorisedForZaaktype("zaaktype3") shouldBe true
             }
 
             Then("only authorised for configured zaaktypen") {
-                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_1_OMSCHRIJVING, false) shouldBe true
-                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_2_OMSCHRIJVING, false) shouldBe true
-                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype("zaaktype3", false) shouldBe false
+                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_1_OMSCHRIJVING) shouldBe true
+                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_2_OMSCHRIJVING) shouldBe true
+                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype("zaaktype3") shouldBe false
             }
         }
     }

--- a/src/test/kotlin/nl/info/zac/authentication/LoggedInUserAuthorisationTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/LoggedInUserAuthorisationTest.kt
@@ -22,22 +22,21 @@ class LoggedInUserAuthorisationTest : BehaviorSpec({
             pabcMappings = mapOf(
                 ZAAK_TYPE_1_OMSCHRIJVING to setOf("applicationRole1"),
                 ZAAK_TYPE_2_OMSCHRIJVING to emptySet()
-            ),
-            pabcIntegrationEnabled = true
+            )
         )
 
         When("authorisation is checked for various zaaktypen") {
 
             Then("authorised for ZAAK_TYPE_1_OMSCHRIJVING (mapped with roles)") {
-                userAuthorizedWithPabc.isAuthorisedForZaaktype(ZAAK_TYPE_1_OMSCHRIJVING) shouldBe true
+                userAuthorizedWithPabc.isAuthorisedForZaaktype(ZAAK_TYPE_1_OMSCHRIJVING, true) shouldBe true
             }
 
             Then("not authorised for ZAAK_TYPE_2_OMSCHRIJVING (mapped but no roles)") {
-                userAuthorizedWithPabc.isAuthorisedForZaaktype(ZAAK_TYPE_2_OMSCHRIJVING) shouldBe false
+                userAuthorizedWithPabc.isAuthorisedForZaaktype(ZAAK_TYPE_2_OMSCHRIJVING, true) shouldBe false
             }
 
             Then("not authorised for zaaktype not present in mappings") {
-                userAuthorizedWithPabc.isAuthorisedForZaaktype("zaaktype3") shouldBe false
+                userAuthorizedWithPabc.isAuthorisedForZaaktype("zaaktype3", true) shouldBe false
             }
         }
     }
@@ -45,27 +44,25 @@ class LoggedInUserAuthorisationTest : BehaviorSpec({
     Given("PABC integration is disabled -> functional roles are used") {
         val userAuthorizedForAllWithPabcDisabled = createLoggedInUser(
             zaakTypes = null,
-            pabcMappings = emptyMap(),
-            pabcIntegrationEnabled = false
+            pabcMappings = emptyMap()
         )
 
         val userAuthorizedWithPabcDisabled = createLoggedInUser(
             zaakTypes = setOf(ZAAK_TYPE_1_OMSCHRIJVING, ZAAK_TYPE_2_OMSCHRIJVING),
-            pabcMappings = emptyMap(),
-            pabcIntegrationEnabled = false
+            pabcMappings = emptyMap()
         )
 
         When("authorisation is evaluated without PABC mappings") {
 
             Then("all zaaktypen: authorised for any zaaktype") {
-                userAuthorizedForAllWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_1_OMSCHRIJVING) shouldBe true
-                userAuthorizedForAllWithPabcDisabled.isAuthorisedForZaaktype("zaaktype3") shouldBe true
+                userAuthorizedForAllWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_1_OMSCHRIJVING, false) shouldBe true
+                userAuthorizedForAllWithPabcDisabled.isAuthorisedForZaaktype("zaaktype3", false) shouldBe true
             }
 
             Then("only authorised for configured zaaktypen") {
-                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_1_OMSCHRIJVING) shouldBe true
-                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_2_OMSCHRIJVING) shouldBe true
-                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype("zaaktype3") shouldBe false
+                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_1_OMSCHRIJVING, false) shouldBe true
+                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype(ZAAK_TYPE_2_OMSCHRIJVING, false) shouldBe true
+                userAuthorizedWithPabcDisabled.isAuthorisedForZaaktype("zaaktype3", false) shouldBe false
             }
         }
     }

--- a/src/test/kotlin/nl/info/zac/authentication/UserPrincipalFilterTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/UserPrincipalFilterTest.kt
@@ -117,10 +117,10 @@ class UserPrincipalFilterTest : BehaviorSpec({
             id = userId
         )
         val roles = arrayListOf(
-            "behandelaar",
+            "fakeRole1",
             "domein_elk_zaaktype"
         )
-        val expectedFunctionalRoles = listOf("behandelaar")
+        val expectedFunctionalRoles = listOf("fakeRole1")
         val pabcRoleNames = listOf("applicationRoleA", "applicationRoleB")
         val zaaktypeName = "fakeZaaktypeOmschrijving1"
         val zaakafhandelParameters = listOf(
@@ -192,7 +192,8 @@ class UserPrincipalFilterTest : BehaviorSpec({
             "fakeGroup2"
         )
         val roles = arrayListOf(
-            "beheerder",
+            "fakeRole1",
+            "fakeRole2",
             domein1
         )
         val zaakafhandelParameters = listOf(
@@ -280,7 +281,7 @@ class UserPrincipalFilterTest : BehaviorSpec({
             "fakeGroup1",
         )
         val roles = arrayListOf(
-            "coordinator",
+            "fakeRole1",
             "domein_elk_zaaktype"
         )
         val zaaktypeName = "fakeZaaktypeOmschrijving1"

--- a/src/test/kotlin/nl/info/zac/authentication/UserPrincipalFilterTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/UserPrincipalFilterTest.kt
@@ -117,10 +117,10 @@ class UserPrincipalFilterTest : BehaviorSpec({
             id = userId
         )
         val roles = arrayListOf(
-            "fakeRole1",
+            "behandelaar",
             "domein_elk_zaaktype"
         )
-        val expectedFunctionalRoles = listOf("fakeRole1")
+        val expectedFunctionalRoles = listOf("behandelaar")
         val pabcRoleNames = listOf("applicationRoleA", "applicationRoleB")
         val zaaktypeName = "fakeZaaktypeOmschrijving1"
         val zaakafhandelParameters = listOf(
@@ -192,8 +192,7 @@ class UserPrincipalFilterTest : BehaviorSpec({
             "fakeGroup2"
         )
         val roles = arrayListOf(
-            "fakeRole1",
-            "fakeRole2",
+            "beheerder",
             domein1
         )
         val zaakafhandelParameters = listOf(
@@ -281,7 +280,7 @@ class UserPrincipalFilterTest : BehaviorSpec({
             "fakeGroup1",
         )
         val roles = arrayListOf(
-            "fakeRole1",
+            "coordinator",
             "domein_elk_zaaktype"
         )
         val zaaktypeName = "fakeZaaktypeOmschrijving1"

--- a/src/test/kotlin/nl/info/zac/configuratie/ConfiguratieServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/configuratie/ConfiguratieServiceTest.kt
@@ -31,6 +31,7 @@ class ConfiguratieServiceTest : BehaviorSpec({
     val gemeenteNaam = "Gemeente Name"
     val gemeenteMail = "gemeente@example.com"
     val bpmnSupport = false
+    val pabcIntegration = false
 
     beforeEach {
         checkUnnecessaryStub()
@@ -55,6 +56,7 @@ class ConfiguratieServiceTest : BehaviorSpec({
             gemeenteNaam,
             gemeenteMail,
             bpmnSupport,
+            pabcIntegration,
             bronOrganisatie,
             verantwoordelijkeOrganisatie,
             catalogusDomein
@@ -113,6 +115,7 @@ class ConfiguratieServiceTest : BehaviorSpec({
                         gemeenteNaam,
                         gemeenteMail,
                         bpmnSupport,
+                        pabcIntegration,
                         bronOrganisatie,
                         verantwoordelijkeOrganisatie,
                         catalogusDomein
@@ -141,6 +144,7 @@ class ConfiguratieServiceTest : BehaviorSpec({
             gemeenteNaam,
             gemeenteMail,
             bpmnSupport,
+            pabcIntegration,
             bronOrganisatie,
             verantwoordelijkeOrganisatie,
             catalogusDomein

--- a/src/test/kotlin/nl/info/zac/policy/PolicyServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/policy/PolicyServiceTest.kt
@@ -367,8 +367,7 @@ class PolicyServiceTest : BehaviorSpec({
             roles = functionalRoles,
             groupIds = emptySet(),
             geautoriseerdeZaaktypen = setOf("zaakType1", "zaakType2"),
-            applicationRolesPerZaaktype = mapOf(zaaktype to pabcRolesForZaakType),
-            pabcIntegrationEnabled = true
+            applicationRolesPerZaaktype = mapOf(zaaktype to pabcRolesForZaakType)
         )
 
         val rqSlot = slot<RuleQuery<UserInput>>()
@@ -404,8 +403,7 @@ class PolicyServiceTest : BehaviorSpec({
             roles = functionalRoles,
             groupIds = emptySet(),
             geautoriseerdeZaaktypen = geautoriseerde,
-            applicationRolesPerZaaktype = emptyMap(),
-            pabcIntegrationEnabled = false
+            applicationRolesPerZaaktype = emptyMap()
         )
 
         val rqSlot = slot<RuleQuery<UserInput>>()

--- a/src/test/kotlin/nl/info/zac/search/SearchServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/SearchServiceTest.kt
@@ -18,6 +18,7 @@ import io.mockk.slot
 import jakarta.enterprise.inject.Instance
 import nl.info.zac.app.search.createZoekParameters
 import nl.info.zac.authentication.LoggedInUser
+import nl.info.zac.configuratie.ConfiguratieService
 import nl.info.zac.search.model.DatumRange
 import nl.info.zac.search.model.DatumVeld
 import nl.info.zac.search.model.FilterParameters
@@ -40,7 +41,6 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.EnumMap
-import kotlin.collections.get
 
 class SearchServiceTest : BehaviorSpec({
     // add static mocking for config provider because the IndexeerService class
@@ -52,11 +52,12 @@ class SearchServiceTest : BehaviorSpec({
     } returns solrUrl
 
     val solrClient = mockk<Http2SolrClient>()
+    var configuratieService = mockk<ConfiguratieService>()
     mockkConstructor(Http2SolrClient.Builder::class)
     every { anyConstructed<Http2SolrClient.Builder>().build() } returns solrClient
     val loggedInUserInstance = mockk<Instance<LoggedInUser>>()
     val loggedInUser = mockk<LoggedInUser>()
-    val zoekService = SearchService(loggedInUserInstance)
+    val zoekService = SearchService(loggedInUserInstance, configuratieService)
 
     beforeEach {
         checkUnnecessaryStub()
@@ -77,7 +78,7 @@ class SearchServiceTest : BehaviorSpec({
         val zaakZoekObject2 = mockk<ZaakZoekObject>()
         val solrParamsSlot = slot<SolrParams>()
         every { loggedInUserInstance.get() } returns loggedInUser
-        every { loggedInUser.pabcIntegrationEnabled } returns false
+        every { configuratieService.featureFlagPabcIntegration() } returns false
         every { loggedInUser.isAuthorisedForAllZaaktypen() } returns true
         every { solrClient.query(capture(solrParamsSlot)) } returns queryResponse
         every { queryResponse.results } returns solrDocumentList
@@ -169,7 +170,7 @@ class SearchServiceTest : BehaviorSpec({
         val taakZoekObject1 = mockk<TaakZoekObject>()
         val solrParamsSlot = slot<SolrParams>()
         every { loggedInUserInstance.get() } returns loggedInUser
-        every { loggedInUser.pabcIntegrationEnabled } returns false
+        every { configuratieService.featureFlagPabcIntegration() } returns false
         every { loggedInUser.isAuthorisedForAllZaaktypen() } returns false
         every { loggedInUser.geautoriseerdeZaaktypen } returns setOf(zaakType1)
         every { solrClient.query(capture(solrParamsSlot)) } returns queryResponse
@@ -249,7 +250,7 @@ class SearchServiceTest : BehaviorSpec({
         val documentZoekObject1 = mockk<DocumentZoekObject>()
         val solrParamsSlot = slot<SolrParams>()
         every { loggedInUserInstance.get() } returns loggedInUser
-        every { loggedInUser.pabcIntegrationEnabled } returns false
+        every { configuratieService.featureFlagPabcIntegration() } returns false
         every { loggedInUser.isAuthorisedForAllZaaktypen() } returns false
         every { loggedInUser.geautoriseerdeZaaktypen } returns setOf(zaakType1)
         every { solrClient.query(capture(solrParamsSlot)) } returns queryResponse
@@ -315,7 +316,7 @@ class SearchServiceTest : BehaviorSpec({
         val solrParamsSlot = slot<SolrParams>()
 
         every { loggedInUserInstance.get() } returns loggedInUser
-        every { loggedInUser.pabcIntegrationEnabled } returns true
+        every { configuratieService.featureFlagPabcIntegration() } returns true
         every { loggedInUser.applicationRolesPerZaaktype } returns mapOf(
             zaakType1 to setOf("fakeApplicationRole1", "fakeApplicationRole2")
         )
@@ -399,7 +400,7 @@ class SearchServiceTest : BehaviorSpec({
         val zaakZoekObject2 = mockk<ZaakZoekObject>()
         val solrParamsSlot = slot<SolrParams>()
         every { loggedInUserInstance.get() } returns loggedInUser
-        every { loggedInUser.pabcIntegrationEnabled } returns false
+        every { configuratieService.featureFlagPabcIntegration() } returns false
         every { loggedInUser.isAuthorisedForAllZaaktypen() } returns true
         every { solrClient.query(capture(solrParamsSlot)) } returns queryResponse
         every { queryResponse.results } returns solrDocumentList


### PR DESCRIPTION
Also for PABC enabled IAM authorization, filter roles based on the ones defined in PABC

Solves [PZ-8219]
