### PR TITLE
chore: move part of the PABC feature flag logic to PolicyService.kt

### DIFF
--- a/src/main/java/net/atos/zac/app/admin/MailtemplateKoppelingRESTService.java
+++ b/src/main/java/net/atos/zac/app/admin/MailtemplateKoppelingRESTService.java
@@ -46,20 +46,20 @@ public class MailtemplateKoppelingRESTService {
     @GET
     @Path("{id}")
     public RESTMailtemplateKoppeling readMailtemplateKoppeling(@PathParam("id") final long id) {
-        assertPolicy(policyService.readOverigeRechten().getBeheren());
+        assertPolicy(policyService.readOverigeRechten(null).getBeheren());
         return RESTMailtemplateKoppelingConverter.convert(mailTemplateKoppelingenService.readMailtemplateKoppeling(id));
     }
 
     @DELETE
     @Path("{id}")
     public void deleteMailtemplateKoppeling(@PathParam("id") final long id) {
-        assertPolicy(policyService.readOverigeRechten().getBeheren());
+        assertPolicy(policyService.readOverigeRechten(null).getBeheren());
         mailTemplateKoppelingenService.delete(id);
     }
 
     @GET
     public List<RESTMailtemplateKoppeling> listMailtemplateKoppelingen() {
-        assertPolicy(policyService.readOverigeRechten().getBeheren());
+        assertPolicy(policyService.readOverigeRechten(null).getBeheren());
         final List<MailtemplateKoppeling> mailtemplateKoppelingList = mailTemplateKoppelingenService.listMailtemplateKoppelingen();
         return mailtemplateKoppelingList.stream().map(mailtemplateKoppeling -> {
             final RESTMailtemplateKoppeling restMailtemplateKoppeling = RESTMailtemplateKoppelingConverter.convert(mailtemplateKoppeling);
@@ -74,7 +74,7 @@ public class MailtemplateKoppelingRESTService {
     public RESTMailtemplateKoppeling storeMailtemplateKoppeling(
             final RESTMailtemplateKoppeling mailtemplateKoppeling
     ) {
-        assertPolicy(policyService.readOverigeRechten().getBeheren());
+        assertPolicy(policyService.readOverigeRechten(null).getBeheren());
         return RESTMailtemplateKoppelingConverter.convert(
                 mailTemplateKoppelingenService.storeMailtemplateKoppeling(
                         RESTMailtemplateKoppelingConverter.convert(mailtemplateKoppeling)

--- a/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/ZaakRestService.kt
@@ -287,21 +287,10 @@ class ZaakRestService @Inject constructor(
         val zaaktypeUUID = restZaak.zaaktype.uuid
         val zaakType = zaakService.readZaakTypeByUUID(zaaktypeUUID)
         assertCanAddBetrokkene(restZaak)
-
-        val loggedInUser = loggedInUserInstance.get()
-        // for PABC-based IAM integration, check if the user has the right to start a zaak
-        if (configuratieService.featureFlagPabcIntegration()) {
-            assertPolicy(policyService.readOverigeRechten(zaakType.omschrijving).startenZaak)
-        } else {
-            // make sure to use the omschrijving of the zaaktype that was retrieved to perform authorization on zaaktype
-            assertPolicy(
-                policyService.readOverigeRechten().startenZaak &&
-                    loggedInUser.isAuthorisedForZaaktype(
-                        zaakType.omschrijving
-                    )
-            )
-        }
-
+        assertPolicy(
+            policyService.readOverigeRechten(zaakType.omschrijving).startenZaak &&
+                policyService.isAuthorisedForZaaktype(zaakType.omschrijving)
+        )
         restZaak.communicatiekanaal?.isNotBlank() == true || throw CommunicationChannelNotFound()
         restZaak.einddatumGepland?.let {
             zaakType.servicenorm?.isNotBlank() == true || throw DueDateNotAllowed()

--- a/src/main/kotlin/nl/info/zac/authentication/LoggedInUser.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/LoggedInUser.kt
@@ -29,13 +29,12 @@ class LoggedInUser(
 ) : User(id, firstName, lastName, displayName, email) {
     fun isAuthorisedForAllZaaktypen(): Boolean = geautoriseerdeZaaktypen == null
 
-    /**
-     * If PABC-based authorization is active, use the map of application roles per zaaktype.
-     * Otherwise, legacy functional (Keycloak) role-based authorization is used.
-     */
     fun isAuthorisedForZaaktype(zaaktypeOmschrijving: String) =
         geautoriseerdeZaaktypen?.contains(zaaktypeOmschrijving) ?: true
 
+    /**
+     * If PABC-based authorization is active, use the map of application roles per zaaktype.
+     */
     fun isAuthorisedForZaaktypePabc(zaaktypeOmschrijving: String) =
         applicationRolesPerZaaktype[zaaktypeOmschrijving]?.isNotEmpty() == true
 }

--- a/src/test/kotlin/nl/info/zac/policy/PolicyServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/policy/PolicyServiceTest.kt
@@ -50,6 +50,7 @@ class PolicyServiceTest : BehaviorSpec({
     val opaEvaluationClient = mockk<OpaEvaluationClient>()
     val ztcClientService = mockk<ZtcClientService>()
     val zrcClientService = mockk<ZrcClientService>()
+    val configuratieService = mockk<ConfiguratieService>()
     val loggedInUser = createLoggedInUser()
 
     val policyService = PolicyService(
@@ -57,7 +58,8 @@ class PolicyServiceTest : BehaviorSpec({
         opaEvaluationClient,
         ztcClientService,
         enkelvoudigInformatieObjectLockService,
-        zrcClientService
+        zrcClientService,
+        configuratieService
     )
 
     Given("zaak with no status") {


### PR DESCRIPTION
Move part of the PABC feature flag logic to PolicyService.kt so it is centralized and can be re-used.

Solves PZ-8292