### PR TITLE
chore: created tests for resultaat

### DIFF
--- a/src/test/kotlin/nl/info/zac/app/decision/DecisionServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/decision/DecisionServiceTest.kt
@@ -370,4 +370,30 @@ class DecisionServiceTest : BehaviorSpec({
             }
         }
     }
+
+    Given("Zaak without resultaat, when a decision is made") {
+        val zaakWithoutResultaat = createZaak(resultaat = null)
+        val besluitToevoegenGegevens = createRestDecisionCreateData()
+        val besluit = createBesluit()
+
+        every { ztcClientService.readBesluittype(besluitToevoegenGegevens.besluittypeUuid) } returns besluitType
+        every { restDecisionConverter.convertToBesluit(zaakWithoutResultaat, besluitToevoegenGegevens) } returns besluit
+        every { brcClientService.createBesluit(besluit) } returns besluit
+        every {
+            drcClientService.readEnkelvoudigInformatieobject(
+                besluitToevoegenGegevens.informatieobjecten!!.first()
+            )
+        } returns enkelvoudigInformatieObject
+        every {
+            brcClientService.createBesluitInformatieobject(any<BesluitInformatieObject>(), "Aanmaken besluit")
+        } returns besluitInformatieObject
+
+        When("createDecision is called") {
+            decisionService.createDecision(zaakWithoutResultaat, besluitToevoegenGegevens)
+
+            Then("zaak.resultaat should still be null") {
+                zaakWithoutResultaat.resultaat shouldBe null
+            }
+        }
+    }
 })


### PR DESCRIPTION
Added unit tests to verify correct resultaat handling:

In DecisionServiceTest.kt, added a test to ensure resultaat is not set when a decision is made.
In PlanItemsRestServiceTest.kt, added a test to ensure resultaat is set when a case is closed via handleZaakAfhandelen.

These tests use mocks and validate the expected behavior for decision creation and case closure.

Solves PZ-8686