### PR TITLE
feat: overhaul versioning to use rolling dev pre-releases and proper hotfix patch versions

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -10,12 +10,11 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: 'Select the version bump.'
+        description: 'Select the version bump for a sprint release.'
         type: choice
         required: true
-        default: 'patch'
+        default: 'minor'
         options:
-          - patch
           - minor
           - major
       hotfix_version:
@@ -51,12 +50,12 @@ jobs:
   validate-input:
     runs-on: ubuntu-24.04
     outputs:
-      version-bump: ${{ github.event.inputs.confirm || 'patch' }}
+      version-bump: ${{ github.event.inputs.confirm || 'minor' }}
     steps:
       - name: Use selected version bump
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          echo "Version will be bumped to next ${{ github.event.inputs.confirm || 'patch' }} number."
+          echo "Version will be bumped to next ${{ github.event.inputs.confirm || 'minor' }} number."
 
       - name: Manual version bump only allowed on main branch
         if: ${{ github.ref != 'refs/heads/main' && github.event_name == 'workflow_dispatch' && (!startsWith(github.ref_name, 'hotfix/') || github.event.inputs.hotfix_version == '') }}
@@ -68,10 +67,10 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [validate-input]
     outputs:
-      version: ${{ steps.set-hotfix-version.outputs.version || steps.get-version.outputs.version }}
-      tag: ${{ steps.set-hotfix-version.outputs.tag || steps.get-version.outputs.tag }}
+      version: ${{ steps.set-hotfix-version.outputs.version || steps.calc-version.outputs.version }}
+      tag: ${{ steps.set-hotfix-version.outputs.tag || steps.calc-version.outputs.tag }}
+      release-type: ${{ steps.release-type.outputs.release-type }}
     steps:
-      # Checkout the repository including tags
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -113,45 +112,59 @@ jobs:
           echo "tag=v${{ github.event.inputs.hotfix_version }}" >> "$GITHUB_OUTPUT"
           echo "Calculated version: ${{ github.event.inputs.hotfix_version }} (tag: v${{ github.event.inputs.hotfix_version }})"
 
-      - name: Get next tag on main
-        if: ${{ !startsWith(github.ref_name, 'hotfix/') && github.ref == 'refs/heads/main' }}
-        id: get-tag-main
-        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRERELEASE: false
-          DEFAULT_BUMP: ${{ needs.validate-input.outputs.version-bump }}
-          FORCE_WITHOUT_CHANGES: ${{ needs.validate-input.outputs.version-bump != 'patch' }}
-          WITH_V: true
-          RELEASE_BRANCHES: main
-          BRANCH_HISTORY: last
-
-      - name: Get next tag on non-main (dry run)
-        if: ${{ !startsWith(github.ref_name, 'hotfix/') && github.ref != 'refs/heads/main' }}
-        id: get-tag-non-main
-        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRERELEASE: false
-          DEFAULT_BUMP: ${{ needs.validate-input.outputs.version-bump }}
-          WITH_V: true
-          RELEASE_BRANCHES: main
-          DRY_RUN: true
-          BRANCH_HISTORY: last
-
-      - name: Extract version (non-hotfix)
-        if: ${{ !startsWith(github.ref_name, 'hotfix/') }}
-        id: get-version
+      - name: Determine release type
+        id: release-type
         run: |
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            TAG='${{ steps.get-tag-main.outputs.new_tag }}'
+          if [[ "${{ startsWith(github.ref_name, 'hotfix/') }}" == "true" ]]; then
+            echo "release-type=hotfix" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "release-type=release" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "release-type=dev" >> "$GITHUB_OUTPUT"
           else
-            TAG='${{ steps.get-tag-non-main.outputs.new_tag }}'
+            echo "release-type=none" >> "$GITHUB_OUTPUT"
           fi
-          VERSION="${TAG#v}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Calculated version: $VERSION (tag: $TAG)"
+
+      - name: Calculate next version
+        if: ${{ !startsWith(github.ref_name, 'hotfix/') }}
+        id: calc-version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST_TAG=$(gh release list --exclude-pre-releases --limit 1 --json tagName -q '.[0].tagName // ""' 2>/dev/null || echo "")
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No previous release found. Starting from v0.0.0"
+            LATEST_TAG="v0.0.0"
+          fi
+          echo "Latest release tag: $LATEST_TAG"
+
+          VERSION="${LATEST_TAG#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+
+          RELEASE_TYPE="${{ steps.release-type.outputs.release-type }}"
+
+          if [ "$RELEASE_TYPE" = "dev" ]; then
+            # Dev builds always assume next minor version
+            MINOR=$((MINOR + 1))
+            NEXT_VERSION="${MAJOR}.${MINOR}.0-dev"
+          else
+            BUMP_TYPE="${{ needs.validate-input.outputs.version-bump }}"
+            case "$BUMP_TYPE" in
+              major)
+                MAJOR=$((MAJOR + 1))
+                MINOR=0
+                ;;
+              minor)
+                MINOR=$((MINOR + 1))
+                ;;
+            esac
+            NEXT_VERSION="${MAJOR}.${MINOR}.0"
+          fi
+
+          echo "version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Calculated version: ${NEXT_VERSION} (release type: ${RELEASE_TYPE})"
 
   paths-filter:
     runs-on: ubuntu-24.04
@@ -245,7 +258,7 @@ jobs:
       # https://github.com/diffplug/spotless/issues/651
       - name: Gradle build
         run: |
-          if [ "${{ needs.validate-input.outputs.version-bump }}" != "patch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             ./gradlew clean build -x test --info --no-configuration-cache
           else
             ./gradlew build -x test --info --no-configuration-cache
@@ -507,6 +520,7 @@ jobs:
     env:
       ZAC_DOCKER_IMAGE: ${{ needs.build.outputs.zac_docker_image }}
       NEXT_VERSION: ${{ needs.determine-version.outputs.version }}
+      RELEASE_TYPE: ${{ needs.determine-version.outputs.release-type }}
     steps:
       - name: Docker Login
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -528,11 +542,17 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: docker tag ${ZAC_DOCKER_IMAGE} ${CONTAINER_REGISTRY_URL}/${APPLICATION_NAME}:latest
 
-      - name: Tag Docker Image with next version tag
+      - name: Tag Docker Image with version tag
         if: env.NEXT_VERSION != ''
+        run: docker tag ${ZAC_DOCKER_IMAGE} ${CONTAINER_REGISTRY_URL}/${APPLICATION_NAME}:${NEXT_VERSION}
+
+      - name: Tag Docker Image with pinned dev build number tag
+        if: ${{ env.RELEASE_TYPE == 'dev' }}
+        run: docker tag ${ZAC_DOCKER_IMAGE} ${CONTAINER_REGISTRY_URL}/${APPLICATION_NAME}:${NEXT_VERSION}.${{ github.run_number }}
+
+      - name: Tag Docker Image with major and minor version tags
+        if: ${{ env.NEXT_VERSION != '' && env.RELEASE_TYPE == 'release' }}
         run: |
-          docker tag ${ZAC_DOCKER_IMAGE} ${CONTAINER_REGISTRY_URL}/${APPLICATION_NAME}:${NEXT_VERSION}
-          # Additionaly tag the image with '$major' and '$major.$minor' tags
           MAJOR_VERSION=$(echo ${NEXT_VERSION} | cut -d '.' -f 1)
           MINOR_VERSION=$(echo ${NEXT_VERSION} | cut -d '.' -f 2)
           docker tag ${ZAC_DOCKER_IMAGE} ${CONTAINER_REGISTRY_URL}/${APPLICATION_NAME}:${MAJOR_VERSION}
@@ -548,16 +568,52 @@ jobs:
     env:
       NEXT_VERSION: ${{ needs.determine-version.outputs.version }}
       NEXT_VERSION_TAG: ${{ needs.determine-version.outputs.tag }}
+      RELEASE_TYPE: ${{ needs.determine-version.outputs.release-type }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Delete existing dev pre-releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dev_tags=$(gh release list --json tagName,isPrerelease -q '[.[] | select(.isPrerelease and (.tagName | endswith("-dev")))] | .[].tagName' 2>/dev/null || echo "")
+          for tag in $dev_tags; do
+            echo "Deleting dev pre-release: $tag"
+            gh release delete "$tag" --yes --cleanup-tag 2>/dev/null || true
+          done
+
       - name: Read dependencies
         id: dependencies
         run: |
           echo "dependencies<<EOF" >> $GITHUB_OUTPUT
           cat DEPENDENCIES.md >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      - name: Create or update GitHub release
+
+      - name: Create dev pre-release
+        if: ${{ env.RELEASE_TYPE == 'dev' }}
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.NEXT_VERSION_TAG }}
+          commit: ${{ github.sha }}
+          name: ${{ env.APPLICATION_NAME }} ${{ env.NEXT_VERSION }} (development build)
+          body: |
+            ⚠️ **This is a development pre-release and is updated with every push to main.**
+
+            Docker image: `${{ env.CONTAINER_REGISTRY_URL }}/${{ env.APPLICATION_NAME }}:${{ env.NEXT_VERSION }}`
+            Build: #${{ github.run_number }} | Commit: `${{ github.sha }}`
+
+            ## Tested Against
+
+            ${{ steps.dependencies.outputs.dependencies }}
+          draft: false
+          prerelease: true
+          makeLatest: false
+          generateReleaseNotes: true
+
+      - name: Create release
+        if: ${{ env.RELEASE_TYPE == 'release' || env.RELEASE_TYPE == 'hotfix' }}
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -567,20 +623,19 @@ jobs:
           body: |
             This release contains the docker image ${{ env.APPLICATION_NAME }} ${{ env.NEXT_VERSION }}, which is available
             at ${{ env.CONTAINER_REGISTRY_URL }}/${{ env.APPLICATION_NAME }}:${{ env.NEXT_VERSION }}
-            
+
             ## Tested Against
-            
+
             ${{ steps.dependencies.outputs.dependencies }}
           draft: false
           prerelease: false
-          allowUpdates: true
-          makeLatest: ${{ github.ref == 'refs/heads/main' }}
+          makeLatest: ${{ env.RELEASE_TYPE == 'release' }}
           generateReleaseNotes: true
 
   trigger-provision:
     needs: [determine-version, push-docker-image, create-release]
     env:
-      NEXT_VERSION: ${{ needs.determine-version.outputs.version }}
+      PROVISION_TAG: ${{ needs.determine-version.outputs.release-type == 'dev' && format('{0}.{1}', needs.determine-version.outputs.version, github.run_number) || needs.determine-version.outputs.version }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     if: ${{ github.ref == 'refs/heads/main' && vars.ENABLE_AUTOMATIC_PROVISION == 'true' }}
@@ -594,7 +649,7 @@ jobs:
               repo: 'dimpact-provisioning',
               workflow_id: 'azure-provision-zaakafhandelcomponent.yml',
               inputs: {
-                tag: '${{ env.NEXT_VERSION }}',
+                tag: '${{ env.PROVISION_TAG }}',
               },
               ref: 'main'
             })

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -128,15 +128,13 @@ jobs:
       - name: Calculate next version
         if: ${{ !startsWith(github.ref_name, 'hotfix/') }}
         id: calc-version
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LATEST_TAG=$(gh release list --exclude-pre-releases --limit 1 --json tagName -q '.[0].tagName // ""' 2>/dev/null || echo "")
+          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [ -z "$LATEST_TAG" ]; then
-            echo "No previous release found. Starting from v0.0.0"
+            echo "No previous release tag found. Starting from v0.0.0"
             LATEST_TAG="v0.0.0"
           fi
-          echo "Latest release tag: $LATEST_TAG"
+          echo "Highest release tag: $LATEST_TAG"
 
           VERSION="${LATEST_TAG#v}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
@@ -574,6 +572,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Delete existing dev pre-releases
+        if: ${{ env.RELEASE_TYPE == 'dev' || env.RELEASE_TYPE == 'release' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -610,6 +609,8 @@ jobs:
           draft: false
           prerelease: true
           makeLatest: false
+          allowUpdates: true
+          updateOnlyUnreleased: true
           generateReleaseNotes: true
 
       - name: Create release
@@ -629,6 +630,7 @@ jobs:
             ${{ steps.dependencies.outputs.dependencies }}
           draft: false
           prerelease: false
+          allowUpdates: true
           makeLatest: ${{ env.RELEASE_TYPE == 'release' }}
           generateReleaseNotes: true
 

--- a/.github/workflows/clean-up-old-zac-docker-images.yml
+++ b/.github/workflows/clean-up-old-zac-docker-images.yml
@@ -28,11 +28,10 @@ jobs:
 
   # Delete old tagged images but keep the 10 most recent, while always preserving:
   #   - 'latest'
-  #   - minor version tags          (e.g. 2.2 or v2.2)
-  #   - patch-zero version tags     (e.g. 2.2.0 or v2.2.0)
-  #   - version tags with a suffix  (e.g. 2.3.3-1 or v2.3.3-1)
-  # This means regular patch releases like 2.3.1, 2.3.2 and build artifacts
-  # like main-12345 are eligible for cleanup.
+  #   - minor version tags              (e.g. 2.2 or v2.2)
+  #   - all patch version tags          (e.g. 4.7.0, 4.6.1 or v4.6.1)
+  #   - version tags with a suffix      (e.g. 4.7.0-dev, but NOT 4.7.0-dev.123)
+  # This means build artifacts like main-12345 are eligible for cleanup.
   #
   # Note: we use a custom script instead of the actions/delete-package-versions
   # action's ignore-versions parameter because for container packages the action
@@ -50,7 +49,7 @@ jobs:
           owner="infonl"
           package="zaakafhandelcomponent"
           keep=10
-          preserve='^(latest|v?\d+\.\d+(\.0|\.\d+-\S+)?)$'
+          preserve='^(latest|v?\d+\.\d+(\.\d+(-[^.\s]+)?)?)$'
 
           echo "Fetching all versions of ${owner}/${package}..."
           versions=$(gh api --paginate \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,101 @@
+# Releasing
+
+This document describes the versioning scheme, release process, and hotfix workflow for ZAC.
+
+## Versioning scheme
+
+ZAC follows [Semantic Versioning](https://semver.org/) with these conventions:
+
+| Version | Meaning | Example |
+|---------|---------|---------|
+| `X.Y.0` | Sprint release (minor or major bump) | `4.7.0`, `5.0.0` |
+| `X.Y.Z` (Z > 0) | Hotfix on a previous release | `4.6.1`, `4.6.2` |
+| `X.Y.0-dev` | Development pre-release (rolling, updated on every push to main) | `4.7.0-dev` |
+| `X.Y.0-dev.N` | Pinned development build (N = GitHub Actions run number) | `4.7.0-dev.123` |
+
+## Development builds
+
+Every push to the `main` branch automatically:
+
+1. Calculates the next version by taking the latest release and bumping the minor version (e.g., `4.6.0` → `4.7.0-dev`)
+2. Builds, tests, and pushes a Docker image with tags:
+   - `latest` — always points to the most recent main build
+   - `X.Y.0-dev` — rolling dev tag, overwritten each build
+   - `X.Y.0-dev.N` — pinned tag with the build number for traceability
+3. Creates (or updates) a single **pre-release** on GitHub named `vX.Y.0-dev`
+   - This pre-release is replaced on every push — there is only ever one dev pre-release visible
+
+No permanent git tags are created for development builds.
+
+## Sprint releases
+
+At the end of a sprint, a release is cut by manually dispatching the **Build, test & deploy** workflow on the `main` branch:
+
+1. Go to **Actions** → **Build, test & deploy** → **Run workflow**
+2. Select the `main` branch
+3. Choose the version bump: **minor** (default, e.g., `4.6.0` → `4.7.0`) or **major** (e.g., `4.6.0` → `5.0.0`)
+4. Click **Run workflow**
+
+The workflow will:
+- Delete the existing `vX.Y.0-dev` pre-release and its tag
+- Build, test, and push a Docker image with tags: `X.Y.0`, `X.Y`, `X`, and `latest`
+- Create a proper **GitHub Release** tagged `vX.Y.0`, marked as **Latest**
+- Trigger automatic provisioning (if enabled)
+
+### After a sprint release
+
+Subsequent development builds will automatically target the next minor version (e.g., `4.8.0-dev`).
+
+## Hotfixes
+
+Hotfixes are for critical fixes to a previously released version. They use proper patch versions (e.g., `4.6.1`).
+
+### Creating a hotfix
+
+1. Create a branch from the release tag:
+   ```bash
+   git checkout -b hotfix/v4.6.1 v4.6.0
+   ```
+2. Apply your fix and push the branch
+3. Go to **Actions** → **Build, test & deploy** → **Run workflow**
+4. Select the `hotfix/v4.6.1` branch
+5. Enter the hotfix version in the **hotfix_version** field (e.g., `4.6.1`)
+6. Click **Run workflow**
+
+The workflow will:
+- Validate the version is a valid semver and the tag does not already exist
+- Build, test, and push a Docker image tagged `4.6.1`
+- Create a **GitHub Release** tagged `v4.6.1` (not marked as Latest, since `main` is ahead)
+
+> **Note:** Hotfix Docker images are intentionally **not** tagged with `latest`, `X`, or `X.Y` to avoid overwriting the current release's tags.
+
+## Docker image tags
+
+| Scenario | Docker tags |
+|----------|-------------|
+| Development build | `latest`, `X.Y.0-dev`, `X.Y.0-dev.N` |
+| Sprint release | `latest`, `X.Y.0`, `X.Y`, `X` |
+| Hotfix | `X.Y.Z` only |
+
+All images are published to `ghcr.io/infonl/zaakafhandelcomponent`.
+
+## GitHub Releases page
+
+The releases page will typically look like:
+
+```
+vX.Y.0-dev          ← Pre-release (rolling development build)
+v4.7.0              ← Latest Release (current sprint)
+v4.6.1              ← Hotfix
+v4.6.0              ← Previous sprint release
+```
+
+## Docker image cleanup
+
+A nightly workflow automatically cleans up old Docker images while preserving:
+- `latest`
+- Minor version tags (e.g., `4.7`)
+- All patch version tags (e.g., `4.7.0`, `4.6.1`)
+- Tags with a simple suffix (e.g., `4.7.0-dev`, but not pinned build tags like `4.7.0-dev.123`)
+
+Build artifacts like `main-12345` are eligible for cleanup beyond the 10 most recent.


### PR DESCRIPTION
This pull request introduces significant improvements to the release and versioning process for the project, with a focus on making development builds, sprint releases, and hotfixes clearer and more robust. The main workflow has been refactored to better handle version calculation, Docker image tagging, and GitHub release creation, and a new `RELEASING.md` document has been added to document the process. Additionally, the Docker image cleanup workflow has been updated to preserve the correct tags.

**Release process and versioning improvements:**

* Added a comprehensive `RELEASING.md` documenting the versioning scheme, release workflow, hotfix process, Docker image tags, and cleanup policy.
* Changed the default version bump for sprint releases from `patch` to `minor` and updated workflow inputs and outputs accordingly. [[1]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5L13-L18) [[2]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5L54-R58)
* Refactored version calculation in the main workflow to use a custom script instead of the `github-tag-action`, supporting dev builds, sprint releases, and hotfixes with consistent tag formats. [[1]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5L116-R167) [[2]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5L71-L74)
* Added logic to distinguish between release types (dev, release, hotfix) and adjusted workflow steps and Docker tagging behavior based on the release type. [[1]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5L116-R167) [[2]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5R523) [[3]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5L531-L535)
* Improved Docker image tagging to include rolling and pinned dev tags, and to tag sprint releases with major and minor tags, while hotfixes only receive the patch tag. [[1]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5L531-L535) [[2]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5L576-R638)

**GitHub Release and Docker image management:**

* Added steps to delete existing dev pre-releases before creating a new one, ensuring only a single rolling dev pre-release exists.
* Split GitHub release creation into separate steps for dev pre-releases and proper releases/hotfixes, with correct tagging and `makeLatest` logic. [[1]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5R571-R616) [[2]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5L576-R638)
* Adjusted the provisioning workflow to use the correct tag for dev builds (including the run number for pinned builds). [[1]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5L576-R638) [[2]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5L597-R652)

**Docker image cleanup workflow:**

* Updated the image cleanup script and documentation to preserve all patch version tags and tags with a simple suffix (e.g., `4.7.0-dev`), while still cleaning up build artifacts and old images. [[1]](diffhunk://#diff-40bebb81342e71d3b7a91b88d28866365c4ac9a46b34286c2ef76dcb13d79d96L32-R34) [[2]](diffhunk://#diff-40bebb81342e71d3b7a91b88d28866365c4ac9a46b34286c2ef76dcb13d79d96L53-R52)

These changes collectively make the release process more predictable, transparent, and maintainable, while ensuring that Docker images and GitHub releases are managed according to best practices.

Solves PZ-10864