### PR TITLE
feat: PZ-10765 Add initiator and other betrokken to BPMN zaak from productaanvraag

### DIFF
--- a/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
+++ b/src/main/kotlin/nl/info/zac/productaanvraag/ProductaanvraagService.kt
@@ -36,6 +36,7 @@ import nl.info.zac.admin.ZaaktypeBpmnConfigurationBeheerService
 import nl.info.zac.admin.ZaaktypeCmmnConfigurationBeheerService
 import nl.info.zac.admin.model.ZaaktypeBpmnConfiguration
 import nl.info.zac.admin.model.ZaaktypeCmmnConfiguration
+import nl.info.zac.admin.model.ZaaktypeConfiguration
 import nl.info.zac.app.zaak.exception.ExplanationRequiredException
 import nl.info.zac.configuration.ConfigurationService
 import nl.info.zac.document.inboxdocument.InboxDocumentService
@@ -346,10 +347,14 @@ class ProductaanvraagService @Inject constructor(
         zaaktypeBpmnConfiguration.groepID?.let {
             assignZaakToGroup(zaak = zaak, groupName = it)
         }
-        // note: BPMN zaaktypes do not yet support a default employee to be assigned to the zaak, as is the case for CMMN
         pairDocumentsWithZaak(productaanvraagDimpact = productaanvraagDimpact, zaak = zaak)
-        // note: BPMN zaaktypes do not yet support adding an initiator nor other betrokkenen to the zaak, as is the case for CMMN
-        // note: BPMN zaaktypes do not yet support automatic email notifications, as is the case for CMMN
+        productaanvraagBetrokkeneService.addInitiatorAndBetrokkenenToZaak(
+            productaanvraag = productaanvraagDimpact,
+            zaak = zaak,
+            brpEnabled = isBrpEnabled(zaaktypeBpmnConfiguration),
+            kvkEnabled = isKvkEnabled(zaaktypeBpmnConfiguration)
+        )
+        // note: BPMN zaaktypes do not support automatic email notifications, as is the case for CMMN
         klantClientService.findProductaanvraagSpecificContactDetails(
             productaanvraagDimpact.bron.kenmerk
         )?.let {
@@ -459,11 +464,11 @@ class ProductaanvraagService @Inject constructor(
         )
     }
 
-    private fun isBrpEnabled(zaaktypeCmmnConfiguration: ZaaktypeCmmnConfiguration) =
-        zaaktypeCmmnConfiguration.zaaktypeBetrokkeneParameters?.brpKoppelen ?: false
+    private fun isBrpEnabled(zaaktypeConfiguration: ZaaktypeConfiguration) =
+        zaaktypeConfiguration.zaaktypeBetrokkeneParameters?.brpKoppelen ?: false
 
-    private fun isKvkEnabled(zaaktypeCmmnConfiguration: ZaaktypeCmmnConfiguration) =
-        zaaktypeCmmnConfiguration.zaaktypeBetrokkeneParameters?.kvkKoppelen ?: false
+    private fun isKvkEnabled(zaaktypeConfiguration: ZaaktypeConfiguration) =
+        zaaktypeConfiguration.zaaktypeBetrokkeneParameters?.kvkKoppelen ?: false
 
     private fun generateProductaanvraagDescription(productaanvraag: ProductaanvraagDimpact) =
         "Productaanvraag '${productaanvraag.bron.naam}' with characteristics '${productaanvraag.bron.kenmerk}' and " +

--- a/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -16,6 +16,7 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import net.atos.client.zgw.zrc.model.Rol
+import net.atos.client.zgw.zrc.model.RolNatuurlijkPersoon
 import net.atos.client.zgw.zrc.model.RolOrganisatorischeEenheid
 import net.atos.zac.admin.ZaaktypeCmmnConfigurationService
 import net.atos.zac.flowable.cmmn.CMMNService
@@ -373,7 +374,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                     }
                 }
 
-                And("the productaanvraag emakl service should be called to send a confirmation of receipt email") {
+                And("the productaanvraag email service should be called to send a confirmation of receipt email") {
                     verify(exactly = 1) {
                         productaanvraagEmailService.sendConfirmationOfReceiptEmailFromProductaanvraag(
                             createdZaak,
@@ -1489,6 +1490,10 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                 zaakTypeUri = zaakType.url,
                 omschrijvingGeneriek = OmschrijvingGeneriekEnum.BEHANDELAAR
             )
+            val rolTypeInitiator = createRolType(
+                zaakTypeUri = zaakType.url,
+                omschrijvingGeneriek = OmschrijvingGeneriekEnum.INITIATOR
+            )
             val bsnNumber = "123456789"
             val productAanvraagORObject = createORObject(
                 record = createObjectRecord(
@@ -1513,6 +1518,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
 
             )
             val zaakDataSlot = slot<Map<String, Any>>()
+            val createdRolSlot = slot<Rol<*>>()
             every { objectsClientService.readObject(productAanvraagObjectUUID) } returns productAanvraagORObject
             every { klantClientService.findProductaanvraagSpecificContactDetails(formulierBron.kenmerk) } returns null
             every {
@@ -1538,7 +1544,8 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             every {
                 ztcClientService.readRoltype(createdZaak.zaaktype, OmschrijvingGeneriekEnum.BEHANDELAAR)
             } returns behandelaarRolType
-            every { zrcClientService.createRol(any<RolOrganisatorischeEenheid>()) } returns createRolOrganisatorischeEenheid()
+            every { ztcClientService.findRoltypen(any(), "Initiator") } returns listOf(rolTypeInitiator)
+            every { zrcClientService.createRol(capture(createdRolSlot)) } returns mockk()
 
             When("the productaanvraag is handled") {
                 productaanvraagService.handleProductaanvraag(productAanvraagObjectUUID)
@@ -1562,7 +1569,18 @@ class ProductaanvraagServiceTest : BehaviorSpec({
                 }
                 And("the group role should be created for the assigned group") {
                     verify(exactly = 1) {
-                        zrcClientService.createRol(any())
+                        zrcClientService.createRol(any<RolOrganisatorischeEenheid>())
+                    }
+                }
+                And("the initiator betrokkene role should be added to the zaak") {
+                    verify(exactly = 1) {
+                        zrcClientService.createRol(any<RolNatuurlijkPersoon>())
+                    }
+                    with(createdRolSlot.captured) {
+                        betrokkeneType shouldBe BetrokkeneTypeEnum.NATUURLIJK_PERSOON
+                        identificatienummer shouldBe bsnNumber
+                        roltype shouldBe rolTypeInitiator.url
+                        zaak shouldBe createdZaak.url
                     }
                 }
                 And("no CMMN process be started") {


### PR DESCRIPTION
Adds initiator and other betrokkenen to BPMN zaken the same as it is done for CMMN zaken.

Solves [PZ-10765]