### PR TITLE
fix(helm): make office-converter containerPort configurable

### DIFF
--- a/charts/zac/Chart.yaml
+++ b/charts/zac/Chart.yaml
@@ -6,7 +6,7 @@
 apiVersion: v2
 name: zaakafhandelcomponent
 description: A Helm chart for installing Zaakafhandelcomponent
-version: 1.0.223
+version: 1.0.224
 appVersion: '4.7'
 icon: https://raw.githubusercontent.com/infonl/dimpact-zaakafhandelcomponent/49f8dee60948282b546ebdfdc5cff6f8bbef0305/docs/manuals/ZAC-gebruikershandleiding/images/pic.svg
 dependencies:

--- a/charts/zac/README.md
+++ b/charts/zac/README.md
@@ -1,6 +1,6 @@
 # zaakafhandelcomponent
 
-![Version: 1.0.223](https://img.shields.io/badge/Version-1.0.223-informational?style=flat-square) ![AppVersion: 4.7](https://img.shields.io/badge/AppVersion-4.7-informational?style=flat-square)
+![Version: 1.0.224](https://img.shields.io/badge/Version-1.0.224-informational?style=flat-square) ![AppVersion: 4.7](https://img.shields.io/badge/AppVersion-4.7-informational?style=flat-square)
 
 A Helm chart for installing Zaakafhandelcomponent
 
@@ -198,6 +198,7 @@ The Github workflow will perform helm-linting and will bump the version if neede
 | objectenApi.token | string | `""` |  |
 | objectenApi.url | string | `""` |  |
 | office_converter.affinity | object | `{}` |  |
+| office_converter.containerPort | int | `3000` | Container port the office-converter listens on. Gotenberg default is 3000; override to 8080 if using an alternative image (e.g. kontextwork-converter). |
 | office_converter.enabled | bool | `true` |  |
 | office_converter.env.CHROMIUM_DISABLE_ROUTES | string | `"true"` |  |
 | office_converter.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/zac/templates/office-converter-deployment.yaml
+++ b/charts/zac/templates/office-converter-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.office_converter.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 3000
+              containerPort: {{ .Values.office_converter.containerPort }}
           {{- with .Values.office_converter.env }}
           env:
             {{- range $key, $value := . }}

--- a/charts/zac/values.yaml
+++ b/charts/zac/values.yaml
@@ -576,6 +576,9 @@ office_converter:
     requests:
       cpu: 100m
       memory: 512Mi
+  # -- Container port the office-converter listens on. Gotenberg default is 3000;
+  # override to 8080 if using an alternative image (e.g. kontextwork-converter).
+  containerPort: 3000
   service:
     type: ClusterIP
     port: 80


### PR DESCRIPTION
Expose `office_converter.containerPort` in values so the port the office-converter container listens on can be overridden. Default remains `3000` (Gotenberg); set to `8080` for alternative images such as `kontextwork-converter`.

