### PR TITLE
feat: do not add initiator nor other betrokkenen yet in the BPMN productaanvraag flow

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/NotificationsTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/NotificationsTest.kt
@@ -17,7 +17,6 @@ import nl.info.zac.itest.client.ItestHttpClient
 import nl.info.zac.itest.config.ItestConfiguration
 import nl.info.zac.itest.config.ItestConfiguration.BETROKKENE_IDENTIFACTION_TYPE_VESTIGING
 import nl.info.zac.itest.config.ItestConfiguration.BETROKKENE_IDENTIFICATION_TYPE_BSN
-import nl.info.zac.itest.config.ItestConfiguration.BETROKKENE_TYPE_NATUURLIJK_PERSOON
 import nl.info.zac.itest.config.ItestConfiguration.CONFIG_GEMEENTE_NAAM
 import nl.info.zac.itest.config.ItestConfiguration.GREENMAIL_API_URI
 import nl.info.zac.itest.config.ItestConfiguration.OBJECTS_BASE_URI
@@ -36,7 +35,6 @@ import nl.info.zac.itest.config.ItestConfiguration.PRODUCTAANVRAAG_ZAAKGEGEVENS_
 import nl.info.zac.itest.config.ItestConfiguration.SCREEN_EVENT_TYPE_ZAAK_ROLLEN
 import nl.info.zac.itest.config.ItestConfiguration.TEST_GEMEENTE_EMAIL_ADDRESS
 import nl.info.zac.itest.config.ItestConfiguration.TEST_KVK_VESTIGINGSNUMMER_1
-import nl.info.zac.itest.config.ItestConfiguration.TEST_PERSON_3_BSN
 import nl.info.zac.itest.config.ItestConfiguration.TEST_PERSON_HENDRIKA_JANSE_BSN
 import nl.info.zac.itest.config.ItestConfiguration.TEST_PERSON_HENDRIKA_JANSE_EMAIL
 import nl.info.zac.itest.config.ItestConfiguration.TEST_SPEC_ORDER_AFTER_INITIALIZATION
@@ -292,27 +290,17 @@ class NotificationsTest : BehaviorSpec({
             val response = itestHttpClient.performGetRequest(
                 url = "$ZAC_API_URI/zaken/zaak/$zaakProductaanvraag3Uuid/betrokkene",
             )
-            Then("the response should be a 200 HTTP response with the betrokkenen defined in the productaanvraag") {
+            Then(
+                """
+                the response should be a 200 HTTP response without any betrokkenen 
+                because we do support adding betrokkenen yet in the BPMN productaanvraag flow
+                """.trimIndent()
+            ) {
                 response.code shouldBe HTTP_OK
                 val responseBody = response.body.string()
                 logger.info { "Response: $responseBody" }
                 responseBody shouldEqualJsonIgnoringExtraneousFields """
-                    [
-                      {
-                        "identificatie": "$TEST_PERSON_3_BSN",
-                        "identificatieType": "BSN",
-                        "roltoelichting": "Overgenomen vanuit de product aanvraag",
-                        "roltype": "Bewindvoerder",
-                        "type": "$BETROKKENE_TYPE_NATUURLIJK_PERSOON"
-                      },
-                      {
-                        "identificatie": "$TEST_PERSON_3_BSN",
-                        "identificatieType": "BSN",
-                        "roltoelichting": "Overgenomen vanuit de product aanvraag",
-                        "roltype": "Medeaanvrager",
-                        "type": "$BETROKKENE_TYPE_NATUURLIJK_PERSOON"
-                      }
-                    ]
+                    []
                 """.trimIndent()
             }
         }

--- a/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
@@ -606,7 +606,7 @@ class ProductaanvraagService @Inject constructor(
         )
         // note: BPMN zaaktypes do not yet support a default employee to be assigned to the zaak, as is the case for CMMN
         pairDocumentsWithZaak(productaanvraagDimpact = productaanvraagDimpact, zaak = zaak)
-        addInitiatorAndBetrokkenenToZaak(productaanvraag = productaanvraagDimpact, zaak = zaak)
+        // note: BPMN zaaktypes do not yet support adding an initiator nor other betrokkenen to the zaak, as is the case for CMMN
         // note: BPMN zaaktypes do not yet support automatic email notifications, as is the case for CMMN
     }
 

--- a/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -21,7 +21,6 @@ import net.atos.client.or.`object`.model.createORObject
 import net.atos.client.or.`object`.model.createObjectRecord
 import net.atos.client.zgw.drc.DrcClientService
 import net.atos.client.zgw.zrc.model.Rol
-import net.atos.client.zgw.zrc.model.RolNatuurlijkPersoon
 import net.atos.client.zgw.zrc.model.RolOrganisatorischeEenheid
 import net.atos.client.zgw.zrc.model.ZaakInformatieobject
 import net.atos.zac.admin.ZaakafhandelParameterService
@@ -1302,9 +1301,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             every {
                 ztcClientService.readRoltype(createdZaak.zaaktype, OmschrijvingGeneriekEnum.BEHANDELAAR)
             } returns behandelaarRolType
-            every { ztcClientService.findRoltypen(any(), "Initiator") } returns listOf(rolTypeInitiator)
             every { zrcClientService.createRol(any<RolOrganisatorischeEenheid>()) } returns createRolOrganisatorischeEenheid()
-            every { zrcClientService.createRol(any<RolNatuurlijkPersoon>()) } returns mockk()
 
             When("the productaanvraag is handled") {
                 productaanvraagService.handleProductaanvraag(productAanvraagObjectUUID)
@@ -1325,8 +1322,8 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                         zrcClientService.createZaakInformatieobject(any(), any())
                     }
                 }
-                And("the group and natuurlijk persoon role should be created for the group and initiator") {
-                    verify(exactly = 2) {
+                And("the group role should be created for the assigned group") {
+                    verify(exactly = 1) {
                         zrcClientService.createRol(any())
                     }
                 }


### PR DESCRIPTION
Do not add initiator nor other betrokkenen yet in the BPMN productaanvraag flow because we do not support adding initiators nor betrokkenen to BPMN zaaktypes currently in ZAC.

Solves PZ-8402