### PR TITLE
chore: flush after adding or deleting an EnkelvoudigInformatieObjectLock in the ZAC database to make sure the database gets updated quickly

### DIFF
--- a/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/EnkelvoudigInformatieObjectLockService.kt
+++ b/src/main/kotlin/nl/info/zac/enkelvoudiginformatieobject/EnkelvoudigInformatieObjectLockService.kt
@@ -36,6 +36,7 @@ class EnkelvoudigInformatieObjectLockService @Inject constructor(
             lock = drcClientService.lockEnkelvoudigInformatieobject(informationObjectUUID)
         }
         entityManager.persist(enkelvoudigInformatieObjectLock)
+        entityManager.flush()
         return enkelvoudigInformatieObjectLock
     }
 
@@ -60,6 +61,7 @@ class EnkelvoudigInformatieObjectLockService @Inject constructor(
         findLock(informationObjectUUID)?.let { lock ->
             drcClientService.unlockEnkelvoudigInformatieobject(informationObjectUUID, lock.lock)
             entityManager.remove(lock)
+            entityManager.flush()
         }
 
     fun hasLockedInformatieobjecten(zaak: Zaak): Boolean {


### PR DESCRIPTION
Flush after adding or deleting an EnkelvoudigInformatieObjectLock in the ZAC database to make sure the database gets updated quickly.

Solves PZ-8390