### PR TITLE
refactor(InformatieObjectLinkComponent): make use of Angular `FormBuilder`

### DIFF
--- a/src/main/app/src/app/documenten/inbox-documenten-list/inbox-documenten-list.component.html
+++ b/src/main/app/src/app/documenten/inbox-documenten-list/inbox-documenten-list.component.html
@@ -8,10 +8,10 @@
     <zac-informatie-object-link
       [infoObject]="selectedInformationObject"
       [sideNav]="actionsSidenav"
-      [actionLabel]="'actie.document.koppelen'"
-      [source]="'inbox-documenten'"
+      actionLabel="actie.document.koppelen"
+      source="inbox-documenten"
       (informationObjectLinked)="retriggerSearch()"
-    ></zac-informatie-object-link>
+    />
   </mat-drawer>
 
   <mat-drawer-content>

--- a/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.html
+++ b/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.html
@@ -8,10 +8,10 @@
     <zac-informatie-object-link
       [infoObject]="selectedInformationObject"
       [sideNav]="actionsSidenav"
-      [actionLabel]="'actie.document.koppelen'"
-      [source]="'ontkoppelde-documenten'"
+      actionLabel="actie.document.koppelen"
+      source="ontkoppelde-documenten"
       (informationObjectLinked)="retriggerSearch()"
-    ></zac-informatie-object-link>
+    />
   </mat-drawer>
 
   <mat-drawer-content>

--- a/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.html
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.html
@@ -14,18 +14,25 @@
 
 <div class="form" *ngIf="infoObject">
   <p>{{ intro }}</p>
-  <mfb-form-field class="flex-1" [field]="caseSearchField"></mfb-form-field>
-  <button
-    mat-raised-button
-    color="primary"
-    [disabled]="!isValid || loading"
-    (click)="searchCases()"
-  >
-    {{ "actie.zoeken" | translate }}
-  </button>
-  <button mat-raised-button (click)="reset()">
-    {{ "actie.wissen" | translate }}
-  </button>
+  <form [formGroup]="form" (submit)="searchCases()" class="mt-2">
+    <fieldset class="p-0">
+      <zac-input [form]="form" key="caseSearch" label="zaak.identificatie" />
+    </fieldset>
+    <fieldset class="p-0">
+      <mat-action-row>
+        <button
+          mat-raised-button
+          type="submit"
+          [disabled]="form.invalid || loading"
+        >
+          {{ "actie.zoeken" | translate }}
+        </button>
+        <button mat-raised-button type="reset" (click)="reset()">
+          {{ "actie.wissen" | translate }}
+        </button>
+      </mat-action-row>
+    </fieldset>
+  </form>
 
   <div class="table-wrapper">
     <table mat-table [dataSource]="cases" matSort>

--- a/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-link/informatie-object-link.component.ts
@@ -8,92 +8,72 @@ import {
   EventEmitter,
   Input,
   OnChanges,
-  OnDestroy,
   OnInit,
   Output,
   SimpleChanges,
 } from "@angular/core";
+import { FormBuilder, Validators } from "@angular/forms";
 import { MatDrawer } from "@angular/material/sidenav";
 import { MatTableDataSource } from "@angular/material/table";
 import { TranslateService } from "@ngx-translate/core";
-import { Subject, takeUntil } from "rxjs";
 import { UtilService } from "src/app/core/service/util.service";
-import { InputFormFieldBuilder } from "src/app/shared/material-form-builder/form-components/input/input-form-field-builder";
-import { AbstractFormControlField } from "src/app/shared/material-form-builder/model/abstract-form-control-field";
 import { GeneratedType } from "src/app/shared/utils/generated-types";
 import { ZoekenService } from "src/app/zoeken/zoeken.service";
 import { InformatieObjectenService } from "../informatie-objecten.service";
 
-enum DocumentAction {
-  LINK = "actie.document.koppelen",
-  MOVE = "actie.document.verplaatsen",
-}
+type DocumentAction = "actie.document.koppelen" | "actie.document.verplaatsen";
 
 @Component({
   selector: "zac-informatie-object-link",
   templateUrl: "./informatie-object-link.component.html",
   styleUrls: ["./informatie-object-link.component.less"],
 })
-export class InformatieObjectLinkComponent
-  implements OnInit, OnChanges, OnDestroy
-{
-  @Input() infoObject!:
-    | GeneratedType<"RESTOntkoppeldDocument">
-    | GeneratedType<"RESTInboxDocument">
-    | GeneratedType<"RestEnkelvoudigInformatieobject">;
+export class InformatieObjectLinkComponent implements OnInit, OnChanges {
+  @Input() infoObject?: GeneratedType<
+    | "RESTOntkoppeldDocument"
+    | "RESTInboxDocument"
+    | "RestEnkelvoudigInformatieobject"
+  > | null = null;
   @Input({ required: true }) sideNav!: MatDrawer;
   @Input({ required: true }) source!: string;
-  @Input({ required: true }) actionLabel!: string;
+  @Input({ required: true })
+  actionLabel!: DocumentAction;
   @Output() informationObjectLinked = new EventEmitter<void>();
 
-  public intro: string = "";
-  public caseSearchField?: AbstractFormControlField<string>;
-  public isValid = false;
-  public loading = false;
+  protected intro = "";
+  protected loading = false;
 
-  public documentAction!: DocumentAction;
-  public actionIcon!: string;
+  protected actionIcon!: string;
 
-  public cases = new MatTableDataSource<
+  protected cases = new MatTableDataSource<
     GeneratedType<"RestZaakKoppelenZoekObject">
   >();
-  public totalCases: number = 0;
-  public caseColumns: string[] = [
+  protected totalCases = 0;
+  protected caseColumns = [
     "identificatie",
     "zaaktypeOmschrijving",
     "statustypeOmschrijving",
     "omschrijving",
     "acties",
-  ];
+  ] as const;
 
-  private ngDestroy = new Subject<void>();
+  protected form = this.formBuilder.group({
+    caseSearch: this.formBuilder.control<string | null>(null, [
+      Validators.minLength(2),
+    ]),
+  });
 
   constructor(
-    private zoekenService: ZoekenService,
-    private informatieObjectService: InformatieObjectenService,
-    private utilService: UtilService,
-    private translate: TranslateService,
+    private readonly zoekenService: ZoekenService,
+    private readonly informatieObjectService: InformatieObjectenService,
+    private readonly utilService: UtilService,
+    private readonly translate: TranslateService,
+    private readonly formBuilder: FormBuilder,
   ) {}
 
   ngOnInit() {
-    this.caseSearchField = new InputFormFieldBuilder()
-      .id("zaak")
-      .label("zaak.identificatie")
-      .build();
-
-    this.caseSearchField.formControl.valueChanges
-      .pipe(takeUntil(this.ngDestroy))
-      .subscribe((value) => {
-        this.isValid = (value?.length ?? 0) >= 2;
-      });
-
-    this.documentAction =
-      this.actionLabel === DocumentAction.LINK
-        ? DocumentAction.LINK
-        : DocumentAction.MOVE;
-
     this.actionIcon =
-      this.documentAction === DocumentAction.LINK ? "link" : "move_item";
+      this.actionLabel === "actie.document.koppelen" ? "link" : "move_item";
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -108,15 +88,15 @@ export class InformatieObjectLinkComponent
     }
   }
 
-  searchCases() {
+  protected searchCases() {
     this.loading = true;
     this.utilService.setLoading(true);
-    if (!this.caseSearchField?.formControl.value) return;
-    if (!this.infoObject.informatieobjectTypeUUID) return;
+    if (!this.infoObject?.informatieobjectTypeUUID) return;
 
+    const { caseSearch } = this.form.value;
     this.zoekenService
       .listDocumentKoppelbareZaken({
-        zaakIdentificator: this.caseSearchField.formControl.value!,
+        zaakIdentificator: caseSearch!,
         informationObjectTypeUuid: this.infoObject.informatieobjectTypeUUID,
       })
       .subscribe({
@@ -133,36 +113,23 @@ export class InformatieObjectLinkComponent
       });
   }
 
-  selectCase(row: GeneratedType<"RestZaakKoppelenZoekObject">) {
-    const linkDocumentDetails: GeneratedType<"RESTDocumentVerplaatsGegevens"> & {
-      documentTitel?: string;
-    } = {
-      documentUUID:
-        "uuid" in this.infoObject
-          ? this.infoObject.uuid
-          : "documentUUID" in this.infoObject
-            ? this.infoObject.documentUUID
-            : "enkelvoudiginformatieobjectUUID" in this.infoObject
-              ? this.infoObject.enkelvoudiginformatieobjectUUID
-              : "",
-      documentTitel: this.infoObject.titel,
-      bron: this.source,
-      nieuweZaakID: row.identificatie ?? undefined,
-    };
-
-    const msgSnackbarKey =
-      this.documentAction === DocumentAction.LINK
-        ? "msg.document.koppelen.uitgevoerd"
-        : "msg.document.verplaatsen.uitgevoerd";
-
+  protected selectCase(row: GeneratedType<"RestZaakKoppelenZoekObject">) {
     this.informatieObjectService
-      .linkDocumentToCase(linkDocumentDetails)
-      .pipe(takeUntil(this.ngDestroy))
+      .linkDocumentToCase({
+        documentUUID: this.getDocumentUUID(),
+        bron: this.source,
+        nieuweZaakID: row.identificatie ?? undefined,
+      })
       .subscribe({
         next: () => {
+          const msgSnackbarKey =
+            this.actionLabel === "actie.document.koppelen"
+              ? "msg.document.koppelen.uitgevoerd"
+              : "msg.document.verplaatsen.uitgevoerd";
+
           this.utilService.openSnackbar(msgSnackbarKey, {
-            document: this.infoObject.titel,
-            case: linkDocumentDetails.nieuweZaakID,
+            document: this.infoObject!.titel,
+            case: row.identificatie ?? undefined,
           });
           this.close();
           this.informationObjectLinked.emit();
@@ -174,24 +141,28 @@ export class InformatieObjectLinkComponent
       });
   }
 
-  close() {
-    this.sideNav.close();
+  private getDocumentUUID() {
+    if (!this.infoObject) return "";
+    if ("uuid" in this.infoObject) return this.infoObject.uuid;
+    if ("documentUUID" in this.infoObject) return this.infoObject.documentUUID;
+    if ("enkelvoudiginformatieobjectUUID" in this.infoObject)
+      return this.infoObject.enkelvoudiginformatieobjectUUID;
+    return "";
+  }
+
+  protected close() {
+    void this.sideNav.close();
     this.reset();
   }
 
-  rowDisabled(row: GeneratedType<"RestZaakKoppelenZoekObject">): boolean {
+  protected rowDisabled(row: GeneratedType<"RestZaakKoppelenZoekObject">) {
     return !row.isKoppelbaar || row.identificatie === this.source;
   }
 
   protected reset() {
-    this.caseSearchField?.formControl.reset();
+    this.form.reset();
     this.cases.data = [];
     this.totalCases = 0;
     this.loading = false;
-  }
-
-  ngOnDestroy() {
-    this.ngDestroy.next();
-    this.ngDestroy.complete();
   }
 }

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.html
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.html
@@ -49,12 +49,12 @@
     ></zac-informatie-object-add>
     <zac-informatie-object-link
       *ngSwitchCase="'actie.document.verplaatsen'"
-      [actionLabel]="'actie.document.verplaatsen'"
+      actionLabel="actie.document.verplaatsen"
       [infoObject]="documentToMove"
       [sideNav]="actionsSidenav"
       [source]="zaak?.identificatie"
       (informationObjectLinked)="updateZaakDocumentList()"
-    ></zac-informatie-object-link>
+    />
   </mat-drawer>
   <mat-drawer-content>
     <div class="flex-row flex-wrap gap-10">

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -125,12 +125,12 @@
     ></zac-besluit-edit>
     <zac-informatie-object-link
       *ngSwitchCase="'actie.document.verplaatsen'"
-      [actionLabel]="'actie.document.verplaatsen'"
+      actionLabel="actie.document.verplaatsen"
       [infoObject]="documentToMove"
       [sideNav]="actionsSidenav"
       [source]="zaak.identificatie"
       (informationObjectLinked)="updateDocumentList()"
-    ></zac-informatie-object-link>
+    />
     <zac-zaak-link
       *ngSwitchCase="'actie.zaak.koppelen'"
       [zaak]="zaak"


### PR DESCRIPTION
This pull request refactors the `zac-informatie-object-link` component and its usage across the application to simplify its API and improve form handling. The main changes include replacing the old custom form field with a reactive Angular form, updating the component inputs to use direct binding (instead of property binding for static values), and cleaning up unnecessary logic and subscriptions.

**Component API and Usage Simplification:**

- Updated all usages of `zac-informatie-object-link` to use direct input bindings for `actionLabel` and `source`, replacing property bindings for static string values. Also replaced closing tags with self-closing tags for clarity and consistency. [[1]](diffhunk://#diff-79ab06fa2e2febd4bcf229f5514aa67175e78535552786d69e884ec6cb0357eaL11-R14) [[2]](diffhunk://#diff-fae4058d6b4178dc2186b6bac5ac744e400ee2cb001d76d98503a6220a84ae4cL11-R14) [[3]](diffhunk://#diff-e4230769f187d3f69f28756e4684500f53662e70d7f21a3e4a331b45ff17ab69L52-R57) [[4]](diffhunk://#diff-77b39b0f489ba66cfa831cae58da307ced947da86c4ff6982a2fd212c09db51cL128-R133)

**Form Handling and Internal Logic Refactor:**

- Replaced the custom `mfb-form-field` and manual validity tracking with a reactive Angular form using `FormBuilder`, and updated the search and reset logic to use this new form. [[1]](diffhunk://#diff-53a93628699cc820242f3654acb21ec5a23e389448c43daea62f7b896c50eb3dL17-R35) [[2]](diffhunk://#diff-11e88818f896eade1b2959f40678c45c0293cc2ae3f5c408440f4ad75cc30939L11-R76)
- Removed the use of `OnDestroy` and RxJS subscriptions for form changes, as the new form approach handles validation and state internally.

**Type and Code Cleanup:**

- Changed the `DocumentAction` from an enum to a string union type, and updated all related logic to use the new type.
- Refactored several methods (`searchCases`, `selectCase`, `close`, `rowDisabled`, `reset`) to use the new form and to simplify the codebase, including extracting document UUID logic into a helper method. [[1]](diffhunk://#diff-11e88818f896eade1b2959f40678c45c0293cc2ae3f5c408440f4ad75cc30939L111-R99) [[2]](diffhunk://#diff-11e88818f896eade1b2959f40678c45c0293cc2ae3f5c408440f4ad75cc30939L136-R132) [[3]](diffhunk://#diff-11e88818f896eade1b2959f40678c45c0293cc2ae3f5c408440f4ad75cc30939L177-L196)

Solves PZ-7675