### PR TITLE
feat: show zaak startdatumBewaartermijn

### DIFF
--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -240,6 +240,12 @@
                   >
                   </zac-static-text>
                   <zac-static-text
+                    *ngIf="zaak.startdatumBewaartermijn"
+                    [label]="'startdatumBewaartermijn' | translate"
+                    [value]="zaak.startdatumBewaartermijn | datum"
+                  >
+                  </zac-static-text>
+                  <zac-static-text
                     *ngIf="zaak.archiefNominatie === 'VERNIETIGEN'"
                     [label]="
                       'archiefNominatie.datum.' + zaak.archiefNominatie

--- a/src/main/app/src/assets/i18n/en.json
+++ b/src/main/app/src/assets/i18n/en.json
@@ -87,6 +87,7 @@
   "publicatiedatum": "Publication date",
   "uiterlijkereactiedatum": "Final response date",
   "einddatum": "End date",
+  "startdatumBewaartermijn": "Source date",
   "zaak.einddatum": "Case end date",
   "zaak.brondatum": "Case archiving source date",
   "streefdatum": "Due date",

--- a/src/main/app/src/assets/i18n/nl.json
+++ b/src/main/app/src/assets/i18n/nl.json
@@ -87,6 +87,7 @@
   "publicatiedatum": "Publicatiedatum",
   "uiterlijkereactiedatum": "Uiterlijke reactiedatum",
   "einddatum": "Einddatum",
+  "startdatumBewaartermijn": "Brondatum",
   "zaak.einddatum": "Zaak einddatum",
   "zaak.brondatum": "Zaak archivering brondatum",
   "streefdatum": "Streefdatum",

--- a/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverter.kt
@@ -121,6 +121,7 @@ class RestZaakConverter @Inject constructor(
             registratiedatum = zaak.registratiedatum,
             archiefNominatie = zaak.archiefnominatie?.name,
             archiefActiedatum = zaak.archiefactiedatum,
+            startdatumBewaartermijn = zaak.startdatumBewaartermijn,
             omschrijving = zaak.omschrijving,
             toelichting = zaak.toelichting,
             zaaktype = restZaaktypeConverter.convert(zaakType),

--- a/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaak.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/model/RestZaak.kt
@@ -19,6 +19,7 @@ import java.util.UUID
 @AllOpen
 data class RestZaak(
     var archiefActiedatum: LocalDate?,
+    var startdatumBewaartermijn: LocalDate?,
     var archiefNominatie: String?,
     var behandelaar: RestUser?,
     var besluiten: List<RestDecision>?,

--- a/src/test/kotlin/nl/info/zac/app/zaak/model/RestZakenFixtures.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/model/RestZakenFixtures.kt
@@ -174,6 +174,7 @@ fun createRestZaak(
     uiterlijkeEinddatumAfdoening = uiterlijkeEinddatumAfdoening,
     publicatiedatum = LocalDate.of(2023, 9, 16),
     archiefActiedatum = LocalDate.of(2023, 10, 15),
+    startdatumBewaartermijn = LocalDate.of(2032, 10, 15),
     archiefNominatie = "Sample Archief Nominatie",
     communicatiekanaal = communicatiekanaal,
     vertrouwelijkheidaanduiding = vertrouwelijkheidaanduiding,


### PR DESCRIPTION
Show zaak startdatumBewaartermijn

When there is a result type selected that triggers archiving, a startdatumBewaartermijn (brondatum) needs to be shown on the case detail page.

Solves PZ-8723