### PR TITLE
fix(bug): edit button overlapping text

### DIFF
--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -94,7 +94,7 @@
                 <mat-icon>topic</mat-icon>
                 {{ "gegevens.algemeen" | translate }}</ng-template>
               <div class="content">
-                <div class="flex flex-row flex-wrap justify-start gap-10">
+                <div class="flex flex-row flex-wrap justify-start gap-10 padding-r">
                   <zac-static-text [label]="'status' | translate" [value]="zaak.status | empty: 'naam'"
                     class="flex-item"></zac-static-text>
                   <zac-static-text [label]="'registratiedatum' | translate" [value]="zaak.registratiedatum | datum"
@@ -113,7 +113,7 @@
                     " class="flex-item"></zac-static-text>
                 </div>
                 <mat-divider class="mat-divider-wrapper"></mat-divider>
-                <div class="flex flex-row relative-parent">
+                <div class="flex flex-row">
                   <div class="fields">
                     <div class="flex flex-row justify-start gap-10">
                       <zac-static-text [label]="'groep' | translate" [value]="zaak.groep?.naam | empty"

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -3,74 +3,188 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-<mat-drawer-container #sideNavContainer class="inner-sidenav-container" [class]="sideNaveMode"
-  xmlns="http://www.w3.org/1999/html">
-  <mat-drawer #menuSidenav position="start" opened="true" disableClose="true" [mode]="sideNaveMode">
-    <zac-side-nav (mode)="menuModeChanged($event)" [menu]="menu" [activeItem]="activeSideAction"
-      (activeItemChange)="menuItemChanged($event)"></zac-side-nav>
+<mat-drawer-container
+  #sideNavContainer
+  class="inner-sidenav-container"
+  [class]="sideNaveMode"
+  xmlns="http://www.w3.org/1999/html"
+>
+  <mat-drawer
+    #menuSidenav
+    position="start"
+    opened="true"
+    disableClose="true"
+    [mode]="sideNaveMode"
+  >
+    <zac-side-nav
+      (mode)="menuModeChanged($event)"
+      [menu]="menu"
+      [activeItem]="activeSideAction"
+      (activeItemChange)="menuItemChanged($event)"
+    ></zac-side-nav>
   </mat-drawer>
-  <mat-drawer #actionsSidenav mode="over" position="end" [ngSwitch]="activeSideAction" class="side-nav-container"
-    (closedStart)="activeSideAction = null">
-    <zac-klant-koppel *ngSwitchCase="'actie.initiator.koppelen'" [sideNav]="actionsSidenav"
-      [context]="zaak.identificatie" (klantGegevens)="initiatorGeselecteerd($event.klant)" [initiator]="true"
-      [allowBedrijf]="allowBedrijf()" [allowPersoon]="allowPersoon()"></zac-klant-koppel>
-    <zac-klant-koppel *ngSwitchCase="'actie.betrokkene.koppelen'" (klantGegevens)="betrokkeneGeselecteerd($event)"
-      [sideNav]="actionsSidenav" [zaaktypeUUID]="zaak.zaaktype.uuid" [context]="zaak.identificatie"
-      [allowBedrijf]="allowBedrijf()" [allowPersoon]="allowPersoon()"></zac-klant-koppel>
-    <zac-bag-zoek *ngSwitchCase="'actie.bagObject.koppelen'" [gekoppeldeBagObjecten]="gekoppeldeBagObjecten"
-      [sideNav]="actionsSidenav" (bagObject)="adresGeselecteerd($event)"></zac-bag-zoek>
-    <zac-case-details-edit *ngSwitchCase="'actie.zaak.wijzigen'" [zaak]="zaak" [loggedInUser]="loggedInUser"
-      [sideNav]="actionsSidenav"></zac-case-details-edit>
-    <zac-case-location-edit *ngSwitchCase="'actie.zaak.locatie.koppelen'" [zaak]="zaak" [sideNav]="actionsSidenav"
-      (locatie)="locationSelected()"></zac-case-location-edit>
-    <zac-informatie-object-create-attended *ngSwitchCase="'actie.document.maken'" [sideNav]="actionsSidenav"
-      [zaak]="zaak" (document)="documentCreated()"></zac-informatie-object-create-attended>
-    <zac-informatie-object-add *ngSwitchCase="'actie.document.toevoegen'" [sideNav]="actionsSidenav" [zaak]="zaak"
-      (document)="documentToegevoegd()"></zac-informatie-object-add>
-    <zac-informatie-verzenden *ngSwitchCase="'actie.document.verzenden'" [sideNav]="actionsSidenav" [zaak]="zaak"
-      (documentSent)="documentSent()"></zac-informatie-verzenden>
-    <zac-human-task-do *ngSwitchCase="actiefPlanItem?.naam ?? 'none'" (done)="taakGestart()" [sideNav]="actionsSidenav"
-      [zaak]="zaak" [planItem]="actiefPlanItem"></zac-human-task-do>
-    <zac-process-task-do *ngSwitchCase="actiefPlanItem?.naam ?? 'none'" (done)="processGestart()" [zaak]="zaak"
-      [planItem]="actiefPlanItem"></zac-process-task-do>
-    <zac-mail-create *ngSwitchCase="'actie.mail.versturen'" (mailVerstuurd)="mailVerstuurd($event)"
-      [sideNav]="actionsSidenav" [zaak]="zaak"></zac-mail-create>
-    <zac-ontvangstbevestiging *ngSwitchCase="'actie.ontvangstbevestiging.versturen'"
-      (ontvangstBevestigd)="ontvangstBevestigd($event)" [sideNav]="actionsSidenav"
-      [zaak]="zaak"></zac-ontvangstbevestiging>
-    <zac-besluit-create *ngSwitchCase="'actie.besluit.vastleggen'" (besluitVastgelegd)="besluitVastgelegd()"
-      [sideNav]="actionsSidenav" [zaak]="zaak"></zac-besluit-create>
-    <zac-besluit-edit *ngSwitchCase="'actie.besluit.wijzigen'" (besluitGewijzigd)="besluitVastgelegd()"
-      [sideNav]="actionsSidenav" [besluit]="teWijzigenBesluit" [zaak]="zaak"></zac-besluit-edit>
-    <zac-informatie-object-link *ngSwitchCase="'actie.document.verplaatsen'"
-      [actionLabel]="'actie.document.verplaatsen'" [infoObject]="documentToMove" [sideNav]="actionsSidenav"
-      [source]="zaak.identificatie" (informationObjectLinked)="updateDocumentList()"></zac-informatie-object-link>
-    <zac-zaak-link *ngSwitchCase="'actie.zaak.koppelen'" [zaak]="zaak" [sideNav]="actionsSidenav"
-      (zaakLinked)="zaakLinked()"></zac-zaak-link>
-    <zac-zaakdata *ngSwitchCase="'actie.zaakdata.bekijken'" [readonly]="true" [sideNav]="actionsSidenav"
-      [zaak]="zaak"></zac-zaakdata>
+  <mat-drawer
+    #actionsSidenav
+    mode="over"
+    position="end"
+    [ngSwitch]="activeSideAction"
+    class="side-nav-container"
+    (closedStart)="activeSideAction = null"
+  >
+    <zac-klant-koppel
+      *ngSwitchCase="'actie.initiator.koppelen'"
+      [sideNav]="actionsSidenav"
+      [context]="zaak.identificatie"
+      (klantGegevens)="initiatorGeselecteerd($event.klant)"
+      [initiator]="true"
+      [allowBedrijf]="allowBedrijf()"
+      [allowPersoon]="allowPersoon()"
+    ></zac-klant-koppel>
+    <zac-klant-koppel
+      *ngSwitchCase="'actie.betrokkene.koppelen'"
+      (klantGegevens)="betrokkeneGeselecteerd($event)"
+      [sideNav]="actionsSidenav"
+      [zaaktypeUUID]="zaak.zaaktype.uuid"
+      [context]="zaak.identificatie"
+      [allowBedrijf]="allowBedrijf()"
+      [allowPersoon]="allowPersoon()"
+    ></zac-klant-koppel>
+    <zac-bag-zoek
+      *ngSwitchCase="'actie.bagObject.koppelen'"
+      [gekoppeldeBagObjecten]="gekoppeldeBagObjecten"
+      [sideNav]="actionsSidenav"
+      (bagObject)="adresGeselecteerd($event)"
+    ></zac-bag-zoek>
+    <zac-case-details-edit
+      *ngSwitchCase="'actie.zaak.wijzigen'"
+      [zaak]="zaak"
+      [loggedInUser]="loggedInUser"
+      [sideNav]="actionsSidenav"
+    ></zac-case-details-edit>
+    <zac-case-location-edit
+      *ngSwitchCase="'actie.zaak.locatie.koppelen'"
+      [zaak]="zaak"
+      [sideNav]="actionsSidenav"
+      (locatie)="locationSelected()"
+    ></zac-case-location-edit>
+    <zac-informatie-object-create-attended
+      *ngSwitchCase="'actie.document.maken'"
+      [sideNav]="actionsSidenav"
+      [zaak]="zaak"
+      (document)="documentCreated()"
+    ></zac-informatie-object-create-attended>
+    <zac-informatie-object-add
+      *ngSwitchCase="'actie.document.toevoegen'"
+      [sideNav]="actionsSidenav"
+      [zaak]="zaak"
+      (document)="documentToegevoegd()"
+    ></zac-informatie-object-add>
+    <zac-informatie-verzenden
+      *ngSwitchCase="'actie.document.verzenden'"
+      [sideNav]="actionsSidenav"
+      [zaak]="zaak"
+      (documentSent)="documentSent()"
+    ></zac-informatie-verzenden>
+    <zac-human-task-do
+      *ngSwitchCase="actiefPlanItem?.naam ?? 'none'"
+      (done)="taakGestart()"
+      [sideNav]="actionsSidenav"
+      [zaak]="zaak"
+      [planItem]="actiefPlanItem"
+    ></zac-human-task-do>
+    <zac-process-task-do
+      *ngSwitchCase="actiefPlanItem?.naam ?? 'none'"
+      (done)="processGestart()"
+      [zaak]="zaak"
+      [planItem]="actiefPlanItem"
+    ></zac-process-task-do>
+    <zac-mail-create
+      *ngSwitchCase="'actie.mail.versturen'"
+      (mailVerstuurd)="mailVerstuurd($event)"
+      [sideNav]="actionsSidenav"
+      [zaak]="zaak"
+    ></zac-mail-create>
+    <zac-ontvangstbevestiging
+      *ngSwitchCase="'actie.ontvangstbevestiging.versturen'"
+      (ontvangstBevestigd)="ontvangstBevestigd($event)"
+      [sideNav]="actionsSidenav"
+      [zaak]="zaak"
+    ></zac-ontvangstbevestiging>
+    <zac-besluit-create
+      *ngSwitchCase="'actie.besluit.vastleggen'"
+      (besluitVastgelegd)="besluitVastgelegd()"
+      [sideNav]="actionsSidenav"
+      [zaak]="zaak"
+    ></zac-besluit-create>
+    <zac-besluit-edit
+      *ngSwitchCase="'actie.besluit.wijzigen'"
+      (besluitGewijzigd)="besluitVastgelegd()"
+      [sideNav]="actionsSidenav"
+      [besluit]="teWijzigenBesluit"
+      [zaak]="zaak"
+    ></zac-besluit-edit>
+    <zac-informatie-object-link
+      *ngSwitchCase="'actie.document.verplaatsen'"
+      [actionLabel]="'actie.document.verplaatsen'"
+      [infoObject]="documentToMove"
+      [sideNav]="actionsSidenav"
+      [source]="zaak.identificatie"
+      (informationObjectLinked)="updateDocumentList()"
+    ></zac-informatie-object-link>
+    <zac-zaak-link
+      *ngSwitchCase="'actie.zaak.koppelen'"
+      [zaak]="zaak"
+      [sideNav]="actionsSidenav"
+      (zaakLinked)="zaakLinked()"
+    ></zac-zaak-link>
+    <zac-zaakdata
+      *ngSwitchCase="'actie.zaakdata.bekijken'"
+      [readonly]="true"
+      [sideNav]="actionsSidenav"
+      [zaak]="zaak"
+    ></zac-zaakdata>
   </mat-drawer>
   <mat-drawer-content>
     <div class="flex-row flex-wrap gap-12">
       <section class="w100 flex-1" *ngIf="showInitiator()">
-        <zac-zaak-initiator-toevoegen class="w100 flex-1" *ngIf="!(showPersoonsgegevens() || showBedrijfsgegevens())"
-          [toevoegenToegestaan]="allowedToAddBetrokkene()" (add)="addOrEditZaakInitiator()">
+        <zac-zaak-initiator-toevoegen
+          class="w100 flex-1"
+          *ngIf="!(showPersoonsgegevens() || showBedrijfsgegevens())"
+          [toevoegenToegestaan]="allowedToAddBetrokkene()"
+          (add)="addOrEditZaakInitiator()"
+        >
         </zac-zaak-initiator-toevoegen>
-        <zac-persoongegevens class="w100 flex-1" *ngIf="showPersoonsgegevens()" [zaakIdentificatie]="zaak.identificatie"
-          [bsn]="zaak.initiatorIdentificatie" action="initiator tonen"
-          [isVerwijderbaar]="zaak.rechten.verwijderenInitiator" [isWijzigbaar]="zaak.rechten.toevoegenInitiatorPersoon"
-          (edit)="addOrEditZaakInitiator()" (delete)="deleteInitiator()">
+        <zac-persoongegevens
+          class="w100 flex-1"
+          *ngIf="showPersoonsgegevens()"
+          [zaakIdentificatie]="zaak.identificatie"
+          [bsn]="zaak.initiatorIdentificatie"
+          action="initiator tonen"
+          [isVerwijderbaar]="zaak.rechten.verwijderenInitiator"
+          [isWijzigbaar]="zaak.rechten.toevoegenInitiatorPersoon"
+          (edit)="addOrEditZaakInitiator()"
+          (delete)="deleteInitiator()"
+        >
         </zac-persoongegevens>
-        <zac-bedrijfsgegevens class="w100 flex-1" *ngIf="showBedrijfsgegevens()"
-          [rsinOfVestigingsnummer]="zaak.initiatorIdentificatie" [kvkNummer]="zaak.kvkNummer"
-          [isVerwijderbaar]="zaak.rechten.verwijderenInitiator" (edit)="addOrEditZaakInitiator()"
-          [isWijzigbaar]="zaak.rechten.toevoegenInitiatorBedrijf" (delete)="deleteInitiator()">
+        <zac-bedrijfsgegevens
+          class="w100 flex-1"
+          *ngIf="showBedrijfsgegevens()"
+          [rsinOfVestigingsnummer]="zaak.initiatorIdentificatie"
+          [kvkNummer]="zaak.kvkNummer"
+          [isVerwijderbaar]="zaak.rechten.verwijderenInitiator"
+          (edit)="addOrEditZaakInitiator()"
+          [isWijzigbaar]="zaak.rechten.toevoegenInitiatorBedrijf"
+          (delete)="deleteInitiator()"
+        >
         </zac-bedrijfsgegevens>
       </section>
       <mat-card class="w50 flex-1">
         <mat-card-header class="flex-col gap-8 space-between">
           <div class="flex-row">
-            <zac-zaak-indicaties [layout]="indicatiesLayout.EXTENDED" [zaak]="zaak"></zac-zaak-indicaties>
+            <zac-zaak-indicaties
+              [layout]="indicatiesLayout.EXTENDED"
+              [zaak]="zaak"
+            ></zac-zaak-indicaties>
           </div>
           <section class="flex-row space-between items-center">
             <div>
@@ -79,10 +193,15 @@
               </mat-card-title>
               <mat-card-subtitle>{{
                 zaak.zaaktype.omschrijving
-                }}</mat-card-subtitle>
+              }}</mat-card-subtitle>
             </div>
-            <button *ngIf="zaak.isProcesGestuurd && zaak.isOpen && !zaak.isHeropend" class="proces-button"
-              (click)="showProces()" [title]="'actie.proces.bekijken' | translate" mat-icon-button>
+            <button
+              *ngIf="zaak.isProcesGestuurd && zaak.isOpen && !zaak.isHeropend"
+              class="proces-button"
+              (click)="showProces()"
+              [title]="'actie.proces.bekijken' | translate"
+              mat-icon-button
+            >
               <mat-icon> play_shapes </mat-icon>
             </button>
           </section>
@@ -92,88 +211,155 @@
             <mat-tab>
               <ng-template mat-tab-label>
                 <mat-icon>topic</mat-icon>
-                {{ "gegevens.algemeen" | translate }}</ng-template>
+                {{ "gegevens.algemeen" | translate }}</ng-template
+              >
               <div class="content">
-                <div class="flex flex-row flex-wrap justify-start gap-10 padding-r">
-                  <zac-static-text [label]="'status' | translate" [value]="zaak.status | empty: 'naam'"
-                    class="flex-item"></zac-static-text>
-                  <zac-static-text [label]="'registratiedatum' | translate" [value]="zaak.registratiedatum | datum"
-                    class="flex-item"></zac-static-text>
-                  <zac-static-text [label]="'resultaat' | translate"
-                    [value]="zaak.resultaat?.resultaattype | empty: 'naam'" class="flex-item"></zac-static-text>
-                  <zac-static-text *ngIf="zaak.einddatum" [label]="'einddatum' | translate"
-                    [value]="zaak.einddatum | datum" class="flex-item"></zac-static-text>
-                  <zac-static-text *ngIf="zaak.archiefNominatie === 'VERNIETIGEN'" [label]="
+                <div
+                  class="flex flex-row flex-wrap justify-start gap-10 padding-r"
+                >
+                  <zac-static-text
+                    [label]="'status' | translate"
+                    [value]="zaak.status | empty: 'naam'"
+                    class="flex-item"
+                  ></zac-static-text>
+                  <zac-static-text
+                    [label]="'registratiedatum' | translate"
+                    [value]="zaak.registratiedatum | datum"
+                    class="flex-item"
+                  ></zac-static-text>
+                  <zac-static-text
+                    [label]="'resultaat' | translate"
+                    [value]="zaak.resultaat?.resultaattype | empty: 'naam'"
+                    class="flex-item"
+                  ></zac-static-text>
+                  <zac-static-text
+                    *ngIf="zaak.einddatum"
+                    [label]="'einddatum' | translate"
+                    [value]="zaak.einddatum | datum"
+                    class="flex-item"
+                  ></zac-static-text>
+                  <zac-static-text
+                    *ngIf="zaak.archiefNominatie === 'VERNIETIGEN'"
+                    [label]="
                       'archiefNominatie.datum.' + zaak.archiefNominatie
                         | translate
-                    " [value]="zaak.archiefActiedatum | datum | empty" class="flex-item"></zac-static-text>
-                  <zac-static-text *ngIf="zaak.archiefNominatie === 'BLIJVEND_BEWAREN'"
-                    [label]="'archiefNominatie' | translate" [value]="
+                    "
+                    [value]="zaak.archiefActiedatum | datum | empty"
+                    class="flex-item"
+                  ></zac-static-text>
+                  <zac-static-text
+                    *ngIf="zaak.archiefNominatie === 'BLIJVEND_BEWAREN'"
+                    [label]="'archiefNominatie' | translate"
+                    [value]="
                       'archiefNominatie.' + zaak.archiefNominatie | translate
-                    " class="flex-item"></zac-static-text>
+                    "
+                    class="flex-item"
+                  ></zac-static-text>
                 </div>
                 <mat-divider class="mat-divider-wrapper"></mat-divider>
                 <div class="flex flex-row">
                   <div class="fields">
                     <div class="flex flex-row justify-start gap-10">
-                      <zac-static-text [label]="'groep' | translate" [value]="zaak.groep?.naam | empty"
-                        class="flex-item"></zac-static-text>
-                      <zac-static-text [label]="'behandelaar' | translate" [value]="zaak.behandelaar?.naam | empty"
-                        class="flex-item"></zac-static-text>
-                      <zac-static-text [label]="'communicatiekanaal' | translate"
-                        [value]="zaak.communicatiekanaal | empty" class="flex-item"></zac-static-text>
+                      <zac-static-text
+                        [label]="'groep' | translate"
+                        [value]="zaak.groep?.naam | empty"
+                        class="flex-item"
+                      ></zac-static-text>
+                      <zac-static-text
+                        [label]="'behandelaar' | translate"
+                        [value]="zaak.behandelaar?.naam | empty"
+                        class="flex-item"
+                      ></zac-static-text>
+                      <zac-static-text
+                        [label]="'communicatiekanaal' | translate"
+                        [value]="zaak.communicatiekanaal | empty"
+                        class="flex-item"
+                      ></zac-static-text>
                     </div>
                     <div class="flex flex-row justify-start gap-10">
-                      <zac-static-text [label]="'startdatum' | translate" [value]="zaak.startdatum | datum | empty"
-                        class="flex-item"></zac-static-text>
-                      <zac-static-text [label]="'streefdatum' | translate"
+                      <zac-static-text
+                        [label]="'startdatum' | translate"
+                        [value]="zaak.startdatum | datum | empty"
+                        class="flex-item"
+                      ></zac-static-text>
+                      <zac-static-text
+                        [label]="'streefdatum' | translate"
                         [value]="zaak.einddatumGepland | datum | empty"
-                        [icon]="dateFieldIconMap.get('einddatumGepland')" class="flex-item">
+                        [icon]="dateFieldIconMap.get('einddatumGepland')"
+                        class="flex-item"
+                      >
                         <mat-icon>label-icon</mat-icon>
                       </zac-static-text>
-                      <zac-static-text [label]="'fataledatum' | translate"
-                        [value]="zaak.uiterlijkeEinddatumAfdoening | datum | empty" [icon]="
-                      dateFieldIconMap.get('uiterlijkeEinddatumAfdoening')" class="flex-item"></zac-static-text>
+                      <zac-static-text
+                        [label]="'fataledatum' | translate"
+                        [value]="
+                          zaak.uiterlijkeEinddatumAfdoening | datum | empty
+                        "
+                        [icon]="
+                          dateFieldIconMap.get('uiterlijkeEinddatumAfdoening')
+                        "
+                        class="flex-item"
+                      ></zac-static-text>
                     </div>
-                    <div *ngIf="zaak.duurVerlenging || zaakOpschorting?.duurDagen"
-                      class="flex flex-row justify-start gap-10 remark">
+                    <div
+                      *ngIf="zaak.duurVerlenging || zaakOpschorting?.duurDagen"
+                      class="flex flex-row justify-start gap-10 remark"
+                    >
                       <div class="flex-col gap-5">
-                        <div class="flex-row items-center gap-5" *ngIf="zaakOpschorting?.duurDagen">
+                        <div
+                          class="flex-row items-center gap-5"
+                          *ngIf="zaakOpschorting?.duurDagen"
+                        >
                           <mat-icon>pause</mat-icon>
                           {{
-                          (zaakOpschorting?.duurDagen === 1
-                          ? "duurDagenOpschorting.enkelvoud"
-                          : "duurDagenOpschorting"
-                          ) | translate: { duur: zaakOpschorting?.duurDagen }
+                            (zaakOpschorting?.duurDagen === 1
+                              ? "duurDagenOpschorting.enkelvoud"
+                              : "duurDagenOpschorting"
+                            ) | translate: { duur: zaakOpschorting?.duurDagen }
                           }}
                         </div>
-                        <div class="flex-row items-center gap-5" *ngIf="zaak.duurVerlenging">
+                        <div
+                          class="flex-row items-center gap-5"
+                          *ngIf="zaak.duurVerlenging"
+                        >
                           <mat-icon>update</mat-icon>
                           {{
-                          "duurVerlenging"
-                          | translate: { duur: zaak.duurVerlenging }
+                            "duurVerlenging"
+                              | translate: { duur: zaak.duurVerlenging }
                           }}
                         </div>
                       </div>
                     </div>
                     <div class="flex flex-row justify-start gap-10">
-                      <zac-static-text [label]="'vertrouwelijkheidaanduiding' | translate" [value]="
-                      zaak.vertrouwelijkheidaanduiding
-                        | vertrouwelijkaanduidingToTranslationKey
-                        | translate
-                        | empty
-                    " class="flex-item"></zac-static-text>
+                      <zac-static-text
+                        [label]="'vertrouwelijkheidaanduiding' | translate"
+                        [value]="
+                          zaak.vertrouwelijkheidaanduiding
+                            | vertrouwelijkaanduidingToTranslationKey
+                            | translate
+                            | empty
+                        "
+                        class="flex-item"
+                      ></zac-static-text>
                     </div>
                     <div class="flex flex-col gap-10">
-                      <zac-static-text [label]="'omschrijving' | translate"
-                        [value]="zaak.omschrijving | empty"></zac-static-text>
-                      <zac-static-text [label]="'toelichting' | translate"
-                        [value]="zaak.toelichting | empty"></zac-static-text>
+                      <zac-static-text
+                        [label]="'omschrijving' | translate"
+                        [value]="zaak.omschrijving | empty"
+                      ></zac-static-text>
+                      <zac-static-text
+                        [label]="'toelichting' | translate"
+                        [value]="zaak.toelichting | empty"
+                      ></zac-static-text>
                     </div>
                   </div>
                   <div class="editable">
-                    <button *ngIf="zaak.rechten.wijzigen || zaak.rechten.toekennen" mat-icon-button
-                      mat-small-icon-button (click)="editCaseDetails()">
+                    <button
+                      *ngIf="zaak.rechten.wijzigen || zaak.rechten.toekennen"
+                      mat-icon-button
+                      mat-small-icon-button
+                      (click)="editCaseDetails()"
+                    >
                       <mat-icon>edit</mat-icon>
                     </button>
                   </div>
@@ -183,30 +369,44 @@
             <mat-tab *ngIf="zaak.zaakgeometrie">
               <ng-template mat-tab-label>
                 <mat-icon>place</mat-icon>
-                {{ "locatie" | translate }}</ng-template>
+                {{ "locatie" | translate }}</ng-template
+              >
               <div class="table-wrapper">
                 <div class="flex flex-row margin-top space-between">
-                  <zac-static-text [label]="'coordinates' | translate" [value]="zaak.zaakgeometrie | location | empty"
-                    class="flex-item text-flexible"></zac-static-text>
+                  <zac-static-text
+                    [label]="'coordinates' | translate"
+                    [value]="zaak.zaakgeometrie | location | empty"
+                    class="flex-item text-flexible"
+                  ></zac-static-text>
                   <div class="editable-location">
-                    <button *ngIf="zaak.rechten.wijzigenLocatie" mat-icon-button mat-small-icon-button
-                      (click)="editLocationDetails()">
+                    <button
+                      *ngIf="zaak.rechten.wijzigenLocatie"
+                      mat-icon-button
+                      mat-small-icon-button
+                      (click)="editLocationDetails()"
+                    >
                       <mat-icon>edit</mat-icon>
                     </button>
                   </div>
                 </div>
 
-                <zac-locatie-tonen [currentLocation]="zaak.zaakgeometrie"></zac-locatie-tonen>
+                <zac-locatie-tonen
+                  [currentLocation]="zaak.zaakgeometrie"
+                ></zac-locatie-tonen>
               </div>
             </mat-tab>
 
             <mat-tab *ngIf="zaak.gerelateerdeZaken?.length">
               <ng-template mat-tab-label>
                 <mat-icon>account_tree</mat-icon>
-                {{ "gerelateerdeZaken" | translate }}</ng-template>
+                {{ "gerelateerdeZaken" | translate }}</ng-template
+              >
               <div class="table-wrapper">
                 <table mat-table [dataSource]="zaak.gerelateerdeZaken">
-                  <ng-container *ngFor="let column of gerelateerdeZaakColumns" [matColumnDef]="column">
+                  <ng-container
+                    *ngFor="let column of gerelateerdeZaakColumns"
+                    [matColumnDef]="column"
+                  >
                     <th mat-header-cell *matHeaderCellDef>
                       {{ "gerelateerde.zaak." + column | translate }}
                     </th>
@@ -217,24 +417,40 @@
                   <ng-container matColumnDef="actions" stickyEnd>
                     <th mat-header-cell *matHeaderCellDef></th>
                     <td mat-cell *matCellDef="let row">
-                      <a *ngIf="row.rechten.lezen" mat-icon-button [routerLink]="['/zaken', row.identificatie]"
-                        (click)="$event.stopPropagation()" [id]="'zaakBekijken_' + row.identificatie + '_button'"
-                        title="{{ 'actie.zaak.bekijken' | translate }}">
+                      <a
+                        *ngIf="row.rechten.lezen"
+                        mat-icon-button
+                        [routerLink]="['/zaken', row.identificatie]"
+                        (click)="$event.stopPropagation()"
+                        [id]="'zaakBekijken_' + row.identificatie + '_button'"
+                        title="{{ 'actie.zaak.bekijken' | translate }}"
+                      >
                         <mat-icon>visibility</mat-icon>
                       </a>
-                      <button *ngIf="row.rechten.wijzigen" mat-icon-button (click)="startZaakOntkoppelenDialog(row)"
+                      <button
+                        *ngIf="row.rechten.wijzigen"
+                        mat-icon-button
+                        (click)="startZaakOntkoppelenDialog(row)"
                         [id]="
                           'zaakOntkoppelen_' + row.identificatie + '_button'
-                        " title="{{ 'actie.zaak.ontkoppelen' | translate }}">
+                        "
+                        title="{{ 'actie.zaak.ontkoppelen' | translate }}"
+                      >
                         <mat-icon>link_off</mat-icon>
                       </button>
                     </td>
                   </ng-container>
-                  <tr mat-header-row *matHeaderRowDef="gerelateerdeZaakColumnsWithAction"></tr>
-                  <tr mat-row *matRowDef="
+                  <tr
+                    mat-header-row
+                    *matHeaderRowDef="gerelateerdeZaakColumnsWithAction"
+                  ></tr>
+                  <tr
+                    mat-row
+                    *matRowDef="
                       let row;
                       columns: gerelateerdeZaakColumnsWithAction
-                    "></tr>
+                    "
+                  ></tr>
                 </table>
               </div>
             </mat-tab>
@@ -245,7 +461,12 @@
                 {{ "historie" | translate }}
               </ng-template>
               <div class="table-wrapper">
-                <table mat-table matSort #historieSort="matSort" [dataSource]="historie">
+                <table
+                  mat-table
+                  matSort
+                  #historieSort="matSort"
+                  [dataSource]="historie"
+                >
                   <ng-container matColumnDef="datum">
                     <th *matHeaderCellDef mat-header-cell mat-sort-header>
                       {{ "datum" | translate }}
@@ -269,7 +490,10 @@
                       {{ "gegeven" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let regel">
-                      <read-more [text]="regel.attribuutLabel | translate" [maxLength]="20"></read-more>
+                      <read-more
+                        [text]="regel.attribuutLabel | translate"
+                        [maxLength]="20"
+                      ></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="actie">
@@ -277,10 +501,13 @@
                       {{ "actie" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let regel">
-                      <read-more [text]="
+                      <read-more
+                        [text]="
                           regel.actie &&
                           ('action.case.' + regel.actie | translate)
-                        " [maxLength]="20"></read-more>
+                        "
+                        [maxLength]="20"
+                      ></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="oudeWaarde">
@@ -288,10 +515,16 @@
                       {{ "waarde.oud" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let regel">
-                      <read-more *ngIf="regel.attribuutLabel !== 'zaakgeometrie'" [text]="regel.oudeWaarde | empty"
-                        [maxLength]="20"></read-more>
-                      <read-more *ngIf="regel.attribuutLabel === 'zaakgeometrie'"
-                        [text]="regel.oudeWaarde | location | empty" [maxLength]="20"></read-more>
+                      <read-more
+                        *ngIf="regel.attribuutLabel !== 'zaakgeometrie'"
+                        [text]="regel.oudeWaarde | empty"
+                        [maxLength]="20"
+                      ></read-more>
+                      <read-more
+                        *ngIf="regel.attribuutLabel === 'zaakgeometrie'"
+                        [text]="regel.oudeWaarde | location | empty"
+                        [maxLength]="20"
+                      ></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="nieuweWaarde">
@@ -299,15 +532,23 @@
                       {{ "waarde.nieuw" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let regel">
-                      <read-more *ngIf="regel.attribuutLabel !== 'zaakgeometrie'" [text]="
+                      <read-more
+                        *ngIf="regel.attribuutLabel !== 'zaakgeometrie'"
+                        [text]="
                           regel.nieuweWaarde | empty | mimetypeToExtension
-                        " [maxLength]="20"></read-more>
-                      <read-more *ngIf="regel.attribuutLabel === 'zaakgeometrie'" [text]="
+                        "
+                        [maxLength]="20"
+                      ></read-more>
+                      <read-more
+                        *ngIf="regel.attribuutLabel === 'zaakgeometrie'"
+                        [text]="
                           regel.nieuweWaarde
                             | location
                             | empty
                             | mimetypeToExtension
-                        " [maxLength]="20"></read-more>
+                        "
+                        [maxLength]="20"
+                      ></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="toelichting">
@@ -315,11 +556,20 @@
                       {{ "reden" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let regel">
-                      <read-more [text]="regel.toelichting" [maxLength]="20"></read-more>
+                      <read-more
+                        [text]="regel.toelichting"
+                        [maxLength]="20"
+                      ></read-more>
                     </td>
                   </ng-container>
-                  <tr mat-header-row *matHeaderRowDef="historieColumns; sticky: true"></tr>
-                  <tr mat-row *matRowDef="let row; columns: historieColumns"></tr>
+                  <tr
+                    mat-header-row
+                    *matHeaderRowDef="historieColumns; sticky: true"
+                  ></tr>
+                  <tr
+                    mat-row
+                    *matRowDef="let row; columns: historieColumns"
+                  ></tr>
                 </table>
               </div>
             </mat-tab>
@@ -336,7 +586,10 @@
                       {{ "roltype" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let betrokkene">
-                      <read-more [text]="betrokkene.roltype" [maxLength]="20"></read-more>
+                      <read-more
+                        [text]="betrokkene.roltype"
+                        [maxLength]="20"
+                      ></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="betrokkeneidentificatie">
@@ -345,23 +598,39 @@
                     </th>
                     <td mat-cell *matCellDef="let betrokkene">
                       {{ betrokkene.identificatie }}
-                      <span *ngIf="betrokkene.kvkNummer">/ {{ betrokkene.kvkNummer }}&nbsp;</span>
-                      <span *ngIf="
+                      <span *ngIf="betrokkene.kvkNummer"
+                        >/ {{ betrokkene.kvkNummer }}&nbsp;</span
+                      >
+                      <span
+                        *ngIf="
                           betrokkene.type === 'NIET_NATUURLIJK_PERSOON' &&
                           betrokkene.identificatieType === 'VN' &&
                           !betrokkene.kvkNummer
-                        ">/ {{ "msg.error.kvk.unknown" | translate }}&nbsp;</span>
-                      <span *ngIf="betrokkene.type === 'NATUURLIJK_PERSOON'"
-                        [matTooltip]="'identificatieType.BSN' | translate">(P)</span>
-                      <span *ngIf="
+                        "
+                        >/ {{ "msg.error.kvk.unknown" | translate }}&nbsp;</span
+                      >
+                      <span
+                        *ngIf="betrokkene.type === 'NATUURLIJK_PERSOON'"
+                        [matTooltip]="'identificatieType.BSN' | translate"
+                        >(P)</span
+                      >
+                      <span
+                        *ngIf="
                           betrokkene.type === 'NIET_NATUURLIJK_PERSOON' &&
                           betrokkene.identificatieType === 'RSIN'
-                        " [matTooltip]="'identificatieType.RSIN' | translate">(R)</span>
-                      <span *ngIf="
+                        "
+                        [matTooltip]="'identificatieType.RSIN' | translate"
+                        >(R)</span
+                      >
+                      <span
+                        *ngIf="
                           (betrokkene.type === 'NIET_NATUURLIJK_PERSOON' &&
                             betrokkene.identificatieType === 'VN') ||
                           betrokkene.type === 'VESTIGING'
-                        " [matTooltip]="'identificatieType.VN' | translate">(V)</span>
+                        "
+                        [matTooltip]="'identificatieType.VN' | translate"
+                        >(V)</span
+                      >
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="betrokkenegegevens">
@@ -369,20 +638,31 @@
                       {{ "gegevens" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let betrokkene">
-                      <button mat-icon-button *ngIf="!betrokkene.gegevens" [disabled]="
+                      <button
+                        mat-icon-button
+                        *ngIf="!betrokkene.gegevens"
+                        [disabled]="
                           betrokkene.type === 'NIET_NATUURLIJK_PERSOON' &&
                           betrokkene.identificatieType === 'VN' &&
                           !betrokkene.kvkNummer
-                        " (click)="betrokkeneGegevensOphalen(betrokkene)">
+                        "
+                        (click)="betrokkeneGegevensOphalen(betrokkene)"
+                      >
                         <mat-icon>more_horiz</mat-icon>
                       </button>
-                      <button mat-icon-button *ngIf="betrokkene.gegevens === 'LOADING'">
+                      <button
+                        mat-icon-button
+                        *ngIf="betrokkene.gegevens === 'LOADING'"
+                      >
                         <mat-icon>hourglass_empty</mat-icon>
                       </button>
-                      <span *ngIf="
+                      <span
+                        *ngIf="
                           betrokkene.gegevens &&
                           betrokkene.gegevens !== 'LOADING'
-                        ">{{ betrokkene.gegevens }}</span>
+                        "
+                        >{{ betrokkene.gegevens }}</span
+                      >
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="roltoelichting">
@@ -390,39 +670,64 @@
                       {{ "toelichting" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let betrokkene">
-                      <read-more [text]="betrokkene.roltoelichting" [maxLength]="20"></read-more>
+                      <read-more
+                        [text]="betrokkene.roltoelichting"
+                        [maxLength]="20"
+                      ></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="actions" stickyEnd>
                     <th mat-header-cell *matHeaderCellDef></th>
                     <td mat-cell *matCellDef="let betrokkene">
-                      <a *ngIf="betrokkene.type === 'NATUURLIJK_PERSOON'" mat-icon-button
-                        [routerLink]="['/persoon', betrokkene.identificatie]" (click)="$event.stopPropagation()" [id]="
+                      <a
+                        *ngIf="betrokkene.type === 'NATUURLIJK_PERSOON'"
+                        mat-icon-button
+                        [routerLink]="['/persoon', betrokkene.identificatie]"
+                        (click)="$event.stopPropagation()"
+                        [id]="
                           'persoonBekijken_' +
                           betrokkene.identificatie +
                           '_button'
-                        " title="{{ 'actie.persoon.bekijken' | translate }}">
+                        "
+                        title="{{ 'actie.persoon.bekijken' | translate }}"
+                      >
                         <mat-icon>visibility</mat-icon>
                       </a>
-                      <a *ngIf="
+                      <a
+                        *ngIf="
                           betrokkene.type === 'NIET_NATUURLIJK_PERSOON' ||
                           betrokkene.type === 'VESTIGING'
-                        " mat-icon-button [routerLink]="['/bedrijf', betrokkene.identificatie]"
-                        (click)="$event.stopPropagation()" [id]="
+                        "
+                        mat-icon-button
+                        [routerLink]="['/bedrijf', betrokkene.identificatie]"
+                        (click)="$event.stopPropagation()"
+                        [id]="
                           'bedrijfBekijken_' +
                           betrokkene.identificatie +
                           '_button'
-                        " title="{{ 'actie.bedrijf.bekijken' | translate }}">
+                        "
+                        title="{{ 'actie.bedrijf.bekijken' | translate }}"
+                      >
                         <mat-icon>visibility</mat-icon>
                       </a>
-                      <button *ngIf="zaak.rechten.verwijderenBetrokkene" mat-icon-button
-                        (click)="deleteBetrokkene(betrokkene)" title="{{ 'actie.betrokkene.ontkoppelen' | translate }}">
+                      <button
+                        *ngIf="zaak.rechten.verwijderenBetrokkene"
+                        mat-icon-button
+                        (click)="deleteBetrokkene(betrokkene)"
+                        title="{{ 'actie.betrokkene.ontkoppelen' | translate }}"
+                      >
                         <mat-icon>link_off</mat-icon>
                       </button>
                     </td>
                   </ng-container>
-                  <tr mat-header-row *matHeaderRowDef="betrokkenenColumns; sticky: true"></tr>
-                  <tr mat-row *matRowDef="let row; columns: betrokkenenColumns"></tr>
+                  <tr
+                    mat-header-row
+                    *matHeaderRowDef="betrokkenenColumns; sticky: true"
+                  ></tr>
+                  <tr
+                    mat-row
+                    *matRowDef="let row; columns: betrokkenenColumns"
+                  ></tr>
                 </table>
               </div>
             </mat-tab>
@@ -439,7 +744,10 @@
                       {{ "identificatie" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let bagObjectGegevens">
-                      <read-more [text]="bagObjectGegevens.bagObject.identificatie" [maxLength]="20"></read-more>
+                      <read-more
+                        [text]="bagObjectGegevens.bagObject.identificatie"
+                        [maxLength]="20"
+                      ></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="type">
@@ -448,8 +756,8 @@
                     </th>
                     <td mat-cell *matCellDef="let bagObjectGegevens">
                       {{
-                      "objecttype." +
-                      bagObjectGegevens.bagObject.bagObjectType | translate
+                        "objecttype." +
+                          bagObjectGegevens.bagObject.bagObjectType | translate
                       }}
                     </td>
                   </ng-container>
@@ -464,27 +772,42 @@
                   <ng-container matColumnDef="actions">
                     <th *matHeaderCellDef mat-header-cell></th>
                     <td *matCellDef="let bagObjectGegevens" mat-cell>
-                      <a mat-icon-button [routerLink]="[
+                      <a
+                        mat-icon-button
+                        [routerLink]="[
                           '/bag-objecten',
                           bagObjectGegevens.bagObject.bagObjectType.toLowerCase(),
                           bagObjectGegevens.bagObject.identificatie,
-                        ]" (click)="$event.stopPropagation()" [id]="
+                        ]"
+                        (click)="$event.stopPropagation()"
+                        [id]="
                           'bagObject_' +
                           bagObjectGegevens.bagObject.identificatie +
                           '_button'
-                        " title="{{ 'actie.bagObject.bekijken' | translate }}">
+                        "
+                        title="{{ 'actie.bagObject.bekijken' | translate }}"
+                      >
                         <mat-icon>visibility</mat-icon>
                       </a>
-                      <button *ngIf="zaak.rechten.behandelen" mat-icon-button
+                      <button
+                        *ngIf="zaak.rechten.behandelen"
+                        mat-icon-button
                         (click)="bagObjectVerwijderen(bagObjectGegevens)"
-                        title="{{ 'actie.bagObject.ontkoppelen' | translate }}">
+                        title="{{ 'actie.bagObject.ontkoppelen' | translate }}"
+                      >
                         <mat-icon>link_off</mat-icon>
                       </button>
                     </td>
                   </ng-container>
 
-                  <tr mat-header-row *matHeaderRowDef="bagObjectenColumns; sticky: true"></tr>
-                  <tr mat-row *matRowDef="let row; columns: bagObjectenColumns"></tr>
+                  <tr
+                    mat-header-row
+                    *matHeaderRowDef="bagObjectenColumns; sticky: true"
+                  ></tr>
+                  <tr
+                    mat-row
+                    *matRowDef="let row; columns: bagObjectenColumns"
+                  ></tr>
                 </table>
               </div>
             </mat-tab>
@@ -492,24 +815,45 @@
         </mat-card-content>
       </mat-card>
       <div class="w50 flex-1 flex-col gap-12">
-        <zac-besluit-view *ngIf="zaak.besluiten?.length" [besluiten]="zaak.besluiten ?? []" [result]="zaak.resultaat"
-          [readonly]="!zaak.isOpen || !zaak.rechten.behandelen" (besluitWijzigen)="besluitWijzigen($event)"
-          (doIntrekking)="doIntrekking($event)"></zac-besluit-view>
+        <zac-besluit-view
+          *ngIf="zaak.besluiten?.length"
+          [besluiten]="zaak.besluiten ?? []"
+          [result]="zaak.resultaat"
+          [readonly]="!zaak.isOpen || !zaak.rechten.behandelen"
+          (besluitWijzigen)="besluitWijzigen($event)"
+          (doIntrekking)="doIntrekking($event)"
+        ></zac-besluit-view>
 
         <mat-card class="flex-grow-1">
           <mat-card-header>
             <mat-card-title>{{ "taken" | translate }}</mat-card-title>
-            <mat-slide-toggle [formControl]="toonAfgerondeTaken" color="primary" (change)="filterTakenOpStatus()">{{
-              "toonAfgerondeTaken" | translate }}</mat-slide-toggle>
+            <mat-slide-toggle
+              [formControl]="toonAfgerondeTaken"
+              color="primary"
+              (change)="filterTakenOpStatus()"
+              >{{ "toonAfgerondeTaken" | translate }}</mat-slide-toggle
+            >
           </mat-card-header>
           <mat-card-content>
             <div class="table-wrapper">
-              <table mat-table matSort multiTemplateDataRows #takenSort="matSort" [dataSource]="takenDataSource">
+              <table
+                mat-table
+                matSort
+                multiTemplateDataRows
+                #takenSort="matSort"
+                [dataSource]="takenDataSource"
+              >
                 <ng-container matColumnDef="collapse">
                   <th mat-header-cell *matHeaderCellDef>
-                    <mat-icon *ngIf="!allTakenExpanded" (click)="expandTaken(true)">expand_more
+                    <mat-icon
+                      *ngIf="!allTakenExpanded"
+                      (click)="expandTaken(true)"
+                      >expand_more
                     </mat-icon>
-                    <mat-icon *ngIf="allTakenExpanded" (click)="expandTaken(false)">expand_less
+                    <mat-icon
+                      *ngIf="allTakenExpanded"
+                      (click)="expandTaken(false)"
+                      >expand_less
                     </mat-icon>
                   </th>
                 </ng-container>
@@ -526,7 +870,10 @@
                     {{ "status" | translate }}
                   </th>
                   <td mat-cell *matCellDef="let taak">
-                    <mat-chip [color]="taskStatusChipColor(taak.data.status)" [highlighted]="true">
+                    <mat-chip
+                      [color]="taskStatusChipColor(taak.data.status)"
+                      [highlighted]="true"
+                    >
                       {{ "taak.status." + taak.data.status | translate }}
                     </mat-chip>
                   </td>
@@ -554,10 +901,15 @@
                   <td mat-cell *matCellDef="let taak">
                     <div class="flex-row items-center gap-5">
                       {{ taak.data.fataledatum | datum | empty }}
-                      <mat-icon *ngIf="
+                      <mat-icon
+                        *ngIf="
                           taak.data.status !== 'AFGEROND' &&
                           isAfterDate(taak.data.fataledatum)
-                        " [title]="'msg.datum.overschreden' | translate" class="error list-icon">warning</mat-icon>
+                        "
+                        [title]="'msg.datum.overschreden' | translate"
+                        class="error list-icon"
+                        >warning</mat-icon
+                      >
                     </div>
                   </td>
                 </ng-container>
@@ -581,14 +933,23 @@
                   <th mat-header-cell *matHeaderCellDef></th>
                   <td mat-cell *matCellDef="let row">
                     <div class="flex-row">
-                      <a *ngIf="row.data.rechten.lezen" mat-icon-button [routerLink]="['/taken', row.data.id]"
-                        (click)="$event.stopPropagation()" [id]="'taakBekijken_' + row.data.id + '_button'"
-                        title="{{ 'actie.taak.bekijken' | translate }}">
+                      <a
+                        *ngIf="row.data.rechten.lezen"
+                        mat-icon-button
+                        [routerLink]="['/taken', row.data.id]"
+                        (click)="$event.stopPropagation()"
+                        [id]="'taakBekijken_' + row.data.id + '_button'"
+                        title="{{ 'actie.taak.bekijken' | translate }}"
+                      >
                         <mat-icon>visibility</mat-icon>
                       </a>
-                      <button mat-icon-button title="{{ 'actie.mij.toekennen' | translate }}"
-                        [id]="'kenTaakAanMijToe_' + row.data.id + '_button'" (click)="assignTaakToMe(row.data, $event)"
-                        *ngIf="showAssignTaakToMe(row.data)">
+                      <button
+                        mat-icon-button
+                        title="{{ 'actie.mij.toekennen' | translate }}"
+                        [id]="'kenTaakAanMijToe_' + row.data.id + '_button'"
+                        (click)="assignTaakToMe(row.data, $event)"
+                        *ngIf="showAssignTaakToMe(row.data)"
+                      >
                         <mat-icon outlined>person_add</mat-icon>
                       </button>
                     </div>
@@ -597,23 +958,47 @@
 
                 <ng-container matColumnDef="expandedTaakDetail">
                   <td mat-cell *matCellDef="let row" colspan="9">
-                    <div class="row-detail" [@detailExpand]="row.expanded ? 'expanded' : 'collapsed'">
+                    <div
+                      class="row-detail"
+                      [@detailExpand]="row.expanded ? 'expanded' : 'collapsed'"
+                    >
                       <div class="flex-row flex-wrap gap-10">
-                        <zac-static-text [label]="'uitkomst' | translate" [value]="
+                        <zac-static-text
+                          [label]="'uitkomst' | translate"
+                          [value]="
                             row.data.taakinformatie?.uitkomst | translate
-                          "></zac-static-text>
-                        <zac-static-text [label]="'bijlage' | translate" *ngIf="row.data.taakinformatie?.bijlagen"
-                          [value]="row.data.taakinformatie?.bijlagen"></zac-static-text>
-                        <zac-static-text [label]="'opmerking' | translate" *ngIf="row.data.taakinformatie?.opmerking"
-                          [value]="row.data.taakinformatie?.opmerking"></zac-static-text>
+                          "
+                        ></zac-static-text>
+                        <zac-static-text
+                          [label]="'bijlage' | translate"
+                          *ngIf="row.data.taakinformatie?.bijlagen"
+                          [value]="row.data.taakinformatie?.bijlagen"
+                        ></zac-static-text>
+                        <zac-static-text
+                          [label]="'opmerking' | translate"
+                          *ngIf="row.data.taakinformatie?.opmerking"
+                          [value]="row.data.taakinformatie?.opmerking"
+                        ></zac-static-text>
                       </div>
                     </div>
                   </td>
                 </ng-container>
-                <tr mat-header-row *matHeaderRowDef="['collapse'].concat(takenColumnsToDisplay)"></tr>
-                <tr mat-row *matRowDef="let row; columns: takenColumnsToDisplay" class="row"
-                  [class.expanded-row]="row.expanded" (click)="expandTaak(row)"></tr>
-                <tr mat-row *matRowDef="let row; columns: ['expandedTaakDetail']" class="collapsed-row"></tr>
+                <tr
+                  mat-header-row
+                  *matHeaderRowDef="['collapse'].concat(takenColumnsToDisplay)"
+                ></tr>
+                <tr
+                  mat-row
+                  *matRowDef="let row; columns: takenColumnsToDisplay"
+                  class="row"
+                  [class.expanded-row]="row.expanded"
+                  (click)="expandTaak(row)"
+                ></tr>
+                <tr
+                  mat-row
+                  *matRowDef="let row; columns: ['expandedTaakDetail']"
+                  class="collapsed-row"
+                ></tr>
                 <tr class="mat-row" *matNoDataRow>
                   <td class="mat-cell" colspan="9">
                     <p *ngIf="takenLoading">{{ "msg.loading" | translate }}</p>
@@ -627,11 +1012,18 @@
           </mat-card-content>
         </mat-card>
       </div>
-      <zac-zaak-documenten #zaakDocumentenComponent class="w100" [zaak]="zaak"
-        (documentMoveToCase)="documentMoveToCase($event)"></zac-zaak-documenten>
+      <zac-zaak-documenten
+        #zaakDocumentenComponent
+        class="w100"
+        [zaak]="zaak"
+        (documentMoveToCase)="documentMoveToCase($event)"
+      ></zac-zaak-documenten>
     </div>
   </mat-drawer-content>
 </mat-drawer-container>
 
-<zac-notities *ngIf="notitieRechten?.lezen || notitieRechten?.wijzigen" [zaakUuid]="zaak.uuid"
-  [notitieRechten]="notitieRechten"></zac-notities>
+<zac-notities
+  *ngIf="notitieRechten?.lezen || notitieRechten?.wijzigen"
+  [zaakUuid]="zaak.uuid"
+  [notitieRechten]="notitieRechten"
+></zac-notities>

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -3,188 +3,74 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-<mat-drawer-container
-  #sideNavContainer
-  class="inner-sidenav-container"
-  [class]="sideNaveMode"
-  xmlns="http://www.w3.org/1999/html"
->
-  <mat-drawer
-    #menuSidenav
-    position="start"
-    opened="true"
-    disableClose="true"
-    [mode]="sideNaveMode"
-  >
-    <zac-side-nav
-      (mode)="menuModeChanged($event)"
-      [menu]="menu"
-      [activeItem]="activeSideAction"
-      (activeItemChange)="menuItemChanged($event)"
-    ></zac-side-nav>
+<mat-drawer-container #sideNavContainer class="inner-sidenav-container" [class]="sideNaveMode"
+  xmlns="http://www.w3.org/1999/html">
+  <mat-drawer #menuSidenav position="start" opened="true" disableClose="true" [mode]="sideNaveMode">
+    <zac-side-nav (mode)="menuModeChanged($event)" [menu]="menu" [activeItem]="activeSideAction"
+      (activeItemChange)="menuItemChanged($event)"></zac-side-nav>
   </mat-drawer>
-  <mat-drawer
-    #actionsSidenav
-    mode="over"
-    position="end"
-    [ngSwitch]="activeSideAction"
-    class="side-nav-container"
-    (closedStart)="activeSideAction = null"
-  >
-    <zac-klant-koppel
-      *ngSwitchCase="'actie.initiator.koppelen'"
-      [sideNav]="actionsSidenav"
-      [context]="zaak.identificatie"
-      (klantGegevens)="initiatorGeselecteerd($event.klant)"
-      [initiator]="true"
-      [allowBedrijf]="allowBedrijf()"
-      [allowPersoon]="allowPersoon()"
-    ></zac-klant-koppel>
-    <zac-klant-koppel
-      *ngSwitchCase="'actie.betrokkene.koppelen'"
-      (klantGegevens)="betrokkeneGeselecteerd($event)"
-      [sideNav]="actionsSidenav"
-      [zaaktypeUUID]="zaak.zaaktype.uuid"
-      [context]="zaak.identificatie"
-      [allowBedrijf]="allowBedrijf()"
-      [allowPersoon]="allowPersoon()"
-    ></zac-klant-koppel>
-    <zac-bag-zoek
-      *ngSwitchCase="'actie.bagObject.koppelen'"
-      [gekoppeldeBagObjecten]="gekoppeldeBagObjecten"
-      [sideNav]="actionsSidenav"
-      (bagObject)="adresGeselecteerd($event)"
-    ></zac-bag-zoek>
-    <zac-case-details-edit
-      *ngSwitchCase="'actie.zaak.wijzigen'"
-      [zaak]="zaak"
-      [loggedInUser]="loggedInUser"
-      [sideNav]="actionsSidenav"
-    ></zac-case-details-edit>
-    <zac-case-location-edit
-      *ngSwitchCase="'actie.zaak.locatie.koppelen'"
-      [zaak]="zaak"
-      [sideNav]="actionsSidenav"
-      (locatie)="locationSelected()"
-    ></zac-case-location-edit>
-    <zac-informatie-object-create-attended
-      *ngSwitchCase="'actie.document.maken'"
-      [sideNav]="actionsSidenav"
-      [zaak]="zaak"
-      (document)="documentCreated()"
-    ></zac-informatie-object-create-attended>
-    <zac-informatie-object-add
-      *ngSwitchCase="'actie.document.toevoegen'"
-      [sideNav]="actionsSidenav"
-      [zaak]="zaak"
-      (document)="documentToegevoegd()"
-    ></zac-informatie-object-add>
-    <zac-informatie-verzenden
-      *ngSwitchCase="'actie.document.verzenden'"
-      [sideNav]="actionsSidenav"
-      [zaak]="zaak"
-      (documentSent)="documentSent()"
-    ></zac-informatie-verzenden>
-    <zac-human-task-do
-      *ngSwitchCase="actiefPlanItem?.naam ?? 'none'"
-      (done)="taakGestart()"
-      [sideNav]="actionsSidenav"
-      [zaak]="zaak"
-      [planItem]="actiefPlanItem"
-    ></zac-human-task-do>
-    <zac-process-task-do
-      *ngSwitchCase="actiefPlanItem?.naam ?? 'none'"
-      (done)="processGestart()"
-      [zaak]="zaak"
-      [planItem]="actiefPlanItem"
-    ></zac-process-task-do>
-    <zac-mail-create
-      *ngSwitchCase="'actie.mail.versturen'"
-      (mailVerstuurd)="mailVerstuurd($event)"
-      [sideNav]="actionsSidenav"
-      [zaak]="zaak"
-    ></zac-mail-create>
-    <zac-ontvangstbevestiging
-      *ngSwitchCase="'actie.ontvangstbevestiging.versturen'"
-      (ontvangstBevestigd)="ontvangstBevestigd($event)"
-      [sideNav]="actionsSidenav"
-      [zaak]="zaak"
-    ></zac-ontvangstbevestiging>
-    <zac-besluit-create
-      *ngSwitchCase="'actie.besluit.vastleggen'"
-      (besluitVastgelegd)="besluitVastgelegd()"
-      [sideNav]="actionsSidenav"
-      [zaak]="zaak"
-    ></zac-besluit-create>
-    <zac-besluit-edit
-      *ngSwitchCase="'actie.besluit.wijzigen'"
-      (besluitGewijzigd)="besluitVastgelegd()"
-      [sideNav]="actionsSidenav"
-      [besluit]="teWijzigenBesluit"
-      [zaak]="zaak"
-    ></zac-besluit-edit>
-    <zac-informatie-object-link
-      *ngSwitchCase="'actie.document.verplaatsen'"
-      [actionLabel]="'actie.document.verplaatsen'"
-      [infoObject]="documentToMove"
-      [sideNav]="actionsSidenav"
-      [source]="zaak.identificatie"
-      (informationObjectLinked)="updateDocumentList()"
-    ></zac-informatie-object-link>
-    <zac-zaak-link
-      *ngSwitchCase="'actie.zaak.koppelen'"
-      [zaak]="zaak"
-      [sideNav]="actionsSidenav"
-      (zaakLinked)="zaakLinked()"
-    ></zac-zaak-link>
-    <zac-zaakdata
-      *ngSwitchCase="'actie.zaakdata.bekijken'"
-      [readonly]="true"
-      [sideNav]="actionsSidenav"
-      [zaak]="zaak"
-    ></zac-zaakdata>
+  <mat-drawer #actionsSidenav mode="over" position="end" [ngSwitch]="activeSideAction" class="side-nav-container"
+    (closedStart)="activeSideAction = null">
+    <zac-klant-koppel *ngSwitchCase="'actie.initiator.koppelen'" [sideNav]="actionsSidenav"
+      [context]="zaak.identificatie" (klantGegevens)="initiatorGeselecteerd($event.klant)" [initiator]="true"
+      [allowBedrijf]="allowBedrijf()" [allowPersoon]="allowPersoon()"></zac-klant-koppel>
+    <zac-klant-koppel *ngSwitchCase="'actie.betrokkene.koppelen'" (klantGegevens)="betrokkeneGeselecteerd($event)"
+      [sideNav]="actionsSidenav" [zaaktypeUUID]="zaak.zaaktype.uuid" [context]="zaak.identificatie"
+      [allowBedrijf]="allowBedrijf()" [allowPersoon]="allowPersoon()"></zac-klant-koppel>
+    <zac-bag-zoek *ngSwitchCase="'actie.bagObject.koppelen'" [gekoppeldeBagObjecten]="gekoppeldeBagObjecten"
+      [sideNav]="actionsSidenav" (bagObject)="adresGeselecteerd($event)"></zac-bag-zoek>
+    <zac-case-details-edit *ngSwitchCase="'actie.zaak.wijzigen'" [zaak]="zaak" [loggedInUser]="loggedInUser"
+      [sideNav]="actionsSidenav"></zac-case-details-edit>
+    <zac-case-location-edit *ngSwitchCase="'actie.zaak.locatie.koppelen'" [zaak]="zaak" [sideNav]="actionsSidenav"
+      (locatie)="locationSelected()"></zac-case-location-edit>
+    <zac-informatie-object-create-attended *ngSwitchCase="'actie.document.maken'" [sideNav]="actionsSidenav"
+      [zaak]="zaak" (document)="documentCreated()"></zac-informatie-object-create-attended>
+    <zac-informatie-object-add *ngSwitchCase="'actie.document.toevoegen'" [sideNav]="actionsSidenav" [zaak]="zaak"
+      (document)="documentToegevoegd()"></zac-informatie-object-add>
+    <zac-informatie-verzenden *ngSwitchCase="'actie.document.verzenden'" [sideNav]="actionsSidenav" [zaak]="zaak"
+      (documentSent)="documentSent()"></zac-informatie-verzenden>
+    <zac-human-task-do *ngSwitchCase="actiefPlanItem?.naam ?? 'none'" (done)="taakGestart()" [sideNav]="actionsSidenav"
+      [zaak]="zaak" [planItem]="actiefPlanItem"></zac-human-task-do>
+    <zac-process-task-do *ngSwitchCase="actiefPlanItem?.naam ?? 'none'" (done)="processGestart()" [zaak]="zaak"
+      [planItem]="actiefPlanItem"></zac-process-task-do>
+    <zac-mail-create *ngSwitchCase="'actie.mail.versturen'" (mailVerstuurd)="mailVerstuurd($event)"
+      [sideNav]="actionsSidenav" [zaak]="zaak"></zac-mail-create>
+    <zac-ontvangstbevestiging *ngSwitchCase="'actie.ontvangstbevestiging.versturen'"
+      (ontvangstBevestigd)="ontvangstBevestigd($event)" [sideNav]="actionsSidenav"
+      [zaak]="zaak"></zac-ontvangstbevestiging>
+    <zac-besluit-create *ngSwitchCase="'actie.besluit.vastleggen'" (besluitVastgelegd)="besluitVastgelegd()"
+      [sideNav]="actionsSidenav" [zaak]="zaak"></zac-besluit-create>
+    <zac-besluit-edit *ngSwitchCase="'actie.besluit.wijzigen'" (besluitGewijzigd)="besluitVastgelegd()"
+      [sideNav]="actionsSidenav" [besluit]="teWijzigenBesluit" [zaak]="zaak"></zac-besluit-edit>
+    <zac-informatie-object-link *ngSwitchCase="'actie.document.verplaatsen'"
+      [actionLabel]="'actie.document.verplaatsen'" [infoObject]="documentToMove" [sideNav]="actionsSidenav"
+      [source]="zaak.identificatie" (informationObjectLinked)="updateDocumentList()"></zac-informatie-object-link>
+    <zac-zaak-link *ngSwitchCase="'actie.zaak.koppelen'" [zaak]="zaak" [sideNav]="actionsSidenav"
+      (zaakLinked)="zaakLinked()"></zac-zaak-link>
+    <zac-zaakdata *ngSwitchCase="'actie.zaakdata.bekijken'" [readonly]="true" [sideNav]="actionsSidenav"
+      [zaak]="zaak"></zac-zaakdata>
   </mat-drawer>
   <mat-drawer-content>
     <div class="flex-row flex-wrap gap-12">
       <section class="w100 flex-1" *ngIf="showInitiator()">
-        <zac-zaak-initiator-toevoegen
-          class="w100 flex-1"
-          *ngIf="!(showPersoonsgegevens() || showBedrijfsgegevens())"
-          [toevoegenToegestaan]="allowedToAddBetrokkene()"
-          (add)="addOrEditZaakInitiator()"
-        >
+        <zac-zaak-initiator-toevoegen class="w100 flex-1" *ngIf="!(showPersoonsgegevens() || showBedrijfsgegevens())"
+          [toevoegenToegestaan]="allowedToAddBetrokkene()" (add)="addOrEditZaakInitiator()">
         </zac-zaak-initiator-toevoegen>
-        <zac-persoongegevens
-          class="w100 flex-1"
-          *ngIf="showPersoonsgegevens()"
-          [zaakIdentificatie]="zaak.identificatie"
-          [bsn]="zaak.initiatorIdentificatie"
-          action="initiator tonen"
-          [isVerwijderbaar]="zaak.rechten.verwijderenInitiator"
-          [isWijzigbaar]="zaak.rechten.toevoegenInitiatorPersoon"
-          (edit)="addOrEditZaakInitiator()"
-          (delete)="deleteInitiator()"
-        >
+        <zac-persoongegevens class="w100 flex-1" *ngIf="showPersoonsgegevens()" [zaakIdentificatie]="zaak.identificatie"
+          [bsn]="zaak.initiatorIdentificatie" action="initiator tonen"
+          [isVerwijderbaar]="zaak.rechten.verwijderenInitiator" [isWijzigbaar]="zaak.rechten.toevoegenInitiatorPersoon"
+          (edit)="addOrEditZaakInitiator()" (delete)="deleteInitiator()">
         </zac-persoongegevens>
-        <zac-bedrijfsgegevens
-          class="w100 flex-1"
-          *ngIf="showBedrijfsgegevens()"
-          [rsinOfVestigingsnummer]="zaak.initiatorIdentificatie"
-          [kvkNummer]="zaak.kvkNummer"
-          [isVerwijderbaar]="zaak.rechten.verwijderenInitiator"
-          (edit)="addOrEditZaakInitiator()"
-          [isWijzigbaar]="zaak.rechten.toevoegenInitiatorBedrijf"
-          (delete)="deleteInitiator()"
-        >
+        <zac-bedrijfsgegevens class="w100 flex-1" *ngIf="showBedrijfsgegevens()"
+          [rsinOfVestigingsnummer]="zaak.initiatorIdentificatie" [kvkNummer]="zaak.kvkNummer"
+          [isVerwijderbaar]="zaak.rechten.verwijderenInitiator" (edit)="addOrEditZaakInitiator()"
+          [isWijzigbaar]="zaak.rechten.toevoegenInitiatorBedrijf" (delete)="deleteInitiator()">
         </zac-bedrijfsgegevens>
       </section>
       <mat-card class="w50 flex-1">
         <mat-card-header class="flex-col gap-8 space-between">
           <div class="flex-row">
-            <zac-zaak-indicaties
-              [layout]="indicatiesLayout.EXTENDED"
-              [zaak]="zaak"
-            ></zac-zaak-indicaties>
+            <zac-zaak-indicaties [layout]="indicatiesLayout.EXTENDED" [zaak]="zaak"></zac-zaak-indicaties>
           </div>
           <section class="flex-row space-between items-center">
             <div>
@@ -193,15 +79,10 @@
               </mat-card-title>
               <mat-card-subtitle>{{
                 zaak.zaaktype.omschrijving
-              }}</mat-card-subtitle>
+                }}</mat-card-subtitle>
             </div>
-            <button
-              *ngIf="zaak.isProcesGestuurd && zaak.isOpen && !zaak.isHeropend"
-              class="proces-button"
-              (click)="showProces()"
-              [title]="'actie.proces.bekijken' | translate"
-              mat-icon-button
-            >
+            <button *ngIf="zaak.isProcesGestuurd && zaak.isOpen && !zaak.isHeropend" class="proces-button"
+              (click)="showProces()" [title]="'actie.proces.bekijken' | translate" mat-icon-button>
               <mat-icon> play_shapes </mat-icon>
             </button>
           </section>
@@ -211,194 +92,121 @@
             <mat-tab>
               <ng-template mat-tab-label>
                 <mat-icon>topic</mat-icon>
-                {{ "gegevens.algemeen" | translate }}</ng-template
-              >
+                {{ "gegevens.algemeen" | translate }}</ng-template>
               <div class="content">
                 <div class="flex flex-row flex-wrap justify-start gap-10">
-                  <zac-static-text
-                    [label]="'status' | translate"
-                    [value]="zaak.status | empty: 'naam'"
-                    class="flex-item"
-                  ></zac-static-text>
-                  <zac-static-text
-                    [label]="'registratiedatum' | translate"
-                    [value]="zaak.registratiedatum | datum"
-                    class="flex-item"
-                  ></zac-static-text>
-                  <zac-static-text
-                    [label]="'resultaat' | translate"
-                    [value]="zaak.resultaat?.resultaattype | empty: 'naam'"
-                    class="flex-item"
-                  ></zac-static-text>
-                  <zac-static-text
-                    *ngIf="zaak.einddatum"
-                    [label]="'einddatum' | translate"
-                    [value]="zaak.einddatum | datum"
-                    class="flex-item"
-                  ></zac-static-text>
-                  <zac-static-text
-                    *ngIf="zaak.archiefNominatie === 'VERNIETIGEN'"
-                    [label]="
+                  <zac-static-text [label]="'status' | translate" [value]="zaak.status | empty: 'naam'"
+                    class="flex-item"></zac-static-text>
+                  <zac-static-text [label]="'registratiedatum' | translate" [value]="zaak.registratiedatum | datum"
+                    class="flex-item"></zac-static-text>
+                  <zac-static-text [label]="'resultaat' | translate"
+                    [value]="zaak.resultaat?.resultaattype | empty: 'naam'" class="flex-item"></zac-static-text>
+                  <zac-static-text *ngIf="zaak.einddatum" [label]="'einddatum' | translate"
+                    [value]="zaak.einddatum | datum" class="flex-item"></zac-static-text>
+                  <zac-static-text *ngIf="zaak.archiefNominatie === 'VERNIETIGEN'" [label]="
                       'archiefNominatie.datum.' + zaak.archiefNominatie
                         | translate
-                    "
-                    [value]="zaak.archiefActiedatum | datum | empty"
-                    class="flex-item"
-                  ></zac-static-text>
-                  <zac-static-text
-                    *ngIf="zaak.archiefNominatie === 'BLIJVEND_BEWAREN'"
-                    [label]="'archiefNominatie' | translate"
-                    [value]="
+                    " [value]="zaak.archiefActiedatum | datum | empty" class="flex-item"></zac-static-text>
+                  <zac-static-text *ngIf="zaak.archiefNominatie === 'BLIJVEND_BEWAREN'"
+                    [label]="'archiefNominatie' | translate" [value]="
                       'archiefNominatie.' + zaak.archiefNominatie | translate
-                    "
-                    class="flex-item"
-                  ></zac-static-text>
+                    " class="flex-item"></zac-static-text>
                 </div>
                 <mat-divider class="mat-divider-wrapper"></mat-divider>
-
-                <div class="flex flex-row justify-start gap-10 editable">
-                  <button
-                    *ngIf="zaak.rechten.wijzigen || zaak.rechten.toekennen"
-                    mat-icon-button
-                    mat-small-icon-button
-                    (click)="editCaseDetails()"
-                  >
-                    <mat-icon>edit</mat-icon>
-                  </button>
-
-                  <zac-static-text
-                    [label]="'groep' | translate"
-                    [value]="zaak.groep?.naam | empty"
-                    class="flex-item"
-                  ></zac-static-text>
-                  <zac-static-text
-                    [label]="'behandelaar' | translate"
-                    [value]="zaak.behandelaar?.naam | empty"
-                    class="flex-item"
-                  ></zac-static-text>
-                  <zac-static-text
-                    [label]="'communicatiekanaal' | translate"
-                    [value]="zaak.communicatiekanaal | empty"
-                    class="flex-item"
-                  ></zac-static-text>
-                </div>
-                <div class="flex flex-row justify-start gap-10">
-                  <zac-static-text
-                    [label]="'startdatum' | translate"
-                    [value]="zaak.startdatum | datum | empty"
-                    class="flex-item"
-                  ></zac-static-text>
-                  <zac-static-text
-                    [label]="'streefdatum' | translate"
-                    [value]="zaak.einddatumGepland | datum | empty"
-                    [icon]="dateFieldIconMap.get('einddatumGepland')"
-                    class="flex-item"
-                  >
-                    <mat-icon>label-icon</mat-icon>
-                  </zac-static-text>
-                  <zac-static-text
-                    [label]="'fataledatum' | translate"
-                    [value]="zaak.uiterlijkeEinddatumAfdoening | datum | empty"
-                    [icon]="
-                      dateFieldIconMap.get('uiterlijkeEinddatumAfdoening')
-                    "
-                    class="flex-item"
-                  ></zac-static-text>
-                </div>
-                <div
-                  *ngIf="zaak.duurVerlenging || zaakOpschorting?.duurDagen"
-                  class="flex flex-row justify-start gap-10 remark"
-                >
-                  <div class="flex-col gap-5">
-                    <div
-                      class="flex-row items-center gap-5"
-                      *ngIf="zaakOpschorting?.duurDagen"
-                    >
-                      <mat-icon>pause</mat-icon>
-                      {{
-                        (zaakOpschorting?.duurDagen === 1
+                <div class="flex flex-row relative-parent">
+                  <div class="fields">
+                    <div class="flex flex-row justify-start gap-10">
+                      <zac-static-text [label]="'groep' | translate" [value]="zaak.groep?.naam | empty"
+                        class="flex-item"></zac-static-text>
+                      <zac-static-text [label]="'behandelaar' | translate" [value]="zaak.behandelaar?.naam | empty"
+                        class="flex-item"></zac-static-text>
+                      <zac-static-text [label]="'communicatiekanaal' | translate"
+                        [value]="zaak.communicatiekanaal | empty" class="flex-item"></zac-static-text>
+                    </div>
+                    <div class="flex flex-row justify-start gap-10">
+                      <zac-static-text [label]="'startdatum' | translate" [value]="zaak.startdatum | datum | empty"
+                        class="flex-item"></zac-static-text>
+                      <zac-static-text [label]="'streefdatum' | translate"
+                        [value]="zaak.einddatumGepland | datum | empty"
+                        [icon]="dateFieldIconMap.get('einddatumGepland')" class="flex-item">
+                        <mat-icon>label-icon</mat-icon>
+                      </zac-static-text>
+                      <zac-static-text [label]="'fataledatum' | translate"
+                        [value]="zaak.uiterlijkeEinddatumAfdoening | datum | empty" [icon]="
+                      dateFieldIconMap.get('uiterlijkeEinddatumAfdoening')" class="flex-item"></zac-static-text>
+                    </div>
+                    <div *ngIf="zaak.duurVerlenging || zaakOpschorting?.duurDagen"
+                      class="flex flex-row justify-start gap-10 remark">
+                      <div class="flex-col gap-5">
+                        <div class="flex-row items-center gap-5" *ngIf="zaakOpschorting?.duurDagen">
+                          <mat-icon>pause</mat-icon>
+                          {{
+                          (zaakOpschorting?.duurDagen === 1
                           ? "duurDagenOpschorting.enkelvoud"
                           : "duurDagenOpschorting"
-                        ) | translate: { duur: zaakOpschorting?.duurDagen }
-                      }}
-                    </div>
-                    <div
-                      class="flex-row items-center gap-5"
-                      *ngIf="zaak.duurVerlenging"
-                    >
-                      <mat-icon>update</mat-icon>
-                      {{
-                        "duurVerlenging"
+                          ) | translate: { duur: zaakOpschorting?.duurDagen }
+                          }}
+                        </div>
+                        <div class="flex-row items-center gap-5" *ngIf="zaak.duurVerlenging">
+                          <mat-icon>update</mat-icon>
+                          {{
+                          "duurVerlenging"
                           | translate: { duur: zaak.duurVerlenging }
-                      }}
+                          }}
+                        </div>
+                      </div>
                     </div>
-                  </div>
-                </div>
-                <div class="flex flex-row justify-start gap-10">
-                  <zac-static-text
-                    [label]="'vertrouwelijkheidaanduiding' | translate"
-                    [value]="
+                    <div class="flex flex-row justify-start gap-10">
+                      <zac-static-text [label]="'vertrouwelijkheidaanduiding' | translate" [value]="
                       zaak.vertrouwelijkheidaanduiding
                         | vertrouwelijkaanduidingToTranslationKey
                         | translate
                         | empty
-                    "
-                    class="flex-item"
-                  ></zac-static-text>
-                </div>
-
-                <div class="flex flex-col gap-10">
-                  <zac-static-text
-                    [label]="'omschrijving' | translate"
-                    [value]="zaak.omschrijving | empty"
-                  ></zac-static-text>
-                  <zac-static-text
-                    [label]="'toelichting' | translate"
-                    [value]="zaak.toelichting | empty"
-                  ></zac-static-text>
+                    " class="flex-item"></zac-static-text>
+                    </div>
+                    <div class="flex flex-col gap-10">
+                      <zac-static-text [label]="'omschrijving' | translate"
+                        [value]="zaak.omschrijving | empty"></zac-static-text>
+                      <zac-static-text [label]="'toelichting' | translate"
+                        [value]="zaak.toelichting | empty"></zac-static-text>
+                    </div>
+                  </div>
+                  <div class="editable">
+                    <button *ngIf="zaak.rechten.wijzigen || zaak.rechten.toekennen" mat-icon-button
+                      mat-small-icon-button (click)="editCaseDetails()">
+                      <mat-icon>edit</mat-icon>
+                    </button>
+                  </div>
                 </div>
               </div>
             </mat-tab>
-
             <mat-tab *ngIf="zaak.zaakgeometrie">
               <ng-template mat-tab-label>
                 <mat-icon>place</mat-icon>
-                {{ "locatie" | translate }}</ng-template
-              >
+                {{ "locatie" | translate }}</ng-template>
               <div class="table-wrapper">
-                <div class="flex flex-col gap-10 editable">
-                  <button
-                    *ngIf="zaak.rechten.wijzigenLocatie"
-                    mat-icon-button
-                    mat-small-icon-button
-                    (click)="editLocationDetails()"
-                  >
-                    <mat-icon>edit</mat-icon>
-                  </button>
-
-                  <zac-static-text
-                    [label]="'coordinates' | translate"
-                    [value]="zaak.zaakgeometrie | location | empty"
-                    class="flex-item"
-                  ></zac-static-text>
-                  <zac-locatie-tonen
-                    [currentLocation]="zaak.zaakgeometrie"
-                  ></zac-locatie-tonen>
+                <div class="flex flex-row margin-top space-between">
+                  <zac-static-text [label]="'coordinates' | translate" [value]="zaak.zaakgeometrie | location | empty"
+                    class="flex-item text-flexible"></zac-static-text>
+                  <div class="editable-location">
+                    <button *ngIf="zaak.rechten.wijzigenLocatie" mat-icon-button mat-small-icon-button
+                      (click)="editLocationDetails()">
+                      <mat-icon>edit</mat-icon>
+                    </button>
+                  </div>
                 </div>
+
+                <zac-locatie-tonen [currentLocation]="zaak.zaakgeometrie"></zac-locatie-tonen>
               </div>
             </mat-tab>
 
             <mat-tab *ngIf="zaak.gerelateerdeZaken?.length">
               <ng-template mat-tab-label>
                 <mat-icon>account_tree</mat-icon>
-                {{ "gerelateerdeZaken" | translate }}</ng-template
-              >
+                {{ "gerelateerdeZaken" | translate }}</ng-template>
               <div class="table-wrapper">
                 <table mat-table [dataSource]="zaak.gerelateerdeZaken">
-                  <ng-container
-                    *ngFor="let column of gerelateerdeZaakColumns"
-                    [matColumnDef]="column"
-                  >
+                  <ng-container *ngFor="let column of gerelateerdeZaakColumns" [matColumnDef]="column">
                     <th mat-header-cell *matHeaderCellDef>
                       {{ "gerelateerde.zaak." + column | translate }}
                     </th>
@@ -409,40 +217,24 @@
                   <ng-container matColumnDef="actions" stickyEnd>
                     <th mat-header-cell *matHeaderCellDef></th>
                     <td mat-cell *matCellDef="let row">
-                      <a
-                        *ngIf="row.rechten.lezen"
-                        mat-icon-button
-                        [routerLink]="['/zaken', row.identificatie]"
-                        (click)="$event.stopPropagation()"
-                        [id]="'zaakBekijken_' + row.identificatie + '_button'"
-                        title="{{ 'actie.zaak.bekijken' | translate }}"
-                      >
+                      <a *ngIf="row.rechten.lezen" mat-icon-button [routerLink]="['/zaken', row.identificatie]"
+                        (click)="$event.stopPropagation()" [id]="'zaakBekijken_' + row.identificatie + '_button'"
+                        title="{{ 'actie.zaak.bekijken' | translate }}">
                         <mat-icon>visibility</mat-icon>
                       </a>
-                      <button
-                        *ngIf="row.rechten.wijzigen"
-                        mat-icon-button
-                        (click)="startZaakOntkoppelenDialog(row)"
+                      <button *ngIf="row.rechten.wijzigen" mat-icon-button (click)="startZaakOntkoppelenDialog(row)"
                         [id]="
                           'zaakOntkoppelen_' + row.identificatie + '_button'
-                        "
-                        title="{{ 'actie.zaak.ontkoppelen' | translate }}"
-                      >
+                        " title="{{ 'actie.zaak.ontkoppelen' | translate }}">
                         <mat-icon>link_off</mat-icon>
                       </button>
                     </td>
                   </ng-container>
-                  <tr
-                    mat-header-row
-                    *matHeaderRowDef="gerelateerdeZaakColumnsWithAction"
-                  ></tr>
-                  <tr
-                    mat-row
-                    *matRowDef="
+                  <tr mat-header-row *matHeaderRowDef="gerelateerdeZaakColumnsWithAction"></tr>
+                  <tr mat-row *matRowDef="
                       let row;
                       columns: gerelateerdeZaakColumnsWithAction
-                    "
-                  ></tr>
+                    "></tr>
                 </table>
               </div>
             </mat-tab>
@@ -453,12 +245,7 @@
                 {{ "historie" | translate }}
               </ng-template>
               <div class="table-wrapper">
-                <table
-                  mat-table
-                  matSort
-                  #historieSort="matSort"
-                  [dataSource]="historie"
-                >
+                <table mat-table matSort #historieSort="matSort" [dataSource]="historie">
                   <ng-container matColumnDef="datum">
                     <th *matHeaderCellDef mat-header-cell mat-sort-header>
                       {{ "datum" | translate }}
@@ -482,10 +269,7 @@
                       {{ "gegeven" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let regel">
-                      <read-more
-                        [text]="regel.attribuutLabel | translate"
-                        [maxLength]="20"
-                      ></read-more>
+                      <read-more [text]="regel.attribuutLabel | translate" [maxLength]="20"></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="actie">
@@ -493,13 +277,10 @@
                       {{ "actie" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let regel">
-                      <read-more
-                        [text]="
+                      <read-more [text]="
                           regel.actie &&
                           ('action.case.' + regel.actie | translate)
-                        "
-                        [maxLength]="20"
-                      ></read-more>
+                        " [maxLength]="20"></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="oudeWaarde">
@@ -507,16 +288,10 @@
                       {{ "waarde.oud" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let regel">
-                      <read-more
-                        *ngIf="regel.attribuutLabel !== 'zaakgeometrie'"
-                        [text]="regel.oudeWaarde | empty"
-                        [maxLength]="20"
-                      ></read-more>
-                      <read-more
-                        *ngIf="regel.attribuutLabel === 'zaakgeometrie'"
-                        [text]="regel.oudeWaarde | location | empty"
-                        [maxLength]="20"
-                      ></read-more>
+                      <read-more *ngIf="regel.attribuutLabel !== 'zaakgeometrie'" [text]="regel.oudeWaarde | empty"
+                        [maxLength]="20"></read-more>
+                      <read-more *ngIf="regel.attribuutLabel === 'zaakgeometrie'"
+                        [text]="regel.oudeWaarde | location | empty" [maxLength]="20"></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="nieuweWaarde">
@@ -524,23 +299,15 @@
                       {{ "waarde.nieuw" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let regel">
-                      <read-more
-                        *ngIf="regel.attribuutLabel !== 'zaakgeometrie'"
-                        [text]="
+                      <read-more *ngIf="regel.attribuutLabel !== 'zaakgeometrie'" [text]="
                           regel.nieuweWaarde | empty | mimetypeToExtension
-                        "
-                        [maxLength]="20"
-                      ></read-more>
-                      <read-more
-                        *ngIf="regel.attribuutLabel === 'zaakgeometrie'"
-                        [text]="
+                        " [maxLength]="20"></read-more>
+                      <read-more *ngIf="regel.attribuutLabel === 'zaakgeometrie'" [text]="
                           regel.nieuweWaarde
                             | location
                             | empty
                             | mimetypeToExtension
-                        "
-                        [maxLength]="20"
-                      ></read-more>
+                        " [maxLength]="20"></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="toelichting">
@@ -548,20 +315,11 @@
                       {{ "reden" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let regel">
-                      <read-more
-                        [text]="regel.toelichting"
-                        [maxLength]="20"
-                      ></read-more>
+                      <read-more [text]="regel.toelichting" [maxLength]="20"></read-more>
                     </td>
                   </ng-container>
-                  <tr
-                    mat-header-row
-                    *matHeaderRowDef="historieColumns; sticky: true"
-                  ></tr>
-                  <tr
-                    mat-row
-                    *matRowDef="let row; columns: historieColumns"
-                  ></tr>
+                  <tr mat-header-row *matHeaderRowDef="historieColumns; sticky: true"></tr>
+                  <tr mat-row *matRowDef="let row; columns: historieColumns"></tr>
                 </table>
               </div>
             </mat-tab>
@@ -578,10 +336,7 @@
                       {{ "roltype" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let betrokkene">
-                      <read-more
-                        [text]="betrokkene.roltype"
-                        [maxLength]="20"
-                      ></read-more>
+                      <read-more [text]="betrokkene.roltype" [maxLength]="20"></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="betrokkeneidentificatie">
@@ -590,39 +345,23 @@
                     </th>
                     <td mat-cell *matCellDef="let betrokkene">
                       {{ betrokkene.identificatie }}
-                      <span *ngIf="betrokkene.kvkNummer"
-                        >/ {{ betrokkene.kvkNummer }}&nbsp;</span
-                      >
-                      <span
-                        *ngIf="
+                      <span *ngIf="betrokkene.kvkNummer">/ {{ betrokkene.kvkNummer }}&nbsp;</span>
+                      <span *ngIf="
                           betrokkene.type === 'NIET_NATUURLIJK_PERSOON' &&
                           betrokkene.identificatieType === 'VN' &&
                           !betrokkene.kvkNummer
-                        "
-                        >/ {{ "msg.error.kvk.unknown" | translate }}&nbsp;</span
-                      >
-                      <span
-                        *ngIf="betrokkene.type === 'NATUURLIJK_PERSOON'"
-                        [matTooltip]="'identificatieType.BSN' | translate"
-                        >(P)</span
-                      >
-                      <span
-                        *ngIf="
+                        ">/ {{ "msg.error.kvk.unknown" | translate }}&nbsp;</span>
+                      <span *ngIf="betrokkene.type === 'NATUURLIJK_PERSOON'"
+                        [matTooltip]="'identificatieType.BSN' | translate">(P)</span>
+                      <span *ngIf="
                           betrokkene.type === 'NIET_NATUURLIJK_PERSOON' &&
                           betrokkene.identificatieType === 'RSIN'
-                        "
-                        [matTooltip]="'identificatieType.RSIN' | translate"
-                        >(R)</span
-                      >
-                      <span
-                        *ngIf="
+                        " [matTooltip]="'identificatieType.RSIN' | translate">(R)</span>
+                      <span *ngIf="
                           (betrokkene.type === 'NIET_NATUURLIJK_PERSOON' &&
                             betrokkene.identificatieType === 'VN') ||
                           betrokkene.type === 'VESTIGING'
-                        "
-                        [matTooltip]="'identificatieType.VN' | translate"
-                        >(V)</span
-                      >
+                        " [matTooltip]="'identificatieType.VN' | translate">(V)</span>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="betrokkenegegevens">
@@ -630,31 +369,20 @@
                       {{ "gegevens" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let betrokkene">
-                      <button
-                        mat-icon-button
-                        *ngIf="!betrokkene.gegevens"
-                        [disabled]="
+                      <button mat-icon-button *ngIf="!betrokkene.gegevens" [disabled]="
                           betrokkene.type === 'NIET_NATUURLIJK_PERSOON' &&
                           betrokkene.identificatieType === 'VN' &&
                           !betrokkene.kvkNummer
-                        "
-                        (click)="betrokkeneGegevensOphalen(betrokkene)"
-                      >
+                        " (click)="betrokkeneGegevensOphalen(betrokkene)">
                         <mat-icon>more_horiz</mat-icon>
                       </button>
-                      <button
-                        mat-icon-button
-                        *ngIf="betrokkene.gegevens === 'LOADING'"
-                      >
+                      <button mat-icon-button *ngIf="betrokkene.gegevens === 'LOADING'">
                         <mat-icon>hourglass_empty</mat-icon>
                       </button>
-                      <span
-                        *ngIf="
+                      <span *ngIf="
                           betrokkene.gegevens &&
                           betrokkene.gegevens !== 'LOADING'
-                        "
-                        >{{ betrokkene.gegevens }}</span
-                      >
+                        ">{{ betrokkene.gegevens }}</span>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="roltoelichting">
@@ -662,64 +390,39 @@
                       {{ "toelichting" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let betrokkene">
-                      <read-more
-                        [text]="betrokkene.roltoelichting"
-                        [maxLength]="20"
-                      ></read-more>
+                      <read-more [text]="betrokkene.roltoelichting" [maxLength]="20"></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="actions" stickyEnd>
                     <th mat-header-cell *matHeaderCellDef></th>
                     <td mat-cell *matCellDef="let betrokkene">
-                      <a
-                        *ngIf="betrokkene.type === 'NATUURLIJK_PERSOON'"
-                        mat-icon-button
-                        [routerLink]="['/persoon', betrokkene.identificatie]"
-                        (click)="$event.stopPropagation()"
-                        [id]="
+                      <a *ngIf="betrokkene.type === 'NATUURLIJK_PERSOON'" mat-icon-button
+                        [routerLink]="['/persoon', betrokkene.identificatie]" (click)="$event.stopPropagation()" [id]="
                           'persoonBekijken_' +
                           betrokkene.identificatie +
                           '_button'
-                        "
-                        title="{{ 'actie.persoon.bekijken' | translate }}"
-                      >
+                        " title="{{ 'actie.persoon.bekijken' | translate }}">
                         <mat-icon>visibility</mat-icon>
                       </a>
-                      <a
-                        *ngIf="
+                      <a *ngIf="
                           betrokkene.type === 'NIET_NATUURLIJK_PERSOON' ||
                           betrokkene.type === 'VESTIGING'
-                        "
-                        mat-icon-button
-                        [routerLink]="['/bedrijf', betrokkene.identificatie]"
-                        (click)="$event.stopPropagation()"
-                        [id]="
+                        " mat-icon-button [routerLink]="['/bedrijf', betrokkene.identificatie]"
+                        (click)="$event.stopPropagation()" [id]="
                           'bedrijfBekijken_' +
                           betrokkene.identificatie +
                           '_button'
-                        "
-                        title="{{ 'actie.bedrijf.bekijken' | translate }}"
-                      >
+                        " title="{{ 'actie.bedrijf.bekijken' | translate }}">
                         <mat-icon>visibility</mat-icon>
                       </a>
-                      <button
-                        *ngIf="zaak.rechten.verwijderenBetrokkene"
-                        mat-icon-button
-                        (click)="deleteBetrokkene(betrokkene)"
-                        title="{{ 'actie.betrokkene.ontkoppelen' | translate }}"
-                      >
+                      <button *ngIf="zaak.rechten.verwijderenBetrokkene" mat-icon-button
+                        (click)="deleteBetrokkene(betrokkene)" title="{{ 'actie.betrokkene.ontkoppelen' | translate }}">
                         <mat-icon>link_off</mat-icon>
                       </button>
                     </td>
                   </ng-container>
-                  <tr
-                    mat-header-row
-                    *matHeaderRowDef="betrokkenenColumns; sticky: true"
-                  ></tr>
-                  <tr
-                    mat-row
-                    *matRowDef="let row; columns: betrokkenenColumns"
-                  ></tr>
+                  <tr mat-header-row *matHeaderRowDef="betrokkenenColumns; sticky: true"></tr>
+                  <tr mat-row *matRowDef="let row; columns: betrokkenenColumns"></tr>
                 </table>
               </div>
             </mat-tab>
@@ -736,10 +439,7 @@
                       {{ "identificatie" | translate }}
                     </th>
                     <td mat-cell *matCellDef="let bagObjectGegevens">
-                      <read-more
-                        [text]="bagObjectGegevens.bagObject.identificatie"
-                        [maxLength]="20"
-                      ></read-more>
+                      <read-more [text]="bagObjectGegevens.bagObject.identificatie" [maxLength]="20"></read-more>
                     </td>
                   </ng-container>
                   <ng-container matColumnDef="type">
@@ -748,8 +448,8 @@
                     </th>
                     <td mat-cell *matCellDef="let bagObjectGegevens">
                       {{
-                        "objecttype." +
-                          bagObjectGegevens.bagObject.bagObjectType | translate
+                      "objecttype." +
+                      bagObjectGegevens.bagObject.bagObjectType | translate
                       }}
                     </td>
                   </ng-container>
@@ -764,42 +464,27 @@
                   <ng-container matColumnDef="actions">
                     <th *matHeaderCellDef mat-header-cell></th>
                     <td *matCellDef="let bagObjectGegevens" mat-cell>
-                      <a
-                        mat-icon-button
-                        [routerLink]="[
+                      <a mat-icon-button [routerLink]="[
                           '/bag-objecten',
                           bagObjectGegevens.bagObject.bagObjectType.toLowerCase(),
                           bagObjectGegevens.bagObject.identificatie,
-                        ]"
-                        (click)="$event.stopPropagation()"
-                        [id]="
+                        ]" (click)="$event.stopPropagation()" [id]="
                           'bagObject_' +
                           bagObjectGegevens.bagObject.identificatie +
                           '_button'
-                        "
-                        title="{{ 'actie.bagObject.bekijken' | translate }}"
-                      >
+                        " title="{{ 'actie.bagObject.bekijken' | translate }}">
                         <mat-icon>visibility</mat-icon>
                       </a>
-                      <button
-                        *ngIf="zaak.rechten.behandelen"
-                        mat-icon-button
+                      <button *ngIf="zaak.rechten.behandelen" mat-icon-button
                         (click)="bagObjectVerwijderen(bagObjectGegevens)"
-                        title="{{ 'actie.bagObject.ontkoppelen' | translate }}"
-                      >
+                        title="{{ 'actie.bagObject.ontkoppelen' | translate }}">
                         <mat-icon>link_off</mat-icon>
                       </button>
                     </td>
                   </ng-container>
 
-                  <tr
-                    mat-header-row
-                    *matHeaderRowDef="bagObjectenColumns; sticky: true"
-                  ></tr>
-                  <tr
-                    mat-row
-                    *matRowDef="let row; columns: bagObjectenColumns"
-                  ></tr>
+                  <tr mat-header-row *matHeaderRowDef="bagObjectenColumns; sticky: true"></tr>
+                  <tr mat-row *matRowDef="let row; columns: bagObjectenColumns"></tr>
                 </table>
               </div>
             </mat-tab>
@@ -807,45 +492,24 @@
         </mat-card-content>
       </mat-card>
       <div class="w50 flex-1 flex-col gap-12">
-        <zac-besluit-view
-          *ngIf="zaak.besluiten?.length"
-          [besluiten]="zaak.besluiten ?? []"
-          [result]="zaak.resultaat"
-          [readonly]="!zaak.isOpen || !zaak.rechten.behandelen"
-          (besluitWijzigen)="besluitWijzigen($event)"
-          (doIntrekking)="doIntrekking($event)"
-        ></zac-besluit-view>
+        <zac-besluit-view *ngIf="zaak.besluiten?.length" [besluiten]="zaak.besluiten ?? []" [result]="zaak.resultaat"
+          [readonly]="!zaak.isOpen || !zaak.rechten.behandelen" (besluitWijzigen)="besluitWijzigen($event)"
+          (doIntrekking)="doIntrekking($event)"></zac-besluit-view>
 
         <mat-card class="flex-grow-1">
           <mat-card-header>
             <mat-card-title>{{ "taken" | translate }}</mat-card-title>
-            <mat-slide-toggle
-              [formControl]="toonAfgerondeTaken"
-              color="primary"
-              (change)="filterTakenOpStatus()"
-              >{{ "toonAfgerondeTaken" | translate }}</mat-slide-toggle
-            >
+            <mat-slide-toggle [formControl]="toonAfgerondeTaken" color="primary" (change)="filterTakenOpStatus()">{{
+              "toonAfgerondeTaken" | translate }}</mat-slide-toggle>
           </mat-card-header>
           <mat-card-content>
             <div class="table-wrapper">
-              <table
-                mat-table
-                matSort
-                multiTemplateDataRows
-                #takenSort="matSort"
-                [dataSource]="takenDataSource"
-              >
+              <table mat-table matSort multiTemplateDataRows #takenSort="matSort" [dataSource]="takenDataSource">
                 <ng-container matColumnDef="collapse">
                   <th mat-header-cell *matHeaderCellDef>
-                    <mat-icon
-                      *ngIf="!allTakenExpanded"
-                      (click)="expandTaken(true)"
-                      >expand_more
+                    <mat-icon *ngIf="!allTakenExpanded" (click)="expandTaken(true)">expand_more
                     </mat-icon>
-                    <mat-icon
-                      *ngIf="allTakenExpanded"
-                      (click)="expandTaken(false)"
-                      >expand_less
+                    <mat-icon *ngIf="allTakenExpanded" (click)="expandTaken(false)">expand_less
                     </mat-icon>
                   </th>
                 </ng-container>
@@ -862,10 +526,7 @@
                     {{ "status" | translate }}
                   </th>
                   <td mat-cell *matCellDef="let taak">
-                    <mat-chip
-                      [color]="taskStatusChipColor(taak.data.status)"
-                      [highlighted]="true"
-                    >
+                    <mat-chip [color]="taskStatusChipColor(taak.data.status)" [highlighted]="true">
                       {{ "taak.status." + taak.data.status | translate }}
                     </mat-chip>
                   </td>
@@ -893,15 +554,10 @@
                   <td mat-cell *matCellDef="let taak">
                     <div class="flex-row items-center gap-5">
                       {{ taak.data.fataledatum | datum | empty }}
-                      <mat-icon
-                        *ngIf="
+                      <mat-icon *ngIf="
                           taak.data.status !== 'AFGEROND' &&
                           isAfterDate(taak.data.fataledatum)
-                        "
-                        [title]="'msg.datum.overschreden' | translate"
-                        class="error list-icon"
-                        >warning</mat-icon
-                      >
+                        " [title]="'msg.datum.overschreden' | translate" class="error list-icon">warning</mat-icon>
                     </div>
                   </td>
                 </ng-container>
@@ -925,23 +581,14 @@
                   <th mat-header-cell *matHeaderCellDef></th>
                   <td mat-cell *matCellDef="let row">
                     <div class="flex-row">
-                      <a
-                        *ngIf="row.data.rechten.lezen"
-                        mat-icon-button
-                        [routerLink]="['/taken', row.data.id]"
-                        (click)="$event.stopPropagation()"
-                        [id]="'taakBekijken_' + row.data.id + '_button'"
-                        title="{{ 'actie.taak.bekijken' | translate }}"
-                      >
+                      <a *ngIf="row.data.rechten.lezen" mat-icon-button [routerLink]="['/taken', row.data.id]"
+                        (click)="$event.stopPropagation()" [id]="'taakBekijken_' + row.data.id + '_button'"
+                        title="{{ 'actie.taak.bekijken' | translate }}">
                         <mat-icon>visibility</mat-icon>
                       </a>
-                      <button
-                        mat-icon-button
-                        title="{{ 'actie.mij.toekennen' | translate }}"
-                        [id]="'kenTaakAanMijToe_' + row.data.id + '_button'"
-                        (click)="assignTaakToMe(row.data, $event)"
-                        *ngIf="showAssignTaakToMe(row.data)"
-                      >
+                      <button mat-icon-button title="{{ 'actie.mij.toekennen' | translate }}"
+                        [id]="'kenTaakAanMijToe_' + row.data.id + '_button'" (click)="assignTaakToMe(row.data, $event)"
+                        *ngIf="showAssignTaakToMe(row.data)">
                         <mat-icon outlined>person_add</mat-icon>
                       </button>
                     </div>
@@ -950,47 +597,23 @@
 
                 <ng-container matColumnDef="expandedTaakDetail">
                   <td mat-cell *matCellDef="let row" colspan="9">
-                    <div
-                      class="row-detail"
-                      [@detailExpand]="row.expanded ? 'expanded' : 'collapsed'"
-                    >
+                    <div class="row-detail" [@detailExpand]="row.expanded ? 'expanded' : 'collapsed'">
                       <div class="flex-row flex-wrap gap-10">
-                        <zac-static-text
-                          [label]="'uitkomst' | translate"
-                          [value]="
+                        <zac-static-text [label]="'uitkomst' | translate" [value]="
                             row.data.taakinformatie?.uitkomst | translate
-                          "
-                        ></zac-static-text>
-                        <zac-static-text
-                          [label]="'bijlage' | translate"
-                          *ngIf="row.data.taakinformatie?.bijlagen"
-                          [value]="row.data.taakinformatie?.bijlagen"
-                        ></zac-static-text>
-                        <zac-static-text
-                          [label]="'opmerking' | translate"
-                          *ngIf="row.data.taakinformatie?.opmerking"
-                          [value]="row.data.taakinformatie?.opmerking"
-                        ></zac-static-text>
+                          "></zac-static-text>
+                        <zac-static-text [label]="'bijlage' | translate" *ngIf="row.data.taakinformatie?.bijlagen"
+                          [value]="row.data.taakinformatie?.bijlagen"></zac-static-text>
+                        <zac-static-text [label]="'opmerking' | translate" *ngIf="row.data.taakinformatie?.opmerking"
+                          [value]="row.data.taakinformatie?.opmerking"></zac-static-text>
                       </div>
                     </div>
                   </td>
                 </ng-container>
-                <tr
-                  mat-header-row
-                  *matHeaderRowDef="['collapse'].concat(takenColumnsToDisplay)"
-                ></tr>
-                <tr
-                  mat-row
-                  *matRowDef="let row; columns: takenColumnsToDisplay"
-                  class="row"
-                  [class.expanded-row]="row.expanded"
-                  (click)="expandTaak(row)"
-                ></tr>
-                <tr
-                  mat-row
-                  *matRowDef="let row; columns: ['expandedTaakDetail']"
-                  class="collapsed-row"
-                ></tr>
+                <tr mat-header-row *matHeaderRowDef="['collapse'].concat(takenColumnsToDisplay)"></tr>
+                <tr mat-row *matRowDef="let row; columns: takenColumnsToDisplay" class="row"
+                  [class.expanded-row]="row.expanded" (click)="expandTaak(row)"></tr>
+                <tr mat-row *matRowDef="let row; columns: ['expandedTaakDetail']" class="collapsed-row"></tr>
                 <tr class="mat-row" *matNoDataRow>
                   <td class="mat-cell" colspan="9">
                     <p *ngIf="takenLoading">{{ "msg.loading" | translate }}</p>
@@ -1004,18 +627,11 @@
           </mat-card-content>
         </mat-card>
       </div>
-      <zac-zaak-documenten
-        #zaakDocumentenComponent
-        class="w100"
-        [zaak]="zaak"
-        (documentMoveToCase)="documentMoveToCase($event)"
-      ></zac-zaak-documenten>
+      <zac-zaak-documenten #zaakDocumentenComponent class="w100" [zaak]="zaak"
+        (documentMoveToCase)="documentMoveToCase($event)"></zac-zaak-documenten>
     </div>
   </mat-drawer-content>
 </mat-drawer-container>
 
-<zac-notities
-  *ngIf="notitieRechten?.lezen || notitieRechten?.wijzigen"
-  [zaakUuid]="zaak.uuid"
-  [notitieRechten]="notitieRechten"
-></zac-notities>
+<zac-notities *ngIf="notitieRechten?.lezen || notitieRechten?.wijzigen" [zaakUuid]="zaak.uuid"
+  [notitieRechten]="notitieRechten"></zac-notities>

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
@@ -58,16 +58,53 @@ mat-slide-toggle {
   margin-top: 10px;
 }
 
-.editable {
-  position: relative;
-  margin-top: 10px;
+.fields-container {
+  width: 100%;
+}
 
-  & button {
-    position: absolute;
-    right: 0;
+.fields {
+  width: 1000px;
+}
+
+.fields-flex-grow {
+  flex: 1 1 auto;  /* takes all available space, but can shrink if needed */
+  min-width: 0;    /* allows text inside to shrink instead of overflowing */
+}
+
+.text-flexible {
+  flex: 1 1 auto;   // can grow and shrink
+  min-width: 0;     // allows text to shrink if needed
+}
+
+.flex-row.relative-parent {
+  position: relative; /* parent for absolute positioning */
+}
+
+.editable {
+  position: absolute;
+  top: -8px;
+  right: 0;
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 1430px) {
+  .editable {
+    display: block;
+    position: relative;
     top: -8px;
-    margin-right: 0;
+    right: 0;
   }
+  .fields {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+}
+
+.editable-location {
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .remark {
@@ -88,4 +125,8 @@ mat-slide-toggle {
   position: relative;
   font-size: 18px;
   top: 2px;
+}
+
+.margin-top {
+  margin-top: 10px;
 }

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
@@ -66,39 +66,22 @@ mat-slide-toggle {
   width: 1000px;
 }
 
-.fields-flex-grow {
-  flex: 1 1 auto;  /* takes all available space, but can shrink if needed */
-  min-width: 0;    /* allows text inside to shrink instead of overflowing */
-}
-
 .text-flexible {
-  flex: 1 1 auto;   // can grow and shrink
-  min-width: 0;     // allows text to shrink if needed
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
-.flex-row.relative-parent {
-  position: relative; /* parent for absolute positioning */
+.padding-r {
+  padding-right: 55px;
 }
 
 .editable {
-  position: absolute;
+  position: relative;
+  display: block;
   top: -8px;
   right: 0;
   display: flex;
   justify-content: flex-end;
-}
-
-@media (max-width: 1430px) {
-  .editable {
-    display: block;
-    position: relative;
-    top: -8px;
-    right: 0;
-  }
-  .fields {
-    flex: 1 1 auto;
-    min-width: 0;
-  }
 }
 
 .editable-location {

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
@@ -80,8 +80,6 @@ mat-slide-toggle {
   display: block;
   top: -8px;
   right: 0;
-  display: flex;
-  justify-content: flex-end;
 }
 
 .editable-location {


### PR DESCRIPTION
This PR fixes the event that when the viewport becomes smaller the edit button(pencil/potloodje) overlaps the Communicatiekanaal and other fields in that row.

There are changes made to the following files
src/main/app/src/app/zaken/zaak-view/zaak-view.component.html:
Re ordered elements in order to make the css work

src/main/app/src/app/zaken/zaak-view/zaak-view.component.less:
Removed the absolute positioning and added improved code

This solution has been discussed with the UX designer and has been deemed the best solution.
Solves PZ-8057