### PR TITLE
feature: E2E check taakgegevens from plan item when opening a task form   

### DIFF
--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -108,8 +108,13 @@ When(
 
     const expectedDate = new Date();
     expectedDate.setDate(expectedDate.getDate() + 14);
+    const expectedDateString = [
+      expectedDate.getFullYear(),
+      String(expectedDate.getMonth() + 1).padStart(2, "0"),
+      String(expectedDate.getDate()).padStart(2, "0"),
+    ].join("-");
     await this.expect(this.page.getByLabel("Fatale datum")).toHaveValue(
-      expectedDate.toISOString().split("T")[0],
+      expectedDateString,
     );
 
     await this.expect(

--- a/src/e2e/step-definitions/zaak.ts
+++ b/src/e2e/step-definitions/zaak.ts
@@ -94,6 +94,8 @@ When(
     user2: z.infer<typeof worldUsers>,
   ) {
     const zaakNumber = this.testStorage.get("caseNumber");
+    const user1Parsed = worldUsers.parse(user1);
+    const user1Profile = users[user1Parsed];
     const user2Parsed = worldUsers.parse(user2);
     const user2Profile = users[user2Parsed];
 
@@ -103,6 +105,16 @@ When(
       .locator("mat-label", { hasText: "E-mailadres" })
       .first()
       .fill("e2e-test@team-dimpact.info.nl");
+
+    const expectedDate = new Date();
+    expectedDate.setDate(expectedDate.getDate() + 14);
+    await this.expect(this.page.getByLabel("Fatale datum")).toHaveValue(
+      expectedDate.toISOString().split("T")[0],
+    );
+
+    await this.expect(
+      this.page.getByLabel("Taak toekennen aan groep").first(),
+    ).toHaveValue(user1Profile.group);
 
     await this.page.getByLabel("Taak toekennen aan groep").first().click();
     await this.page

--- a/src/e2e/support/worlds/groups.ts
+++ b/src/e2e/support/worlds/groups.ts
@@ -4,11 +4,11 @@
  */
 
 const TestGroupA = {
-  name: "Test Groep A",
+  name: "Test groep A",
 };
 
 const TestGroupB = {
-  name: "Test Groep B",
+  name: "Test groep B",
 };
 
 export const groups = {


### PR DESCRIPTION
When opening a human task form, the groepId and fataleDatum configured on the plan item were being ignored. This PR pre-selects the group and pre-fills the deadline date from the plan item so handlers don't have to set them  
  manually.                                                                                                                                                                                                                          
                                                                                                                                                                                                                                     
Also adds e2e assertions to verify both fields are correctly populated, and fixes the capitalisation of test group names to match what the application actually displays.

Solves PZ-10376