### PR TITLE
chore: make more legacy IAM code deprecated for better overview later on

### DIFF
--- a/docs/solution-architecture/iamArchitecture.md
+++ b/docs/solution-architecture/iamArchitecture.md
@@ -164,6 +164,7 @@ block-beta
     
     %% workaround to make sure titles of sub-blocks are vertically aligned
     %% see: https://github.com/mermaid-js/mermaid/issues/5423
+    class IAM BT
     class keycloakBlockTitle BT
     class zacBlockTitle BT
     class pabcBlockTitle BT
@@ -171,7 +172,7 @@ block-beta
 
     style Keycloak fill:darkgrey,stroke:#333,stroke-width:4px
     style ZAC fill:red,stroke:#333,stroke-width:4px
-    style PABC fill:darkslateblue,stroke:#333,stroke-width:4px
+    style PABC fill:grey,stroke:#333,stroke-width:4px
 ```
 
 ### Scenarios

--- a/src/main/kotlin/nl/info/zac/authentication/LoggedInUser.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/LoggedInUser.kt
@@ -19,6 +19,10 @@ class LoggedInUser(
     /**
      * List of zaaktypen for which the logged-in user is authorised, or 'null' if the user is authorised for all zaaktypen.
      */
+    @Deprecated(
+        "In PABC-based authorization, the concept of being authorized for a zaaktype is meaningless, " +
+            "since a user is always authorised for a zaaktype _for specific application roles_."
+    )
     val geautoriseerdeZaaktypen: Set<String>? = null,
 
     /**
@@ -28,14 +32,19 @@ class LoggedInUser(
     val applicationRolesPerZaaktype: Map<String, Set<String>> = emptyMap(),
 
 ) : User(id, firstName, lastName, displayName, email) {
+    @Deprecated(
+        "In PABC-based authorization, the concept of being authorized for a zaaktype is meaningless, " +
+            "since a user is always authorised for a zaaktype _for specific application roles_."
+    )
     fun isAuthorisedForAllZaaktypen(): Boolean = geautoriseerdeZaaktypen == null
 
     /**
      * Check if a zaaktype is authorised when PABC is disabled
-     *
-     * @deprecated In PABC-based authorization, the concept of being authorised just for a zaaktype is meaningless,
-     * since you are authorised for specific application roles for a zaaktype.
      */
+    @Deprecated(
+        "In PABC-based authorization, the concept of being authorized for a zaaktype is meaningless, " +
+            "since a user is always authorised for a zaaktype _for specific application roles_."
+    )
     fun isAuthorisedForZaaktype(zaaktypeOmschrijving: String) =
         geautoriseerdeZaaktypen?.contains(zaaktypeOmschrijving) ?: true
 }

--- a/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
@@ -168,7 +168,7 @@ constructor(
      */
     @Deprecated(
         "In PABC-based authorization, the concept of being authorized for a zaaktype is meaningless, " +
-            "since a user is always authorised for a zaaktype _for specific application roles_."
+            "since a user is always authorized for a zaaktype _for specific application roles_."
     )
     private fun getAuthorisedZaaktypen(roles: Set<String>): Set<String>? =
         if (roles.contains(ZACRole.DOMEIN_ELK_ZAAKTYPE.value)) {

--- a/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/UserPrincipalFilter.kt
@@ -166,6 +166,10 @@ constructor(
      * Returns the active zaaktypen for which the user is authorised, or `null` if the user is
      * authorised for all zaaktypen.
      */
+    @Deprecated(
+        "In PABC-based authorization, the concept of being authorized for a zaaktype is meaningless, " +
+            "since a user is always authorised for a zaaktype _for specific application roles_."
+    )
     private fun getAuthorisedZaaktypen(roles: Set<String>): Set<String>? =
         if (roles.contains(ZACRole.DOMEIN_ELK_ZAAKTYPE.value)) {
             null

--- a/src/main/kotlin/nl/info/zac/policy/PolicyService.kt
+++ b/src/main/kotlin/nl/info/zac/policy/PolicyService.kt
@@ -64,9 +64,10 @@ class PolicyService @Inject constructor(
 ) {
     /**
      * Read 'overige' permissions.
-     * Note that for PABC-based authorization, the 'zaaktype' parameter is required, but for legacy
-     * ZAC-only authorization it is ignored.
-     * Until the old legacy authorization has been removed, it is therefore nullable.
+     *
+     * @param zaaktypeDescription Optional zaaktype description to include in the input. In the legacy
+     * non-PABC IAM architecture it is not used but in the new PABC-based IAM architecture it is,
+     * but only for those 'overige rechten' permissions that are zaaktype-specific.
      */
     fun readOverigeRechten(zaaktypeDescription: String? = null) =
         evaluationClient.readOverigeRechten(
@@ -241,11 +242,10 @@ class PolicyService @Inject constructor(
             )
         ).result
 
-    /**
-     * @deprecated For PABC-based authorization, the concept of being authorised for a zaaktype is meaningless,
-     * since you are always authorised for specific application roles for a zaaktype,
-     * so we always return true in that case.
-     */
+    @Deprecated(
+        "In PABC-based authorization, the concept of being authorized for a zaaktype is meaningless, " +
+            "since a user is always authorised for a zaaktype _for specific application roles_."
+    )
     fun isAuthorisedForZaaktype(zaakTypeOmschrijving: String) =
         if (configuratieService.featureFlagPabcIntegration()) {
             true

--- a/src/main/kotlin/nl/info/zac/policy/PolicyService.kt
+++ b/src/main/kotlin/nl/info/zac/policy/PolicyService.kt
@@ -243,7 +243,7 @@ class PolicyService @Inject constructor(
         ).result
 
     @Deprecated(
-        "In PABC-based authorization, the concept of being authorized for a zaaktype is meaningless, " +
+        "In PABC-based authorisation, the concept of being authorised for a zaaktype is meaningless, " +
             "since a user is always authorised for a zaaktype _for specific application roles_."
     )
     fun isAuthorisedForZaaktype(zaakTypeOmschrijving: String) =


### PR DESCRIPTION
Make more legacy IAM code deprecated for better overview later on. Also use @Deprecated annotation instead of @deprecated JavaDoc/KDoc tag. And cleaned up new IAM diagram a little.

Solves PZ-8734