### PR TITLE
fix: solved issue where we did not delete temporary locks that we create during uploading of a new version of an enkelvoudiginformatieobject

### DIFF
--- a/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/EnkelvoudigInformatieObjectLockService.kt
+++ b/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/EnkelvoudigInformatieObjectLockService.kt
@@ -29,13 +29,15 @@ class EnkelvoudigInformatieObjectLockService @Inject constructor(
     private val zrcClientService: ZrcClientService
 ) {
     @Transactional(REQUIRED)
-    fun createLock(informationObjectUUID: UUID, userID: String): EnkelvoudigInformatieObjectLock =
-        EnkelvoudigInformatieObjectLock().apply {
+    fun createLock(informationObjectUUID: UUID, userID: String): EnkelvoudigInformatieObjectLock {
+        val enkelvoudigInformatieObjectLock = EnkelvoudigInformatieObjectLock().apply {
             enkelvoudiginformatieobjectUUID = informationObjectUUID
             userId = userID
             lock = drcClientService.lockEnkelvoudigInformatieobject(informationObjectUUID)
-            entityManager.persist(this)
         }
+        entityManager.persist(enkelvoudigInformatieObjectLock)
+        return enkelvoudigInformatieObjectLock
+    }
 
     fun findLock(informationObjectUUID: UUID): EnkelvoudigInformatieObjectLock? {
         val builder = entityManager.criteriaBuilder

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectUpdateServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectUpdateServiceTest.kt
@@ -209,7 +209,9 @@ class EnkelvoudigInformatieObjectUpdateServiceTest : BehaviorSpec({
             val explanation = "fakeExplanation"
             val enkelvoudigInformatieObjectLock = createEnkelvoudigInformatieObjectLock()
             val enkelvoudigInformatieObject = createEnkelvoudigInformatieObject()
-            every { enkelvoudigInformatieObjectLockService.findLock(enkelvoudigInformatieObjectUUID) } returns enkelvoudigInformatieObjectLock
+            every {
+                enkelvoudigInformatieObjectLockService.findLock(enkelvoudigInformatieObjectUUID)
+            } returns enkelvoudigInformatieObjectLock
             every {
                 drcClientService.updateEnkelvoudigInformatieobject(
                     enkelvoudigInformatieObjectUUID, enkelvoudigInformatieObjectWithLockRequest, explanation

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectUpdateServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectUpdateServiceTest.kt
@@ -18,7 +18,9 @@ import net.atos.client.zgw.drc.DrcClientService
 import net.atos.zac.flowable.task.FlowableTaskService
 import net.atos.zac.flowable.task.TaakVariabelenService
 import net.atos.zac.flowable.task.exception.TaskNotFoundException
+import nl.info.client.zgw.drc.model.createEnkelvoudigInformatieObject
 import nl.info.client.zgw.drc.model.createEnkelvoudigInformatieObjectCreateLockRequest
+import nl.info.client.zgw.drc.model.createEnkelvoudigInformatieObjectWithLockRequest
 import nl.info.client.zgw.model.createZaakInformatieobjectForCreatesAndUpdates
 import nl.info.client.zgw.shared.ZGWApiService
 import nl.info.client.zgw.zrc.model.generated.Zaak
@@ -26,6 +28,7 @@ import nl.info.test.org.flowable.task.api.createTestTask
 import nl.info.zac.authentication.LoggedInUser
 import nl.info.zac.configuratie.ConfiguratieService
 import nl.info.zac.enkelvoudiginformatieobject.EnkelvoudigInformatieObjectLockService
+import nl.info.zac.model.createEnkelvoudigInformatieObjectLock
 import nl.info.zac.policy.PolicyService
 import nl.info.zac.policy.output.createTaakRechten
 import java.util.UUID
@@ -59,91 +62,183 @@ class EnkelvoudigInformatieObjectUpdateServiceTest : BehaviorSpec({
         checkUnnecessaryStub()
     }
 
-    Given("Zaak, lock request and an open task") {
-        every {
-            zgwApiService.createZaakInformatieobjectForZaak(
-                zaak,
-                enkelvoudigInformatieObjectCreateLockRequest,
-                enkelvoudigInformatieObjectCreateLockRequest.titel,
-                enkelvoudigInformatieObjectCreateLockRequest.beschrijving,
-                ConfiguratieService.OMSCHRIJVING_VOORWAARDEN_GEBRUIKSRECHTEN
-            )
-        } returns zaakInformatieObject
-        every { flowableTaskService.findOpenTask(taskId) } returns task
-        every { taakVariabelenService.setTaakdocumenten(task, any<List<UUID>>()) } just runs
+    Context("Creating a zaak informatie object for a zaak") {
+        Given("Zaak, lock request and an open task") {
+            every {
+                zgwApiService.createZaakInformatieobjectForZaak(
+                    zaak,
+                    enkelvoudigInformatieObjectCreateLockRequest,
+                    enkelvoudigInformatieObjectCreateLockRequest.titel,
+                    enkelvoudigInformatieObjectCreateLockRequest.beschrijving,
+                    ConfiguratieService.OMSCHRIJVING_VOORWAARDEN_GEBRUIKSRECHTEN
+                )
+            } returns zaakInformatieObject
+            every { flowableTaskService.findOpenTask(taskId) } returns task
+            every { taakVariabelenService.setTaakdocumenten(task, any<List<UUID>>()) } just runs
 
-        When("creating information object for a task is called") {
-            every { policyService.readTaakRechten(task) } returns createTaakRechten()
+            When("creating information object for a task is called") {
+                every { policyService.readTaakRechten(task) } returns createTaakRechten()
 
-            val zaakInfo = enkelvoudigInformatieObjectUpdateService.createZaakInformatieobjectForZaak(
-                zaak = zaak,
-                enkelvoudigInformatieObjectCreateLockRequest = enkelvoudigInformatieObjectCreateLockRequest,
-                taskId = taskId
-            )
+                val zaakInfo = enkelvoudigInformatieObjectUpdateService.createZaakInformatieobjectForZaak(
+                    zaak = zaak,
+                    enkelvoudigInformatieObjectCreateLockRequest = enkelvoudigInformatieObjectCreateLockRequest,
+                    taskId = taskId
+                )
 
-            Then("correct zaak info object is returned") {
-                zaakInfo shouldBe zaakInformatieObject
+                Then("correct zaak info object is returned") {
+                    zaakInfo shouldBe zaakInformatieObject
+                }
+
+                And("task document is set") {
+                    verify(exactly = 1) {
+                        taakVariabelenService.setTaakdocumenten(task, any<List<UUID>>())
+                    }
+                }
             }
+        }
 
-            And("task document is set") {
-                verify(exactly = 1) {
-                    taakVariabelenService.setTaakdocumenten(task, any<List<UUID>>())
+        Given("Zaak, lock request and non-eligible task") {
+            every {
+                zgwApiService.createZaakInformatieobjectForZaak(
+                    zaak,
+                    enkelvoudigInformatieObjectCreateLockRequest,
+                    enkelvoudigInformatieObjectCreateLockRequest.titel,
+                    enkelvoudigInformatieObjectCreateLockRequest.beschrijving,
+                    ConfiguratieService.OMSCHRIJVING_VOORWAARDEN_GEBRUIKSRECHTEN
+                )
+            } returns zaakInformatieObject
+            every { flowableTaskService.findOpenTask(taskId) } returns null
+
+            When("creating information object for a non-open task") {
+                val exception = shouldThrow<TaskNotFoundException> {
+                    enkelvoudigInformatieObjectUpdateService.createZaakInformatieobjectForZaak(
+                        zaak = zaak,
+                        enkelvoudigInformatieObjectCreateLockRequest = enkelvoudigInformatieObjectCreateLockRequest,
+                        taskId = taskId,
+                    )
+                }
+
+                Then("thrown exception mentions the task id") {
+                    exception.message shouldBe "No open task found with task id: '$taskId'"
+                }
+            }
+        }
+
+        Given("Zaak, lock request and internal (pre-authenticated) call") {
+            every {
+                zgwApiService.createZaakInformatieobjectForZaak(
+                    zaak,
+                    enkelvoudigInformatieObjectCreateLockRequest,
+                    enkelvoudigInformatieObjectCreateLockRequest.titel,
+                    enkelvoudigInformatieObjectCreateLockRequest.beschrijving,
+                    ConfiguratieService.OMSCHRIJVING_VOORWAARDEN_GEBRUIKSRECHTEN
+                )
+            } returns zaakInformatieObject
+            every { flowableTaskService.findOpenTask(taskId) } returns task
+            every { taakVariabelenService.setTaakdocumenten(task, any<List<UUID>>()) } just runs
+
+            When("creating information object for a non-open task") {
+                enkelvoudigInformatieObjectUpdateService.createZaakInformatieobjectForZaak(
+                    zaak = zaak,
+                    enkelvoudigInformatieObjectCreateLockRequest = enkelvoudigInformatieObjectCreateLockRequest,
+                    taskId = taskId,
+                    skipPolicyCheck = true
+                )
+
+                Then("policy check is skipped") {
+                    verify(exactly = 0) {
+                        policyService.readTaakRechten(task)
+                    }
                 }
             }
         }
     }
 
-    Given("Zaak, lock request and non-eligible task") {
-        every {
-            zgwApiService.createZaakInformatieobjectForZaak(
-                zaak,
-                enkelvoudigInformatieObjectCreateLockRequest,
-                enkelvoudigInformatieObjectCreateLockRequest.titel,
-                enkelvoudigInformatieObjectCreateLockRequest.beschrijving,
-                ConfiguratieService.OMSCHRIJVING_VOORWAARDEN_GEBRUIKSRECHTEN
-            )
-        } returns zaakInformatieObject
-        every { flowableTaskService.findOpenTask(taskId) } returns null
-
-        When("creating information object for a non-open task") {
-            val exception = shouldThrow<TaskNotFoundException> {
-                enkelvoudigInformatieObjectUpdateService.createZaakInformatieobjectForZaak(
-                    zaak = zaak,
-                    enkelvoudigInformatieObjectCreateLockRequest = enkelvoudigInformatieObjectCreateLockRequest,
-                    taskId = taskId,
+    Context("Updating enkelvoudig informatieobjecten with lock data") {
+        Given("An enkelvoudig informatie object and no existing lock") {
+            val enkelvoudigInformatieObjectUUID = UUID.randomUUID()
+            val enkelvoudigInformatieObjectWithLockRequest = createEnkelvoudigInformatieObjectWithLockRequest()
+            val explanation = "fakeExplanation"
+            val userId = "fakeUserId"
+            val enkelvoudigInformatieObjectLock = createEnkelvoudigInformatieObjectLock()
+            val enkelvoudigInformatieObject = createEnkelvoudigInformatieObject()
+            every { loggedInUserInstance.get().id } returns userId
+            every { enkelvoudigInformatieObjectLockService.findLock(enkelvoudigInformatieObjectUUID) } returns null
+            every {
+                enkelvoudigInformatieObjectLockService.createLock(enkelvoudigInformatieObjectUUID, userId)
+            } returns enkelvoudigInformatieObjectLock
+            every {
+                drcClientService.updateEnkelvoudigInformatieobject(
+                    enkelvoudigInformatieObjectUUID, enkelvoudigInformatieObjectWithLockRequest, explanation
                 )
-            }
+            } returns enkelvoudigInformatieObject
+            every {
+                enkelvoudigInformatieObjectLockService.deleteLock(enkelvoudigInformatieObjectUUID)
+            } returns Unit
 
-            Then("thrown exception mentions the task id") {
-                exception.message shouldBe "No open task found with task id: '$taskId'"
+            When("updating the object with lock data") {
+                val updatedEnkelvoudigInformatieObject =
+                    enkelvoudigInformatieObjectUpdateService.updateEnkelvoudigInformatieObjectWithLockData(
+                        enkelvoudigInformatieObjectUUID,
+                        enkelvoudigInformatieObjectWithLockRequest,
+                        explanation
+                    )
+
+                Then("the object is updated successfully") {
+                    updatedEnkelvoudigInformatieObject shouldBe enkelvoudigInformatieObject
+                    verify(exactly = 1) {
+                        drcClientService.updateEnkelvoudigInformatieobject(
+                            enkelvoudigInformatieObjectUUID,
+                            enkelvoudigInformatieObjectWithLockRequest,
+                            explanation
+                        )
+                    }
+                }
+                And("a temporary lock is created and deleted") {
+                    verify(exactly = 1) {
+                        enkelvoudigInformatieObjectLockService.createLock(enkelvoudigInformatieObjectUUID, userId)
+                        enkelvoudigInformatieObjectLockService.deleteLock(enkelvoudigInformatieObjectUUID)
+                    }
+                }
             }
         }
-    }
 
-    Given("Zaak, lock request and internal (pre-authenticated) call") {
-        every {
-            zgwApiService.createZaakInformatieobjectForZaak(
-                zaak,
-                enkelvoudigInformatieObjectCreateLockRequest,
-                enkelvoudigInformatieObjectCreateLockRequest.titel,
-                enkelvoudigInformatieObjectCreateLockRequest.beschrijving,
-                ConfiguratieService.OMSCHRIJVING_VOORWAARDEN_GEBRUIKSRECHTEN
-            )
-        } returns zaakInformatieObject
-        every { flowableTaskService.findOpenTask(taskId) } returns task
-        every { taakVariabelenService.setTaakdocumenten(task, any<List<UUID>>()) } just runs
+        Given("An enkelvoudig informatie object and an existing lock") {
+            val enkelvoudigInformatieObjectUUID = UUID.randomUUID()
+            val enkelvoudigInformatieObjectWithLockRequest = createEnkelvoudigInformatieObjectWithLockRequest()
+            val explanation = "fakeExplanation"
+            val enkelvoudigInformatieObjectLock = createEnkelvoudigInformatieObjectLock()
+            val enkelvoudigInformatieObject = createEnkelvoudigInformatieObject()
+            every { enkelvoudigInformatieObjectLockService.findLock(enkelvoudigInformatieObjectUUID) } returns enkelvoudigInformatieObjectLock
+            every {
+                drcClientService.updateEnkelvoudigInformatieobject(
+                    enkelvoudigInformatieObjectUUID, enkelvoudigInformatieObjectWithLockRequest, explanation
+                )
+            } returns enkelvoudigInformatieObject
 
-        When("creating information object for a non-open task") {
-            enkelvoudigInformatieObjectUpdateService.createZaakInformatieobjectForZaak(
-                zaak = zaak,
-                enkelvoudigInformatieObjectCreateLockRequest = enkelvoudigInformatieObjectCreateLockRequest,
-                taskId = taskId,
-                skipPolicyCheck = true
-            )
+            When("updating the object with lock data") {
+                val updatedEnkelvoudigInformatieObject =
+                    enkelvoudigInformatieObjectUpdateService.updateEnkelvoudigInformatieObjectWithLockData(
+                        enkelvoudigInformatieObjectUUID,
+                        enkelvoudigInformatieObjectWithLockRequest,
+                        explanation
+                    )
 
-            Then("policy check is skipped") {
-                verify(exactly = 0) {
-                    policyService.readTaakRechten(task)
+                Then("the object is updated successfully") {
+                    updatedEnkelvoudigInformatieObject shouldBe enkelvoudigInformatieObject
+                    verify(exactly = 1) {
+                        drcClientService.updateEnkelvoudigInformatieobject(
+                            enkelvoudigInformatieObjectUUID,
+                            enkelvoudigInformatieObjectWithLockRequest,
+                            explanation
+                        )
+                    }
+                }
+                And("no temporary lock is created nor deleted") {
+                    verify(exactly = 0) {
+                        enkelvoudigInformatieObjectLockService.createLock(any(), any())
+                        enkelvoudigInformatieObjectLockService.deleteLock(any())
+                    }
                 }
             }
         }


### PR DESCRIPTION
Solved issue where we did not delete temporary locks that we create during uploading of a new version of an enkelvoudiginformatieobject. Do that any temporary locks that were accidentally created in OpenZaak because of this issue are need to be deleted manually still!

Solves PZ-8385