### PR TITLE
fix(app): Angular v19 migration - regression - Fix wrong icon color in document/task lists + taken card

### DIFF
--- a/.claude/commands/migrate-ng19-standalone-components.md
+++ b/.claude/commands/migrate-ng19-standalone-components.md
@@ -22,6 +22,7 @@ These gates exist because the user explicitly asked for them and has corrected s
 
 | Pattern | Detail |
 |---|---|
+| `<a mat-icon-button>` → use `MatIconAnchor` | `MatAnchor` is for `<a mat-button>`; `MatIconAnchor` is for `<a mat-icon-button>`. Using the wrong one leaves the anchor unstyled → browser default blue (rgb(0,0,238)). Always check the directive on `<a>` elements when adding button imports. |
 | Service mocking (`TestBed.inject` + `jest.spyOn`) | See Spec Conventions → Service mocking below |
 | `MatDialog` in standalone | `fixture.debugElement.injector.get(MatDialog)` — standalone gets its own injector, not root |
 | Shell isolation (`TestBed.overrideComponent`) | `TestBed.overrideComponent(Shell, { remove: { imports: [Real] }, add: { imports: [Stub] } })` |

--- a/src/main/app/src/app/dashboard/taken-card/taken-card.component.ts
+++ b/src/main/app/src/app/dashboard/taken-card/taken-card.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component } from "@angular/core";
-import { MatAnchor } from "@angular/material/button";
+import { MatIconAnchor } from "@angular/material/button";
 import { MatIcon } from "@angular/material/icon";
 import { MatPaginator } from "@angular/material/paginator";
 import { MatSort, MatSortHeader } from "@angular/material/sort";
@@ -54,7 +54,7 @@ import { DashboardCardComponent } from "../dashboard-card/dashboard-card.compone
     MatRow,
     MatNoDataRow,
     MatPaginator,
-    MatAnchor,
+    MatIconAnchor,
     MatIcon,
     RouterLink,
     TranslateModule,

--- a/src/main/app/src/app/documenten/inbox-documenten-list/inbox-documenten-list.component.ts
+++ b/src/main/app/src/app/documenten/inbox-documenten-list/inbox-documenten-list.component.ts
@@ -12,7 +12,7 @@ import {
   OnInit,
   ViewChild,
 } from "@angular/core";
-import { MatAnchor, MatIconButton } from "@angular/material/button";
+import { MatIconAnchor, MatIconButton } from "@angular/material/button";
 import { MatDialog } from "@angular/material/dialog";
 import { MatIcon } from "@angular/material/icon";
 import { MatPaginator } from "@angular/material/paginator";
@@ -86,7 +86,7 @@ import { InboxDocumentenService } from "../inbox-documenten.service";
     MatSortHeader,
     MatPaginator,
     MatIconButton,
-    MatAnchor,
+    MatIconAnchor,
     MatIcon,
     TranslateModule,
     TekstFilterComponent,

--- a/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.ts
+++ b/src/main/app/src/app/documenten/ontkoppelde-documenten-list/ontkoppelde-documenten-list.component.ts
@@ -12,7 +12,7 @@ import {
   OnInit,
   ViewChild,
 } from "@angular/core";
-import { MatAnchor, MatIconButton } from "@angular/material/button";
+import { MatIconAnchor, MatIconButton } from "@angular/material/button";
 import { MatDialog } from "@angular/material/dialog";
 import { MatFormField } from "@angular/material/form-field";
 import { MatIcon } from "@angular/material/icon";
@@ -89,7 +89,7 @@ import { OntkoppeldeDocumentenService } from "../ontkoppelde-documenten.service"
     MatSortHeader,
     MatPaginator,
     MatIconButton,
-    MatAnchor,
+    MatIconAnchor,
     MatIcon,
     MatFormField,
     MatSelect,


### PR DESCRIPTION
FE - Angular v19 migration to standalone - Fix for wrong icon color

- Replace `MatAnchor` with `MatIconAnchor` in InboxDocumentenList, OntkoppeldeDocumentenList and TakenCard
- `<a mat-icon-button>` requires `MatIconAnchor`, not `MatAnchor` — without it the anchor renders with default browser link color rgb(0,0,238)

Solves PZ-10894
