### PR TITLE
fix: hopefully make BPMN e2e test scenario more resilient

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -86,11 +86,11 @@ HEADLESS=true ./start-e2e-with-test-env.sh
 #### Running only a single test feature
 
 To run a single test feature (or similar features with the same tag), you can use the `TAGS` environment variable.
-For example, to only run the test scenario(s) with the tag `@bpmn` in headless mode on the TEST environment, 
+For example, to only run the test scenario(s) with the tag `@bpmn` in headless mode on the TEST environment,
 you can use the following command:
 
 ```shell
- HEADLESS=true TAGS="@bpmn" ./start-e2e-with-test-env.sh
+HEADLESS=true TAGS="@bpmn" ./start-e2e-with-test-env.sh
 ```
 
 ### Writing e2e tests

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -83,6 +83,16 @@ To run the tests in headless mode you can use the following command:
 HEADLESS=true ./start-e2e-with-test-env.sh
 ```
 
+#### Running only a single test feature
+
+To run a single test feature (or similar features with the same tag), you can use the `TAGS` environment variable.
+For example, to only run the test scenario(s) with the tag `@bpmn` in headless mode on the TEST environment, 
+you can use the following command:
+
+```shell
+ HEADLESS=true TAGS="@bpmn" ./start-e2e-with-test-env.sh
+```
+
 ### Writing e2e tests
 
 We have predefined steps that you can use to write tests. You can find them in the [src/main/e2e/step-definitions](../../src/e2e/step-definitions) folder. each file in this folder represents a specific domain, like "zaak" is meant for non reusables steps that are specific to the "zaak" domain. steps in common are meant to be reusable across domains.

--- a/src/e2e/step-definitions/bpmn.ts
+++ b/src/e2e/step-definitions/bpmn.ts
@@ -136,13 +136,15 @@ Then(
     documentName: string,
   ) {
     const form = formioForm(this.page);
-    await form
-      .getByRole("searchbox", { name: "Select one or more documents" })
-      .fill(documentName);
+    const searchbox = form.getByRole("searchbox", {
+      name: "Select one or more documents",
+    });
+    await searchbox.click();
+    await searchbox.fill(documentName);
 
     await expect(
       this.page.getByRole("option", { name: documentName, exact: true }),
-    ).toContainText(documentName, { timeout: ONE_MINUTE_IN_MS });
+    ).toBeVisible({ timeout: ONE_MINUTE_IN_MS });
   },
 );
 


### PR DESCRIPTION
Improved the interaction with the document selection search box in BPMN e2e tests by ensuring proper visibility expectations. Updated testing documentation with steps to run single feature tests using the `TAGS` environment variable.

Solves PZ-10901
