### PR TITLE
feat: made group name in zaaktype - BPMN process definitions mandatory

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/ZaaktypeBpmnProcessDefinitionRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/ZaaktypeBpmnProcessDefinitionRestServiceTest.kt
@@ -22,10 +22,10 @@ class ZaaktypeBpmnProcessDefinitionRestServiceTest : BehaviorSpec({
     val logger = KotlinLogging.logger {}
     val itestHttpClient = ItestHttpClient()
 
-    Given("No existing zaaktype to BPMN process definition mappings") {
+    Given("No existing zaaktype - BPMN process definition mapping") {
         When("a mapping is created") {
             val response = itestHttpClient.performJSONPostRequest(
-                url = "$ZAC_API_URI/bpmn-process-definition/$BPMN_TEST_PROCESS_ID/connect",
+                url = "$ZAC_API_URI/zaaktype-bpmn-process-definition/$BPMN_TEST_PROCESS_ID",
                 requestBodyAsString = """{ 
                   "zaaktypeUuid": "$ZAAKTYPE_BPMN_TEST_UUID",
                   "zaaktypeOmschrijving": "$ZAAKTYPE_BPMN_TEST_DESCRIPTION",

--- a/src/main/kotlin/nl/info/zac/app/admin/ZaaktypeBpmnProcessDefinitionRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/ZaaktypeBpmnProcessDefinitionRestService.kt
@@ -24,7 +24,7 @@ import nl.info.zac.util.AllOpen
 import nl.info.zac.util.NoArgConstructor
 
 @Singleton
-@Path("bpmn-process-definition")
+@Path("zaaktype-bpmn-process-definition")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 @AllOpen
@@ -34,8 +34,8 @@ class ZaaktypeBpmnProcessDefinitionRestService @Inject constructor(
     private val policyService: PolicyService
 ) {
     @POST
-    @Path("{processDefinitionKey}/connect")
-    fun connectWithZaaktype(
+    @Path("{processDefinitionKey}")
+    fun createZaaktypeBpmnProcessDefinition(
         @NotEmpty @PathParam("processDefinitionKey") processDefinitionKey: String,
         @Valid restZaaktypeBpmnProcessDefinition: RestZaaktypeBpmnProcessDefinition
     ): Response {

--- a/src/main/kotlin/nl/info/zac/app/admin/model/RestZaaktypeBpmnProcessDefinition.kt
+++ b/src/main/kotlin/nl/info/zac/app/admin/model/RestZaaktypeBpmnProcessDefinition.kt
@@ -20,5 +20,6 @@ data class RestZaaktypeBpmnProcessDefinition(
 
     var productaanvraagtype: String?,
 
-    var groepNaam: String?
+    @field:NotNull
+    var groepNaam: String
 )

--- a/src/main/kotlin/nl/info/zac/flowable/bpmn/model/ZaaktypeBpmnProcessDefinition.kt
+++ b/src/main/kotlin/nl/info/zac/flowable/bpmn/model/ZaaktypeBpmnProcessDefinition.kt
@@ -51,11 +51,9 @@ class ZaaktypeBpmnProcessDefinition {
     var productaanvraagtype: String? = null
 
     /**
-     * Optional name of the group to assign when starting a BPMN process via the Dimpact productaanvraag flow.
-     * When a BPMN process is started from the UI, the user selects the group; but when it is started from
-     * [nl.info.zac.notification.NotificationReceiver], there is no selection, so this value is used.
-     * If null, the productaanvraag flow fails to create a BPMN process.
+     * Name of the user group that will be assigned by default to BPMN zaken started for this zaaktype.
+     * Note that the group name acts as the unique group ID. Both terms are used interchangeably.
      */
-    @Column(name = "naam_groep")
-    var groepNaam: String? = null
+    @Column(name = "naam_groep", nullable = false)
+    lateinit var groepNaam: String
 }

--- a/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
@@ -593,7 +593,7 @@ class ProductaanvraagService @Inject constructor(
             zaaktype,
             zaaktypeBpmnProcessDefinition.bpmnProcessDefinitionKey,
             zaakData = buildMap {
-                zaaktypeBpmnProcessDefinition.groepNaam?.let { put(VAR_ZAAK_GROUP, it) }
+                put(VAR_ZAAK_GROUP, zaaktypeBpmnProcessDefinition.groepNaam)
             }
         )
         pairProductaanvraagWithZaak(productaanvraagObject, bpmnZaak.url)

--- a/src/main/resources/schemas/V80__make_group_mandatory_in_bpmn_process_definition.sql
+++ b/src/main/resources/schemas/V80__make_group_mandatory_in_bpmn_process_definition.sql
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+ALTER TABLE ${schema}.zaaktype_bpmn_process_definition
+    ALTER COLUMN naam_groep SET NOT NULL;

--- a/src/test/kotlin/nl/info/zac/flowable/bpmn/ZaaktypeBpmnProcessDefinitionServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/flowable/bpmn/ZaaktypeBpmnProcessDefinitionServiceTest.kt
@@ -37,7 +37,7 @@ class ZaaktypeBpmnProcessDefinitionServiceTest : BehaviorSpec({
         checkUnnecessaryStub()
     }
 
-    Context("Creating a BPMN process definition mapping") {
+    Context("Creating a zaaktype - BPMN process definition") {
         Given("A zaaktype - BPMN process definition relation") {
             val zaaktypeBpmnProcessDefinition = createZaaktypeBpmnProcessDefinition()
             every { entityManager.persist(zaaktypeBpmnProcessDefinition) } just Runs
@@ -54,7 +54,7 @@ class ZaaktypeBpmnProcessDefinitionServiceTest : BehaviorSpec({
         }
     }
 
-    Context("Deleting a BPMN process definition mapping") {
+    Context("Deleting a zaaktype - BPMN process definition") {
         Given("A stored zaaktype BPMN process definition relation") {
             val zaaktypeBpmnProcessDefinition = createZaaktypeBpmnProcessDefinition()
             every { entityManager.remove(zaaktypeBpmnProcessDefinition) } just Runs
@@ -71,7 +71,7 @@ class ZaaktypeBpmnProcessDefinitionServiceTest : BehaviorSpec({
         }
     }
 
-    Context("finding a BPMN process definition by zaaktype UUID") {
+    Context("Finding a BPMN process definition by zaaktype UUID") {
         Given("A valid zaaktype UUID with a corresponding BPMN process definition") {
             val zaaktypeUUID = UUID.randomUUID()
             val zaaktypeBpmnProcessDefinition = createZaaktypeBpmnProcessDefinition(zaaktypeUuid = zaaktypeUUID)


### PR DESCRIPTION
Made group name in zaaktype - BPMN process definitions mandatory. Renamed code a bit here and there for consistency.

Solves PZ-8392