### PR TITLE
chore: only allow JRE 21 versions in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -637,7 +637,7 @@
         "docker"
       ],
       "versioning": "loose",
-      "allowedVersions": "/jre-ubi10-minimal$/"
+      "allowedVersions": "/^21.*jre-ubi10-minimal$/"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
Only allow JRE 21 versions in Renovate. Any JRE above 21 is not supported (yet) by WildFly.

Solves PZ-10852