### PR TITLE
refactor(BesluitCreateComponent): make use of the Angular FormBuilder

### DIFF
--- a/src/main/app/src/app/zaken/besluit-create/besluit-create.component.html
+++ b/src/main/app/src/app/zaken/besluit-create/besluit-create.component.html
@@ -9,31 +9,78 @@
     <mat-icon>close</mat-icon>
   </button>
 </mat-toolbar>
-<mat-divider/>
+<mat-divider />
 
 <form [formGroup]="form" (ngSubmit)="submit()" class="mt-2">
+  <fieldset>
+    <zac-select
+      [form]="form"
+      key="resultaat"
+      [options]="resultaattypes"
+      optionDisplayValue="naam"
+    />
+    <zac-select
+      [form]="form"
+      key="besluit"
+      [options]="besluittypes"
+      optionDisplayValue="naam"
+    />
+    <zac-date [form]="form" key="ingangsdatum" />
+    <zac-date [form]="form" key="vervaldatum" />
+    <zac-textarea [form]="form" key="toelichting" />
+  </fieldset>
+  <section *ngIf="form.controls.besluit.value?.publication?.enabled">
+    <mat-divider />
     <fieldset>
-        <zac-select [form]="form" key="resultaat" [options]="resultaattypes" optionDisplayValue="naam" />
-        <zac-select [form]="form" key="besluit" [options]="besluittypes" optionDisplayValue="naam" />
-        <zac-date [form]="form" key="ingangsdatum" />
-        <zac-date [form]="form" key="vervaldatum" />
-        <zac-textarea [form]="form" key="toelichting" />
+      <div class="mb-2">
+        {{ "besluit.publicatie.indicatie.koptitel" | translate }}
+      </div>
+      <zac-date [form]="form" key="publicatiedatum" />
+      <div
+        class="mb-2"
+        *ngIf="
+          (form.controls.besluit.value?.publication?.publicationTermDays ??
+            0) <= 1
+        "
+      >
+        {{ "besluit.publicatie.indicatie.onderschrift" | translate }}
+      </div>
+      <div
+        class="mb-2"
+        *ngIf="
+          (form.controls.besluit.value?.publication?.publicationTermDays ?? 0) >
+          1
+        "
+      >
+        {{
+          "besluit.publicatie.indicatie.onderschrift.meervoud"
+            | translate
+              : {
+                  publicationTermDays:
+                    form.controls.besluit.value?.publication
+                      ?.publicationTermDays,
+                }
+        }}
+      </div>
+      <zac-date [form]="form" key="uiterlijkereactiedatum" />
     </fieldset>
-    <section *ngIf="form.controls.besluit.value?.publication?.enabled">
-<mat-divider/>
-        <fieldset>
-            <div class="mb-2">{{"besluit.publicatie.indicatie.koptitel" | translate}}</div>
-            <zac-date [form]="form" key="publicatiedatum" />
-            <div class="mb-2" *ngIf="(form.controls.besluit.value?.publication?.publicationTermDays ?? 0) <= 1">
-                {{"besluit.publicatie.indicatie.onderschrift" | translate}}
-            </div>
-            <div class="mb-2" *ngIf="(form.controls.besluit.value?.publication?.publicationTermDays ?? 0) > 1">
-                {{"besluit.publicatie.indicatie.onderschrift.meervoud" | translate: { publicationTermDays : form.controls.besluit.value?.publication?.publicationTermDays } }}
-            </div>
-            <zac-date [form]="form" key="uiterlijkereactiedatum" />
-        </fieldset>
-    </section>
-    <fieldset>
-        <mfb-form-field [field]="documentenField" />
-    </fieldset>
+  </section>
+  <fieldset>
+    <mfb-form-field [field]="documentenField" />
+  </fieldset>
+  <fieldset>
+    <mat-action-row>
+      <button
+        mat-raised-button
+        type="submit"
+        color="primary"
+        [disabled]="!form.valid"
+      >
+        {{ "actie.aanmaken" | translate }}
+      </button>
+      <button mat-raised-button (click)="sideNav.close()" type="reset">
+        {{ "actie.annuleren" | translate }}
+      </button>
+    </mat-action-row>
+  </fieldset>
 </form>

--- a/src/main/app/src/app/zaken/besluit-create/besluit-create.component.html
+++ b/src/main/app/src/app/zaken/besluit-create/besluit-create.component.html
@@ -9,13 +9,31 @@
     <mat-icon>close</mat-icon>
   </button>
 </mat-toolbar>
-<mat-divider></mat-divider>
+<mat-divider/>
 
-<div class="form">
-  <mfb-form
-    *ngIf="fields"
-    (formSubmit)="onFormSubmit($event)"
-    [formFields]="fields"
-    [config]="formConfig"
-  ></mfb-form>
-</div>
+<form [formGroup]="form" (ngSubmit)="submit()" class="mt-2">
+    <fieldset>
+        <zac-select [form]="form" key="resultaat" [options]="resultaattypes" optionDisplayValue="naam" />
+        <zac-select [form]="form" key="besluit" [options]="besluittypes" optionDisplayValue="naam" />
+        <zac-date [form]="form" key="ingangsdatum" />
+        <zac-date [form]="form" key="vervaldatum" />
+        <zac-textarea [form]="form" key="toelichting" />
+    </fieldset>
+    <section *ngIf="form.controls.besluit.value?.publication?.enabled">
+<mat-divider/>
+        <fieldset>
+            <div class="mb-2">{{"besluit.publicatie.indicatie.koptitel" | translate}}</div>
+            <zac-date [form]="form" key="publicatiedatum" />
+            <div class="mb-2" *ngIf="(form.controls.besluit.value?.publication?.publicationTermDays ?? 0) <= 1">
+                {{"besluit.publicatie.indicatie.onderschrift" | translate}}
+            </div>
+            <div class="mb-2" *ngIf="(form.controls.besluit.value?.publication?.publicationTermDays ?? 0) > 1">
+                {{"besluit.publicatie.indicatie.onderschrift.meervoud" | translate: { publicationTermDays : form.controls.besluit.value?.publication?.publicationTermDays } }}
+            </div>
+            <zac-date [form]="form" key="uiterlijkereactiedatum" />
+        </fieldset>
+    </section>
+    <fieldset>
+        <mfb-form-field [field]="documentenField" />
+    </fieldset>
+</form>

--- a/src/main/app/src/app/zaken/besluit-create/besluit-create.component.ts
+++ b/src/main/app/src/app/zaken/besluit-create/besluit-create.component.ts
@@ -114,6 +114,7 @@ export class BesluitCreateComponent implements OnInit {
     this.form.controls.publicatiedatum.valueChanges
       .pipe(takeUntilDestroyed())
       .subscribe((value) => {
+        console.log(value, value?.toISOString());
         if (!value) {
           this.form.controls.uiterlijkereactiedatum.setValue(null);
           this.form.controls.uiterlijkereactiedatum.clearValidators();
@@ -131,7 +132,10 @@ export class BesluitCreateComponent implements OnInit {
     date: Moment,
     responseTermDays?: number | null,
   ) {
-    const uiterlijkereactiedatum = date.add(responseTermDays ?? 0, "days");
+    const uiterlijkereactiedatum = date
+      .clone()
+      .add(responseTermDays ?? 0, "days");
+    console.log(responseTermDays);
     this.form.controls.uiterlijkereactiedatum.setValue(uiterlijkereactiedatum);
     this.form.controls.uiterlijkereactiedatum.addValidators(
       Validators.min(moment(uiterlijkereactiedatum).startOf("day").valueOf()),
@@ -175,9 +179,14 @@ export class BesluitCreateComponent implements OnInit {
             }
           : {}),
       })
-      .subscribe(() => {
-        this.utilService.openSnackbar("msg.besluit.vastgelegd");
-        this.besluitVastgelegd.emit(true);
+      .subscribe({
+        next: () => {
+          this.utilService.openSnackbar("msg.besluit.vastgelegd");
+          this.besluitVastgelegd.emit(true);
+        },
+        error: () => {
+          this.besluitVastgelegd.emit(false);
+        },
       });
   }
 }


### PR DESCRIPTION
This pull request refactors the `BesluitCreateComponent` to replace the dynamic, field-builder-based form with a fully reactive Angular form. The new implementation simplifies the component's structure, improves maintainability, and provides more explicit control over form state and validation. The form fields and logic for publication-related fields are now handled directly in the component and template, rather than being generated dynamically.

Key changes include:

**Migration to Reactive Forms:**

* Replaced the dynamic form field builder approach with a statically defined reactive form using Angular's `FormBuilder`, moving all form field definitions and validation into the component class.
* Updated the template (`besluit-create.component.html`) to use Angular form controls and custom components (`zac-select`, `zac-date`, etc.) bound to the reactive form, removing the use of the `mfb-form` dynamic form component.

**Publication Fields Logic:**

* Publication-related fields (such as publication date and response date) are now conditionally displayed and managed using reactive form controls and value change subscriptions, instead of dynamically adding/removing fields.

**Form Submission and Data Handling:**

* Refactored the submit logic to use the new reactive form's value, mapping it directly to the API call, and handling publication data inclusion based on form state.

**Code Simplification and Cleanup:**

* Removed unused imports, the dynamic form field array, and all logic related to the old field builder system. The component now implements only `OnInit` instead of both `OnInit` and `OnDestroy`. [[1]](diffhunk://#diff-9038ac0c46f2720654a5618cf3dcbe2ebf3f03aeeb31a5a5136d4fa502c9a550L6-L33) [[2]](diffhunk://#diff-9038ac0c46f2720654a5618cf3dcbe2ebf3f03aeeb31a5a5136d4fa502c9a550L42-R190)

**Document Handling:**

* Updated the logic for loading and setting document values to work with the new form structure, ensuring documents are correctly associated with the decision type selection.

Solves PZ-7675