### PR TITLE
fix: reverted BRP Personen Mock Docker image upgrade because the new version crashes on a Mac (ARM)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -261,7 +261,8 @@ services:
         condition: service_started
 
   brp-personen-mock:
-    image: ghcr.io/brp-api/personen-mock:2.7.0-202508211438@sha256:43062e9200a1ae7cb92f1830acf0ab7ca19272dea0756400caaeb4748bed9fa5
+    # do not upgrade to version '2.7.0-202508211438' because that fails to run on a Mac (ARM)
+    image: ghcr.io/brp-api/personen-mock:2.7.0-202507011650@sha256:5c8006ac4e4b7e96a32a7a1a42cab43f74ca95f0174cdb6b40dece2e717f8df4
     platform: linux/amd64
     environment:
       - ASPNETCORE_ENVIRONMENT=Release


### PR DESCRIPTION
Reverted BRP Personen Mock Docker image upgrade because the new version crashes on a Mac (ARM).

Solves PZ-8279