### PR TITLE
fix: Added logic for showing RSIN in betrokkene list

### DIFF
--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.html
@@ -707,11 +707,25 @@
                       >
                         <mat-icon>visibility</mat-icon>
                       </a>
+                        <a
+                                *ngIf="
+                          (betrokkene.type === 'NIET_NATUURLIJK_PERSOON' ||
+                            betrokkene.type === 'VESTIGING') &&
+                          betrokkene.identificatieType === 'RSIN' &&
+                          betrokkene.identificatie
+                        "
+                                mat-icon-button
+                                [routerLink]="bedrijfRouteLink(betrokkene)"
+                                title="{{ 'actie.bedrijf.bekijken' | translate }}"
+                        >
+                            <mat-icon>visibility</mat-icon>
+                        </a>
                       <mat-icon
                         *ngIf="
                           (betrokkene.type === 'NIET_NATUURLIJK_PERSOON' ||
                             betrokkene.type === 'VESTIGING') &&
-                          !betrokkene.kvkNummer
+                            betrokkene.identificatieType != 'RSIN' &&
+                           !betrokkene.kvkNummer
                         "
                         class="mr-2"
                         color="warn"


### PR DESCRIPTION
This PR fixes the logic that shows the RSIN in the behandelaren list even when it has no KvK number. It also introduces another functionality that is needed which is getting a bedrijf for the `bedrijf-view.component.ts` through its RSIN.

Solves PZ-8749