### PR TITLE
feat: Pass commit SHA to provisioning and so it can pick up commit messages

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Find previous release tag
         id: prev-tag
         run: |
-          PREV_TAG=$(git tag -l 'v*' --sort=-v:refname --merged HEAD | grep -m 1 -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
+          PREV_TAG=$(git tag -l 'v*' --sort=-v:refname --merged HEAD | grep -m 1 -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)
           echo "tag=${PREV_TAG:-}" >> "$GITHUB_OUTPUT"
           echo "Previous release tag: ${PREV_TAG:-none}"
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Find previous release tag
         id: prev-tag
         run: |
-          PREV_TAG=$(git tag -l 'v*' --sort=-v:refname --merged HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          PREV_TAG=$(git tag -l 'v*' --sort=-v:refname --merged HEAD | grep -m 1 -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
           echo "tag=${PREV_TAG:-}" >> "$GITHUB_OUTPUT"
           echo "Previous release tag: ${PREV_TAG:-none}"
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -130,7 +130,7 @@ jobs:
         if: ${{ !startsWith(github.ref_name, 'hotfix/') }}
         id: calc-version
         run: |
-          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -m 1 -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
+          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -m 1 -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)
           if [ -z "$LATEST_TAG" ]; then
             echo "No previous release tag found. Starting from v0.0.0"
             LATEST_TAG="v0.0.0"

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -70,6 +70,7 @@ jobs:
       version: ${{ steps.set-hotfix-version.outputs.version || steps.calc-version.outputs.version }}
       tag: ${{ steps.set-hotfix-version.outputs.tag || steps.calc-version.outputs.tag }}
       release-type: ${{ steps.release-type.outputs.release-type }}
+      previous-tag: ${{ steps.prev-tag.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -163,6 +164,13 @@ jobs:
           echo "version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=v${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Calculated version: ${NEXT_VERSION} (release type: ${RELEASE_TYPE})"
+
+      - name: Find previous release tag
+        id: prev-tag
+        run: |
+          PREV_TAG=$(git tag -l 'v*' --sort=-v:refname --merged HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          echo "tag=${PREV_TAG:-}" >> "$GITHUB_OUTPUT"
+          echo "Previous release tag: ${PREV_TAG:-none}"
 
   paths-filter:
     runs-on: ubuntu-24.04
@@ -567,6 +575,7 @@ jobs:
       NEXT_VERSION: ${{ needs.determine-version.outputs.version }}
       NEXT_VERSION_TAG: ${{ needs.determine-version.outputs.tag }}
       RELEASE_TYPE: ${{ needs.determine-version.outputs.release-type }}
+      PREVIOUS_TAG: ${{ needs.determine-version.outputs.previous-tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -589,6 +598,20 @@ jobs:
           cat DEPENDENCIES.md >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Generate release notes
+        id: release-notes
+        if: ${{ env.PREVIOUS_TAG != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          gh api repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name="${{ env.NEXT_VERSION_TAG }}" \
+            -f target_commitish="${{ github.sha }}" \
+            -f previous_tag_name="${{ env.PREVIOUS_TAG }}" \
+            --jq '.body' >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Create dev pre-release
         if: ${{ env.RELEASE_TYPE == 'dev' }}
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
@@ -606,12 +629,13 @@ jobs:
             ## Tested Against
 
             ${{ steps.dependencies.outputs.dependencies }}
+
+            ${{ steps.release-notes.outputs.notes }}
           draft: false
           prerelease: true
           makeLatest: false
           allowUpdates: true
           updateOnlyUnreleased: true
-          generateReleaseNotes: true
 
       - name: Create release
         if: ${{ env.RELEASE_TYPE == 'release' || env.RELEASE_TYPE == 'hotfix' }}
@@ -628,11 +652,12 @@ jobs:
             ## Tested Against
 
             ${{ steps.dependencies.outputs.dependencies }}
+
+            ${{ steps.release-notes.outputs.notes }}
           draft: false
           prerelease: false
           allowUpdates: true
           makeLatest: ${{ env.RELEASE_TYPE == 'release' }}
-          generateReleaseNotes: true
 
   trigger-provision:
     needs: [determine-version, push-docker-image, create-release]
@@ -652,6 +677,7 @@ jobs:
               workflow_id: 'azure-provision-zaakafhandelcomponent.yml',
               inputs: {
                 tag: '${{ env.PROVISION_TAG }}',
+                commit_sha: '${{ github.sha }}',
               },
               ref: 'main'
             })

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -130,7 +130,7 @@ jobs:
         if: ${{ !startsWith(github.ref_name, 'hotfix/') }}
         id: calc-version
         run: |
-          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -m 1 -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
           if [ -z "$LATEST_TAG" ]; then
             echo "No previous release tag found. Starting from v0.0.0"
             LATEST_TAG="v0.0.0"

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -45,5 +45,6 @@ jobs:
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           skip_existing: true
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve the release process, particularly around release note generation and tagging. The main improvements are the automated determination of the previous release tag, generating more accurate release notes, and refining the release creation steps. These changes enhance the clarity and reliability of release information.

**Release process improvements:**

* Added a step to automatically find the previous release tag (`prev-tag`) during the workflow, making it available as an output for subsequent steps. [[1]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5R168-R174) [[2]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5R73) [[3]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5R578)
* Introduced a new step to generate release notes using the GitHub CLI (`gh api .../releases/generate-notes`) based on the previous and current tags, and included these notes in the release body instead of relying on the `generateReleaseNotes` flag. [[1]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5R601-R614) [[2]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5R632-L614) [[3]](diffhunk://#diff-22f49dea8896855b65ec7f98c2dccafa1b7317f851952fc98ee59f29d84f8af5R655-L635)

**Workflow consistency and metadata:**

* Updated the workflow to pass the current commit SHA as an input to the Azure provision workflow, improving traceability.
* In the Helm chart release workflow, set `mark_as_latest: false` to avoid automatically marking new charts as the latest, which can prevent accidental upgrades.

Solves PZ-10889