### PR TITLE
docs: fix deserialisation issue for retrieving old inbox- and detached documents from Open Zaak

### DIFF
--- a/src/main/resources/api-specs/zgw/drc-openapi.yaml
+++ b/src/main/resources/api-specs/zgw/drc-openapi.yaml
@@ -6432,7 +6432,7 @@ components:
       - sha_256
       - sha_512
       - sha_3
-       # manual change by INFO.nl: can be an empty string in the Open Zaak response
+      # manual change by INFO.nl: can be an empty string in the Open Zaak response
       - ''
       type: string
     AuditTrail:

--- a/src/main/resources/api-specs/zgw/drc-openapi.yaml
+++ b/src/main/resources/api-specs/zgw/drc-openapi.yaml
@@ -6432,6 +6432,8 @@ components:
       - sha_256
       - sha_512
       - sha_3
+       # manual change by INFO.nl: can be an empty string in the Open Zaak response
+      - ''
       type: string
     AuditTrail:
       type: object


### PR DESCRIPTION
Fixed deserialisation issue for retrieving old inbox- and detached documents from Open Zaak by supporting AuditTrailRegel objects in Open Zaak DRC client reponses that have an 'integriteit' with an empty string for the 'algoritme' field, even though this is not allowed according to the ZGW DRC API spec.

On environments older inbox- and detached document records have AuditTrailRegel records in the Open Zaak database with a `nieuw` value that contains the following for the `integriteit` field: `"integriteit": {"datum": null, "waarde": "", "algoritme": ""}`. An empty string for `algoritme` is not allowed according to the ZGW DRC API spec (it is an enum), but apparently it can be an empty string for older records. We have seen similar issues in Open Zaak for many other fields, where often empty string values are allowed, which is different from this case.

Solves PZ-10884