### PR TITLE
feat: allow the release action to create a tag on the commit sha if the chosen tag does not exists.

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -559,6 +559,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.NEXT_VERSION_TAG }}
+          commit: ${{ github.sha }}
           name: ${{ env.APPLICATION_NAME }} ${{ env.NEXT_VERSION }}
           body: |
             This release contains the docker image ${{ env.APPLICATION_NAME }} ${{ env.NEXT_VERSION }}, which is available


### PR DESCRIPTION
Should only apply on hotfix runs, as we explicitly add the tag ourselves for main branch runs. 

Solves PZ-8221