### PR TITLE
feat(app): Contact details email - in every form email input make contact prevail initiator email

### DIFF
--- a/.claude/commands/migrate-ng19-standalone-components.md
+++ b/.claude/commands/migrate-ng19-standalone-components.md
@@ -1,6 +1,6 @@
 # Generic TDD Standalone Migration Plan
 
-**Progress: 75 remaining** (2026-04-08)
+**Progress: 71 remaining** (2026-04-09)
 Re-verify: `grep -rl "standalone: false" src/app --include="*.ts" | grep -v "spec.ts" | grep -v "material-form-builder" | wc -l` (from `src/main/app/`)
 
 ---

--- a/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie.ts
+++ b/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie.ts
@@ -88,10 +88,9 @@ export class AanvullendeInformatieFormulier extends AbstractTaakFormulier {
       Validators.required,
       Validators.email,
     ]);
-    if (zaak.zaakSpecificContactDetails?.emailAddress) {
-      emailControl.setValue(
-        zaak.zaakSpecificContactDetails?.emailAddress ?? null,
-      );
+    const emailAddress = zaak.zaakSpecificContactDetails?.emailAddress;
+    if (emailAddress) {
+      emailControl.setValue(emailAddress);
     } else {
       const temporaryPersonId = zaak.initiatorIdentificatie?.temporaryPersonId;
       if (temporaryPersonId) {

--- a/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie.ts
+++ b/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie.ts
@@ -88,18 +88,20 @@ export class AanvullendeInformatieFormulier extends AbstractTaakFormulier {
       Validators.required,
       Validators.email,
     ]);
-    if (
-      zaak.initiatorIdentificatie?.type &&
-      zaak.initiatorIdentificatie?.temporaryPersonId
-    ) {
-      this.klantenService
-        .getContactDetailsForPerson(
-          zaak.initiatorIdentificatie.temporaryPersonId,
-        )
-        .subscribe((value) => {
-          if (!value.emailadres) return;
-          emailControl.setValue(value.emailadres);
-        });
+    if (zaak.zaakSpecificContactDetails?.emailAddress) {
+      emailControl.setValue(
+        zaak.zaakSpecificContactDetails?.emailAddress ?? null,
+      );
+    } else {
+      const temporaryPersonId = zaak.initiatorIdentificatie?.temporaryPersonId;
+      if (temporaryPersonId) {
+        this.klantenService
+          .getContactDetailsForPerson(temporaryPersonId)
+          .subscribe((value) => {
+            if (!value.emailadres) return;
+            emailControl.setValue(value.emailadres);
+          });
+      }
     }
 
     const formFields: FormField[] = [

--- a/src/main/app/src/app/klanten/persoonsgegevens/persoonsgegevens.component.less
+++ b/src/main/app/src/app/klanten/persoonsgegevens/persoonsgegevens.component.less
@@ -19,6 +19,7 @@
 }
 
 .hint {
+  margin-left: 4px;
   color: #757575;
   font-size: 13px;
   font-style: italic;

--- a/src/main/app/src/app/mail/mail-create/mail-create.component.html
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.html
@@ -29,7 +29,7 @@
     <zac-input [form]="form" key="ontvanger">
       <button
         (click)="setOntvanger()"
-        *ngIf="contactEmailAdress"
+        *ngIf="contactEmailAddress"
         type="button"
         mat-icon-button
         matSuffix

--- a/src/main/app/src/app/mail/mail-create/mail-create.component.html
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.html
@@ -29,7 +29,7 @@
     <zac-input [form]="form" key="ontvanger">
       <button
         (click)="setOntvanger()"
-        *ngIf="this.contactGegevens?.emailadres"
+        *ngIf="contactEmailAdress"
         type="button"
         mat-icon-button
         matSuffix

--- a/src/main/app/src/app/mail/mail-create/mail-create.component.spec.ts
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.spec.ts
@@ -185,7 +185,7 @@ describe(MailCreateComponent.name, () => {
       expect(component["documents"]).toEqual(mockDocuments);
     });
 
-    it("should set contactEmailAddress from contact details when initiator has temporaryPersonId", () => {
+    it("should prioritize contact details email address when initiator has temporaryPersonId", () => {
       expect(component["contactEmailAddress"]).toEqual(
         mockContactGegevens.emailadres,
       );

--- a/src/main/app/src/app/mail/mail-create/mail-create.component.spec.ts
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.spec.ts
@@ -13,7 +13,6 @@ import {
   provideExperimentalZonelessChangeDetection,
 } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { ReactiveFormsModule } from "@angular/forms";
 import { MatDrawer } from "@angular/material/sidenav";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { TranslateModule } from "@ngx-translate/core";
@@ -25,9 +24,6 @@ import { UtilService } from "../../core/service/util.service";
 import { InformatieObjectenService } from "../../informatie-objecten/informatie-objecten.service";
 import { KlantenService } from "../../klanten/klanten.service";
 import { MailtemplateService } from "../../mailtemplate/mailtemplate.service";
-import { MaterialFormBuilderModule } from "../../shared/material-form-builder/material-form-builder.module";
-import { MaterialModule } from "../../shared/material/material.module";
-import { PipesModule } from "../../shared/pipes/pipes.module";
 import { GeneratedType } from "../../shared/utils/generated-types";
 import { ZakenService } from "../../zaken/zaken.service";
 import { MailService } from "../mail.service";
@@ -100,13 +96,9 @@ describe(MailCreateComponent.name, () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [MailCreateComponent],
       imports: [
-        ReactiveFormsModule,
+        MailCreateComponent,
         TranslateModule.forRoot(),
-        PipesModule,
-        MaterialModule,
-        MaterialFormBuilderModule,
         NoopAnimationsModule,
       ],
       providers: [

--- a/src/main/app/src/app/mail/mail-create/mail-create.component.spec.ts
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.spec.ts
@@ -185,8 +185,8 @@ describe(MailCreateComponent.name, () => {
       expect(component["documents"]).toEqual(mockDocuments);
     });
 
-    it("should set contactEmailAdress from contact details when initiator has temporaryPersonId", () => {
-      expect(component["contactEmailAdress"]).toEqual(
+    it("should set contactEmailAddress from contact details when initiator has temporaryPersonId", () => {
+      expect(component["contactEmailAddress"]).toEqual(
         mockContactGegevens.emailadres,
       );
     });
@@ -205,13 +205,13 @@ describe(MailCreateComponent.name, () => {
       jest.mocked(klantenService.getContactDetailsForPerson).mockClear();
       localFixture.detectChanges();
 
-      expect(localFixture.componentInstance["contactEmailAdress"]).toBe(
+      expect(localFixture.componentInstance["contactEmailAddress"]).toBe(
         emailAddress,
       );
       expect(klantenService.getContactDetailsForPerson).not.toHaveBeenCalled();
     });
 
-    it("should not set contactEmailAdress when initiator has no temporaryPersonId", () => {
+    it("should not set contactEmailAddress when initiator has no temporaryPersonId", () => {
       const localFixture = TestBed.createComponent(MailCreateComponent);
       localFixture.componentRef.setInput("sideNav", mockSideNav);
       localFixture.componentRef.setInput(
@@ -223,7 +223,7 @@ describe(MailCreateComponent.name, () => {
       );
       localFixture.detectChanges();
 
-      expect(localFixture.componentInstance["contactEmailAdress"]).toBeNull();
+      expect(localFixture.componentInstance["contactEmailAddress"]).toBeNull();
     });
   });
 
@@ -236,8 +236,8 @@ describe(MailCreateComponent.name, () => {
       );
     });
 
-    it("should set ontvanger to null when contactEmailAdress is null", () => {
-      component["contactEmailAdress"] = null;
+    it("should set ontvanger to null when contactEmailAddress is null", () => {
+      component["contactEmailAddress"] = null;
 
       component["setOntvanger"]();
 
@@ -261,8 +261,7 @@ describe(MailCreateComponent.name, () => {
 
       const req = httpTestingController.expectOne(
         (request) =>
-          request.url.includes("/rest/mail/send/") &&
-          request.method === "POST",
+          request.url.includes("/rest/mail/send/") && request.method === "POST",
       );
 
       expect(req.request.body).toMatchObject({
@@ -293,8 +292,7 @@ describe(MailCreateComponent.name, () => {
 
       const req = httpTestingController.expectOne(
         (request) =>
-          request.url.includes("/rest/mail/send/") &&
-          request.method === "POST",
+          request.url.includes("/rest/mail/send/") && request.method === "POST",
       );
 
       expect(req.request.body.bijlagen).toBe("doc-1;doc-2");
@@ -320,8 +318,7 @@ describe(MailCreateComponent.name, () => {
 
       const req = httpTestingController.expectOne(
         (request) =>
-          request.url.includes("/rest/mail/send/") &&
-          request.method === "POST",
+          request.url.includes("/rest/mail/send/") && request.method === "POST",
       );
 
       req.flush({});
@@ -351,8 +348,7 @@ describe(MailCreateComponent.name, () => {
 
       const req = httpTestingController.expectOne(
         (request) =>
-          request.url.includes("/rest/mail/send/") &&
-          request.method === "POST",
+          request.url.includes("/rest/mail/send/") && request.method === "POST",
       );
 
       req.flush({}, { status: 500, statusText: "Internal Server Error" });

--- a/src/main/app/src/app/mail/mail-create/mail-create.component.spec.ts
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.spec.ts
@@ -1,0 +1,365 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import { provideHttpClient } from "@angular/common/http";
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from "@angular/common/http/testing";
+import {
+  ComponentRef,
+  provideExperimentalZonelessChangeDetection,
+} from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ReactiveFormsModule } from "@angular/forms";
+import { MatDrawer } from "@angular/material/sidenav";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { TranslateModule } from "@ngx-translate/core";
+import { provideQueryClient } from "@tanstack/angular-query-experimental";
+import { of } from "rxjs";
+import { fromPartial } from "src/test-helpers";
+import { testQueryClient } from "../../../../setupJest";
+import { UtilService } from "../../core/service/util.service";
+import { InformatieObjectenService } from "../../informatie-objecten/informatie-objecten.service";
+import { KlantenService } from "../../klanten/klanten.service";
+import { MailtemplateService } from "../../mailtemplate/mailtemplate.service";
+import { MaterialFormBuilderModule } from "../../shared/material-form-builder/material-form-builder.module";
+import { MaterialModule } from "../../shared/material/material.module";
+import { PipesModule } from "../../shared/pipes/pipes.module";
+import { GeneratedType } from "../../shared/utils/generated-types";
+import { ZakenService } from "../../zaken/zaken.service";
+import { MailService } from "../mail.service";
+import { MailCreateComponent } from "./mail-create.component";
+
+describe(MailCreateComponent.name, () => {
+  let component: MailCreateComponent;
+  let componentRef: ComponentRef<MailCreateComponent>;
+  let fixture: ComponentFixture<MailCreateComponent>;
+  let httpTestingController: HttpTestingController;
+  let zakenService: ZakenService;
+  let informatieObjectenService: InformatieObjectenService;
+  let mailtemplateService: MailtemplateService;
+  let klantenService: KlantenService;
+  let utilService: UtilService;
+
+  const mockSideNav = fromPartial<MatDrawer>({
+    close: jest.fn(),
+  });
+
+  const mockZaak = fromPartial<GeneratedType<"RestZaak">>({
+    uuid: "test-zaak-uuid",
+    identificatie: "ZAAK-2025-001",
+    initiatorIdentificatie: fromPartial<
+      GeneratedType<"BetrokkeneIdentificatie">
+    >({
+      type: "BSN",
+      temporaryPersonId: "person-123",
+    }),
+  });
+
+  const mockAfzenders = [
+    fromPartial<GeneratedType<"RestZaakAfzender">>({
+      defaultMail: true,
+      id: 1,
+      mail: "beheerder@example.com",
+      speciaal: true,
+      suffix: "gegevens.mail.afzender.MEDEWERKER",
+    }),
+    fromPartial<GeneratedType<"RestZaakAfzender">>({
+      defaultMail: false,
+      mail: "gemeente@example.com",
+      speciaal: true,
+      suffix: "gegevens.mail.afzender.GEMEENTE",
+    }),
+  ];
+
+  const mockDefaultAfzender = mockAfzenders[0];
+
+  const mockMailtemplate = fromPartial<GeneratedType<"RESTMailtemplate">>({
+    onderwerp: "<p>Bevestiging ontvangst</p>",
+    body: "<p>Geachte,</p>",
+    variabelen: ["ZAAK_NUMMER", "ZAAK_TYPE"],
+  });
+
+  const mockDocuments = [
+    fromPartial<GeneratedType<"RestEnkelvoudigInformatieobject">>({
+      uuid: "doc-1",
+      titel: "Document 1",
+    }),
+    fromPartial<GeneratedType<"RestEnkelvoudigInformatieobject">>({
+      uuid: "doc-2",
+      titel: "Document 2",
+    }),
+  ];
+
+  const mockContactGegevens = fromPartial<GeneratedType<"RestContactDetails">>({
+    emailadres: "initiator@example.com",
+  });
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MailCreateComponent],
+      imports: [
+        ReactiveFormsModule,
+        TranslateModule.forRoot(),
+        PipesModule,
+        MaterialModule,
+        MaterialFormBuilderModule,
+        NoopAnimationsModule,
+      ],
+      providers: [
+        provideExperimentalZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideQueryClient(testQueryClient),
+        ZakenService,
+        InformatieObjectenService,
+        MailService,
+        MailtemplateService,
+        KlantenService,
+        UtilService,
+      ],
+    }).compileComponents();
+
+    zakenService = TestBed.inject(ZakenService);
+    informatieObjectenService = TestBed.inject(InformatieObjectenService);
+    mailtemplateService = TestBed.inject(MailtemplateService);
+    klantenService = TestBed.inject(KlantenService);
+    utilService = TestBed.inject(UtilService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    jest
+      .spyOn(zakenService, "listAfzendersVoorZaak")
+      .mockReturnValue(of(mockAfzenders));
+    jest
+      .spyOn(zakenService, "readDefaultAfzenderVoorZaak")
+      .mockReturnValue(of(mockDefaultAfzender));
+    jest
+      .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
+      .mockReturnValue(of(mockDocuments));
+    jest
+      .spyOn(mailtemplateService, "findMailtemplate")
+      .mockReturnValue(of(mockMailtemplate));
+    jest
+      .spyOn(klantenService, "getContactDetailsForPerson")
+      .mockReturnValue(of(mockContactGegevens));
+
+    fixture = TestBed.createComponent(MailCreateComponent);
+    componentRef = fixture.componentRef;
+    componentRef.setInput("sideNav", mockSideNav);
+    componentRef.setInput("zaak", mockZaak);
+
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    httpTestingController.verify();
+  });
+
+  describe("ngOnInit", () => {
+    it("should load verzender options", () => {
+      expect(component["verzenderOptions"]).toEqual(mockAfzenders);
+    });
+
+    it("should set default afzender in form", () => {
+      expect(component["form"].controls.verzender.value).toEqual(
+        mockDefaultAfzender,
+      );
+    });
+
+    it("should load mailtemplate and patch form values", () => {
+      expect(component["form"].controls.onderwerp.value).toEqual(
+        mockMailtemplate.onderwerp,
+      );
+      expect(component["form"].controls.body.value).toEqual(
+        mockMailtemplate.body,
+      );
+      expect(component["variabelen"]).toEqual(mockMailtemplate.variabelen);
+    });
+
+    it("should load documents for the zaak", () => {
+      expect(component["documents"]).toEqual(mockDocuments);
+    });
+
+    it("should set contactEmailAdress from contact details when initiator has temporaryPersonId", () => {
+      expect(component["contactEmailAdress"]).toEqual(
+        mockContactGegevens.emailadres,
+      );
+    });
+
+    it("should use zaakSpecificContactDetails email address when available and skip contact details lookup", () => {
+      const emailAddress = "zaak-contact@example.com";
+      const localFixture = TestBed.createComponent(MailCreateComponent);
+      localFixture.componentRef.setInput("sideNav", mockSideNav);
+      localFixture.componentRef.setInput(
+        "zaak",
+        fromPartial<GeneratedType<"RestZaak">>({
+          uuid: "test-zaak-uuid",
+          zaakSpecificContactDetails: fromPartial({ emailAddress }),
+        }),
+      );
+      jest.mocked(klantenService.getContactDetailsForPerson).mockClear();
+      localFixture.detectChanges();
+
+      expect(localFixture.componentInstance["contactEmailAdress"]).toBe(
+        emailAddress,
+      );
+      expect(klantenService.getContactDetailsForPerson).not.toHaveBeenCalled();
+    });
+
+    it("should not set contactEmailAdress when initiator has no temporaryPersonId", () => {
+      const localFixture = TestBed.createComponent(MailCreateComponent);
+      localFixture.componentRef.setInput("sideNav", mockSideNav);
+      localFixture.componentRef.setInput(
+        "zaak",
+        fromPartial<GeneratedType<"RestZaak">>({
+          uuid: "test-zaak-uuid",
+          initiatorIdentificatie: null,
+        }),
+      );
+      localFixture.detectChanges();
+
+      expect(localFixture.componentInstance["contactEmailAdress"]).toBeNull();
+    });
+  });
+
+  describe("setOntvanger", () => {
+    it("should set ontvanger field with contact email address", () => {
+      component["setOntvanger"]();
+
+      expect(component["form"].controls.ontvanger.value).toEqual(
+        mockContactGegevens.emailadres,
+      );
+    });
+
+    it("should set ontvanger to null when contactEmailAdress is null", () => {
+      component["contactEmailAdress"] = null;
+
+      component["setOntvanger"]();
+
+      expect(component["form"].controls.ontvanger.value).toBeNull();
+    });
+  });
+
+  describe("onFormSubmit", () => {
+    it("should call sendMail mutation with correct data", async () => {
+      component["form"].patchValue({
+        verzender: mockDefaultAfzender,
+        ontvanger: "recipient@example.com",
+        onderwerp: "<p>Test onderwerp</p>",
+        body: "<p>Test body</p>",
+        bijlagen: [mockDocuments[0]],
+      });
+
+      component.onFormSubmit();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const req = httpTestingController.expectOne(
+        (request) =>
+          request.url.includes("/rest/mail/send/") &&
+          request.method === "POST",
+      );
+
+      expect(req.request.body).toMatchObject({
+        verzender: mockDefaultAfzender.mail,
+        replyTo: undefined,
+        ontvanger: "recipient@example.com",
+        onderwerp: "Test onderwerp",
+        body: "<p>Test body</p>",
+        bijlagen: mockDocuments[0].uuid,
+        createDocumentFromMail: true,
+      });
+
+      req.flush({});
+    });
+
+    it("should join multiple bijlagen UUIDs with semicolon", async () => {
+      component["form"].patchValue({
+        verzender: mockDefaultAfzender,
+        ontvanger: "recipient@example.com",
+        onderwerp: "<p>Test onderwerp</p>",
+        body: "<p>Test body</p>",
+        bijlagen: mockDocuments,
+      });
+
+      component.onFormSubmit();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const req = httpTestingController.expectOne(
+        (request) =>
+          request.url.includes("/rest/mail/send/") &&
+          request.method === "POST",
+      );
+
+      expect(req.request.body.bijlagen).toBe("doc-1;doc-2");
+
+      req.flush({});
+    });
+
+    it("should emit mailVerstuurd(true) and show snackbar on success", async () => {
+      jest.spyOn(utilService, "openSnackbar");
+      const emitSpy = jest.spyOn(component["mailVerstuurd"], "emit");
+
+      component["form"].patchValue({
+        verzender: mockDefaultAfzender,
+        ontvanger: "recipient@example.com",
+        onderwerp: "<p>Test onderwerp</p>",
+        body: "<p>Test body</p>",
+        bijlagen: [],
+      });
+
+      component.onFormSubmit();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const req = httpTestingController.expectOne(
+        (request) =>
+          request.url.includes("/rest/mail/send/") &&
+          request.method === "POST",
+      );
+
+      req.flush({});
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(utilService.openSnackbar).toHaveBeenCalledWith(
+        "msg.email.verstuurd",
+      );
+      expect(emitSpy).toHaveBeenCalledWith(true);
+    });
+
+    it("should emit mailVerstuurd(false) on error", async () => {
+      const emitSpy = jest.spyOn(component["mailVerstuurd"], "emit");
+
+      component["form"].patchValue({
+        verzender: mockDefaultAfzender,
+        ontvanger: "recipient@example.com",
+        onderwerp: "<p>Test onderwerp</p>",
+        body: "<p>Test body</p>",
+        bijlagen: [],
+      });
+
+      component.onFormSubmit();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const req = httpTestingController.expectOne(
+        (request) =>
+          request.url.includes("/rest/mail/send/") &&
+          request.method === "POST",
+      );
+
+      req.flush({}, { status: 500, statusText: "Internal Server Error" });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(emitSpy).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/src/main/app/src/app/mail/mail-create/mail-create.component.ts
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.ts
@@ -3,15 +3,23 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
+import { NgIf } from "@angular/common";
 import { Component, input, OnInit, output } from "@angular/core";
-import { FormBuilder, Validators } from "@angular/forms";
+import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
+import { MatButtonModule } from "@angular/material/button";
+import { MatDividerModule } from "@angular/material/divider";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
 import { MatDrawer } from "@angular/material/sidenav";
+import { MatToolbarModule } from "@angular/material/toolbar";
+import { TranslateModule } from "@ngx-translate/core";
 import { injectMutation } from "@tanstack/angular-query-experimental";
 import { UtilService } from "../../core/service/util.service";
 import { InformatieObjectenService } from "../../informatie-objecten/informatie-objecten.service";
 import { KlantenService } from "../../klanten/klanten.service";
 import { MailtemplateService } from "../../mailtemplate/mailtemplate.service";
 import { DocumentenLijstFormField } from "../../shared/material-form-builder/form-components/documenten-lijst/documenten-lijst-form-field";
+import { MaterialFormBuilderModule } from "../../shared/material-form-builder/material-form-builder.module";
 import { GeneratedType } from "../../shared/utils/generated-types";
 import { ZakenService } from "../../zaken/zaken.service";
 import { MailService } from "../mail.service";
@@ -20,7 +28,18 @@ import { MailService } from "../mail.service";
   selector: "zac-mail-create",
   templateUrl: "./mail-create.component.html",
   styleUrls: ["./mail-create.component.less"],
-  standalone: false,
+  standalone: true,
+  imports: [
+    NgIf,
+    ReactiveFormsModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatButtonModule,
+    MatDividerModule,
+    MatFormFieldModule,
+    TranslateModule,
+    MaterialFormBuilderModule,
+  ],
 })
 export class MailCreateComponent implements OnInit {
   protected readonly zaak = input.required<GeneratedType<"RestZaak">>();

--- a/src/main/app/src/app/mail/mail-create/mail-create.component.ts
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.ts
@@ -62,7 +62,7 @@ export class MailCreateComponent implements OnInit {
   });
 
   protected verzenderOptions: GeneratedType<"RestZaakAfzender">[] = [];
-  protected contactGegevens: GeneratedType<"RestContactDetails"> | null = null;
+  protected contactEmailAdress: string | null = null;
   protected variabelen: string[] = [];
   protected documents: GeneratedType<"RestEnkelvoudigInformatieobject">[] = [];
 
@@ -107,14 +107,20 @@ export class MailCreateComponent implements OnInit {
         this.documents = documents;
       });
 
-    const initiatorIdentificatie = this.zaak().initiatorIdentificatie;
-    if (!initiatorIdentificatie?.temporaryPersonId) return;
+    const emailAddress = this.zaak().zaakSpecificContactDetails?.emailAddress;
+    if (emailAddress) {
+      this.contactEmailAdress = emailAddress;
+      return;
+    }
+
+    const temporaryPersonId =
+      this.zaak().initiatorIdentificatie?.temporaryPersonId;
+    if (!temporaryPersonId) return;
 
     this.klantenService
-      .getContactDetailsForPerson(initiatorIdentificatie.temporaryPersonId)
-      .subscribe((contactGegevens) => {
-        if (!contactGegevens.emailadres) return;
-        this.contactGegevens = contactGegevens;
+      .getContactDetailsForPerson(temporaryPersonId)
+      .subscribe((gegevens) => {
+        this.contactEmailAdress = gegevens?.emailadres ?? null;
       });
   }
 
@@ -133,8 +139,6 @@ export class MailCreateComponent implements OnInit {
   }
 
   protected setOntvanger() {
-    this.form.controls.ontvanger.setValue(
-      this.contactGegevens?.emailadres ?? null,
-    );
+    this.form.controls.ontvanger.setValue(this.contactEmailAdress ?? null);
   }
 }

--- a/src/main/app/src/app/mail/mail-create/mail-create.component.ts
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.ts
@@ -62,7 +62,7 @@ export class MailCreateComponent implements OnInit {
   });
 
   protected verzenderOptions: GeneratedType<"RestZaakAfzender">[] = [];
-  protected contactEmailAdress: string | null = null;
+  protected contactEmailAddress: string | null = null;
   protected variabelen: string[] = [];
   protected documents: GeneratedType<"RestEnkelvoudigInformatieobject">[] = [];
 
@@ -109,7 +109,7 @@ export class MailCreateComponent implements OnInit {
 
     const emailAddress = this.zaak().zaakSpecificContactDetails?.emailAddress;
     if (emailAddress) {
-      this.contactEmailAdress = emailAddress;
+      this.contactEmailAddress = emailAddress;
       return;
     }
 
@@ -120,7 +120,7 @@ export class MailCreateComponent implements OnInit {
     this.klantenService
       .getContactDetailsForPerson(temporaryPersonId)
       .subscribe((gegevens) => {
-        this.contactEmailAdress = gegevens?.emailadres ?? null;
+        this.contactEmailAddress = gegevens?.emailadres ?? null;
       });
   }
 
@@ -139,6 +139,6 @@ export class MailCreateComponent implements OnInit {
   }
 
   protected setOntvanger() {
-    this.form.controls.ontvanger.setValue(this.contactEmailAdress ?? null);
+    this.form.controls.ontvanger.setValue(this.contactEmailAddress ?? null);
   }
 }

--- a/src/main/app/src/app/mail/mail.module.ts
+++ b/src/main/app/src/app/mail/mail.module.ts
@@ -10,8 +10,7 @@ import { MailCreateComponent } from "./mail-create/mail-create.component";
 import { OntvangstbevestigingComponent } from "./ontvangstbevestiging/ontvangstbevestiging.component";
 
 @NgModule({
-  declarations: [MailCreateComponent],
+  imports: [SharedModule, MailCreateComponent, OntvangstbevestigingComponent],
   exports: [MailCreateComponent, OntvangstbevestigingComponent],
-  imports: [SharedModule, OntvangstbevestigingComponent],
 })
 export class MailModule {}

--- a/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.html
+++ b/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.html
@@ -31,7 +31,7 @@
     <zac-input [form]="form" key="ontvanger">
       <button
         (click)="setOntvanger()"
-        *ngIf="this.contactGegevens?.emailadres"
+        *ngIf="this.contactEmailAdress"
         type="button"
         mat-icon-button
         matSuffix

--- a/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.html
+++ b/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.html
@@ -31,7 +31,7 @@
     <zac-input [form]="form" key="ontvanger">
       <button
         (click)="setOntvanger()"
-        *ngIf="this.contactEmailAdress"
+        *ngIf="this.contactEmailAddress"
         type="button"
         mat-icon-button
         matSuffix

--- a/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.spec.ts
+++ b/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.spec.ts
@@ -207,7 +207,7 @@ describe(OntvangstbevestigingComponent.name, () => {
       expect(component["variables"]).toEqual(mockMailtemplate.variabelen);
     });
 
-    it("should set contactEmailAddress from contact details when initiator has temporaryPersonId", () => {
+    it("should prioritize contact details email address when initiator has temporaryPersonId", () => {
       expect(component["contactEmailAddress"]).toEqual(
         mockContactGegevens.emailadres,
       );

--- a/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.spec.ts
+++ b/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.spec.ts
@@ -207,8 +207,8 @@ describe(OntvangstbevestigingComponent.name, () => {
       expect(component["variables"]).toEqual(mockMailtemplate.variabelen);
     });
 
-    it("should set contactEmailAdress from contact details when initiator has temporaryPersonId", () => {
-      expect(component["contactEmailAdress"]).toEqual(
+    it("should set contactEmailAddress from contact details when initiator has temporaryPersonId", () => {
+      expect(component["contactEmailAddress"]).toEqual(
         mockContactGegevens.emailadres,
       );
     });
@@ -230,7 +230,9 @@ describe(OntvangstbevestigingComponent.name, () => {
       jest.mocked(klantenService.getContactDetailsForPerson).mockClear();
       fixture.detectChanges();
 
-      expect(fixture.componentInstance["contactEmailAdress"]).toBe(emailAddress);
+      expect(fixture.componentInstance["contactEmailAddress"]).toBe(
+        emailAddress,
+      );
       expect(klantenService.getContactDetailsForPerson).not.toHaveBeenCalled();
     });
 
@@ -248,7 +250,7 @@ describe(OntvangstbevestigingComponent.name, () => {
       component = fixture.componentInstance;
       fixture.detectChanges();
 
-      expect(component["contactEmailAdress"]).toBeNull();
+      expect(component["contactEmailAddress"]).toBeNull();
     });
   });
 
@@ -261,8 +263,8 @@ describe(OntvangstbevestigingComponent.name, () => {
       );
     });
 
-    it("should set ontvanger to null when contactEmailAdress is null", () => {
-      component["contactEmailAdress"] = null;
+    it("should set ontvanger to null when contactEmailAddress is null", () => {
+      component["contactEmailAddress"] = null;
 
       component.setOntvanger();
 

--- a/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.spec.ts
+++ b/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.spec.ts
@@ -207,8 +207,31 @@ describe(OntvangstbevestigingComponent.name, () => {
       expect(component["variables"]).toEqual(mockMailtemplate.variabelen);
     });
 
-    it("should load contact details when initiator has temporaryPersonId", () => {
-      expect(component["contactGegevens"]).toEqual(mockContactGegevens);
+    it("should set contactEmailAdress from contact details when initiator has temporaryPersonId", () => {
+      expect(component["contactEmailAdress"]).toEqual(
+        mockContactGegevens.emailadres,
+      );
+    });
+
+    it("should use zaakSpecificContactDetails email address when available and skip contact details lookup", () => {
+      const emailAddress = "zaak-contact@example.com";
+      fixture = TestBed.createComponent(OntvangstbevestigingComponent);
+      componentRef = fixture.componentRef;
+      componentRef.setInput("sideNav", mockSideNav);
+      componentRef.setInput(
+        "zaak",
+        fromPartial<GeneratedType<"RestZaak">>({
+          uuid: "test-zaak-uuid",
+          zaakSpecificContactDetails: fromPartial({
+            emailAddress,
+          }),
+        }),
+      );
+      jest.mocked(klantenService.getContactDetailsForPerson).mockClear();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance["contactEmailAdress"]).toBe(emailAddress);
+      expect(klantenService.getContactDetailsForPerson).not.toHaveBeenCalled();
     });
 
     it("should not load contact details when initiator has no temporaryPersonId", () => {
@@ -225,7 +248,7 @@ describe(OntvangstbevestigingComponent.name, () => {
       component = fixture.componentInstance;
       fixture.detectChanges();
 
-      expect(component["contactGegevens"]).toBeNull();
+      expect(component["contactEmailAdress"]).toBeNull();
     });
   });
 
@@ -238,13 +261,8 @@ describe(OntvangstbevestigingComponent.name, () => {
       );
     });
 
-    it("should set ontvanger to null when contactGegevens has no email", () => {
-      component["contactGegevens"] = fromPartial<
-        GeneratedType<"RestContactDetails">
-      >({
-        emailadres: null,
-        telefoonnummer: "0612345678",
-      });
+    it("should set ontvanger to null when contactEmailAdress is null", () => {
+      component["contactEmailAdress"] = null;
 
       component.setOntvanger();
 

--- a/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.ts
+++ b/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.ts
@@ -38,7 +38,7 @@ export class OntvangstbevestigingComponent implements OnInit {
 
   protected afzenders: GeneratedType<"RestZaakAfzender">[] = [];
   protected variables: GeneratedType<"MailTemplateVariables">[] = [];
-  protected contactGegevens: GeneratedType<"RestContactDetails"> | null = null;
+  protected contactEmailAdress: string | null = null;
   protected documents: GeneratedType<"RestEnkelvoudigInformatieobject">[] = [];
 
   protected readonly sendAcknowledgeReceiptMutation = injectMutation(() => ({
@@ -98,6 +98,13 @@ export class OntvangstbevestigingComponent implements OnInit {
         this.variables = mailtemplate?.variabelen ?? [];
       });
 
+    const emailAddress = this.zaak().zaakSpecificContactDetails?.emailAddress;
+
+    if (emailAddress) {
+      this.contactEmailAdress = emailAddress;
+      return;
+    }
+
     const temporaryPersonId =
       this.zaak().initiatorIdentificatie?.temporaryPersonId;
 
@@ -106,14 +113,12 @@ export class OntvangstbevestigingComponent implements OnInit {
     this.klantenService
       .getContactDetailsForPerson(temporaryPersonId)
       .subscribe((gegevens) => {
-        this.contactGegevens = gegevens;
+        this.contactEmailAdress = gegevens?.emailadres ?? null;
       });
   }
 
   setOntvanger() {
-    this.form.controls.ontvanger.setValue(
-      this.contactGegevens?.emailadres ?? null,
-    );
+    this.form.controls.ontvanger.setValue(this.contactEmailAdress ?? null);
   }
 
   submit() {

--- a/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.ts
+++ b/src/main/app/src/app/mail/ontvangstbevestiging/ontvangstbevestiging.component.ts
@@ -38,7 +38,7 @@ export class OntvangstbevestigingComponent implements OnInit {
 
   protected afzenders: GeneratedType<"RestZaakAfzender">[] = [];
   protected variables: GeneratedType<"MailTemplateVariables">[] = [];
-  protected contactEmailAdress: string | null = null;
+  protected contactEmailAddress: string | null = null;
   protected documents: GeneratedType<"RestEnkelvoudigInformatieobject">[] = [];
 
   protected readonly sendAcknowledgeReceiptMutation = injectMutation(() => ({
@@ -101,7 +101,7 @@ export class OntvangstbevestigingComponent implements OnInit {
     const emailAddress = this.zaak().zaakSpecificContactDetails?.emailAddress;
 
     if (emailAddress) {
-      this.contactEmailAdress = emailAddress;
+      this.contactEmailAddress = emailAddress;
       return;
     }
 
@@ -113,12 +113,12 @@ export class OntvangstbevestigingComponent implements OnInit {
     this.klantenService
       .getContactDetailsForPerson(temporaryPersonId)
       .subscribe((gegevens) => {
-        this.contactEmailAdress = gegevens?.emailadres ?? null;
+        this.contactEmailAddress = gegevens?.emailadres ?? null;
       });
   }
 
   setOntvanger() {
-    this.form.controls.ontvanger.setValue(this.contactEmailAdress ?? null);
+    this.form.controls.ontvanger.setValue(this.contactEmailAddress ?? null);
   }
 
   submit() {

--- a/src/main/app/src/app/shared/form/form-actions/form-actions.component.spec.ts
+++ b/src/main/app/src/app/shared/form/form-actions/form-actions.component.spec.ts
@@ -22,8 +22,11 @@ describe(ZacFormActions.name, () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ZacFormActions],
-      imports: [TranslateModule.forRoot(), NoopAnimationsModule],
+      imports: [
+        ZacFormActions,
+        TranslateModule.forRoot(),
+        NoopAnimationsModule,
+      ],
     }).compileComponents();
 
     const formBuilder = TestBed.inject(FormBuilder);

--- a/src/main/app/src/app/shared/form/form-actions/form-actions.component.ts
+++ b/src/main/app/src/app/shared/form/form-actions/form-actions.component.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import { Component, computed, ElementRef, inject, input, Signal } from "@angular/core";
+import {
+  Component,
+  computed,
+  ElementRef,
+  inject,
+  input,
+  Signal,
+} from "@angular/core";
 import { FormGroup } from "@angular/forms";
 
 @Component({
@@ -38,8 +45,9 @@ export class ZacFormActions {
 
   protected readonly form =
     input.required<Pick<FormGroup, "valid" | "disabled" | "dirty">>();
-  protected readonly mutation =
-    input.required<{ isPending: Signal<boolean> }>();
+  protected readonly mutation = input.required<{
+    isPending: Signal<boolean>;
+  }>();
 
   protected readonly onCancel = (event: MouseEvent) => {
     const cancelEvent = new CustomEvent("cancel", {

--- a/src/main/app/src/app/shared/form/form-actions/form-actions.component.ts
+++ b/src/main/app/src/app/shared/form/form-actions/form-actions.component.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
+import { NgTemplateOutlet } from "@angular/common";
 import {
   Component,
   computed,
@@ -12,11 +13,26 @@ import {
   Signal,
 } from "@angular/core";
 import { FormGroup } from "@angular/forms";
+import { MatButtonModule } from "@angular/material/button";
+import { MatDialogActions } from "@angular/material/dialog";
+import { MatExpansionPanelActionRow } from "@angular/material/expansion";
+import { MatIconModule } from "@angular/material/icon";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { TranslateModule } from "@ngx-translate/core";
 
 @Component({
   selector: "zac-form-actions",
   templateUrl: "./form-actions.component.html",
-  standalone: false,
+  standalone: true,
+  imports: [
+    NgTemplateOutlet,
+    MatDialogActions,
+    MatExpansionPanelActionRow,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+    MatIconModule,
+    TranslateModule,
+  ],
 })
 export class ZacFormActions {
   private readonly host = inject(ElementRef<HTMLElement>);

--- a/src/main/app/src/app/shared/form/form-actions/form-actions.component.ts
+++ b/src/main/app/src/app/shared/form/form-actions/form-actions.component.ts
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import { Component, computed, ElementRef, inject, input } from "@angular/core";
+import { Component, computed, ElementRef, inject, input, Signal } from "@angular/core";
 import { FormGroup } from "@angular/forms";
-import { CreateMutationResult } from "@tanstack/angular-query-experimental";
 
 @Component({
   selector: "zac-form-actions",
@@ -40,7 +39,7 @@ export class ZacFormActions {
   protected readonly form =
     input.required<Pick<FormGroup, "valid" | "disabled" | "dirty">>();
   protected readonly mutation =
-    input.required<Pick<CreateMutationResult, "isPending">>();
+    input.required<{ isPending: Signal<boolean> }>();
 
   protected readonly onCancel = (event: MouseEvent) => {
     const cancelEvent = new CustomEvent("cancel", {

--- a/src/main/app/src/app/shared/material-form-builder/material-form-builder.module.ts
+++ b/src/main/app/src/app/shared/material-form-builder/material-form-builder.module.ts
@@ -121,7 +121,6 @@ import { FormComponent } from "./form/form/form.component";
     ZacDocuments,
     ZacRadio,
     ZacForm,
-    ZacFormActions,
   ],
   exports: [
     FileDragAndDropDirective,
@@ -188,6 +187,7 @@ import { FormComponent } from "./form/form/form.component";
     MatExpansionPanelActionRow,
     EmptyPipe,
     CapitalizeFirstLetterPipe,
+    ZacFormActions,
   ],
   providers: [
     {

--- a/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.spec.ts
+++ b/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.spec.ts
@@ -45,20 +45,25 @@ describe(IntakeAfrondenDialogComponent.name, () => {
     emailadres: "initiator@example.com",
   });
 
-  const mockMailtemplateOntvankelijk =
-    fromPartial<GeneratedType<"RESTMailtemplate">>({
-      onderwerp: "Zaak ontvankelijk",
-      body: "<p>Uw zaak is ontvangen</p>",
-    });
+  const mockMailtemplateOntvankelijk = fromPartial<
+    GeneratedType<"RESTMailtemplate">
+  >({
+    onderwerp: "Zaak ontvankelijk",
+    body: "<p>Uw zaak is ontvangen</p>",
+  });
 
-  const mockMailtemplateNietOntvankelijk =
-    fromPartial<GeneratedType<"RESTMailtemplate">>({
-      onderwerp: "Zaak niet ontvankelijk",
-      body: "<p>Uw zaak is niet ontvankelijk</p>",
-    });
+  const mockMailtemplateNietOntvankelijk = fromPartial<
+    GeneratedType<"RESTMailtemplate">
+  >({
+    onderwerp: "Zaak niet ontvankelijk",
+    body: "<p>Uw zaak is niet ontvankelijk</p>",
+  });
 
   function makeZaak(
-    intakeMail: "BESCHIKBAAR_AAN" | "BESCHIKBAAR_UIT" | "NIET_BESCHIKBAAR" = "BESCHIKBAAR_AAN",
+    intakeMail:
+      | "BESCHIKBAAR_AAN"
+      | "BESCHIKBAAR_UIT"
+      | "NIET_BESCHIKBAAR" = "BESCHIKBAAR_AAN",
     temporaryPersonId: string | null = "person-123",
   ) {
     return fromPartial<GeneratedType<"RestZaak">>({
@@ -89,7 +94,10 @@ describe(IntakeAfrondenDialogComponent.name, () => {
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
-        { provide: MAT_DIALOG_DATA, useValue: { zaak, planItem: mockPlanItem } },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: { zaak, planItem: mockPlanItem },
+        },
         { provide: MatDialogRef, useValue: mockDialogRef },
         ZakenService,
         PlanItemsService,
@@ -163,9 +171,13 @@ describe(IntakeAfrondenDialogComponent.name, () => {
       const zaak = fromPartial<GeneratedType<"RestZaak">>({
         uuid: "zaak-uuid",
         zaaktype: fromPartial({
-          zaakafhandelparameters: fromPartial({ intakeMail: "BESCHIKBAAR_AAN" }),
+          zaakafhandelparameters: fromPartial({
+            intakeMail: "BESCHIKBAAR_AAN",
+          }),
         }),
-        zaakSpecificContactDetails: fromPartial({ emailAddress: "zaak@example.com" }),
+        zaakSpecificContactDetails: fromPartial({
+          emailAddress: "zaak@example.com",
+        }),
       });
       await setup(zaak);
 
@@ -256,9 +268,7 @@ describe(IntakeAfrondenDialogComponent.name, () => {
 
       component["afronden"]();
 
-      expect(
-        planItemsService.doUserEventListenerPlanItem,
-      ).toHaveBeenCalledWith(
+      expect(planItemsService.doUserEventListenerPlanItem).toHaveBeenCalledWith(
         expect.objectContaining({
           actie: "INTAKE_AFRONDEN",
           planItemInstanceId: mockPlanItem.id,
@@ -291,9 +301,7 @@ describe(IntakeAfrondenDialogComponent.name, () => {
 
       component["afronden"]();
 
-      expect(
-        planItemsService.doUserEventListenerPlanItem,
-      ).toHaveBeenCalledWith(
+      expect(planItemsService.doUserEventListenerPlanItem).toHaveBeenCalledWith(
         expect.objectContaining({
           restMailGegevens: expect.objectContaining({
             onderwerp: mockMailtemplateNietOntvankelijk.onderwerp,
@@ -312,9 +320,7 @@ describe(IntakeAfrondenDialogComponent.name, () => {
 
       component["afronden"]();
 
-      expect(
-        planItemsService.doUserEventListenerPlanItem,
-      ).toHaveBeenCalledWith(
+      expect(planItemsService.doUserEventListenerPlanItem).toHaveBeenCalledWith(
         expect.objectContaining({ restMailGegevens: null }),
       );
     });

--- a/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.spec.ts
+++ b/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.spec.ts
@@ -1,0 +1,344 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import { provideHttpClient } from "@angular/common/http";
+import { provideHttpClientTesting } from "@angular/common/http/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ReactiveFormsModule } from "@angular/forms";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { TranslateModule } from "@ngx-translate/core";
+import { of, throwError } from "rxjs";
+import { fromPartial } from "src/test-helpers";
+import { UtilService } from "../../core/service/util.service";
+import { KlantenService } from "../../klanten/klanten.service";
+import { MailtemplateService } from "../../mailtemplate/mailtemplate.service";
+import { PlanItemsService } from "../../plan-items/plan-items.service";
+import { MaterialModule } from "../../shared/material/material.module";
+import { GeneratedType } from "../../shared/utils/generated-types";
+import { ZakenService } from "../zaken.service";
+import { IntakeAfrondenDialogComponent } from "./intake-afronden-dialog.component";
+
+describe(IntakeAfrondenDialogComponent.name, () => {
+  let component: IntakeAfrondenDialogComponent;
+  let fixture: ComponentFixture<IntakeAfrondenDialogComponent>;
+  let zakenService: ZakenService;
+  let mailtemplateService: MailtemplateService;
+  let klantenService: KlantenService;
+  let planItemsService: PlanItemsService;
+  const mockDialogRef = { close: jest.fn() };
+
+  const mockPlanItem = fromPartial<GeneratedType<"RESTPlanItem">>({
+    id: "plan-item-1",
+    userEventListenerActie: "INTAKE_AFRONDEN",
+  });
+
+  const mockAfzender = fromPartial<GeneratedType<"RestZaakAfzender">>({
+    defaultMail: true,
+    mail: "beheerder@example.com",
+    replyTo: "reply@example.com",
+  });
+
+  const mockContactGegevens = fromPartial<GeneratedType<"RestContactDetails">>({
+    emailadres: "initiator@example.com",
+  });
+
+  const mockMailtemplateOntvankelijk =
+    fromPartial<GeneratedType<"RESTMailtemplate">>({
+      onderwerp: "Zaak ontvankelijk",
+      body: "<p>Uw zaak is ontvangen</p>",
+    });
+
+  const mockMailtemplateNietOntvankelijk =
+    fromPartial<GeneratedType<"RESTMailtemplate">>({
+      onderwerp: "Zaak niet ontvankelijk",
+      body: "<p>Uw zaak is niet ontvankelijk</p>",
+    });
+
+  function makeZaak(
+    intakeMail: "BESCHIKBAAR_AAN" | "BESCHIKBAAR_UIT" | "NIET_BESCHIKBAAR" = "BESCHIKBAAR_AAN",
+    temporaryPersonId: string | null = "person-123",
+  ) {
+    return fromPartial<GeneratedType<"RestZaak">>({
+      uuid: "zaak-uuid",
+      zaaktype: fromPartial({
+        zaakafhandelparameters: fromPartial({ intakeMail }),
+      }),
+      initiatorIdentificatie: temporaryPersonId
+        ? fromPartial<GeneratedType<"BetrokkeneIdentificatie">>({
+            type: "BSN",
+            temporaryPersonId,
+          })
+        : null,
+    });
+  }
+
+  async function setup(zaak: GeneratedType<"RestZaak"> = makeZaak()) {
+    mockDialogRef.close = jest.fn();
+
+    await TestBed.configureTestingModule({
+      declarations: [IntakeAfrondenDialogComponent],
+      imports: [
+        ReactiveFormsModule,
+        TranslateModule.forRoot(),
+        MaterialModule,
+        NoopAnimationsModule,
+      ],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: MAT_DIALOG_DATA, useValue: { zaak, planItem: mockPlanItem } },
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        ZakenService,
+        PlanItemsService,
+        MailtemplateService,
+        KlantenService,
+        UtilService,
+      ],
+    }).compileComponents();
+
+    zakenService = TestBed.inject(ZakenService);
+    mailtemplateService = TestBed.inject(MailtemplateService);
+    klantenService = TestBed.inject(KlantenService);
+    planItemsService = TestBed.inject(PlanItemsService);
+
+    jest
+      .spyOn(zakenService, "listAfzendersVoorZaak")
+      .mockReturnValue(of([mockAfzender]));
+    jest
+      .spyOn(zakenService, "readDefaultAfzenderVoorZaak")
+      .mockReturnValue(of(mockAfzender));
+    jest
+      .spyOn(mailtemplateService, "findMailtemplate")
+      .mockImplementation((key) =>
+        key === "ZAAK_ONTVANKELIJK"
+          ? of(mockMailtemplateOntvankelijk)
+          : of(mockMailtemplateNietOntvankelijk),
+      );
+    jest
+      .spyOn(klantenService, "getContactDetailsForPerson")
+      .mockReturnValue(of(mockContactGegevens));
+
+    fixture = TestBed.createComponent(IntakeAfrondenDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  describe("mail availability", () => {
+    it("mailBeschikbaar is true when intakeMail is BESCHIKBAAR_AAN", async () => {
+      await setup(makeZaak("BESCHIKBAAR_AAN"));
+      expect(component.mailBeschikbaar).toBe(true);
+    });
+
+    it("mailBeschikbaar is true when intakeMail is BESCHIKBAAR_UIT", async () => {
+      await setup(makeZaak("BESCHIKBAAR_UIT"));
+      expect(component.mailBeschikbaar).toBe(true);
+    });
+
+    it("mailBeschikbaar is false when intakeMail is NIET_BESCHIKBAAR", async () => {
+      await setup(makeZaak("NIET_BESCHIKBAAR"));
+      expect(component.mailBeschikbaar).toBe(false);
+    });
+
+    it("sendMailDefault is true when intakeMail is BESCHIKBAAR_AAN", async () => {
+      await setup(makeZaak("BESCHIKBAAR_AAN"));
+      expect(component.sendMailDefault).toBe(true);
+    });
+
+    it("sendMailDefault is false when intakeMail is BESCHIKBAAR_UIT", async () => {
+      await setup(makeZaak("BESCHIKBAAR_UIT"));
+      expect(component.sendMailDefault).toBe(false);
+    });
+  });
+
+  describe("initiatorEmail", () => {
+    it("is set from contact details when temporaryPersonId is present", async () => {
+      await setup(makeZaak("BESCHIKBAAR_AAN", "person-123"));
+      expect(component.initiatorEmail).toBe(mockContactGegevens.emailadres);
+    });
+
+    it("is set from zaakSpecificContactDetails when available, without calling klantenService", async () => {
+      const zaak = fromPartial<GeneratedType<"RestZaak">>({
+        uuid: "zaak-uuid",
+        zaaktype: fromPartial({
+          zaakafhandelparameters: fromPartial({ intakeMail: "BESCHIKBAAR_AAN" }),
+        }),
+        zaakSpecificContactDetails: fromPartial({ emailAddress: "zaak@example.com" }),
+      });
+      await setup(zaak);
+
+      expect(component.initiatorEmail).toBe("zaak@example.com");
+      expect(klantenService.getContactDetailsForPerson).not.toHaveBeenCalled();
+    });
+
+    it("is undefined when initiator has no temporaryPersonId", async () => {
+      await setup(makeZaak("BESCHIKBAAR_AAN", null));
+      expect(component.initiatorEmail).toBeUndefined();
+      expect(klantenService.getContactDetailsForPerson).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ontvankelijk validation", () => {
+    beforeEach(async () => setup());
+
+    it("makes reden required when ontvankelijk is false", () => {
+      component.formGroup.get("ontvankelijk")?.setValue(false);
+      expect(
+        component.formGroup.get("reden")?.errors?.["required"],
+      ).toBeTruthy();
+    });
+
+    it("clears reden required when ontvankelijk is true", () => {
+      component.formGroup.get("ontvankelijk")?.setValue(false);
+      component.formGroup.get("ontvankelijk")?.setValue(true);
+      expect(component.formGroup.get("reden")?.errors).toBeNull();
+    });
+  });
+
+  describe("sendMail toggle", () => {
+    beforeEach(async () => setup(makeZaak("BESCHIKBAAR_UIT")));
+
+    it("adds required validators to verzender and ontvanger when sendMail is checked", () => {
+      component.formGroup.get("sendMail")?.setValue(true);
+      component.formGroup.get("verzender")?.setValue(null); // clear pre-filled default
+      expect(
+        component.formGroup.get("verzender")?.errors?.["required"],
+      ).toBeTruthy();
+      expect(
+        component.formGroup.get("ontvanger")?.errors?.["required"],
+      ).toBeTruthy();
+    });
+
+    it("removes validators from verzender and ontvanger when sendMail is unchecked", () => {
+      component.formGroup.get("sendMail")?.setValue(true);
+      component.formGroup.get("sendMail")?.setValue(false);
+      expect(component.formGroup.get("verzender")?.errors).toBeNull();
+      expect(component.formGroup.get("ontvanger")?.errors).toBeNull();
+    });
+  });
+
+  describe("setInitiatorEmail", () => {
+    beforeEach(async () => setup());
+
+    it("sets ontvanger to initiatorEmail", () => {
+      component["setInitiatorEmail"]();
+      expect(component.formGroup.get("ontvanger")?.value).toBe(
+        component.initiatorEmail,
+      );
+    });
+  });
+
+  describe("close", () => {
+    beforeEach(async () => setup());
+
+    it("calls dialogRef.close()", () => {
+      component["close"]();
+      expect(mockDialogRef.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("afronden", () => {
+    beforeEach(async () => setup());
+
+    it("calls planItemsService with correct mail data when ontvankelijk and sendMail are true", () => {
+      jest
+        .spyOn(planItemsService, "doUserEventListenerPlanItem")
+        .mockReturnValue(of(undefined) as never);
+
+      component.formGroup.patchValue({
+        ontvankelijk: true,
+        sendMail: true,
+        verzender: mockAfzender,
+        ontvanger: "recipient@example.com",
+      });
+
+      component["afronden"]();
+
+      expect(
+        planItemsService.doUserEventListenerPlanItem,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actie: "INTAKE_AFRONDEN",
+          planItemInstanceId: mockPlanItem.id,
+          zaakUuid: "zaak-uuid",
+          zaakOntvankelijk: true,
+          restMailGegevens: expect.objectContaining({
+            verzender: mockAfzender.mail,
+            replyTo: mockAfzender.replyTo,
+            ontvanger: "recipient@example.com",
+            onderwerp: mockMailtemplateOntvankelijk.onderwerp,
+            body: mockMailtemplateOntvankelijk.body,
+            createDocumentFromMail: true,
+          }),
+        }),
+      );
+    });
+
+    it("uses niet-ontvankelijk mailtemplate when ontvankelijk is false", () => {
+      jest
+        .spyOn(planItemsService, "doUserEventListenerPlanItem")
+        .mockReturnValue(of(undefined) as never);
+
+      component.formGroup.patchValue({
+        ontvankelijk: false,
+        reden: "Onvoldoende informatie",
+        sendMail: true,
+        verzender: mockAfzender,
+        ontvanger: "recipient@example.com",
+      });
+
+      component["afronden"]();
+
+      expect(
+        planItemsService.doUserEventListenerPlanItem,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          restMailGegevens: expect.objectContaining({
+            onderwerp: mockMailtemplateNietOntvankelijk.onderwerp,
+            body: mockMailtemplateNietOntvankelijk.body,
+          }),
+        }),
+      );
+    });
+
+    it("sends null restMailGegevens when sendMail is false", () => {
+      jest
+        .spyOn(planItemsService, "doUserEventListenerPlanItem")
+        .mockReturnValue(of(undefined) as never);
+
+      component.formGroup.patchValue({ ontvankelijk: true, sendMail: false });
+
+      component["afronden"]();
+
+      expect(
+        planItemsService.doUserEventListenerPlanItem,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ restMailGegevens: null }),
+      );
+    });
+
+    it("closes dialog with true on success", () => {
+      jest
+        .spyOn(planItemsService, "doUserEventListenerPlanItem")
+        .mockReturnValue(of(undefined) as never);
+
+      component.formGroup.patchValue({ ontvankelijk: true });
+      component["afronden"]();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith(true);
+    });
+
+    it("closes dialog with false on error", () => {
+      jest
+        .spyOn(planItemsService, "doUserEventListenerPlanItem")
+        .mockReturnValue(throwError(() => new Error("server error")) as never);
+
+      component.formGroup.patchValue({ ontvankelijk: true });
+      component["afronden"]();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.spec.ts
+++ b/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.spec.ts
@@ -6,7 +6,6 @@
 import { provideHttpClient } from "@angular/common/http";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { ReactiveFormsModule } from "@angular/forms";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { TranslateModule } from "@ngx-translate/core";
@@ -16,7 +15,6 @@ import { UtilService } from "../../core/service/util.service";
 import { KlantenService } from "../../klanten/klanten.service";
 import { MailtemplateService } from "../../mailtemplate/mailtemplate.service";
 import { PlanItemsService } from "../../plan-items/plan-items.service";
-import { MaterialModule } from "../../shared/material/material.module";
 import { GeneratedType } from "../../shared/utils/generated-types";
 import { ZakenService } from "../zaken.service";
 import { IntakeAfrondenDialogComponent } from "./intake-afronden-dialog.component";
@@ -84,11 +82,9 @@ describe(IntakeAfrondenDialogComponent.name, () => {
     mockDialogRef.close = jest.fn();
 
     await TestBed.configureTestingModule({
-      declarations: [IntakeAfrondenDialogComponent],
       imports: [
-        ReactiveFormsModule,
+        IntakeAfrondenDialogComponent,
         TranslateModule.forRoot(),
-        MaterialModule,
         NoopAnimationsModule,
       ],
       providers: [

--- a/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.ts
+++ b/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.ts
@@ -77,7 +77,8 @@ export class IntakeAfrondenDialogComponent implements OnDestroy {
     this.mailBeschikbaar = zap?.intakeMail !== "NIET_BESCHIKBAAR";
     this.sendMailDefault = zap?.intakeMail === "BESCHIKBAAR_AAN";
 
-    const emailAddress = this.data.zaak.zaakSpecificContactDetails?.emailAddress;
+    const emailAddress =
+      this.data.zaak.zaakSpecificContactDetails?.emailAddress;
     if (emailAddress) {
       this.initiatorEmail = emailAddress;
     } else {

--- a/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.ts
+++ b/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.ts
@@ -3,15 +3,32 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
+import { AsyncPipe, NgFor, NgIf } from "@angular/common";
 import { Component, Inject, OnDestroy } from "@angular/core";
 import {
   AbstractControl,
   FormBuilder,
   FormGroup,
+  ReactiveFormsModule,
   Validators,
 } from "@angular/forms";
-import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
-import { TranslateService } from "@ngx-translate/core";
+import { MatButtonModule } from "@angular/material/button";
+import { MatCheckboxModule } from "@angular/material/checkbox";
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from "@angular/material/dialog";
+import { MatDividerModule } from "@angular/material/divider";
+import { MatExpansionModule } from "@angular/material/expansion";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
+import { MatInputModule } from "@angular/material/input";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { MatRadioModule } from "@angular/material/radio";
+import { MatSelectModule } from "@angular/material/select";
+import { MatToolbarModule } from "@angular/material/toolbar";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { Observable, Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { UtilService } from "../../core/service/util.service";
@@ -26,7 +43,26 @@ import { ZakenService } from "../zaken.service";
 @Component({
   templateUrl: "intake-afronden-dialog.component.html",
   styleUrls: ["./intake-afronden-dialog.component.less"],
-  standalone: false,
+  standalone: true,
+  imports: [
+    NgIf,
+    NgFor,
+    AsyncPipe,
+    ReactiveFormsModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatButtonModule,
+    MatDividerModule,
+    MatDialogModule,
+    MatRadioModule,
+    MatCheckboxModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatExpansionModule,
+    MatProgressSpinnerModule,
+    TranslateModule,
+  ],
 })
 export class IntakeAfrondenDialogComponent implements OnDestroy {
   loading = false;

--- a/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.ts
+++ b/src/main/app/src/app/zaken/intake-afronden-dialog/intake-afronden-dialog.component.ts
@@ -77,19 +77,21 @@ export class IntakeAfrondenDialogComponent implements OnDestroy {
     this.mailBeschikbaar = zap?.intakeMail !== "NIET_BESCHIKBAAR";
     this.sendMailDefault = zap?.intakeMail === "BESCHIKBAAR_AAN";
 
-    if (
-      this.data.zaak.initiatorIdentificatie?.type &&
-      this.data.zaak.initiatorIdentificatie?.temporaryPersonId
-    ) {
-      this.klantenService
-        .getContactDetailsForPerson(
-          this.data.zaak.initiatorIdentificatie.temporaryPersonId,
-        )
-        .subscribe((gegevens) => {
-          if (gegevens.emailadres) {
-            this.initiatorEmail = gegevens.emailadres;
-          }
-        });
+    const emailAddress = this.data.zaak.zaakSpecificContactDetails?.emailAddress;
+    if (emailAddress) {
+      this.initiatorEmail = emailAddress;
+    } else {
+      const temporaryPersonId =
+        this.data.zaak.initiatorIdentificatie?.temporaryPersonId;
+      if (temporaryPersonId) {
+        this.klantenService
+          .getContactDetailsForPerson(temporaryPersonId)
+          .subscribe((gegevens) => {
+            if (gegevens.emailadres) {
+              this.initiatorEmail = gegevens.emailadres;
+            }
+          });
+      }
     }
 
     this.formGroup = this.formBuilder.group({

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.html
@@ -136,6 +136,7 @@
       "
       mat-raised-button
       color="primary"
+      type="button"
       (click)="openBesluitVastleggen()"
     >
       {{ "actie.besluit.vastleggen" | translate }}

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.spec.ts
@@ -12,7 +12,6 @@ import {
 } from "@angular/common/http/testing";
 import { provideExperimentalZonelessChangeDetection } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { ReactiveFormsModule } from "@angular/forms";
 import { MatButtonHarness } from "@angular/material/button/testing";
 import { MatCheckboxHarness } from "@angular/material/checkbox/testing";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
@@ -28,10 +27,6 @@ import { fromPartial } from "src/test-helpers";
 import { testQueryClient } from "../../../../setupJest";
 import { KlantenService } from "../../klanten/klanten.service";
 import { MailtemplateService } from "../../mailtemplate/mailtemplate.service";
-import { MaterialFormBuilderModule } from "../../shared/material-form-builder/material-form-builder.module";
-import { MaterialModule } from "../../shared/material/material.module";
-import { PipesModule } from "../../shared/pipes/pipes.module";
-import { StaticTextComponent } from "../../shared/static-text/static-text.component";
 import { GeneratedType } from "../../shared/utils/generated-types";
 import { CustomValidators } from "../../shared/validators/customValidators";
 import { ZakenService } from "../zaken.service";
@@ -116,14 +111,9 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
     TestBed.resetTestingModule();
 
     await TestBed.configureTestingModule({
-      declarations: [ZaakAfhandelenDialogComponent],
       imports: [
-        StaticTextComponent,
-        ReactiveFormsModule,
+        ZaakAfhandelenDialogComponent,
         TranslateModule.forRoot(),
-        PipesModule,
-        MaterialModule,
-        MaterialFormBuilderModule,
         NoopAnimationsModule,
       ],
       providers: [

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.spec.ts
@@ -22,11 +22,12 @@ import { MatSelectHarness } from "@angular/material/select/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { TranslateModule } from "@ngx-translate/core";
 import { provideQueryClient } from "@tanstack/angular-query-experimental";
-import { QueryClient } from "@tanstack/query-core";
 import { randomUUID } from "crypto";
 import { of } from "rxjs";
 import { fromPartial } from "src/test-helpers";
 import { testQueryClient } from "../../../../setupJest";
+import { KlantenService } from "../../klanten/klanten.service";
+import { MailtemplateService } from "../../mailtemplate/mailtemplate.service";
 import { MaterialFormBuilderModule } from "../../shared/material-form-builder/material-form-builder.module";
 import { MaterialModule } from "../../shared/material/material.module";
 import { PipesModule } from "../../shared/pipes/pipes.module";
@@ -39,10 +40,10 @@ import { ZaakAfhandelenDialogComponent } from "./zaak-afhandelen-dialog.componen
 describe(ZaakAfhandelenDialogComponent.name, () => {
   let fixture: ComponentFixture<ZaakAfhandelenDialogComponent>;
   let loader: HarnessLoader;
-
-  let dialogRef: MatDialogRef<ZaakAfhandelenDialogComponent>;
-  let queryClient: QueryClient;
   let httpTestingController: HttpTestingController;
+  let zakenService: ZakenService;
+  let mailtemplateService: MailtemplateService;
+  let klantenService: KlantenService;
 
   const mockDialogRef = {
     close: jest.fn(),
@@ -108,12 +109,6 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
     body: "Test Body",
   });
 
-  const mockZakenService = {
-    listResultaattypes: jest.fn().mockReturnValue(of(mockResultaattypes)),
-    listAfzenders: jest.fn().mockReturnValue(of(mockAfzenders)),
-    getMailTemplate: jest.fn().mockReturnValue(of(mockMailtemplate)),
-  };
-
   const createTestBed = async (
     zaakMock: GeneratedType<"RestZaak">,
     planItemMock?: GeneratedType<"RESTPlanItem"> | null,
@@ -136,35 +131,56 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
         provideHttpClient(),
         provideHttpClientTesting(),
         provideQueryClient(testQueryClient),
-        {
-          provide: MatDialogRef,
-          useValue: mockDialogRef,
-        },
+        { provide: MatDialogRef, useValue: mockDialogRef },
         {
           provide: MAT_DIALOG_DATA,
-          useValue: {
-            zaak: zaakMock,
-            planItem: planItemMock,
-          },
+          useValue: { zaak: zaakMock, planItem: planItemMock },
         },
-        { provide: ZakenService, useValue: mockZakenService },
         CustomValidators,
+        ZakenService,
+        MailtemplateService,
+        KlantenService,
       ],
     }).compileComponents();
 
-    dialogRef = TestBed.inject(MatDialogRef);
-    queryClient = TestBed.inject(QueryClient);
     httpTestingController = TestBed.inject(HttpTestingController);
+    zakenService = TestBed.inject(ZakenService);
+    mailtemplateService = TestBed.inject(MailtemplateService);
+    klantenService = TestBed.inject(KlantenService);
 
-    queryClient.setQueryData(
+    jest
+      .spyOn(zakenService, "listResultaattypes")
+      .mockReturnValue(of(mockResultaattypes));
+    jest
+      .spyOn(zakenService, "listAfzendersVoorZaak")
+      .mockReturnValue(of(mockAfzenders));
+    jest
+      .spyOn(mailtemplateService, "findMailtemplate")
+      .mockReturnValue(of(mockMailtemplate));
+    jest
+      .spyOn(klantenService, "getContactDetailsForPerson")
+      .mockReturnValue(
+        of(
+          fromPartial<GeneratedType<"RestContactDetails">>({
+            emailadres: "initiator@example.com",
+          }),
+        ),
+      );
+
+    testQueryClient.setQueryData(
       ["resultaattypes", zaakMock.zaaktype.uuid],
       mockResultaattypes,
     );
-    queryClient.setQueryData(["afzenders", zaakMock.uuid], mockAfzenders);
-    queryClient.setQueryData(["mailtemplate", zaakMock.uuid], mockMailtemplate);
-    queryClient.setQueryData(
+    testQueryClient.setQueryData(["afzenders", zaakMock.uuid], mockAfzenders);
+    testQueryClient.setQueryData(
+      ["mailtemplate", zaakMock.uuid],
+      mockMailtemplate,
+    );
+    testQueryClient.setQueryData(
       ["initiatorEmail", zaakMock.initiatorIdentificatie?.temporaryPersonId],
-      { emailadres: "initiator@example.com" },
+      fromPartial<GeneratedType<"RestContactDetails">>({
+        emailadres: "initiator@example.com",
+      }),
     );
 
     fixture = TestBed.createComponent(ZaakAfhandelenDialogComponent);
@@ -173,7 +189,13 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
   };
 
   beforeEach(async () => {
+    mockDialogRef.close = jest.fn();
     await createTestBed(mockZaak, mockPlanItem);
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    httpTestingController.verify();
   });
 
   describe("sendMail checkbox", () => {
@@ -240,18 +262,16 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
       );
       await closeButton.click();
 
-      expect(dialogRef.close).toHaveBeenCalled();
+      expect(mockDialogRef.close).toHaveBeenCalled();
     });
   });
 
   describe("form validation", () => {
-    it("should disable submit button when form is invalid", async () => {
-      const submitButton = await loader.getHarness(
-        MatButtonHarness.with({ text: /actie\.zaak\.afhandelen/ }),
+    it("should disable submit button when form is invalid", () => {
+      const submitBtn = fixture.nativeElement.querySelector(
+        'button[type="submit"]',
       );
-      const isDisabled = await submitButton.isDisabled();
-
-      expect(isDisabled).toBe(true);
+      expect(submitBtn.disabled).toBe(true);
     });
 
     it("should enable submit button when form is valid", async () => {
@@ -260,13 +280,12 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
 
       const options = await resultaattypeSelect.getOptions();
       await options[2]?.click();
+      fixture.detectChanges();
 
-      const submitButton = await loader.getHarness(
-        MatButtonHarness.with({ text: /actie\.zaak\.afhandelen/ }),
+      const submitBtn = fixture.nativeElement.querySelector(
+        'button[type="submit"]',
       );
-      const isDisabled = await submitButton.isDisabled();
-
-      expect(isDisabled).toBe(false);
+      expect(submitBtn.disabled).toBe(false);
     });
   });
 
@@ -296,6 +315,7 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
           resultaattypeUuid: "resultaat-3",
         }),
       );
+      req.flush({});
     });
 
     it("should send over a 'brondatumEigenschap' when a brondatumEigenschap is required", async () => {
@@ -330,6 +350,7 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
           brondatumEigenschap: "2021-12-31T23:00:00.000Z",
         }),
       );
+      req.flush({});
     });
 
     it("should not allow the form to be submitted when a brondatumEigenschap is required", async () => {
@@ -338,13 +359,12 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
 
       const options = await resultaattypeSelect.getOptions();
       await options[0]?.click();
+      fixture.detectChanges();
 
-      const submitButton = await loader.getHarness(
-        MatButtonHarness.with({ text: /actie\.zaak\.afhandelen/ }),
+      const submitBtn = fixture.nativeElement.querySelector(
+        'button[type="submit"]',
       );
-      const isDisabled = await submitButton.isDisabled();
-
-      expect(isDisabled).toBe(true);
+      expect(submitBtn.disabled).toBe(true);
     });
   });
 
@@ -474,6 +494,29 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
     );
   });
 
+  describe("setInitiatorEmail", () => {
+    it("sets ontvanger to initiatorEmailQuery emailadres when no zaakSpecificContactDetails", () => {
+      fixture.componentInstance["setInitiatorEmail"]();
+      expect(
+        fixture.componentInstance.formGroup.controls.ontvanger.value,
+      ).toBe("initiator@example.com");
+    });
+
+    it("sets ontvanger to zaakSpecificContactDetails.emailAddress when available", async () => {
+      const mockZaakWithContact = fromPartial<GeneratedType<"RestZaak">>({
+        ...mockZaak,
+        uuid: "test-zaak-uuid-contact",
+        zaakSpecificContactDetails: fromPartial({ emailAddress: "contact@example.com" }),
+      });
+      await createTestBed(mockZaakWithContact, mockPlanItem);
+
+      fixture.componentInstance["setInitiatorEmail"]();
+      expect(
+        fixture.componentInstance.formGroup.controls.ontvanger.value,
+      ).toBe("contact@example.com");
+    });
+  });
+
   describe("Open dialog with zaakafhandelparameters afrondenMail BESCHIKBAAR_AAN", () => {
     beforeEach(async () => {
       const mockZaakWithAfrondenMailAan = fromPartial<
@@ -570,6 +613,7 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
           resultaattypeUuid: "resultaat-3",
         }),
       );
+      req.flush({});
     });
   });
 });

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.spec.ts
@@ -157,15 +157,13 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
     jest
       .spyOn(mailtemplateService, "findMailtemplate")
       .mockReturnValue(of(mockMailtemplate));
-    jest
-      .spyOn(klantenService, "getContactDetailsForPerson")
-      .mockReturnValue(
-        of(
-          fromPartial<GeneratedType<"RestContactDetails">>({
-            emailadres: "initiator@example.com",
-          }),
-        ),
-      );
+    jest.spyOn(klantenService, "getContactDetailsForPerson").mockReturnValue(
+      of(
+        fromPartial<GeneratedType<"RestContactDetails">>({
+          emailadres: "initiator@example.com",
+        }),
+      ),
+    );
 
     testQueryClient.setQueryData(
       ["resultaattypes", zaakMock.zaaktype.uuid],
@@ -497,23 +495,25 @@ describe(ZaakAfhandelenDialogComponent.name, () => {
   describe("setInitiatorEmail", () => {
     it("sets ontvanger to initiatorEmailQuery emailadres when no zaakSpecificContactDetails", () => {
       fixture.componentInstance["setInitiatorEmail"]();
-      expect(
-        fixture.componentInstance.formGroup.controls.ontvanger.value,
-      ).toBe("initiator@example.com");
+      expect(fixture.componentInstance.formGroup.controls.ontvanger.value).toBe(
+        "initiator@example.com",
+      );
     });
 
     it("sets ontvanger to zaakSpecificContactDetails.emailAddress when available", async () => {
       const mockZaakWithContact = fromPartial<GeneratedType<"RestZaak">>({
         ...mockZaak,
         uuid: "test-zaak-uuid-contact",
-        zaakSpecificContactDetails: fromPartial({ emailAddress: "contact@example.com" }),
+        zaakSpecificContactDetails: fromPartial({
+          emailAddress: "contact@example.com",
+        }),
       });
       await createTestBed(mockZaakWithContact, mockPlanItem);
 
       fixture.componentInstance["setInitiatorEmail"]();
-      expect(
-        fixture.componentInstance.formGroup.controls.ontvanger.value,
-      ).toBe("contact@example.com");
+      expect(fixture.componentInstance.formGroup.controls.ontvanger.value).toBe(
+        "contact@example.com",
+      );
     });
   });
 

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
@@ -237,7 +237,9 @@ export class ZaakAfhandelenDialogComponent {
   }
 
   protected setInitiatorEmail() {
-    const email = this.initiatorEmailQuery.data()?.emailadres;
+    const email =
+      this.data.zaak.zaakSpecificContactDetails?.emailAddress ??
+      this.initiatorEmailQuery.data()?.emailadres;
     this.formGroup.controls.ontvanger.setValue(email ?? null);
   }
 

--- a/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component.ts
@@ -3,10 +3,23 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
+import { NgFor, NgIf } from "@angular/common";
 import { Component, effect, inject } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { FormBuilder, Validators } from "@angular/forms";
-import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
+import { MatButtonModule } from "@angular/material/button";
+import { MatCheckboxModule } from "@angular/material/checkbox";
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from "@angular/material/dialog";
+import { MatDividerModule } from "@angular/material/divider";
+import { MatExpansionModule } from "@angular/material/expansion";
+import { MatIconModule } from "@angular/material/icon";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { MatToolbarModule } from "@angular/material/toolbar";
+import { TranslateModule } from "@ngx-translate/core";
 import {
   injectMutation,
   injectQuery,
@@ -17,6 +30,8 @@ import { FoutAfhandelingService } from "src/app/fout-afhandeling/fout-afhandelin
 import { KlantenService } from "../../klanten/klanten.service";
 import { MailtemplateService } from "../../mailtemplate/mailtemplate.service";
 import { ZacQueryClient } from "../../shared/http/zac-query-client";
+import { MaterialFormBuilderModule } from "../../shared/material-form-builder/material-form-builder.module";
+import { StaticTextComponent } from "../../shared/static-text/static-text.component";
 import { GeneratedType } from "../../shared/utils/generated-types";
 import { CustomValidators } from "../../shared/validators/customValidators";
 import { ZakenService } from "../zaken.service";
@@ -24,7 +39,23 @@ import { ZakenService } from "../zaken.service";
 @Component({
   templateUrl: "zaak-afhandelen-dialog.component.html",
   styleUrls: ["./zaak-afhandelen-dialog.component.less"],
-  standalone: false,
+  standalone: true,
+  imports: [
+    NgIf,
+    NgFor,
+    ReactiveFormsModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatButtonModule,
+    MatDividerModule,
+    MatDialogModule,
+    MatCheckboxModule,
+    MatExpansionModule,
+    MatProgressSpinnerModule,
+    TranslateModule,
+    StaticTextComponent,
+    MaterialFormBuilderModule,
+  ],
 })
 export class ZaakAfhandelenDialogComponent {
   private readonly dialogRef = inject(

--- a/src/main/app/src/app/zaken/zaken.module.ts
+++ b/src/main/app/src/app/zaken/zaken.module.ts
@@ -21,8 +21,6 @@ import { ZoekenModule } from "../zoeken/zoeken.module";
 import { BesluitCreateComponent } from "./besluit-create/besluit-create.component";
 import { BesluitEditComponent } from "./besluit-edit/besluit-edit.component";
 import { BesluitViewComponent } from "./besluit-view/besluit-view.component";
-import { IntakeAfrondenDialogComponent } from "./intake-afronden-dialog/intake-afronden-dialog.component";
-import { ZaakAfhandelenDialogComponent } from "./zaak-afhandelen-dialog/zaak-afhandelen-dialog.component";
 import { ZaakCreateComponent } from "./zaak-create/zaak-create.component";
 import { CaseDetailsEditComponent } from "./zaak-details-wijzigen/zaak-details-wijzigen.component";
 import { ZaakDocumentenComponent } from "./zaak-documenten/zaak-documenten.component";
@@ -48,7 +46,6 @@ import { ZakenWerkvoorraadComponent } from "./zaken-werkvoorraad/zaken-werkvoorr
     BesluitCreateComponent,
     BesluitEditComponent,
     BesluitViewComponent,
-    IntakeAfrondenDialogComponent,
     ZaakViewComponent,
     BetrokkeneLinkComponent,
     ZaakVerkortComponent,
@@ -56,7 +53,6 @@ import { ZakenWerkvoorraadComponent } from "./zaken-werkvoorraad/zaken-werkvoorr
     ZakenWerkvoorraadComponent,
     ZakenMijnComponent,
     ZakenAfgehandeldComponent,
-    ZaakAfhandelenDialogComponent,
     ZakenVerdelenDialogComponent,
     ZaakOntkoppelenDialogComponent,
     ZakenVrijgevenDialogComponent,


### PR DESCRIPTION
FE - Contact details email - in every form email input make contact prevail initiator email

Touched components/forms that now let contact details email prevail the initiator email:

- formulieren/taken/model/aanvullende-informatie.ts — form model
- klanten/persoonsgegevens/persoonsgegevens.component — styles only
- mail/mail-create/mail-create.component — template, spec, and logic
- mail/ontvangstbevestiging/ontvangstbevestiging.component — template, spec, and logic
- zaken/intake-afronden-dialog/intake-afronden-dialog.component — spec and logic
- zaken/zaak-afhandelen-dialog/zaak-afhandelen-dialog.component — template, spec, and logic

Solves PZ-10629