### PR TITLE
chore: use separate functional roles for new IAM architecture

### DIFF
--- a/docs/solution-architecture/iamArchitecture.md
+++ b/docs/solution-architecture/iamArchitecture.md
@@ -1,6 +1,6 @@
 # Identity and Access Management (IAM)
 
-## Current ZAC IAM architecture
+## Current ('legacy') ZAC IAM architecture
 
 The current IAM (Identity and Access Management) architecture of ZAC is illustrated in the following diagram:
 

--- a/scripts/docker-compose/imports/keycloak/realms/zaakafhandelcomponent-realm.json
+++ b/scripts/docker-compose/imports/keycloak/realms/zaakafhandelcomponent-realm.json
@@ -428,6 +428,46 @@
           "attributes": {}
         },
         {
+          "id": "f3e2e2b1-2d0e-4c8e-9f3a-5e1f3c6d1f4e",
+          "name": "raadpleger_domein_test_1",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "a4acb4ef-4e2c-462d-81f3-e20af8326952",
+          "attributes": {}
+        },
+        {
+          "id": "f5c3c8e4-2d6b-4f4a-9f1e-3c9e2b7a6d5f",
+          "name": "behandelaar_domein_test_1",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "a4acb4ef-4e2c-462d-81f3-e20af8326952",
+          "attributes": {}
+        },
+        {
+          "id": "c1d2e3f4-5a6b-7c8d-9e0f-1a2b3c4d5e6f",
+          "name": "coordinator_domein_test_1",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "a4acb4ef-4e2c-462d-81f3-e20af8326952",
+          "attributes": {}
+        },
+        {
+          "id": "e1f3c6d1-2d0e-4c8e-9f3a-f3e2e2b15e1f",
+          "name": "recordmanager_domein_test_1_en_domein_test_2",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "a4acb4ef-4e2c-462d-81f3-e20af8326952",
+          "attributes": {}
+        },
+        {
+          "id": "d1f4e2e2-b12d-0e4c-8e9f-3a5e1f3c6d1f",
+          "name": "beheerder_elk_domein",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "a4acb4ef-4e2c-462d-81f3-e20af8326952",
+          "attributes": {}
+        },
+        {
           "id": "79226e68-19c9-4fce-a407-8e883a75bd25",
           "name": "domein_elk_zaaktype",
           "composite": false,
@@ -462,7 +502,12 @@
           "behandelaar",
           "coordinator",
           "recordmanager",
-          "beheerder"
+          "beheerder",
+          "raadpleger_domein_test_1",
+          "behandelaar_domein_test_1",
+          "coordinator_domein_test_1",
+          "recordmanager_domein_test_1_en_domein_test_2",
+          "beheerder_elk_domein"
         ]
       }
     },
@@ -481,7 +526,12 @@
           "behandelaar",
           "coordinator",
           "recordmanager",
-          "beheerder"
+          "beheerder",
+          "raadpleger_domein_test_1",
+          "behandelaar_domein_test_1",
+          "coordinator_domein_test_1",
+          "recordmanager_domein_test_1_en_domein_test_2",
+          "beheerder_elk_domein"
         ]
       }
     },
@@ -499,7 +549,11 @@
           "raadpleger",
           "behandelaar",
           "coordinator",
-          "recordmanager"
+          "recordmanager",
+          "raadpleger_domein_test_1",
+          "behandelaar_domein_test_1",
+          "coordinator_domein_test_1",
+          "recordmanager_domein_test_1_en_domein_test_2"
         ]
       }
     },
@@ -512,7 +566,13 @@
         "email": ["${ZAC_GROUP_DOMEIN_TEST_1_EMAIL_ADDRESS}"]
       },
       "clientRoles": {
-        "zaakafhandelcomponent": ["domein_test_1", "raadpleger", "behandelaar"]
+        "zaakafhandelcomponent": [
+          "domein_test_1",
+          "raadpleger",
+          "behandelaar",
+          "raadpleger_domein_test_1",
+          "behandelaar_domein_test_1"
+        ]
       }
     },
     {
@@ -528,7 +588,10 @@
           "domein_elk_zaaktype",
           "raadpleger",
           "behandelaar",
-          "coordinator"
+          "coordinator",
+          "raadpleger_domein_test_1",
+          "behandelaar_domein_test_1",
+          "coordinator_domein_test_1"
         ]
       }
     },
@@ -544,7 +607,9 @@
         "zaakafhandelcomponent": [
           "domein_elk_zaaktype",
           "raadpleger",
-          "behandelaar"
+          "behandelaar",
+          "raadpleger_domein_test_1",
+          "behandelaar_domein_test_1"
         ]
       }
     },
@@ -557,7 +622,11 @@
         "email": ["${ZAC_GROUP_RAADPLEGERS_1_EMAIL_ADDRESS}"]
       },
       "clientRoles": {
-        "zaakafhandelcomponent": ["domein_elk_zaaktype", "raadpleger"]
+        "zaakafhandelcomponent": [
+          "domein_elk_zaaktype",
+          "raadpleger",
+          "raadpleger_domein_test_1"
+        ]
       }
     }
   ],

--- a/scripts/docker-compose/imports/pabc-database/database/1-setup-applicatie.sql
+++ b/scripts/docker-compose/imports/pabc-database/database/1-setup-applicatie.sql
@@ -7,13 +7,12 @@ INSERT INTO "ApplicationRoles" ("Id", "Name", "Application") VALUES
     ('c54a72b5-053b-4c3e-ac9f-c6034a6e23ea','beheerder','zaakafhandelcomponent');
 
 -- create ZAC example functional roles
--- note that for now the functional roles map 1-on-1 to the application roles (this will change in future)
 INSERT INTO "FunctionalRoles" ("Id", "Name") VALUES
-    ('f0c1b2d3-4e5f-6789-0a1b-2c3d4e5f6789','raadpleger'),
-    ('12345678-90ab-cdef-1234-567890abcdef','behandelaar'),
-    ('23456789-0abc-def1-2345-67890abcdef1','coordinator'),
-    ('34567890-abcd-ef12-3456-7890abcdef12','recordmanager'),
-    ('45678901-bcde-f123-4567-890abcdef123','beheerder');
+    ('f0c1b2d3-4e5f-6789-0a1b-2c3d4e5f6789','raadpleger_domein_test_1'),
+    ('12345678-90ab-cdef-1234-567890abcdef','behandelaar_domein_test_1'),
+    ('23456789-0abc-def1-2345-67890abcdef1','coordinator_domein_test_1'),
+    ('34567890-abcd-ef12-3456-7890abcdef12','recordmanager_domein_test_1_en_domein_test_2'),
+    ('45678901-bcde-f123-4567-890abcdef123','beheerder_elk_domein');
 
 -- create ZAC example domains
 INSERT INTO "Domains" ("Id", "Name", "Description") VALUES
@@ -23,31 +22,31 @@ INSERT INTO "Domains" ("Id", "Name", "Description") VALUES
 -- create mappings between domains, functional roles and application roles
 INSERT INTO "Mappings" ("Id", "FunctionalRoleId", "DomainId", "ApplicationRoleId") VALUES
     -- create mappings for all functional roles to the corresponding application role in 'domein_test_1' where a functional role also contains all 'underlying' application roles
-    ('15e01325-d883-4e42-9152-9137be5f443b', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'raadpleger'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
-    ('4e4a88ae-b582-452e-af81-1cbc1b955e5e', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'behandelaar'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
-    ('898d49e5-b899-4e7b-b99c-895e5bed8294', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'behandelaar'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
-    ('eb1ba239-948e-4577-9655-8cc81a4a1526', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'coordinator'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
-    ('1135fffe-d160-439a-b3fa-75e30ea76ce0', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'coordinator'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
-    ('0b197823-4676-4c19-ad09-f7488f235f50', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'coordinator'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'coordinator')),
-    ('eb6ab6fd-925e-45a2-a01b-64634090ba2f', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
-    ('d99bcdfd-4727-4cc4-bc1d-6530ca766309', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
-    ('c76c0c86-f974-434e-a21c-8380a8fbdb10', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'coordinator')),
-    ('0c502a34-7b48-4437-a223-842d4d048bab', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'recordmanager')),
-    ('e468514b-f4cf-4b1e-bc5d-653bdbcc4587', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
-    ('b15ab065-126d-4311-8170-18b047173903', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
-    ('ac0f0745-8e74-4966-a706-b8ef0e806bdc', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'coordinator')),
-    ('5fcb04d7-731e-4b87-98c0-3afd8692d064', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'beheerder')),
-    ('33c36417-b0df-45db-8c11-36d18cf63425', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'recordmanager')),
+    ('15e01325-d883-4e42-9152-9137be5f443b', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'raadpleger_domein_test_1'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
+    ('4e4a88ae-b582-452e-af81-1cbc1b955e5e', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'behandelaar_domein_test_1'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
+    ('898d49e5-b899-4e7b-b99c-895e5bed8294', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'behandelaar_domein_test_1'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
+    ('eb1ba239-948e-4577-9655-8cc81a4a1526', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'coordinator_domein_test_1'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
+    ('1135fffe-d160-439a-b3fa-75e30ea76ce0', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'coordinator_domein_test_1'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
+    ('0b197823-4676-4c19-ad09-f7488f235f50', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'coordinator_domein_test_1'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'coordinator')),
+    ('eb6ab6fd-925e-45a2-a01b-64634090ba2f', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager_domein_test_1_en_domein_test_2'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
+    ('d99bcdfd-4727-4cc4-bc1d-6530ca766309', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager_domein_test_1_en_domein_test_2'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
+    ('c76c0c86-f974-434e-a21c-8380a8fbdb10', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager_domein_test_1_en_domein_test_2'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'coordinator')),
+    ('0c502a34-7b48-4437-a223-842d4d048bab', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager_domein_test_1_en_domein_test_2'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'recordmanager')),
+    ('e468514b-f4cf-4b1e-bc5d-653bdbcc4587', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder_elk_domein'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
+    ('b15ab065-126d-4311-8170-18b047173903', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder_elk_domein'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
+    ('ac0f0745-8e74-4966-a706-b8ef0e806bdc', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder_elk_domein'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'coordinator')),
+    ('5fcb04d7-731e-4b87-98c0-3afd8692d064', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder_elk_domein'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'beheerder')),
+    ('33c36417-b0df-45db-8c11-36d18cf63425', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder_elk_domein'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_1'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'recordmanager')),
     -- create mappings for recordmanager and beheerder to the corresponding application role in 'domein_test_2'
-    ('699daaf5-9978-4739-9a18-2cfb26958e77', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
-    ('db7e0427-68ec-4bd9-ad3b-a5a945230b24', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
-    ('0e5dc382-c26b-491f-8a45-6025f150c3a9', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'coordinator')),
-    ('a87ed914-096f-4d73-82de-ef87c033adb8', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'recordmanager')),
-    ('6ff6a97c-ad32-4822-b23b-ec2a99c3a87a', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
-    ('8695329f-c258-4420-ba98-851611e6f2ec', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
-    ('4c299601-a0e5-4987-883c-47c65c26fe98', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'coordinator')),
-    ('db8073b8-7d23-4d81-b8db-7edc690bf046', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'recordmanager')),
-    ('e6990d64-55af-40b8-af54-b1f4b1083bce', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'beheerder'));
+    ('699daaf5-9978-4739-9a18-2cfb26958e77', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager_domein_test_1_en_domein_test_2'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
+    ('db7e0427-68ec-4bd9-ad3b-a5a945230b24', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager_domein_test_1_en_domein_test_2'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
+    ('0e5dc382-c26b-491f-8a45-6025f150c3a9', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager_domein_test_1_en_domein_test_2'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'coordinator')),
+    ('a87ed914-096f-4d73-82de-ef87c033adb8', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'recordmanager_domein_test_1_en_domein_test_2'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'recordmanager')),
+    ('6ff6a97c-ad32-4822-b23b-ec2a99c3a87a', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder_elk_domein'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'raadpleger')),
+    ('8695329f-c258-4420-ba98-851611e6f2ec', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder_elk_domein'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'behandelaar')),
+    ('4c299601-a0e5-4987-883c-47c65c26fe98', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder_elk_domein'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'coordinator')),
+    ('db8073b8-7d23-4d81-b8db-7edc690bf046', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder_elk_domein'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'recordmanager')),
+    ('e6990d64-55af-40b8-af54-b1f4b1083bce', (SELECT "Id" FROM "FunctionalRoles" WHERE "Name" = 'beheerder_elk_domein'), (SELECT "Id" FROM "Domains" WHERE "Name" = 'domein_test_2'), (SELECT "Id" FROM "ApplicationRoles" WHERE "Name" = 'beheerder'));
 
 -- create zaaktype entity types
 INSERT INTO "EntityTypes" ("Id", "EntityTypeId", "Type", "Name", "Uri") VALUES

--- a/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
@@ -98,6 +98,7 @@ constructor(
             } else {
                 LOG.info(
                     "User logged in: '${loggedInUser.id}' with groups: ${loggedInUser.groupIds}, " +
+                        "functional roles: '${loggedInUser.roles}' " +
                         "and application roles per zaaktype: ${loggedInUser.applicationRolesPerZaaktype}"
                 )
             }


### PR DESCRIPTION
Use separate functional roles for new IAM architecture in our Docker Compose setup so that they are not confused with the roles used in the old legacy IAM architecture and so that we have more flexibility.

Solves PZ-8575