### PR TITLE
fix: inbox documents list sorting

### DIFF
--- a/src/main/app/src/app/documenten/inbox-documenten-list/inbox-documenten-list.component.ts
+++ b/src/main/app/src/app/documenten/inbox-documenten-list/inbox-documenten-list.component.ts
@@ -90,7 +90,7 @@ export class InboxDocumentenListComponent
 
   ngOnInit() {
     super.ngOnInit();
-    this.listParametersSort = SessionStorageUtil.getItem(
+    this.listParameters = SessionStorageUtil.getItem(
       "INBOX_DOCUMENTEN_ZOEKPARAMETERS" satisfies WerklijstZoekParameter,
       this.createDefaultParameters(),
     );


### PR DESCRIPTION
The PR fixes the sorting in de inboxDocuments list. It contains a simple fix that stores the sessionStorage in the correct property

Solves PZ-8354