### PR TITLE
fix: event shows popup, always search `enkelvoudigeInformatieObjecten`

### DIFF
--- a/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.ts
+++ b/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.ts
@@ -149,27 +149,27 @@ export class ZaakDocumentenComponent
   }
 
   private loadInformatieObjecten(event?: ScreenEvent) {
-    if (!event?.objectId.detail) return;
-
-    this.informatieObjectenService
-      .readEnkelvoudigInformatieobjectByZaakInformatieobjectUUID(
-        event.objectId.detail,
-      )
-      .subscribe((enkelvoudigInformatieobject) => {
-        this.utilService
-          .openSnackbarAction(
-            "msg.document.toegevoegd.aan.zaak",
-            "actie.document.bekijken",
-            { document: enkelvoudigInformatieobject.titel },
-            7,
-          )
-          .subscribe(() => {
-            this.router.navigate([
-              "/informatie-objecten",
-              enkelvoudigInformatieobject.uuid,
-            ]);
-          });
-      });
+    if (event?.objectId.detail) {
+      this.informatieObjectenService
+        .readEnkelvoudigInformatieobjectByZaakInformatieobjectUUID(
+          event.objectId.detail,
+        )
+        .subscribe((enkelvoudigInformatieobject) => {
+          this.utilService
+            .openSnackbarAction(
+              "msg.document.toegevoegd.aan.zaak",
+              "actie.document.bekijken",
+              { document: enkelvoudigInformatieobject.titel },
+              7,
+            )
+            .subscribe(() => {
+              this.router.navigate([
+                "/informatie-objecten",
+                enkelvoudigInformatieobject.uuid,
+              ]);
+            });
+        });
+    }
 
     this.searchEnkelvoudigeInformatieObjecten();
   }


### PR DESCRIPTION
Fix a bug that was introduced by https://github.com/infonl/dimpact-zaakafhandelcomponent/pull/4335/files#diff-f0fd51e348bf68cd55b8d594d6c0cff97bc84670e76fbec025697af72ae5a7da

Solves [PZ-7129](https://dimpact.atlassian.net/browse/PZ-7129)