### PR TITLE
test(formulieren): add comprehensive specs for new-style taak formulieren

### DIFF
--- a/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie.spec.ts
@@ -31,6 +31,22 @@ describe("AanvullendeInformatieFormulier", () => {
     rechten: { behandelen: true },
   });
 
+  const mockAfzender = fromPartial<
+    GeneratedType<"RestZaakAfzender"> & { key: string; value: string }
+  >({
+    mail: "afzender@example.com",
+    defaultMail: false,
+    replyTo: "reply@example.com",
+  });
+
+  const mockDefaultAfzender = fromPartial<
+    GeneratedType<"RestZaakAfzender"> & { key: string; value: string }
+  >({
+    mail: "default@example.com",
+    defaultMail: true,
+    replyTo: "default-reply@example.com",
+  });
+
   beforeEach(() => {
     zakenService = {
       listAfzendersVoorZaak: jest.fn().mockReturnValue(of([])),
@@ -65,87 +81,710 @@ describe("AanvullendeInformatieFormulier", () => {
   });
 
   describe("requestForm", () => {
-    it("should not pre-fill taakFataleDatum when planItem has no fataleDatum", async () => {
-      const planItem = fromPartial<GeneratedType<"RESTPlanItem">>({});
+    describe("field structure", () => {
+      it("should return exactly 10 fields for a non-suspendable zaak", async () => {
+        const fields = await formulier.requestForm(mockZaak);
 
-      const fields = await formulier.requestForm(mockZaak, planItem);
-
-      const datumField = fields.find((f) => f.key === "taakFataledatum");
-      expect(datumField?.control?.value).toBeNull();
-    });
-
-    it("should not pre-fill taakFataleDatum when planItem is undefined", async () => {
-      const fields = await formulier.requestForm(mockZaak, undefined);
-
-      const datumField = fields.find((f) => f.key === "taakFataledatum");
-      expect(datumField?.control?.value).toBeNull();
-    });
-
-    it("should pre-fill taakFataleDatum from planItem.fataleDatum", async () => {
-      const fataleDatum = "2026-06-01";
-      const planItem = fromPartial<GeneratedType<"RESTPlanItem">>({
-        fataleDatum,
+        expect(fields.length).toBe(10);
       });
 
-      const fields = await formulier.requestForm(mockZaak, planItem);
+      it("should return 11 fields for a suspendable zaak (adds zaakOpschorten)", async () => {
+        const suspendableZaak = fromPartial<GeneratedType<"RestZaak">>({
+          uuid: "zaak-uuid",
+          zaaktype: { opschortingMogelijk: true },
+          rechten: { behandelen: true },
+          redenOpschorting: undefined,
+          isHeropend: false,
+          eerdereOpschorting: false,
+        });
 
-      const datumField = fields.find((f) => f.key === "taakFataledatum");
-      expect(moment.isMoment(datumField?.control?.value)).toBe(true);
-      expect(
-        (datumField?.control?.value as moment.Moment).isSame(
-          moment(fataleDatum),
-          "day",
-        ),
-      ).toBe(true);
-    });
+        const fields = await formulier.requestForm(suspendableZaak);
 
-    it("should pre-fill the email from initiatorIdentificatie when both type and temporaryPersonId are set", async () => {
-      klantenService.getContactDetailsForPerson.mockReturnValue(
-        of(
-          fromPartial<GeneratedType<"RestContactDetails">>({
-            emailadres: "test@example.com",
-          }),
-        ),
-      );
-      const zaakWithInitiator = fromPartial<GeneratedType<"RestZaak">>({
-        ...mockZaak,
-        initiatorIdentificatie: {
-          type: "BSN",
-          temporaryPersonId: "person-123",
-        },
+        expect(fields.length).toBe(11);
       });
 
-      const fields = await formulier.requestForm(zaakWithInitiator);
+      it("should return fields in the expected order", async () => {
+        const fields = await formulier.requestForm(mockZaak);
 
-      expect(klantenService.getContactDetailsForPerson).toHaveBeenCalledWith(
-        "person-123",
-      );
-      const emailField = fields.find((f) => f.key === "emailadres");
-      expect(emailField?.control?.value).toBe("test@example.com");
-    });
-
-    it("should not call getContactDetailsForPerson when initiatorIdentificatie is absent", async () => {
-      await formulier.requestForm(mockZaak);
-
-      expect(klantenService.getContactDetailsForPerson).not.toHaveBeenCalled();
-    });
-
-    it("should not set email when getContactDetailsForPerson returns no emailadres", async () => {
-      klantenService.getContactDetailsForPerson.mockReturnValue(
-        of(fromPartial<GeneratedType<"RestContactDetails">>({})),
-      );
-      const zaakWithInitiator = fromPartial<GeneratedType<"RestZaak">>({
-        ...mockZaak,
-        initiatorIdentificatie: {
-          type: "BSN",
-          temporaryPersonId: "person-123",
-        },
+        expect(fields.map((f) => f.key)).toEqual([
+          "taakStuurGegevens.sendMail",
+          "taakStuurGegevens.mail",
+          "verzender",
+          "replyTo",
+          "emailadres",
+          "body",
+          "datumGevraagd",
+          "bijlagen",
+          "taakFataledatum",
+          "messageField",
+        ]);
       });
 
-      const fields = await formulier.requestForm(zaakWithInitiator);
+      it("should set sendMail hidden to true with value true", async () => {
+        const fields = await formulier.requestForm(mockZaak);
 
-      const emailField = fields.find((f) => f.key === "emailadres");
-      expect(emailField?.control?.value).toBeNull();
+        const field = fields.find((f) => f.key === "taakStuurGegevens.sendMail");
+        expect(field?.hidden).toBe(true);
+        expect(field?.control?.value).toBe(true);
+      });
+
+      it("should set mail hidden to true with value TAAK_AANVULLENDE_INFORMATIE", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "taakStuurGegevens.mail");
+        expect(field?.hidden).toBe(true);
+        expect(field?.control?.value).toBe("TAAK_AANVULLENDE_INFORMATIE");
+      });
+
+      it("should set replyTo as hidden", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "replyTo");
+        expect(field?.hidden).toBe(true);
+      });
+
+      it("should set datumGevraagd as hidden with a moment value", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "datumGevraagd");
+        expect(field?.hidden).toBe(true);
+        expect(moment.isMoment(field?.control?.value)).toBe(true);
+      });
+
+      it("should set body control value to mail template body", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "body");
+        expect(field?.control?.value).toBe("template body");
+      });
+
+      it("should call findMailtemplate with TAAK_AANVULLENDE_INFORMATIE and zaak uuid", async () => {
+        await formulier.requestForm(mockZaak);
+
+        expect(mailtemplateService.findMailtemplate).toHaveBeenCalledWith(
+          "TAAK_AANVULLENDE_INFORMATIE",
+          "zaak-uuid",
+        );
+      });
+
+      it("should call listEnkelvoudigInformatieobjecten with zaak uuid for bijlagen", async () => {
+        await formulier.requestForm(mockZaak);
+
+        expect(
+          informatieObjectenService.listEnkelvoudigInformatieobjecten,
+        ).toHaveBeenCalledWith({ zaakUUID: "zaak-uuid" });
+      });
+
+      it("should use empty array for body variables when mailtemplate variabelen is null", async () => {
+        mailtemplateService.findMailtemplate.mockReturnValue(
+          of({ body: "template body", variabelen: null }),
+        );
+
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "body");
+        expect(
+          ("variables" in field! ? field.variables : undefined),
+        ).toEqual([]);
+      });
+    });
+
+    describe("verzender", () => {
+      it("should set verzender options from listAfzendersVoorZaak", async () => {
+        zakenService.listAfzendersVoorZaak.mockReturnValue(
+          of([mockAfzender, mockDefaultAfzender]),
+        );
+
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "verzender");
+        expect(
+          ("options" in field! ? (field.options as unknown[]) : []).length,
+        ).toBe(2);
+      });
+
+      it("should pre-select the default afzender", async () => {
+        zakenService.listAfzendersVoorZaak.mockReturnValue(
+          of([mockAfzender, mockDefaultAfzender]),
+        );
+
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "verzender");
+        expect((field?.control?.value as { mail: string })?.mail).toBe(
+          "default@example.com",
+        );
+      });
+
+      it("should set verzender to null when no default afzender exists", async () => {
+        zakenService.listAfzendersVoorZaak.mockReturnValue(of([mockAfzender]));
+
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "verzender");
+        expect(field?.control?.value).toBeNull();
+      });
+
+      it("should update replyTo when verzender changes", async () => {
+        zakenService.listAfzendersVoorZaak.mockReturnValue(
+          of([mockAfzender, mockDefaultAfzender]),
+        );
+
+        const fields = await formulier.requestForm(mockZaak);
+
+        const verzenderField = fields.find((f) => f.key === "verzender");
+        const replyToField = fields.find((f) => f.key === "replyTo");
+
+        verzenderField?.control?.setValue({
+          ...mockAfzender,
+          key: mockAfzender.mail,
+          value: mockAfzender.mail,
+        });
+
+        expect(replyToField?.control?.value).toBe("reply@example.com");
+      });
+
+      it("should set replyTo to null when verzender is cleared", async () => {
+        zakenService.listAfzendersVoorZaak.mockReturnValue(
+          of([mockDefaultAfzender]),
+        );
+
+        const fields = await formulier.requestForm(mockZaak);
+
+        const verzenderField = fields.find((f) => f.key === "verzender");
+        const replyToField = fields.find((f) => f.key === "replyTo");
+
+        verzenderField?.control?.setValue(null);
+
+        expect(replyToField?.control?.value).toBeNull();
+      });
+    });
+
+    describe("taakFataleDatum", () => {
+      it("should not pre-fill taakFataleDatum when planItem has no fataleDatum", async () => {
+        const planItem = fromPartial<GeneratedType<"RESTPlanItem">>({});
+
+        const fields = await formulier.requestForm(mockZaak, planItem);
+
+        const datumField = fields.find((f) => f.key === "taakFataledatum");
+        expect(datumField?.control?.value).toBeNull();
+      });
+
+      it("should not pre-fill taakFataleDatum when planItem is undefined", async () => {
+        const fields = await formulier.requestForm(mockZaak, undefined);
+
+        const datumField = fields.find((f) => f.key === "taakFataledatum");
+        expect(datumField?.control?.value).toBeNull();
+      });
+
+      it("should pre-fill taakFataleDatum from planItem.fataleDatum", async () => {
+        const fataleDatum = "2026-06-01";
+        const planItem = fromPartial<GeneratedType<"RESTPlanItem">>({
+          fataleDatum,
+        });
+
+        const fields = await formulier.requestForm(mockZaak, planItem);
+
+        const datumField = fields.find((f) => f.key === "taakFataledatum");
+        expect(moment.isMoment(datumField?.control?.value)).toBe(true);
+        expect(
+          (datumField?.control?.value as moment.Moment).isSame(
+            moment(fataleDatum),
+            "day",
+          ),
+        ).toBe(true);
+      });
+    });
+
+    describe("messageField", () => {
+      it("should return leeg message key when zaak has no uiterlijkeEinddatumAfdoening", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "messageField");
+        expect(field?.control?.value).toBe(
+          "msg.taak.aanvullendeInformatie.fataleDatumZaak.leeg",
+        );
+      });
+
+      it("should return overig.opgeschort message key when zaak has fataleDatum but no taak fataleDatum and zaak is not suspendable", async () => {
+        const zaakWithFatalDatum = fromPartial<GeneratedType<"RestZaak">>({
+          ...mockZaak,
+          uiterlijkeEinddatumAfdoening: "2026-12-31",
+          zaaktype: { opschortingMogelijk: false },
+        });
+
+        const fields = await formulier.requestForm(zaakWithFatalDatum);
+
+        const field = fields.find((f) => f.key === "messageField");
+        expect(field?.control?.value).toBe(
+          "msg.taak.aanvullendeInformatie.fataleDatumTaak.overig.opgeschort",
+        );
+      });
+
+      it("should return overig message key when zaak has fataleDatum but no taak fataleDatum and zaak is suspendable", async () => {
+        const zaakWithFatalDatum = fromPartial<GeneratedType<"RestZaak">>({
+          ...mockZaak,
+          uiterlijkeEinddatumAfdoening: "2026-12-31",
+          zaaktype: { opschortingMogelijk: true },
+          rechten: { behandelen: true },
+        });
+
+        const fields = await formulier.requestForm(zaakWithFatalDatum);
+
+        const field = fields.find((f) => f.key === "messageField");
+        expect(field?.control?.value).toBe(
+          "msg.taak.aanvullendeInformatie.fataleDatumTaak.overig",
+        );
+      });
+
+      it("should update messageField when taakFataleDatum changes to a date after zaak fataleDatum", async () => {
+        const zaakWithFatalDatum = fromPartial<GeneratedType<"RestZaak">>({
+          ...mockZaak,
+          uiterlijkeEinddatumAfdoening: "2026-06-01",
+          zaaktype: { opschortingMogelijk: false },
+        });
+
+        const fields = await formulier.requestForm(zaakWithFatalDatum);
+
+        const taakFataledatumField = fields.find(
+          (f) => f.key === "taakFataledatum",
+        );
+        const messageField = fields.find((f) => f.key === "messageField");
+
+        taakFataledatumField?.control?.setValue(moment("2026-12-31"));
+
+        expect(messageField?.control?.value).toBe(
+          "msg.taak.aanvullendeInformatie.fataleDatumTaak.overschreden.opgeschort",
+        );
+      });
+
+      it("should update messageField to overig when taakFataleDatum changes to a date before zaak fataleDatum", async () => {
+        const zaakWithFatalDatum = fromPartial<GeneratedType<"RestZaak">>({
+          ...mockZaak,
+          uiterlijkeEinddatumAfdoening: "2026-12-31",
+          zaaktype: { opschortingMogelijk: false },
+        });
+
+        const fields = await formulier.requestForm(zaakWithFatalDatum);
+
+        const taakFataledatumField = fields.find(
+          (f) => f.key === "taakFataledatum",
+        );
+        const messageField = fields.find((f) => f.key === "messageField");
+
+        taakFataledatumField?.control?.setValue(moment("2026-06-01"));
+
+        expect(messageField?.control?.value).toBe(
+          "msg.taak.aanvullendeInformatie.fataleDatumTaak.overig.opgeschort",
+        );
+      });
+    });
+
+    describe("emailadres", () => {
+      it("should pre-fill the email from zaakSpecificContactDetails when present", async () => {
+        const zaakWithEmail = fromPartial<GeneratedType<"RestZaak">>({
+          ...mockZaak,
+          zaakSpecificContactDetails: { emailAddress: "specific@example.com" },
+        });
+
+        const fields = await formulier.requestForm(zaakWithEmail);
+
+        const emailField = fields.find((f) => f.key === "emailadres");
+        expect(emailField?.control?.value).toBe("specific@example.com");
+      });
+
+      it("should pre-fill the email from initiatorIdentificatie when both type and temporaryPersonId are set", async () => {
+        klantenService.getContactDetailsForPerson.mockReturnValue(
+          of(
+            fromPartial<GeneratedType<"RestContactDetails">>({
+              emailadres: "test@example.com",
+            }),
+          ),
+        );
+        const zaakWithInitiator = fromPartial<GeneratedType<"RestZaak">>({
+          ...mockZaak,
+          initiatorIdentificatie: {
+            type: "BSN",
+            temporaryPersonId: "person-123",
+          },
+        });
+
+        const fields = await formulier.requestForm(zaakWithInitiator);
+
+        expect(klantenService.getContactDetailsForPerson).toHaveBeenCalledWith(
+          "person-123",
+        );
+        const emailField = fields.find((f) => f.key === "emailadres");
+        expect(emailField?.control?.value).toBe("test@example.com");
+      });
+
+      it("should not call getContactDetailsForPerson when initiatorIdentificatie is absent", async () => {
+        await formulier.requestForm(mockZaak);
+
+        expect(klantenService.getContactDetailsForPerson).not.toHaveBeenCalled();
+      });
+
+      it("should not set email when getContactDetailsForPerson returns no emailadres", async () => {
+        klantenService.getContactDetailsForPerson.mockReturnValue(
+          of(fromPartial<GeneratedType<"RestContactDetails">>({})),
+        );
+        const zaakWithInitiator = fromPartial<GeneratedType<"RestZaak">>({
+          ...mockZaak,
+          initiatorIdentificatie: {
+            type: "BSN",
+            temporaryPersonId: "person-123",
+          },
+        });
+
+        const fields = await formulier.requestForm(zaakWithInitiator);
+
+        const emailField = fields.find((f) => f.key === "emailadres");
+        expect(emailField?.control?.value).toBeNull();
+      });
+    });
+
+    describe("zaakOpschorten", () => {
+      const suspendableZaak = fromPartial<GeneratedType<"RestZaak">>({
+        uuid: "zaak-uuid",
+        zaaktype: { opschortingMogelijk: true },
+        rechten: { behandelen: true },
+        redenOpschorting: undefined,
+        isHeropend: false,
+        eerdereOpschorting: false,
+      });
+
+      it("should not include zaakOpschorten field when zaak is not suspendable", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(fields.find((f) => f.key === "zaakOpschorten")).toBeUndefined();
+      });
+
+      it("should not include zaakOpschorten when zaak has redenOpschorting", async () => {
+        const zaak = fromPartial<GeneratedType<"RestZaak">>({
+          ...suspendableZaak,
+          redenOpschorting: "already suspended",
+        });
+
+        const fields = await formulier.requestForm(zaak);
+
+        expect(fields.find((f) => f.key === "zaakOpschorten")).toBeUndefined();
+      });
+
+      it("should not include zaakOpschorten when zaak isHeropend", async () => {
+        const zaak = fromPartial<GeneratedType<"RestZaak">>({
+          ...suspendableZaak,
+          isHeropend: true,
+        });
+
+        const fields = await formulier.requestForm(zaak);
+
+        expect(fields.find((f) => f.key === "zaakOpschorten")).toBeUndefined();
+      });
+
+      it("should not include zaakOpschorten when zaak rechten.behandelen is false", async () => {
+        const zaak = fromPartial<GeneratedType<"RestZaak">>({
+          ...suspendableZaak,
+          rechten: { behandelen: false },
+        });
+
+        const fields = await formulier.requestForm(zaak);
+
+        expect(fields.find((f) => f.key === "zaakOpschorten")).toBeUndefined();
+      });
+
+      it("should not include zaakOpschorten when zaak has eerdereOpschorting", async () => {
+        const zaak = fromPartial<GeneratedType<"RestZaak">>({
+          ...suspendableZaak,
+          eerdereOpschorting: true,
+        });
+
+        const fields = await formulier.requestForm(zaak);
+
+        expect(fields.find((f) => f.key === "zaakOpschorten")).toBeUndefined();
+      });
+
+      it("should include zaakOpschorten field when zaak is suspendable", async () => {
+        const fields = await formulier.requestForm(suspendableZaak);
+
+        expect(
+          fields.find((f) => f.key === "zaakOpschorten"),
+        ).toBeDefined();
+      });
+
+      it("should initialize zaakOpschorten as false", async () => {
+        const fields = await formulier.requestForm(suspendableZaak);
+
+        const field = fields.find((f) => f.key === "zaakOpschorten");
+        expect(field?.control?.value).toBe(false);
+      });
+
+      it("should add required validator to taakFataleDatum when zaakOpschorten is checked", async () => {
+        const fields = await formulier.requestForm(suspendableZaak);
+
+        const zaakOpschortenField = fields.find(
+          (f) => f.key === "zaakOpschorten",
+        );
+        const taakFataledatumField = fields.find(
+          (f) => f.key === "taakFataledatum",
+        );
+
+        zaakOpschortenField?.control?.setValue(true);
+
+        expect(taakFataledatumField?.control?.hasValidator).toBeDefined();
+        expect(
+          taakFataledatumField?.control?.errors?.["required"],
+        ).toBeDefined();
+      });
+
+      it("should remove required validator from taakFataleDatum when zaakOpschorten is unchecked", async () => {
+        const fields = await formulier.requestForm(suspendableZaak);
+
+        const zaakOpschortenField = fields.find(
+          (f) => f.key === "zaakOpschorten",
+        );
+        const taakFataledatumField = fields.find(
+          (f) => f.key === "taakFataledatum",
+        );
+
+        zaakOpschortenField?.control?.setValue(true);
+        zaakOpschortenField?.control?.setValue(false);
+
+        expect(taakFataledatumField?.control?.errors?.["required"]).toBeUndefined();
+      });
+    });
+  });
+
+  describe("handleForm", () => {
+    const mockTaak = fromPartial<GeneratedType<"RestTask">>({
+      status: "TOEGEKEND",
+      rechten: { wijzigen: true },
+      taakdata: {},
+    });
+
+    describe("field structure", () => {
+      it("should return exactly 6 base fields", async () => {
+        const fields = await formulier.handleForm(mockTaak, mockZaak);
+
+        expect(fields.length).toBe(6);
+      });
+
+      it("should return fields in the expected order", async () => {
+        const fields = await formulier.handleForm(mockTaak, mockZaak);
+
+        expect(fields.map((f) => f.key)).toEqual([
+          "verzender",
+          "emailadres",
+          "body",
+          "datumGevraagd",
+          "datumGeleverd",
+          "aanvullendeInformatie",
+        ]);
+      });
+
+      it("should render verzender, emailadres and body as plain-text", async () => {
+        const fields = await formulier.handleForm(mockTaak, mockZaak);
+
+        expect(fields.find((f) => f.key === "verzender")?.type).toBe(
+          "plain-text",
+        );
+        expect(fields.find((f) => f.key === "emailadres")?.type).toBe(
+          "plain-text",
+        );
+        expect(fields.find((f) => f.key === "body")?.type).toBe("plain-text");
+      });
+
+      it("should render datumGevraagd as readonly date", async () => {
+        const fields = await formulier.handleForm(mockTaak, mockZaak);
+
+        const field = fields.find((f) => f.key === "datumGevraagd");
+        expect(field?.type).toBe("date");
+        expect(field?.readonly).toBe(true);
+        expect(field?.control?.disabled).toBe(true);
+      });
+
+      it("should pre-fill datumGevraagd from taakdata", async () => {
+        const taakWithData = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: { datumGevraagd: "2026-01-15" },
+        });
+
+        const fields = await formulier.handleForm(taakWithData, mockZaak);
+
+        const field = fields.find((f) => f.key === "datumGevraagd");
+        expect(field?.control?.value).toBe("2026-01-15");
+      });
+
+      it("should pre-fill datumGeleverd from taakdata", async () => {
+        const taakWithData = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: { datumGeleverd: "2026-02-01" },
+        });
+
+        const fields = await formulier.handleForm(taakWithData, mockZaak);
+
+        const field = fields.find((f) => f.key === "datumGeleverd");
+        expect(field?.control?.value).toBe("2026-02-01");
+      });
+
+      it("should render aanvullendeInformatie as required radio with the 3 expected options", async () => {
+        const fields = await formulier.handleForm(mockTaak, mockZaak);
+
+        const field = fields.find((f) => f.key === "aanvullendeInformatie");
+        expect(field?.type).toBe("radio");
+        expect(
+          ("options" in field! ? field.options : []),
+        ).toEqual([
+          "aanvullende-informatie.geleverd-akkoord",
+          "aanvullende-informatie.geleverd-niet-akkoord",
+          "aanvullende-informatie.niet-geleverd",
+        ]);
+        field?.control?.setValue(null);
+        field?.control?.markAsTouched();
+        expect(field?.control?.errors?.["required"]).toBeDefined();
+      });
+
+      it("should handle undefined taakdata gracefully", async () => {
+        const taakWithoutData = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: undefined,
+        });
+
+        const fields = await formulier.handleForm(taakWithoutData, mockZaak);
+
+        const datumGevraagd = fields.find((f) => f.key === "datumGevraagd");
+        const datumGeleverd = fields.find((f) => f.key === "datumGeleverd");
+        const aanvullendeInformatie = fields.find(
+          (f) => f.key === "aanvullendeInformatie",
+        );
+        expect(datumGevraagd?.control?.value).toBeFalsy();
+        expect(datumGeleverd?.control?.value).toBeFalsy();
+        expect(aanvullendeInformatie?.control?.value).toBeFalsy();
+      });
+
+      it("should pre-fill aanvullendeInformatie from taakdata", async () => {
+        const taakWithData = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: {
+            aanvullendeInformatie: "aanvullende-informatie.geleverd-akkoord",
+          },
+        });
+
+        const fields = await formulier.handleForm(taakWithData, mockZaak);
+
+        const field = fields.find((f) => f.key === "aanvullendeInformatie");
+        expect(field?.control?.value).toBe(
+          "aanvullende-informatie.geleverd-akkoord",
+        );
+      });
+    });
+
+    describe("zaakHervatten", () => {
+      it("should not include zaakHervatten when zaak is not opgeschort", async () => {
+        const fields = await formulier.handleForm(mockTaak, mockZaak);
+
+        expect(fields.find((f) => f.key === "zaakHervatten")).toBeUndefined();
+      });
+
+      it("should include zaakHervatten when zaak is opgeschort and taak can be changed", async () => {
+        const opgeschortZaak = fromPartial<GeneratedType<"RestZaak">>({
+          ...mockZaak,
+          isOpgeschort: true,
+          rechten: { behandelen: true },
+        });
+
+        const fields = await formulier.handleForm(mockTaak, opgeschortZaak);
+
+        expect(
+          fields.find((f) => f.key === "zaakHervatten"),
+        ).toBeDefined();
+      });
+
+      it("should pre-fill zaakHervatten from taakdata", async () => {
+        const opgeschortZaak = fromPartial<GeneratedType<"RestZaak">>({
+          ...mockZaak,
+          isOpgeschort: true,
+          rechten: { behandelen: true },
+        });
+        const taakWithData = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: { zaakHervatten: "true" },
+        });
+
+        const fields = await formulier.handleForm(taakWithData, opgeschortZaak);
+
+        const field = fields.find((f) => f.key === "zaakHervatten");
+        expect((field?.control?.value as { value: string })?.value).toBe(
+          "true",
+        );
+      });
+
+      it("should show zaakHervatten on AFGEROND taak when taakdata zaakHervatten is true", async () => {
+        const afgerondTaak = fromPartial<GeneratedType<"RestTask">>({
+          status: "AFGEROND",
+          rechten: { wijzigen: true },
+          taakdata: { zaakHervatten: "true" },
+        });
+
+        const fields = await formulier.handleForm(afgerondTaak, mockZaak);
+
+        expect(fields.find((f) => f.key === "zaakHervatten")).toBeDefined();
+      });
+
+      it("should set zaakHervatten control to null when taakdata value does not match any option", async () => {
+        const opgeschortZaak = fromPartial<GeneratedType<"RestZaak">>({
+          ...mockZaak,
+          isOpgeschort: true,
+          rechten: { behandelen: true },
+        });
+        const taakWithUnknownValue = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: { zaakHervatten: "unknown-value" },
+        });
+
+        const fields = await formulier.handleForm(
+          taakWithUnknownValue,
+          opgeschortZaak,
+        );
+
+        const field = fields.find((f) => f.key === "zaakHervatten");
+        expect(field?.control?.value).toBeNull();
+      });
+
+      it("should show zaakHervatten when taak rechten.wijzigen is false and zaakHervatten taakdata is true", async () => {
+        const taakZonderWijzigen = fromPartial<GeneratedType<"RestTask">>({
+          status: "TOEGEKEND",
+          rechten: { wijzigen: false },
+          taakdata: { zaakHervatten: "true" },
+        });
+
+        const fields = await formulier.handleForm(taakZonderWijzigen, mockZaak);
+
+        expect(fields.find((f) => f.key === "zaakHervatten")).toBeDefined();
+      });
+
+      it("should not show zaakHervatten when taak rechten.wijzigen is false and zaakHervatten taakdata is not true", async () => {
+        const taakZonderWijzigen = fromPartial<GeneratedType<"RestTask">>({
+          status: "TOEGEKEND",
+          rechten: { wijzigen: false },
+          taakdata: { zaakHervatten: "false" },
+        });
+
+        const fields = await formulier.handleForm(taakZonderWijzigen, mockZaak);
+
+        expect(fields.find((f) => f.key === "zaakHervatten")).toBeUndefined();
+      });
+
+      it("should not show zaakHervatten on AFGEROND taak when taakdata zaakHervatten is not true", async () => {
+        const afgerondTaak = fromPartial<GeneratedType<"RestTask">>({
+          status: "AFGEROND",
+          rechten: { wijzigen: true },
+          taakdata: { zaakHervatten: "false" },
+        });
+
+        const fields = await formulier.handleForm(afgerondTaak, mockZaak);
+
+        expect(fields.find((f) => f.key === "zaakHervatten")).toBeUndefined();
+      });
     });
   });
 });

--- a/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie.spec.ts
@@ -123,7 +123,9 @@ describe("AanvullendeInformatieFormulier", () => {
       it("should set sendMail hidden to true with value true", async () => {
         const fields = await formulier.requestForm(mockZaak);
 
-        const field = fields.find((f) => f.key === "taakStuurGegevens.sendMail");
+        const field = fields.find(
+          (f) => f.key === "taakStuurGegevens.sendMail",
+        );
         expect(field?.hidden).toBe(true);
         expect(field?.control?.value).toBe(true);
       });
@@ -183,9 +185,7 @@ describe("AanvullendeInformatieFormulier", () => {
         const fields = await formulier.requestForm(mockZaak);
 
         const field = fields.find((f) => f.key === "body");
-        expect(
-          ("variables" in field! ? field.variables : undefined),
-        ).toEqual([]);
+        expect("variables" in field! ? field.variables : undefined).toEqual([]);
       });
     });
 
@@ -421,7 +421,9 @@ describe("AanvullendeInformatieFormulier", () => {
       it("should not call getContactDetailsForPerson when initiatorIdentificatie is absent", async () => {
         await formulier.requestForm(mockZaak);
 
-        expect(klantenService.getContactDetailsForPerson).not.toHaveBeenCalled();
+        expect(
+          klantenService.getContactDetailsForPerson,
+        ).not.toHaveBeenCalled();
       });
 
       it("should not set email when getContactDetailsForPerson returns no emailadres", async () => {
@@ -506,9 +508,7 @@ describe("AanvullendeInformatieFormulier", () => {
       it("should include zaakOpschorten field when zaak is suspendable", async () => {
         const fields = await formulier.requestForm(suspendableZaak);
 
-        expect(
-          fields.find((f) => f.key === "zaakOpschorten"),
-        ).toBeDefined();
+        expect(fields.find((f) => f.key === "zaakOpschorten")).toBeDefined();
       });
 
       it("should initialize zaakOpschorten as false", async () => {
@@ -549,7 +549,9 @@ describe("AanvullendeInformatieFormulier", () => {
         zaakOpschortenField?.control?.setValue(true);
         zaakOpschortenField?.control?.setValue(false);
 
-        expect(taakFataledatumField?.control?.errors?.["required"]).toBeUndefined();
+        expect(
+          taakFataledatumField?.control?.errors?.["required"],
+        ).toBeUndefined();
       });
     });
   });
@@ -631,9 +633,7 @@ describe("AanvullendeInformatieFormulier", () => {
 
         const field = fields.find((f) => f.key === "aanvullendeInformatie");
         expect(field?.type).toBe("radio");
-        expect(
-          ("options" in field! ? field.options : []),
-        ).toEqual([
+        expect("options" in field! ? field.options : []).toEqual([
           "aanvullende-informatie.geleverd-akkoord",
           "aanvullende-informatie.geleverd-niet-akkoord",
           "aanvullende-informatie.niet-geleverd",
@@ -694,9 +694,7 @@ describe("AanvullendeInformatieFormulier", () => {
 
         const fields = await formulier.handleForm(mockTaak, opgeschortZaak);
 
-        expect(
-          fields.find((f) => f.key === "zaakHervatten"),
-        ).toBeDefined();
+        expect(fields.find((f) => f.key === "zaakHervatten")).toBeDefined();
       });
 
       it("should pre-fill zaakHervatten from taakdata", async () => {

--- a/src/main/app/src/app/formulieren/taken/model/abstract-taak-formulier.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/abstract-taak-formulier.spec.ts
@@ -1,0 +1,233 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from "@angular/common/http";
+import { HarnessLoader } from "@angular/cdk/testing";
+import { TestbedHarnessEnvironment } from "@angular/cdk/testing/testbed";
+import { ComponentRef } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { AbstractControl, FormBuilder, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { MatAutocompleteHarness } from "@angular/material/autocomplete/testing";
+import { MatCheckboxHarness } from "@angular/material/checkbox/testing";
+import { MatDatepickerInputHarness } from "@angular/material/datepicker/testing";
+import { MatInputHarness } from "@angular/material/input/testing";
+import { MatRadioGroupHarness } from "@angular/material/radio/testing";
+import { MatSelectHarness } from "@angular/material/select/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { RouterModule } from "@angular/router";
+import { TranslateModule } from "@ngx-translate/core";
+import { of } from "rxjs";
+import { FormField, ZacForm } from "../../../shared/form/form";
+import { MaterialFormBuilderModule } from "../../../shared/material-form-builder/material-form-builder.module";
+import { GeneratedType } from "../../../shared/utils/generated-types";
+import { AbstractTaakFormulier } from "./abstract-taak-formulier";
+
+class TestFormulier extends AbstractTaakFormulier {
+  async requestForm(zaak: GeneratedType<"RestZaak">): Promise<FormField[]> {
+    void zaak;
+    return [
+      {
+        type: "input",
+        key: "inputField",
+        label: "input-label",
+        control: this.formBuilder.control(""),
+      },
+      {
+        type: "textarea",
+        key: "textareaField",
+        label: "textarea-label",
+        control: this.formBuilder.control(""),
+      },
+      {
+        type: "date",
+        key: "dateField",
+        label: "date-label",
+        control: this.formBuilder.control(null),
+      },
+      {
+        type: "select",
+        key: "selectField",
+        label: "select-label",
+        options: [{ key: "a", value: "Option A" }],
+        control: this.formBuilder.control(null),
+      },
+      {
+        type: "radio",
+        key: "radioField",
+        label: "radio-label",
+        options: ["option-1", "option-2"],
+        control: this.formBuilder.control(null),
+      },
+      {
+        type: "checkbox",
+        key: "checkboxField",
+        label: "checkbox-label",
+        control: this.formBuilder.control(false),
+      },
+      {
+        type: "auto-complete",
+        key: "autoCompleteField",
+        label: "auto-complete-label",
+        options: [{ id: "1", naam: "User A" }],
+        control: this.formBuilder.control(null),
+      },
+      {
+        type: "documents",
+        key: "documentsField",
+        label: "documents-label",
+        options: of([]),
+      },
+      {
+        type: "html-editor",
+        key: "htmlEditorField",
+        label: "html-editor-label",
+        variables: [],
+        control: this.formBuilder.control("<p>some html</p>"),
+      },
+      {
+        type: "plain-text",
+        key: "plainTextField",
+        label: "plain-text-label",
+        control: this.formBuilder.control("some text"),
+      },
+      {
+        type: "input",
+        key: "hiddenField",
+        label: "hidden-label",
+        hidden: true,
+        control: this.formBuilder.control("hidden-value"),
+      },
+    ];
+  }
+
+  async handleForm(taak: GeneratedType<"RestTask">): Promise<FormField[]> {
+    void taak;
+    return [];
+  }
+}
+
+describe(AbstractTaakFormulier.name, () => {
+  let formulier: TestFormulier;
+  let fixture: ComponentFixture<ZacForm<Record<string, AbstractControl<unknown, unknown>>>>;
+  let componentRef: ComponentRef<ZacForm<Record<string, AbstractControl<unknown, unknown>>>>;
+  let loader: HarnessLoader;
+  let formGroup: FormGroup;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        NoopAnimationsModule,
+        TranslateModule.forRoot(),
+        RouterModule.forRoot([]),
+        MaterialFormBuilderModule,
+      ],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        FormBuilder,
+      ],
+    }).compileComponents();
+
+    formulier = TestBed.runInInjectionContext(() => new TestFormulier());
+  });
+
+  describe("requestForm rendering", () => {
+    beforeEach(async () => {
+      const fields = await formulier.requestForm(
+        { uuid: "zaak-uuid" } as GeneratedType<"RestZaak">,
+      );
+
+      formGroup = new FormGroup({});
+      for (const field of fields) {
+        formGroup.addControl(
+          field.key,
+          field.control ?? new FormBuilder().control(null),
+        );
+      }
+
+      fixture = TestBed.createComponent(ZacForm);
+      componentRef = fixture.componentRef;
+      componentRef.setInput("fields", fields);
+      componentRef.setInput("form", formGroup);
+      fixture.detectChanges();
+
+      loader = TestbedHarnessEnvironment.loader(fixture);
+    });
+
+    it("should render an input field", async () => {
+      const inputs = await loader.getAllHarnesses(MatInputHarness);
+      // textarea also resolves as MatInputHarness — filter to type=text only
+      const textInputs = await Promise.all(
+        inputs.map(async (h) => ({ h, type: await h.getType() })),
+      );
+      expect(textInputs.some(({ type }) => type === "text")).toBe(true);
+    });
+
+    it("should render a textarea field", async () => {
+      const inputs = await loader.getAllHarnesses(MatInputHarness);
+      const types = await Promise.all(inputs.map((h) => h.getType()));
+      expect(types).toContain("textarea");
+    });
+
+    it("should render a date field", async () => {
+      const datepicker = await loader.getHarnessOrNull(
+        MatDatepickerInputHarness,
+      );
+      expect(datepicker).not.toBeNull();
+    });
+
+    it("should render a select field", async () => {
+      const select = await loader.getHarnessOrNull(MatSelectHarness);
+      expect(select).not.toBeNull();
+    });
+
+    it("should render a radio group", async () => {
+      const radioGroup = await loader.getHarnessOrNull(MatRadioGroupHarness);
+      expect(radioGroup).not.toBeNull();
+    });
+
+    it("should render a checkbox", async () => {
+      const checkbox = await loader.getHarnessOrNull(MatCheckboxHarness);
+      expect(checkbox).not.toBeNull();
+    });
+
+    it("should render an auto-complete field", async () => {
+      const autocomplete = await loader.getHarnessOrNull(
+        MatAutocompleteHarness,
+      );
+      expect(autocomplete).not.toBeNull();
+    });
+
+    // No Material harness available — zac-documents is a custom component
+    it("should render a documents field", () => {
+      expect(
+        fixture.nativeElement.querySelector("zac-documents"),
+      ).not.toBeNull();
+    });
+
+    // No Material harness available — zac-html-editor wraps ngx-editor
+    it("should render an html-editor field", () => {
+      expect(
+        fixture.nativeElement.querySelector("zac-html-editor"),
+      ).not.toBeNull();
+    });
+
+    // No Material harness available — plain-text renders as a <section>
+    it("should render a plain-text field", () => {
+      expect(
+        fixture.nativeElement.querySelector("fieldset section"),
+      ).not.toBeNull();
+    });
+
+    it("should not render hidden fields", () => {
+      // @if (!field.hidden) suppresses the hidden field — only one zac-input in the DOM
+      const zacInputs = fixture.nativeElement.querySelectorAll("zac-input");
+      expect(zacInputs.length).toBe(1);
+    });
+  });
+});

--- a/src/main/app/src/app/formulieren/taken/model/abstract-taak-formulier.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/abstract-taak-formulier.spec.ts
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from "@angular/common/http";
 import { HarnessLoader } from "@angular/cdk/testing";
 import { TestbedHarnessEnvironment } from "@angular/cdk/testing/testbed";
 import { ComponentRef } from "@angular/core";
@@ -127,10 +123,7 @@ describe(AbstractTaakFormulier.name, () => {
         RouterModule.forRoot([]),
         MaterialFormBuilderModule,
       ],
-      providers: [
-        provideHttpClient(withInterceptorsFromDi()),
-        FormBuilder,
-      ],
+      providers: [FormBuilder],
     }).compileComponents();
 
     formulier = TestBed.runInInjectionContext(() => new TestFormulier());

--- a/src/main/app/src/app/formulieren/taken/model/abstract-taak-formulier.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/abstract-taak-formulier.spec.ts
@@ -7,7 +7,12 @@ import { HarnessLoader } from "@angular/cdk/testing";
 import { TestbedHarnessEnvironment } from "@angular/cdk/testing/testbed";
 import { ComponentRef } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { AbstractControl, FormBuilder, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import {
+  AbstractControl,
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+} from "@angular/forms";
 import { MatAutocompleteHarness } from "@angular/material/autocomplete/testing";
 import { MatCheckboxHarness } from "@angular/material/checkbox/testing";
 import { MatDatepickerInputHarness } from "@angular/material/datepicker/testing";
@@ -109,8 +114,12 @@ class TestFormulier extends AbstractTaakFormulier {
 
 describe(AbstractTaakFormulier.name, () => {
   let formulier: TestFormulier;
-  let fixture: ComponentFixture<ZacForm<Record<string, AbstractControl<unknown, unknown>>>>;
-  let componentRef: ComponentRef<ZacForm<Record<string, AbstractControl<unknown, unknown>>>>;
+  let fixture: ComponentFixture<
+    ZacForm<Record<string, AbstractControl<unknown, unknown>>>
+  >;
+  let componentRef: ComponentRef<
+    ZacForm<Record<string, AbstractControl<unknown, unknown>>>
+  >;
   let loader: HarnessLoader;
   let formGroup: FormGroup;
 
@@ -131,9 +140,9 @@ describe(AbstractTaakFormulier.name, () => {
 
   describe("requestForm rendering", () => {
     beforeEach(async () => {
-      const fields = await formulier.requestForm(
-        { uuid: "zaak-uuid" } as GeneratedType<"RestZaak">,
-      );
+      const fields = await formulier.requestForm({
+        uuid: "zaak-uuid",
+      } as GeneratedType<"RestZaak">);
 
       formGroup = new FormGroup({});
       for (const field of fields) {

--- a/src/main/app/src/app/formulieren/taken/model/advies.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/advies.spec.ts
@@ -1,0 +1,351 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { TranslateService } from "@ngx-translate/core";
+import { of } from "rxjs";
+import { FoutAfhandelingService } from "src/app/fout-afhandeling/fout-afhandeling.service";
+import { fromPartial } from "../../../../test-helpers";
+import { InformatieObjectenService } from "../../../informatie-objecten/informatie-objecten.service";
+import { GeneratedType } from "../../../shared/utils/generated-types";
+import { AdviesFormulier } from "./advies";
+
+describe("AdviesFormulier", () => {
+  let formulier: AdviesFormulier;
+  let informatieObjectenService: {
+    listEnkelvoudigInformatieobjecten: jest.Mock;
+  };
+  let translateService: { instant: jest.Mock };
+
+  const mockZaak = fromPartial<GeneratedType<"RestZaak">>({
+    uuid: "zaak-uuid",
+  });
+
+  const mockDocument = fromPartial<
+    GeneratedType<"RestEnkelvoudigInformatieobject">
+  >({ uuid: "doc-uuid-1", titel: "Document 1" });
+
+  beforeEach(() => {
+    informatieObjectenService = {
+      listEnkelvoudigInformatieobjecten: jest.fn().mockReturnValue(of([])),
+    };
+    translateService = {
+      instant: jest.fn().mockReturnValue("translated-value"),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: FoutAfhandelingService, useValue: {} },
+        { provide: TranslateService, useValue: translateService },
+        {
+          provide: InformatieObjectenService,
+          useValue: informatieObjectenService,
+        },
+      ],
+    });
+
+    formulier = TestBed.inject(AdviesFormulier);
+  });
+
+  describe("requestForm", () => {
+    describe("field structure", () => {
+      it("should return exactly 2 fields", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(fields.length).toBe(2);
+      });
+
+      it("should return fields with keys: vraag, relevanteDocumenten", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(fields.map((f) => f.key)).toEqual([
+          "vraag",
+          "relevanteDocumenten",
+        ]);
+      });
+
+      it("should render vraag as a textarea", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(fields.find((f) => f.key === "vraag")?.type).toBe("textarea");
+      });
+
+      it("should render relevanteDocumenten as documents", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(
+          fields.find((f) => f.key === "relevanteDocumenten")?.type,
+        ).toBe("documents");
+      });
+    });
+
+    describe("vraag field", () => {
+      it("should initialize vraag as empty string", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(fields.find((f) => f.key === "vraag")?.control?.value).toBe("");
+      });
+
+      it("should require vraag", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const control = fields.find((f) => f.key === "vraag")?.control;
+        control?.setValue("");
+        control?.markAsTouched();
+
+        expect(control?.errors?.["required"]).toBeDefined();
+      });
+
+      it("should enforce maxLength of 1000 on vraag", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const control = fields.find((f) => f.key === "vraag")?.control;
+        control?.setValue("a".repeat(1001));
+
+        expect(control?.errors?.["maxlength"]).toBeDefined();
+      });
+
+      it("should accept a valid vraag within 1000 characters", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const control = fields.find((f) => f.key === "vraag")?.control;
+        control?.setValue("a".repeat(1000));
+
+        expect(control?.errors).toBeNull();
+      });
+    });
+
+    describe("relevanteDocumenten field", () => {
+      it("should set viewDocumentInNewTab to true", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "relevanteDocumenten");
+        expect(
+          "viewDocumentInNewTab" in field! ? field.viewDocumentInNewTab : false,
+        ).toBe(true);
+      });
+
+      it("should fetch documents for the zaak", async () => {
+        await formulier.requestForm(mockZaak);
+
+        expect(
+          informatieObjectenService.listEnkelvoudigInformatieobjecten,
+        ).toHaveBeenCalledWith({ zaakUUID: "zaak-uuid" });
+      });
+
+      it("should pass fetched documents as options", async () => {
+        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
+          of([mockDocument]),
+        );
+
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "relevanteDocumenten");
+        expect(
+          "options" in field! ? field.options : [],
+        ).toEqual([mockDocument]);
+      });
+    });
+  });
+
+  describe("handleForm", () => {
+    const mockTaak = fromPartial<GeneratedType<"RestTask">>({
+      zaakUuid: "zaak-uuid",
+      taakdata: {},
+      tabellen: { ADVIES: ["akkoord", "niet-akkoord"] },
+    });
+
+    describe("field structure", () => {
+      it("should return exactly 4 fields", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.length).toBe(4);
+      });
+
+      it("should return fields with keys: titel, vraag, relevanteDocumenten, advies", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.map((f) => f.key)).toEqual([
+          "titel",
+          "vraag",
+          "relevanteDocumenten",
+          "advies",
+        ]);
+      });
+
+      it("should render titel as plain-text", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.find((f) => f.key === "titel")?.type).toBe("plain-text");
+      });
+
+      it("should render vraag as plain-text", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.find((f) => f.key === "vraag")?.type).toBe("plain-text");
+      });
+
+      it("should render relevanteDocumenten as documents", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(
+          fields.find((f) => f.key === "relevanteDocumenten")?.type,
+        ).toBe("documents");
+      });
+
+      it("should render advies as radio", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.find((f) => f.key === "advies")?.type).toBe("radio");
+      });
+    });
+
+    describe("titel field", () => {
+      it("should use translated msg.advies.behandelen as value", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(translateService.instant).toHaveBeenCalledWith(
+          "msg.advies.behandelen",
+        );
+        expect(fields.find((f) => f.key === "titel")?.control?.value).toBe(
+          "translated-value",
+        );
+      });
+    });
+
+    describe("vraag field", () => {
+      it("should have label vraag", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.find((f) => f.key === "vraag")?.label).toBe("vraag");
+      });
+    });
+
+    describe("relevanteDocumenten field", () => {
+      it("should be readonly", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(
+          fields.find((f) => f.key === "relevanteDocumenten")?.readonly,
+        ).toBe(true);
+      });
+
+      it("should fetch documents using zaakUuid and relevanteDocumenten UUIDs from taakdata", async () => {
+        const taakWithDocumenten = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: { relevanteDocumenten: "doc-uuid-1;doc-uuid-2" },
+        });
+
+        await formulier.handleForm(taakWithDocumenten);
+
+        expect(
+          informatieObjectenService.listEnkelvoudigInformatieobjecten,
+        ).toHaveBeenCalledWith({
+          zaakUUID: "zaak-uuid",
+          informatieobjectUUIDs: ["doc-uuid-1", "doc-uuid-2"],
+        });
+      });
+
+      it("should fetch with empty UUIDs when relevanteDocumenten taakdata is absent", async () => {
+        await formulier.handleForm(mockTaak);
+
+        expect(
+          informatieObjectenService.listEnkelvoudigInformatieobjecten,
+        ).toHaveBeenCalledWith({
+          zaakUUID: "zaak-uuid",
+          informatieobjectUUIDs: [],
+        });
+      });
+
+      it("should fetch with empty UUIDs when taakdata is undefined", async () => {
+        const taakWithoutData = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: undefined,
+        });
+
+        await formulier.handleForm(taakWithoutData);
+
+        expect(
+          informatieObjectenService.listEnkelvoudigInformatieobjecten,
+        ).toHaveBeenCalledWith({
+          zaakUUID: "zaak-uuid",
+          informatieobjectUUIDs: [],
+        });
+      });
+    });
+
+    describe("advies field", () => {
+      it("should use options from taak.tabellen ADVIES", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        const field = fields.find((f) => f.key === "advies");
+        expect(
+          "options" in field! ? field.options : [],
+        ).toEqual(["akkoord", "niet-akkoord"]);
+      });
+
+      it("should fall back to empty options when tabellen is undefined", async () => {
+        const taakWithoutTabellen = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          tabellen: undefined,
+        });
+
+        const fields = await formulier.handleForm(taakWithoutTabellen);
+
+        const field = fields.find((f) => f.key === "advies");
+        expect(
+          "options" in field! ? field.options : null,
+        ).toEqual([]);
+      });
+
+      it("should fall back to empty options when ADVIES key is absent from tabellen", async () => {
+        const taakWithoutAdviesTabellen = fromPartial<
+          GeneratedType<"RestTask">
+        >({
+          ...mockTaak,
+          tabellen: {},
+        });
+
+        const fields = await formulier.handleForm(taakWithoutAdviesTabellen);
+
+        const field = fields.find((f) => f.key === "advies");
+        expect(
+          "options" in field! ? field.options : null,
+        ).toEqual([]);
+      });
+
+      it("should require advies", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        const control = fields.find((f) => f.key === "advies")?.control;
+        control?.setValue(null);
+        control?.markAsTouched();
+
+        expect(control?.errors?.["required"]).toBeDefined();
+      });
+
+      it("should pre-fill advies from taakdata", async () => {
+        const taakWithAdvies = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: { advies: "akkoord" },
+        });
+
+        const fields = await formulier.handleForm(taakWithAdvies);
+
+        expect(
+          fields.find((f) => f.key === "advies")?.control?.value,
+        ).toBe("akkoord");
+      });
+
+      it("should have no advies pre-filled when taakdata is empty", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(
+          fields.find((f) => f.key === "advies")?.control?.value,
+        ).toBeFalsy();
+      });
+    });
+  });
+});

--- a/src/main/app/src/app/formulieren/taken/model/advies.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/advies.spec.ts
@@ -75,9 +75,9 @@ describe("AdviesFormulier", () => {
       it("should render relevanteDocumenten as documents", async () => {
         const fields = await formulier.requestForm(mockZaak);
 
-        expect(
-          fields.find((f) => f.key === "relevanteDocumenten")?.type,
-        ).toBe("documents");
+        expect(fields.find((f) => f.key === "relevanteDocumenten")?.type).toBe(
+          "documents",
+        );
       });
     });
 
@@ -143,9 +143,9 @@ describe("AdviesFormulier", () => {
         const fields = await formulier.requestForm(mockZaak);
 
         const field = fields.find((f) => f.key === "relevanteDocumenten");
-        expect(
-          "options" in field! ? field.options : [],
-        ).toEqual([mockDocument]);
+        expect("options" in field! ? field.options : []).toEqual([
+          mockDocument,
+        ]);
       });
     });
   });
@@ -190,9 +190,9 @@ describe("AdviesFormulier", () => {
       it("should render relevanteDocumenten as documents", async () => {
         const fields = await formulier.handleForm(mockTaak);
 
-        expect(
-          fields.find((f) => f.key === "relevanteDocumenten")?.type,
-        ).toBe("documents");
+        expect(fields.find((f) => f.key === "relevanteDocumenten")?.type).toBe(
+          "documents",
+        );
       });
 
       it("should render advies as radio", async () => {
@@ -281,9 +281,10 @@ describe("AdviesFormulier", () => {
         const fields = await formulier.handleForm(mockTaak);
 
         const field = fields.find((f) => f.key === "advies");
-        expect(
-          "options" in field! ? field.options : [],
-        ).toEqual(["akkoord", "niet-akkoord"]);
+        expect("options" in field! ? field.options : []).toEqual([
+          "akkoord",
+          "niet-akkoord",
+        ]);
       });
 
       it("should fall back to empty options when tabellen is undefined", async () => {
@@ -295,9 +296,7 @@ describe("AdviesFormulier", () => {
         const fields = await formulier.handleForm(taakWithoutTabellen);
 
         const field = fields.find((f) => f.key === "advies");
-        expect(
-          "options" in field! ? field.options : null,
-        ).toEqual([]);
+        expect("options" in field! ? field.options : null).toEqual([]);
       });
 
       it("should fall back to empty options when ADVIES key is absent from tabellen", async () => {
@@ -311,9 +310,7 @@ describe("AdviesFormulier", () => {
         const fields = await formulier.handleForm(taakWithoutAdviesTabellen);
 
         const field = fields.find((f) => f.key === "advies");
-        expect(
-          "options" in field! ? field.options : null,
-        ).toEqual([]);
+        expect("options" in field! ? field.options : null).toEqual([]);
       });
 
       it("should require advies", async () => {
@@ -334,9 +331,9 @@ describe("AdviesFormulier", () => {
 
         const fields = await formulier.handleForm(taakWithAdvies);
 
-        expect(
-          fields.find((f) => f.key === "advies")?.control?.value,
-        ).toBe("akkoord");
+        expect(fields.find((f) => f.key === "advies")?.control?.value).toBe(
+          "akkoord",
+        );
       });
 
       it("should have no advies pre-filled when taakdata is empty", async () => {

--- a/src/main/app/src/app/formulieren/taken/model/goedkeuren.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/goedkeuren.spec.ts
@@ -80,9 +80,9 @@ describe("GoedkeurenFormulier", () => {
       it("should render relevanteDocumenten as documents", async () => {
         const fields = await formulier.requestForm(mockZaak);
 
-        expect(
-          fields.find((f) => f.key === "relevanteDocumenten")?.type,
-        ).toBe("documents");
+        expect(fields.find((f) => f.key === "relevanteDocumenten")?.type).toBe(
+          "documents",
+        );
       });
     });
 
@@ -363,9 +363,9 @@ describe("GoedkeurenFormulier", () => {
 
         const fields = await formulier.handleForm(taakWithGoedkeuren);
 
-        expect(
-          fields.find((f) => f.key === "goedkeuren")?.control?.value,
-        ).toBe(`goedkeuren.${Goedkeuring.akkoord}`);
+        expect(fields.find((f) => f.key === "goedkeuren")?.control?.value).toBe(
+          `goedkeuren.${Goedkeuring.akkoord}`,
+        );
       });
 
       it("should have no goedkeuren pre-filled when taakdata is empty", async () => {

--- a/src/main/app/src/app/formulieren/taken/model/goedkeuren.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/goedkeuren.spec.ts
@@ -1,0 +1,380 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { TranslateService } from "@ngx-translate/core";
+import { of } from "rxjs";
+import { FoutAfhandelingService } from "src/app/fout-afhandeling/fout-afhandeling.service";
+import { fromPartial } from "../../../../test-helpers";
+import { InformatieObjectenService } from "../../../informatie-objecten/informatie-objecten.service";
+import { GeneratedType } from "../../../shared/utils/generated-types";
+import { Goedkeuring } from "../goedkeuring.enum";
+import { GoedkeurenFormulier } from "./goedkeuren";
+
+describe("GoedkeurenFormulier", () => {
+  let formulier: GoedkeurenFormulier;
+  let informatieObjectenService: {
+    listEnkelvoudigInformatieobjecten: jest.Mock;
+  };
+  let translateService: { instant: jest.Mock };
+
+  const mockZaak = fromPartial<GeneratedType<"RestZaak">>({
+    uuid: "zaak-uuid",
+  });
+
+  const mockDocument1 = fromPartial<
+    GeneratedType<"RestEnkelvoudigInformatieobject">
+  >({ uuid: "doc-uuid-1", titel: "Document 1" });
+
+  const mockDocument2 = fromPartial<
+    GeneratedType<"RestEnkelvoudigInformatieobject">
+  >({ uuid: "doc-uuid-2", titel: "Document 2" });
+
+  beforeEach(() => {
+    informatieObjectenService = {
+      listEnkelvoudigInformatieobjecten: jest.fn().mockReturnValue(of([])),
+    };
+    translateService = {
+      instant: jest.fn().mockReturnValue("translated-value"),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: FoutAfhandelingService, useValue: {} },
+        { provide: TranslateService, useValue: translateService },
+        {
+          provide: InformatieObjectenService,
+          useValue: informatieObjectenService,
+        },
+      ],
+    });
+
+    formulier = TestBed.inject(GoedkeurenFormulier);
+  });
+
+  describe("requestForm", () => {
+    describe("field structure", () => {
+      it("should return exactly 2 fields", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(fields.length).toBe(2);
+      });
+
+      it("should return fields in the expected order", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(fields.map((f) => f.key)).toEqual([
+          "vraag",
+          "relevanteDocumenten",
+        ]);
+      });
+
+      it("should render vraag as a textarea", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(fields.find((f) => f.key === "vraag")?.type).toBe("textarea");
+      });
+
+      it("should render relevanteDocumenten as documents", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(
+          fields.find((f) => f.key === "relevanteDocumenten")?.type,
+        ).toBe("documents");
+      });
+    });
+
+    describe("vraag field", () => {
+      it("should initialize vraag as empty string", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(fields.find((f) => f.key === "vraag")?.control?.value).toBe("");
+      });
+
+      it("should require vraag", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const control = fields.find((f) => f.key === "vraag")?.control;
+        control?.setValue("");
+        control?.markAsTouched();
+
+        expect(control?.errors?.["required"]).toBeDefined();
+      });
+
+      it("should enforce maxLength of 1000 on vraag", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const control = fields.find((f) => f.key === "vraag")?.control;
+        control?.setValue("a".repeat(1001));
+
+        expect(control?.errors?.["maxlength"]).toBeDefined();
+      });
+
+      it("should accept a valid vraag within 1000 characters", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        const control = fields.find((f) => f.key === "vraag")?.control;
+        control?.setValue("a".repeat(1000));
+
+        expect(control?.errors).toBeNull();
+      });
+    });
+
+    describe("relevanteDocumenten field", () => {
+      it("should fetch documents as an Observable (not awaited) for the zaak", async () => {
+        await formulier.requestForm(mockZaak);
+
+        expect(
+          informatieObjectenService.listEnkelvoudigInformatieobjecten,
+        ).toHaveBeenCalledWith({ zaakUUID: "zaak-uuid" });
+      });
+
+      it("should pass the Observable directly as options without resolving it", async () => {
+        const documentsObservable = of([mockDocument1]);
+        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
+          documentsObservable,
+        );
+
+        const fields = await formulier.requestForm(mockZaak);
+
+        const field = fields.find((f) => f.key === "relevanteDocumenten");
+        // options is the Observable itself, not a resolved array
+        expect("options" in field! ? field.options : null).toBe(
+          documentsObservable,
+        );
+      });
+
+      it("should not have a control (display-only field)", async () => {
+        const fields = await formulier.requestForm(mockZaak);
+
+        expect(
+          fields.find((f) => f.key === "relevanteDocumenten")?.control,
+        ).toBeUndefined();
+      });
+    });
+  });
+
+  describe("handleForm", () => {
+    const mockTaak = fromPartial<GeneratedType<"RestTask">>({
+      zaakUuid: "zaak-uuid",
+      zaakIdentificatie: "ZAAK-2026-001",
+      taakdata: {},
+    });
+
+    describe("field structure", () => {
+      it("should return exactly 4 fields", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.length).toBe(4);
+      });
+
+      it("should return fields in the expected order", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.map((f) => f.key)).toEqual([
+          "titel",
+          "vraag",
+          "ondertekenen",
+          "goedkeuren",
+        ]);
+      });
+
+      it("should render titel as plain-text", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.find((f) => f.key === "titel")?.type).toBe("plain-text");
+      });
+
+      it("should render vraag as plain-text", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.find((f) => f.key === "vraag")?.type).toBe("plain-text");
+      });
+
+      it("should render ondertekenen as documents", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.find((f) => f.key === "ondertekenen")?.type).toBe(
+          "documents",
+        );
+      });
+
+      it("should render goedkeuren as radio", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.find((f) => f.key === "goedkeuren")?.type).toBe("radio");
+      });
+    });
+
+    describe("titel field", () => {
+      it("should translate msg.goedkeuring.behandelen with zaaknummer", async () => {
+        await formulier.handleForm(mockTaak);
+
+        expect(translateService.instant).toHaveBeenCalledWith(
+          "msg.goedkeuring.behandelen",
+          { zaaknummer: "ZAAK-2026-001" },
+        );
+      });
+
+      it("should set titel control value to translated string", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.find((f) => f.key === "titel")?.control?.value).toBe(
+          "translated-value",
+        );
+      });
+    });
+
+    describe("vraag field", () => {
+      it("should have label vraag", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(fields.find((f) => f.key === "vraag")?.label).toBe("vraag");
+      });
+    });
+
+    describe("ondertekenen field", () => {
+      it("should fetch relevanteDocumenten by UUID from taakdata", async () => {
+        const taakWithDocumenten = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: { relevanteDocumenten: "doc-uuid-1;doc-uuid-2" },
+        });
+
+        await formulier.handleForm(taakWithDocumenten);
+
+        expect(
+          informatieObjectenService.listEnkelvoudigInformatieobjecten,
+        ).toHaveBeenCalledWith({
+          zaakUUID: "zaak-uuid",
+          informatieobjectUUIDs: ["doc-uuid-1", "doc-uuid-2"],
+        });
+      });
+
+      it("should fetch with empty UUIDs when relevanteDocumenten taakdata is absent", async () => {
+        await formulier.handleForm(mockTaak);
+
+        expect(
+          informatieObjectenService.listEnkelvoudigInformatieobjecten,
+        ).toHaveBeenCalledWith({
+          zaakUUID: "zaak-uuid",
+          informatieobjectUUIDs: [],
+        });
+      });
+
+      it("should fetch with empty UUIDs when taakdata is undefined", async () => {
+        const taakWithoutData = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: undefined,
+        });
+
+        await formulier.handleForm(taakWithoutData);
+
+        expect(
+          informatieObjectenService.listEnkelvoudigInformatieobjecten,
+        ).toHaveBeenCalledWith({
+          zaakUUID: "zaak-uuid",
+          informatieobjectUUIDs: [],
+        });
+      });
+
+      it("should set ondertekenen options to fetched documents", async () => {
+        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
+          of([mockDocument1, mockDocument2]),
+        );
+
+        const fields = await formulier.handleForm(mockTaak);
+
+        const field = fields.find((f) => f.key === "ondertekenen");
+        expect("options" in field! ? field.options : []).toEqual([
+          mockDocument1,
+          mockDocument2,
+        ]);
+      });
+
+      it("should pre-check documents that were previously signed (ondertekenen taakdata)", async () => {
+        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
+          of([mockDocument1, mockDocument2]),
+        );
+        const taakWithSigned = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: { ondertekenen: "doc-uuid-1" },
+        });
+
+        const fields = await formulier.handleForm(taakWithSigned);
+
+        const control = fields.find((f) => f.key === "ondertekenen")?.control;
+        expect(control?.value).toEqual([mockDocument1]);
+      });
+
+      it("should not pre-check documents that were not previously signed", async () => {
+        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
+          of([mockDocument1, mockDocument2]),
+        );
+        const taakWithSigned = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: { ondertekenen: "doc-uuid-1" },
+        });
+
+        const fields = await formulier.handleForm(taakWithSigned);
+
+        const control = fields.find((f) => f.key === "ondertekenen")?.control;
+        expect(control?.value).not.toContainEqual(mockDocument2);
+      });
+
+      it("should initialize ondertekenen as empty when no documents were previously signed", async () => {
+        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
+          of([mockDocument1, mockDocument2]),
+        );
+
+        const fields = await formulier.handleForm(mockTaak);
+
+        const control = fields.find((f) => f.key === "ondertekenen")?.control;
+        expect(control?.value).toEqual([]);
+      });
+    });
+
+    describe("goedkeuren field", () => {
+      it("should have options derived from Goedkeuring enum with goedkeuren. prefix", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        const field = fields.find((f) => f.key === "goedkeuren");
+        expect("options" in field! ? field.options : []).toEqual(
+          Object.values(Goedkeuring).map((v) => `goedkeuren.${v}`),
+        );
+      });
+
+      it("should require goedkeuren", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        const control = fields.find((f) => f.key === "goedkeuren")?.control;
+        control?.setValue(null);
+        control?.markAsTouched();
+
+        expect(control?.errors?.["required"]).toBeDefined();
+      });
+
+      it("should pre-fill goedkeuren from taakdata", async () => {
+        const taakWithGoedkeuren = fromPartial<GeneratedType<"RestTask">>({
+          ...mockTaak,
+          taakdata: { goedkeuren: `goedkeuren.${Goedkeuring.akkoord}` },
+        });
+
+        const fields = await formulier.handleForm(taakWithGoedkeuren);
+
+        expect(
+          fields.find((f) => f.key === "goedkeuren")?.control?.value,
+        ).toBe(`goedkeuren.${Goedkeuring.akkoord}`);
+      });
+
+      it("should have no goedkeuren pre-filled when taakdata is empty", async () => {
+        const fields = await formulier.handleForm(mockTaak);
+
+        expect(
+          fields.find((f) => f.key === "goedkeuren")?.control?.value,
+        ).toBeFalsy();
+      });
+    });
+  });
+});


### PR DESCRIPTION
FE - add comprehensive specs for new-style taak formulieren

## Summary
- Add full spec for `AanvullendeInformatieFormulier` (100% coverage, 54 tests) as the blueprint
- Add rendering contract spec for `AbstractTaakFormulier` via `ZacForm` — covers all field types (input, textarea, date, select, radio, checkbox, auto-complete, documents, html-editor, plain-text, hidden)
- Add full spec for `AdviesFormulier` (100% coverage, 29 tests)
- Add full spec for `GoedkeurenFormulier` (100% coverage, 31 tests)

These specs form the safety net for the upcoming refactor of `ExternAdviesVastleggen` to the new pattern.

Solves PZ-10890
