### PR TITLE
fix: creating zaak without PABC

### DIFF
--- a/src/main/kotlin/nl/info/zac/policy/PolicyService.kt
+++ b/src/main/kotlin/nl/info/zac/policy/PolicyService.kt
@@ -37,7 +37,6 @@ import nl.info.zac.policy.input.ZaakData
 import nl.info.zac.policy.input.ZaakInput
 import nl.info.zac.policy.output.DocumentRechten
 import nl.info.zac.policy.output.NotitieRechten
-import nl.info.zac.policy.output.OverigeRechten
 import nl.info.zac.policy.output.TaakRechten
 import nl.info.zac.policy.output.WerklijstRechten
 import nl.info.zac.policy.output.ZaakRechten

--- a/src/test/kotlin/nl/info/zac/policy/PolicyServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/policy/PolicyServiceTest.kt
@@ -5,10 +5,8 @@
 
 package nl.info.zac.policy
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk


### PR DESCRIPTION
zaaktype is now correctly processed in no-PABC case

Solves PZ-8552