### PR TITLE
fix(zaak-create): only create class when value exists

### DIFF
--- a/src/main/app/src/app/zaken/zaak-create/zaak-create.component.ts
+++ b/src/main/app/src/app/zaken/zaak-create/zaak-create.component.ts
@@ -150,9 +150,9 @@ export class ZaakCreateComponent implements OnDestroy {
       .createZaak({
         zaak: {
           ...value,
-          initiatorIdentificatie: new BetrokkeneIdentificatie(
-            value.initiatorIdentificatie!,
-          ),
+          initiatorIdentificatie: value.initiatorIdentificatie
+            ? new BetrokkeneIdentificatie(value.initiatorIdentificatie)
+            : null,
           vertrouwelijkheidaanduiding: value.vertrouwelijkheidaanduiding?.value,
           startdatum: value.startdatum?.toISOString(),
           omschrijving: value.omschrijving!,


### PR DESCRIPTION
This pull request makes a small but important fix to the `ZaakCreateComponent` to ensure that the `initiatorIdentificatie` property is only set when a value is provided, preventing possible errors when the value is missing.

- Updated the assignment of `initiatorIdentificatie` in the `createZaak` method to set it to `null` if no value is provided, improving robustness when handling optional form input.
