### PR TITLE
fix(bug): edit button overlapping text

### DIFF
--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -368,8 +368,8 @@
                 {{ "locatie" | translate }}</ng-template
               >
               <div class="table-wrapper">
-                <div class="flex flex-col gap-10 mt-2 editable">
-                  <div class="flex flex-row items-center space-between">
+                <div class="flex flex-col gap-10 mt-2">
+                  <div class="flex flex-row space-between">
                     <zac-static-text
                       label="coordinates"
                       [value]="zaak.zaakgeometrie | location"

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.less
@@ -37,9 +37,8 @@ mat-slide-toggle {
 }
 
 .flex-item {
-  flex: 0 1 calc(33% - 5px);
-  box-sizing: border-box;
-  max-width: 300px;
+  flex: 1 0 auto;
+  min-width: 150px;
 }
 
 .flex-double-item {
@@ -56,20 +55,6 @@ mat-slide-toggle {
 
 .replace_me_margin {
   margin-top: 10px;
-}
-
-.fields-container {
-  width: 100%;
-}
-
-.fields {
-  max-width: 1000px;
-  width: 100%;
-}
-
-.text-flexible {
-  flex: 1 1 auto;
-  min-width: 0;
 }
 
 .zaak-grid {
@@ -90,18 +75,6 @@ mat-slide-toggle {
 
 .grid-placeholder {
   visibility: hidden;
-}
-
-.editable {
-  display: block;
-  top: -8px;
-  right: 0;
-}
-
-.editable-location {
-  flex: 0 0 auto;
-  display: flex;
-  justify-content: flex-end;
 }
 
 .remark {


### PR DESCRIPTION
This pull request fixes the overlapping of the edit button on the zaakgegevens fields and the location field. It also refactors the whole of the zaakgegevens on the zaak-view html page. It now uses the [grid layout](https://css-tricks.com/snippets/css/complete-guide-grid/#aa-introduction) to show the fields in a better ordered way.



Solves PZ-8057