### PR TITLE
fix: searchbox selector for BPMN e2e tests

### DIFF
--- a/src/e2e/step-definitions/bpmn.ts
+++ b/src/e2e/step-definitions/bpmn.ts
@@ -37,7 +37,9 @@ Then(
       this.page.getByRole("button", { name: "Create" }),
     ).toBeVisible();
     await expect(
-      this.page.getByRole('searchbox', { name: 'Select one or more documents' })
+      this.page.getByRole("searchbox", {
+        name: "Select one or more documents",
+      }),
     ).toBeVisible();
     await expect(this.page.getByLabel("Communication channel")).toBeVisible();
   },
@@ -171,8 +173,14 @@ When(
     await this.page
       .getByRole("searchbox", { name: "Select one or more documents" })
       .fill("");
-    await this.page.getByLabel("Test form").getByText("file A", { exact: true }).click();
-    await this.page.getByLabel("Test form").getByText("file B", { exact: true }).click();
+    await this.page
+      .getByLabel("Test form")
+      .getByText("file A", { exact: true })
+      .click();
+    await this.page
+      .getByLabel("Test form")
+      .getByText("file B", { exact: true })
+      .click();
     await this.page.getByLabel("Communication channel").selectOption("E-mail");
     await this.page.getByLabel("Select result").click();
     await this.page.getByLabel("Select result").selectOption("Verleend");


### PR DESCRIPTION
e2e tests fail to find the list of documents attached to a task/zaak

Solves PZ-8789