### PR TITLE
feat: PZ-10802 Automatisch ARM64-Docker images bouwen en lokaal gebruiken

### DIFF
--- a/docker-compose.arm64-override.yaml
+++ b/docker-compose.arm64-override.yaml
@@ -1,0 +1,76 @@
+#
+# SPDX-FileCopyrightText: 2026 INFO.nl
+# SPDX-License-Identifier: EUPL-1.2+
+#
+services:
+  openzaak-database:
+    image: ghcr.io/infonl/postgis:17-3.5@sha256:179b2f72f953e097d712392d87b89e1d6b6cb11a645201a823c2162637e7086c
+    platform: linux/arm64
+
+  openzaak.local:
+    image: ghcr.io/infonl/open-zaak:1.26.0@sha256:2ea59a8213d7b4fb02dd1a348c143b443cbb6cfce993f2fec28ca07dd8e4066b
+    platform: linux/arm64
+
+  openzaak-celery:
+    image: ghcr.io/infonl/open-zaak:1.26.0@sha256:2ea59a8213d7b4fb02dd1a348c143b443cbb6cfce993f2fec28ca07dd8e4066b
+    platform: linux/arm64
+
+  objecten-api.local:
+    image: ghcr.io/infonl/objects-api:3.3.1@sha256:725d02dd487497f4186ea9c7154bc8c8cd083fdd6099e422901b7e35fc17e6c1
+    platform: linux/arm64
+
+  objecten-api-database:
+    image: ghcr.io/infonl/postgis:17-3.5@sha256:179b2f72f953e097d712392d87b89e1d6b6cb11a645201a823c2162637e7086c
+    platform: linux/arm64
+
+  objecten-api-import:
+    image: ghcr.io/infonl/objects-api:3.3.1@sha256:725d02dd487497f4186ea9c7154bc8c8cd083fdd6099e422901b7e35fc17e6c1
+    platform: linux/arm64
+
+  openklant.local:
+    image: ghcr.io/infonl/open-klant:2.14.0@sha256:61195dc3abc4238941367c25308f693dbde139721837e606875ee549513c8ce9
+    platform: linux/arm64
+
+  opennotificaties-database:
+    image: ghcr.io/infonl/postgis:17-3.5@sha256:179b2f72f953e097d712392d87b89e1d6b6cb11a645201a823c2162637e7086c
+    platform: linux/arm64
+
+  opennotificaties:
+    image: ghcr.io/infonl/open-notificaties:1.13.0@sha256:f4645611462a96aba5e6138ff29dc21568f22b7cb2810938469d26d24c72af1e
+    platform: linux/arm64
+
+  opennotificaties-init:
+    image: ghcr.io/infonl/open-notificaties:1.13.0@sha256:f4645611462a96aba5e6138ff29dc21568f22b7cb2810938469d26d24c72af1e
+    platform: linux/arm64
+
+  opennotificaties-celery:
+    image: ghcr.io/infonl/open-notificaties:1.13.0@sha256:f4645611462a96aba5e6138ff29dc21568f22b7cb2810938469d26d24c72af1e
+    platform: linux/arm64
+
+  openarchiefbeheer-database:
+    image: ghcr.io/infonl/postgis:17-3.5@sha256:179b2f72f953e097d712392d87b89e1d6b6cb11a645201a823c2162637e7086c
+    platform: linux/arm64
+
+  openarchiefbeheer-web:
+    image: ghcr.io/infonl/open-archiefbeheer:1.1.1@sha256:e28956d9266e13935addf14ae772d730a22304377ee0e9f0e66ed754c0d2191d
+    platform: linux/arm64
+
+  openarchiefbeheer-web-init:
+    image: ghcr.io/infonl/open-archiefbeheer:1.1.1@sha256:e28956d9266e13935addf14ae772d730a22304377ee0e9f0e66ed754c0d2191d
+    platform: linux/arm64
+
+  openarchiefbeheer-celery:
+    image: ghcr.io/infonl/open-archiefbeheer:1.1.1@sha256:e28956d9266e13935addf14ae772d730a22304377ee0e9f0e66ed754c0d2191d
+    platform: linux/arm64
+
+  openarchiefbeheer-celery-beat:
+    image: ghcr.io/infonl/open-archiefbeheer:1.1.1@sha256:e28956d9266e13935addf14ae772d730a22304377ee0e9f0e66ed754c0d2191d
+    platform: linux/arm64
+
+  pabc-migrations:
+    image: ghcr.io/infonl/pabc-migrations:1.1.0@sha256:393017fdef406aa5e166a2bcd2ff7c2b08e424fe846a19d28d2cf8ab5ca6731d
+    platform: linux/arm64
+
+  pabc-api:
+    image: ghcr.io/infonl/pabc-api:1.1.0@sha256:ae4ae30ef7af6cde3614460cfed314e8da1d8d39ac233fd7be607f3125389dc2
+    platform: linux/arm64

--- a/docs/development/installDockerCompose.md
+++ b/docs/development/installDockerCompose.md
@@ -80,7 +80,13 @@ DOCKER_USE_ARM64_CONTAINERS=true ./start-docker-compose.sh
 
 ```
 
-You can also add this environment variable to your shell for convenience.
+You can also add this environment variable to your shell for convenience by adding to your
+local `~/.zshrc`:
+
+```
+# ZAC
+export DOCKER_USE_ARM64_CONTAINERS=true
+```
 
 ### Notes
 

--- a/docs/development/installDockerCompose.md
+++ b/docs/development/installDockerCompose.md
@@ -70,6 +70,18 @@ start up ZAC or even build the ZAC Docker Image first beforehand:
 ./start-docker-compose.sh -h
 ```
 
+### Using arm64 containers on a Mac
+
+If you want to run arm64 containers, you can set the environment variable `DOCKER_USE_ARM64_CONTAINERS=true`
+before starting the shell script:
+
+```
+DOCKER_USE_ARM64_CONTAINERS=true ./start-docker-compose.sh
+
+```
+
+You can also add this environment variable to your shell for convenience.
+
 ### Notes
 
 #### Using the latest version of ZAC

--- a/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
@@ -258,9 +258,9 @@ class ZacItestProjectConfig : AbstractProjectConfig() {
         System.getenv(DOCKER_USE_ARM64_CONTAINERS_ENV_VAR)
             ?.takeIf { it.isNotBlank() }
             ?.let {
-            composeFiles.add(File("docker-compose.arm64-override.yaml"))
-            logger.info { "Using arm64 containers" }
-        }
+                composeFiles.add(File("docker-compose.arm64-override.yaml"))
+                logger.info { "Using arm64 containers" }
+            }
 
         return ComposeContainer("zac-itest-", composeFiles)
             .withEnv(dockerComposeOverrideEnvironment)

--- a/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
@@ -111,6 +111,7 @@ class ZacItestProjectConfig : AbstractProjectConfig() {
     companion object {
         private const val DO_NOT_START_DOCKER_COMPOSE_ENV_VAR = "DO_NOT_START_DOCKER_COMPOSE"
         private const val TESTCONTAINERS_RYUK_DISABLED_ENV_VAR = "TESTCONTAINERS_RYUK_DISABLED"
+        private const val DOCKER_USE_ARM64_CONTAINERS_ENV_VAR = "DOCKER_USE_ARM64_CONTAINERS"
 
         private val logger = KotlinLogging.logger {}
         private val itestHttpClient = ItestHttpClient()
@@ -244,7 +245,7 @@ class ZacItestProjectConfig : AbstractProjectConfig() {
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
+    @Suppress("UNCHECKED_CAST", "LongMethod")
     private fun createDockerComposeContainer(): ComposeContainer {
         logger.info { "Using Docker Compose environment variables: $dockerComposeOverrideEnvironment" }
 
@@ -253,7 +254,13 @@ class ZacItestProjectConfig : AbstractProjectConfig() {
         val envFile = Files.createTempFile("zac-itest", ".env").toFile()
         emptyEnvFile = envFile
 
-        return ComposeContainer("zac-itest-", File("docker-compose.yaml"))
+        val composeFiles: MutableList<File> = mutableListOf(File("docker-compose.yaml"))
+        System.getenv(DOCKER_USE_ARM64_CONTAINERS_ENV_VAR)?.let {
+            composeFiles.add(File("docker-compose.arm64-override.yaml"))
+            logger.info { "Using arm64 containers" }
+        }
+
+        return ComposeContainer("zac-itest-", composeFiles)
             .withEnv(dockerComposeOverrideEnvironment)
             .withOptions(
                 "--profile zac",

--- a/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
@@ -255,7 +255,9 @@ class ZacItestProjectConfig : AbstractProjectConfig() {
         emptyEnvFile = envFile
 
         val composeFiles: MutableList<File> = mutableListOf(File("docker-compose.yaml"))
-        System.getenv(DOCKER_USE_ARM64_CONTAINERS_ENV_VAR)?.let {
+        System.getenv(DOCKER_USE_ARM64_CONTAINERS_ENV_VAR)
+            ?.takeIf { it.isNotBlank() }
+            ?.let {
             composeFiles.add(File("docker-compose.arm64-override.yaml"))
             logger.info { "Using arm64 containers" }
         }

--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -138,4 +138,9 @@ fi
 # Uses the 1Password CLI tools to set up the environment variables for running Docker Compose and ZAC in IntelliJ.
 # Please see docs/INSTALL.md for details on how to use this script.
 echo "Starting Docker Compose environment with profiles [$profilesList] ..."
-export APP_ENV=devlocal && export COMPOSE_PROFILES=$profilesList && export OTEL_SDK_DISABLED=$disableZacOpenTelemetry && op run --env-file="./.env.tpl" --no-masking -- docker compose --project-name zac up -d
+if [ ! -z $DOCKER_USE_ARM64_CONTAINERS ]; then
+  echo "Using arm64 containers ..."
+  export APP_ENV=devlocal && export COMPOSE_PROFILES=$profilesList && export OTEL_SDK_DISABLED=$disableZacOpenTelemetry && op run --env-file="./.env.tpl" --no-masking -- docker compose -f docker-compose.yaml -f docker-compose.arm64-override.yaml --project-name zac up -d
+else
+  export APP_ENV=devlocal && export COMPOSE_PROFILES=$profilesList && export OTEL_SDK_DISABLED=$disableZacOpenTelemetry && op run --env-file="./.env.tpl" --no-masking -- docker compose --project-name zac up -d
+fi

--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -138,9 +138,14 @@ fi
 # Uses the 1Password CLI tools to set up the environment variables for running Docker Compose and ZAC in IntelliJ.
 # Please see docs/INSTALL.md for details on how to use this script.
 echo "Starting Docker Compose environment with profiles [$profilesList] ..."
-if [ ! -z $DOCKER_USE_ARM64_CONTAINERS ]; then
+if [ -n "${DOCKER_USE_ARM64_CONTAINERS:-}" ]; then
   echo "Using arm64 containers ..."
-  export APP_ENV=devlocal && export COMPOSE_PROFILES=$profilesList && export OTEL_SDK_DISABLED=$disableZacOpenTelemetry && op run --env-file="./.env.tpl" --no-masking -- docker compose -f docker-compose.yaml -f docker-compose.arm64-override.yaml --project-name zac up -d
+  compose_files="-f docker-compose.yaml"
+  if [ -f docker-compose.override.yml ]; then
+    compose_files="$compose_files -f docker-compose.override.yml"
+  fi
+  compose_files="$compose_files -f docker-compose.arm64-override.yaml"
+  export APP_ENV=devlocal && export COMPOSE_PROFILES=$profilesList && export OTEL_SDK_DISABLED=$disableZacOpenTelemetry && op run --env-file="./.env.tpl" --no-masking -- docker compose $compose_files --project-name zac up -d
 else
   export APP_ENV=devlocal && export COMPOSE_PROFILES=$profilesList && export OTEL_SDK_DISABLED=$disableZacOpenTelemetry && op run --env-file="./.env.tpl" --no-masking -- docker compose --project-name zac up -d
 fi


### PR DESCRIPTION
This change allows you to use arm64 Docker containers using the development cycle.

When you set the environment variable `DOCKER_USE_ARM64_CONTAINERS` to any value, both the shell script `start-docker-compose.sh` and the integration tests will use the arm64 container images specified in the Docker compose override file `docker-compose.arm64-override.yaml`.

The images itself are maintained in the repository [https://github.com/infonl/dimpact-docker](https://github.com/infonl/dimpact-docker). The packages are available at [https://github.com/orgs/infonl/packages](https://github.com/orgs/infonl/packages).

Solves [PZ-10802]