### PR TITLE
feature: rename smart-documents tables to remove CMMN

### DIFF
--- a/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplate.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplate.kt
@@ -22,18 +22,18 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 @Entity
-@Table(schema = FlywayIntegrator.SCHEMA, name = "zaaktype_cmmn_smartdocuments_document_template_parameters")
+@Table(schema = FlywayIntegrator.SCHEMA, name = "zaaktype_smartdocuments_document_template_parameters")
 @SequenceGenerator(
     schema = FlywayIntegrator.SCHEMA,
-    name = "sq_zaaktype_cmmn_smartdocuments_document_template_parameters",
-    sequenceName = "sq_zaaktype_cmmn_smartdocuments_document_template_parameters",
+    name = "sq_zaaktype_smartdocuments_document_template_parameters",
+    sequenceName = "sq_zaaktype_smartdocuments_document_template_parameters",
     allocationSize = 1
 )
 @AllOpen
 class SmartDocumentsTemplate {
     @Id
     @GeneratedValue(
-        generator = "sq_zaaktype_cmmn_smartdocuments_document_template_parameters",
+        generator = "sq_zaaktype_smartdocuments_document_template_parameters",
         strategy = GenerationType.SEQUENCE
     )
     @Column(name = "id")
@@ -59,3 +59,4 @@ class SmartDocumentsTemplate {
     @Column(name = "informatie_object_type_uuid", nullable = false)
     lateinit var informatieObjectTypeUUID: UUID
 }
+

--- a/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplate.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplate.kt
@@ -59,4 +59,3 @@ class SmartDocumentsTemplate {
     @Column(name = "informatie_object_type_uuid", nullable = false)
     lateinit var informatieObjectTypeUUID: UUID
 }
-

--- a/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplateGroup.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplateGroup.kt
@@ -1,4 +1,3 @@
-
 /*
  * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+

--- a/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplateGroup.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplateGroup.kt
@@ -1,3 +1,4 @@
+
 /*
  * SPDX-FileCopyrightText: 2024 INFO.nl
  * SPDX-License-Identifier: EUPL-1.2+
@@ -23,18 +24,18 @@ import nl.info.zac.util.AllOpen
 import java.time.ZonedDateTime
 
 @Entity
-@Table(schema = FlywayIntegrator.SCHEMA, name = "zaaktype_cmmn_smartdocuments_document_template_group_parameters")
+@Table(schema = FlywayIntegrator.SCHEMA, name = "zaaktype_smartdocuments_document_template_group_parameters")
 @SequenceGenerator(
     schema = FlywayIntegrator.SCHEMA,
-    name = "sq_zaaktype_cmmn_smartdocuments_document_template_group_parameters",
-    sequenceName = "sq_zaaktype_cmmn_smartdocuments_document_template_group_parameters",
+    name = "sq_zaaktype_smartdocuments_document_template_group_parameters",
+    sequenceName = "sq_zaaktype_smartdocuments_document_template_group_parameters",
     allocationSize = 1
 )
 @AllOpen
 class SmartDocumentsTemplateGroup {
     @Id
     @GeneratedValue(
-        generator = "sq_zaaktype_cmmn_smartdocuments_document_template_group_parameters",
+        generator = "sq_zaaktype_smartdocuments_document_template_group_parameters",
         strategy = GenerationType.SEQUENCE
     )
     @Column(name = "id")
@@ -63,3 +64,4 @@ class SmartDocumentsTemplateGroup {
     @JoinColumn(name = "zaaktype_configuration_id", nullable = false)
     lateinit var zaaktypeCmmnConfiguration: ZaaktypeCmmnConfiguration
 }
+

--- a/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplateGroup.kt
+++ b/src/main/kotlin/nl/info/zac/smartdocuments/templates/model/SmartDocumentsTemplateGroup.kt
@@ -64,4 +64,3 @@ class SmartDocumentsTemplateGroup {
     @JoinColumn(name = "zaaktype_configuration_id", nullable = false)
     lateinit var zaaktypeCmmnConfiguration: ZaaktypeCmmnConfiguration
 }
-

--- a/src/main/resources/schemas/V93__update-smart_documents_tables.sql
+++ b/src/main/resources/schemas/V93__update-smart_documents_tables.sql
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+ALTER TABLE ${schema}.zaaktype_cmmn_smartdocuments_document_template_group_parameters
+    RENAME TO zaaktype_smartdocuments_document_template_group_parameters;
+
+ALTER SEQUENCE ${schema}.sq_zaaktype_cmmn_smartdocuments_document_template_group_parameters
+    RENAME TO sq_zaaktype_smartdocuments_document_template_group_parameters;
+
+ALTER TABLE ${schema}.zaaktype_smartdocuments_document_template_group_parameters
+    DROP CONSTRAINT fk_zaaktype_cmmn_configuration;
+
+ALTER TABLE ${schema}.zaaktype_smartdocuments_document_template_group_parameters
+    ADD CONSTRAINT fk_zaaktype_configuration
+        FOREIGN KEY (zaaktype_configuration_id)
+        REFERENCES ${schema}.zaaktype_configuration(id)
+        ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE ${schema}.zaaktype_cmmn_smartdocuments_document_template_parameters
+    RENAME TO zaaktype_smartdocuments_document_template_parameters;
+
+ALTER SEQUENCE ${schema}.sq_zaaktype_cmmn_smartdocuments_document_template_parameters
+    RENAME TO sq_zaaktype_smartdocuments_document_template_parameters;
+
+ALTER TABLE ${schema}.zaaktype_smartdocuments_document_template_parameters
+    DROP CONSTRAINT fk_zaaktype_cmmn_configuration;
+
+ALTER TABLE ${schema}.zaaktype_smartdocuments_document_template_parameters
+    ADD CONSTRAINT fk_zaaktype_configuration
+        FOREIGN KEY (zaaktype_configuration_id)
+        REFERENCES ${schema}.zaaktype_configuration(id)
+        ON UPDATE CASCADE ON DELETE CASCADE;


### PR DESCRIPTION
This PR renames the smart-documents tables to remove the cmmn_ part of the title

Solves PZ-10703