### PR TITLE
fix: fixed IllegalStateException when code attempts to retrieve logged-in user with invalidated session

### DIFF
--- a/src/main/java/net/atos/zac/webdav/WebdavStore.java
+++ b/src/main/java/net/atos/zac/webdav/WebdavStore.java
@@ -5,7 +5,7 @@
 package net.atos.zac.webdav;
 
 import static net.atos.zac.util.time.DateTimeConverterUtil.convertToDate;
-import static nl.info.zac.authentication.SecurityUtilKt.setLoggedInUser;
+import static nl.info.zac.authentication.LoggedInUserProviderKt.setLoggedInUser;
 import static nl.info.zac.util.Base64ConvertersKt.toBase64String;
 
 import java.io.File;

--- a/src/main/java/net/atos/zac/websocket/WebSocketServerEndPoint.java
+++ b/src/main/java/net/atos/zac/websocket/WebSocketServerEndPoint.java
@@ -9,6 +9,7 @@ import static jakarta.websocket.CloseReason.CloseCodes.VIOLATED_POLICY;
 import static net.atos.zac.websocket.SubscriptionType.DELETE_ALL;
 import static net.atos.zac.websocket.WebsocketHandshakeInterceptor.HTTP_SESSION;
 import static nl.info.zac.authentication.LoggedInUserProvider.LOGGED_IN_USER_SESSION_ATTRIBUTE;
+import static nl.info.zac.authentication.LoggedInUserProviderKt.getLoggedInUser;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -42,8 +43,7 @@ public class WebSocketServerEndPoint {
     @OnOpen
     public void open(final Session session, final EndpointConfig conf) {
         final HttpSession httpSession = (HttpSession) conf.getUserProperties().get(HTTP_SESSION);
-        final LoggedInUser loggedInUser = httpSession != null ? (LoggedInUser) httpSession.getAttribute(LOGGED_IN_USER_SESSION_ATTRIBUTE) :
-                null;
+        final LoggedInUser loggedInUser = httpSession != null ? getLoggedInUser(httpSession) : null;
         if (loggedInUser == null) {
             denyAccess(session, "no logged in user");
         } else {

--- a/src/main/java/net/atos/zac/websocket/WebSocketServerEndPoint.java
+++ b/src/main/java/net/atos/zac/websocket/WebSocketServerEndPoint.java
@@ -32,12 +32,15 @@ public class WebSocketServerEndPoint {
 
     private static final Logger LOG = Logger.getLogger(WebSocketServerEndPoint.class.getName());
 
+    private final SessionRegistry registry;
+
     @Inject
-    private SessionRegistry registry;
+    public WebSocketServerEndPoint(final SessionRegistry registry) {
+        this.registry = registry;
+    }
 
     @OnOpen
     public void open(final Session session, final EndpointConfig conf) {
-        // Check that there is a logged in employee (and that authentication has taken place).
         final HttpSession httpSession = (HttpSession) conf.getUserProperties().get(HTTP_SESSION);
         final LoggedInUser loggedInUser = httpSession != null ? (LoggedInUser) httpSession.getAttribute(LOGGED_IN_USER_SESSION_ATTRIBUTE) :
                 null;
@@ -81,8 +84,8 @@ public class WebSocketServerEndPoint {
         try {
             // According to the RFC, this close reason should be used if the other reasons are not applicable.
             session.close(new CloseReason(VIOLATED_POLICY, reason));
-        } catch (IOException e) {
-            log(session, e);
+        } catch (IOException ioException) {
+            log(session, ioException);
         }
     }
 

--- a/src/main/java/net/atos/zac/websocket/WebSocketServerEndPoint.java
+++ b/src/main/java/net/atos/zac/websocket/WebSocketServerEndPoint.java
@@ -8,7 +8,7 @@ package net.atos.zac.websocket;
 import static jakarta.websocket.CloseReason.CloseCodes.VIOLATED_POLICY;
 import static net.atos.zac.websocket.SubscriptionType.DELETE_ALL;
 import static net.atos.zac.websocket.WebsocketHandshakeInterceptor.HTTP_SESSION;
-import static nl.info.zac.authentication.SecurityUtil.LOGGED_IN_USER_SESSION_ATTRIBUTE;
+import static nl.info.zac.authentication.LoggedInUserProvider.LOGGED_IN_USER_SESSION_ATTRIBUTE;
 
 import java.io.IOException;
 import java.util.logging.Level;

--- a/src/main/kotlin/nl/info/client/brp/util/BrpClientHeadersFactory.kt
+++ b/src/main/kotlin/nl/info/client/brp/util/BrpClientHeadersFactory.kt
@@ -9,7 +9,7 @@ import jakarta.enterprise.inject.UnsatisfiedResolutionException
 import jakarta.inject.Inject
 import jakarta.ws.rs.core.MultivaluedMap
 import nl.info.zac.authentication.LoggedInUser
-import nl.info.zac.authentication.SecurityUtil.Companion.FUNCTIONEEL_GEBRUIKER
+import nl.info.zac.authentication.LoggedInUserProvider.Companion.FUNCTIONEEL_GEBRUIKER
 import nl.info.zac.configuration.BrpConfiguration
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory
 

--- a/src/main/kotlin/nl/info/zac/authentication/LoggedInUserProvider.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/LoggedInUserProvider.kt
@@ -8,12 +8,12 @@ import jakarta.enterprise.inject.Instance
 import jakarta.enterprise.inject.Produces
 import jakarta.inject.Inject
 import jakarta.servlet.http.HttpSession
-import nl.info.zac.authentication.SecurityUtil.Companion.FUNCTIONEEL_GEBRUIKER
-import nl.info.zac.authentication.SecurityUtil.Companion.LOGGED_IN_USER_SESSION_ATTRIBUTE
+import nl.info.zac.authentication.LoggedInUserProvider.Companion.FUNCTIONEEL_GEBRUIKER
+import nl.info.zac.authentication.LoggedInUserProvider.Companion.LOGGED_IN_USER_SESSION_ATTRIBUTE
 import java.io.Serial
 import java.io.Serializable
 
-class SecurityUtil @Inject constructor(
+class LoggedInUserProvider @Inject constructor(
     @ActiveSession
     val httpSession: Instance<HttpSession>
 ) : Serializable {
@@ -68,10 +68,16 @@ class SecurityUtil @Inject constructor(
 
 /**
  * If there is a logged-in user in the given [httpSession], return it.
- * Otherwise, if there is an HTTP Session but if it does not contain a logged-in user attribute, return `null`.
+ * Returns `null` if the session does not contain a logged-in user attribute or if the session has been
+ * invalidated (e.g. the user logged out while a request was still in-flight).
  */
 fun getLoggedInUser(httpSession: HttpSession) =
-    httpSession.getAttribute(LOGGED_IN_USER_SESSION_ATTRIBUTE)?.let { it as LoggedInUser }
+    try {
+        httpSession.getAttribute(LOGGED_IN_USER_SESSION_ATTRIBUTE)?.let { it as LoggedInUser }
+    } catch (_: IllegalStateException) {
+        // Session was invalidated (user logged out) while the request was still in-flight; treat as no session.
+        null
+    }
 
 fun setLoggedInUser(httpSession: HttpSession, loggedInUser: LoggedInUser) =
     httpSession.setAttribute(LOGGED_IN_USER_SESSION_ATTRIBUTE, loggedInUser)

--- a/src/main/kotlin/nl/info/zac/search/IndexingService.kt
+++ b/src/main/kotlin/nl/info/zac/search/IndexingService.kt
@@ -16,7 +16,7 @@ import nl.info.client.zgw.shared.ZgwApiService
 import nl.info.client.zgw.util.extractUuid
 import nl.info.client.zgw.zrc.ZrcClientService
 import nl.info.zac.app.task.model.TaakSortering
-import nl.info.zac.authentication.SecurityUtil.Companion.systemUser
+import nl.info.zac.authentication.LoggedInUserProvider.Companion.systemUser
 import nl.info.zac.search.converter.AbstractZoekObjectConverter
 import nl.info.zac.search.model.zoekobject.ZoekObject
 import nl.info.zac.search.model.zoekobject.ZoekObjectType

--- a/src/test/kotlin/net/atos/zac/websocket/WebSocketServerEndPointTest.kt
+++ b/src/test/kotlin/net/atos/zac/websocket/WebSocketServerEndPointTest.kt
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: 2025 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+package net.atos.zac.websocket
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.checkUnnecessaryStub
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import jakarta.servlet.http.HttpSession
+import jakarta.websocket.CloseReason
+import jakarta.websocket.EndpointConfig
+import jakarta.websocket.Session
+import net.atos.zac.websocket.WebsocketHandshakeInterceptor.HTTP_SESSION
+import nl.info.zac.authentication.LoggedInUser
+import nl.info.zac.authentication.LoggedInUserProvider.Companion.LOGGED_IN_USER_SESSION_ATTRIBUTE
+
+class WebSocketServerEndPointTest : BehaviorSpec({
+    val registry = mockk<SessionRegistry>()
+    val endpoint = WebSocketServerEndPoint(registry)
+
+    beforeEach {
+        checkUnnecessaryStub()
+    }
+
+    Given("a WebSocket open event with no HTTP session in the endpoint config") {
+        val wsSession = mockk<Session>(relaxed = true)
+        val endpointConfig = mockk<EndpointConfig>()
+        every { endpointConfig.userProperties } returns mutableMapOf()
+
+        When("open is called") {
+            endpoint.open(wsSession, endpointConfig)
+
+            Then("access is denied and the WebSocket session is closed with VIOLATED_POLICY") {
+                verify(exactly = 1) {
+                    wsSession.close(match { it.closeCode.code == CloseReason.CloseCodes.VIOLATED_POLICY.code })
+                }
+            }
+        }
+    }
+
+    Given("a WebSocket open event with an HTTP session that has no logged-in user") {
+        val wsSession = mockk<Session>(relaxed = true)
+        val endpointConfig = mockk<EndpointConfig>()
+        val httpSession = mockk<HttpSession>()
+        every { endpointConfig.userProperties } returns mutableMapOf<String, Any>(HTTP_SESSION to httpSession)
+        every { httpSession.getAttribute(LOGGED_IN_USER_SESSION_ATTRIBUTE) } returns null
+
+        When("open is called") {
+            endpoint.open(wsSession, endpointConfig)
+
+            Then("access is denied and the WebSocket session is closed with VIOLATED_POLICY") {
+                verify(exactly = 1) {
+                    wsSession.close(match { it.closeCode.code == CloseReason.CloseCodes.VIOLATED_POLICY.code })
+                }
+            }
+        }
+    }
+
+    Given("a WebSocket open event with an authenticated HTTP session") {
+        val wsSession = mockk<Session>(relaxed = true)
+        val endpointConfig = mockk<EndpointConfig>()
+        val httpSession = mockk<HttpSession>()
+        val wsUserProperties = mutableMapOf<String, Any>()
+        val loggedInUser = LoggedInUser(
+            id = "user-123",
+            firstName = "Test",
+            lastName = "User",
+            displayName = null,
+            email = null,
+            roles = emptySet(),
+            groupIds = emptySet()
+        )
+        every { wsSession.userProperties } returns wsUserProperties
+        every { endpointConfig.userProperties } returns mutableMapOf<String, Any>(HTTP_SESSION to httpSession)
+        every { httpSession.getAttribute(LOGGED_IN_USER_SESSION_ATTRIBUTE) } returns loggedInUser
+
+        When("open is called") {
+            endpoint.open(wsSession, endpointConfig)
+
+            Then("the WebSocket session is opened and the user ID is stored in session properties") {
+                wsUserProperties[LOGGED_IN_USER_SESSION_ATTRIBUTE] shouldBe "user-123"
+            }
+        }
+    }
+
+    Given("an open WebSocket session receiving a non-null subscription message") {
+        val wsSession = mockk<Session>(relaxed = true)
+        val message = SubscriptionType.DELETE_ALL.message()
+        every { registry.deleteAll(wsSession) } just runs
+
+        When("the message is processed") {
+            endpoint.processMessage(message, wsSession)
+
+            Then("the message is registered with the session registry") {
+                verify(exactly = 1) { registry.deleteAll(wsSession) }
+            }
+        }
+    }
+
+    Given("an open WebSocket session receiving a null subscription message") {
+        val wsSession = mockk<Session>(relaxed = true)
+
+        When("the message is processed") {
+            endpoint.processMessage(null, wsSession)
+
+            Then("no registry operation is performed") {
+                verify(exactly = 0) { registry.deleteAll(wsSession) }
+            }
+        }
+    }
+
+    Given("a WebSocket session close event") {
+        val wsSession = mockk<Session>(relaxed = true)
+        val closeReason = CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "normal close")
+        every { registry.deleteAll(wsSession) } just runs
+
+        When("close is called") {
+            endpoint.close(wsSession, closeReason)
+
+            Then("DELETE_ALL is processed for the session to prevent resource leaks") {
+                verify(exactly = 1) { registry.deleteAll(wsSession) }
+            }
+        }
+    }
+
+    Given("a WebSocket error event with an exception that has a message") {
+        val wsSession = mockk<Session>(relaxed = true)
+
+        When("the error handler is called") {
+            endpoint.log(wsSession, RuntimeException("connection reset"))
+
+            Then("the error is logged without throwing") { }
+        }
+    }
+
+    Given("a WebSocket error event with an exception that has no message") {
+        val wsSession = mockk<Session>(relaxed = true)
+
+        When("the error handler is called") {
+            endpoint.log(wsSession, object : Exception() {})
+
+            Then("the class simple name is used as log message and no exception is thrown") { }
+        }
+    }
+})

--- a/src/test/kotlin/net/atos/zac/websocket/WebSocketServerEndPointTest.kt
+++ b/src/test/kotlin/net/atos/zac/websocket/WebSocketServerEndPointTest.kt
@@ -63,6 +63,24 @@ class WebSocketServerEndPointTest : BehaviorSpec({
         }
     }
 
+    Given("a WebSocket open event with an invalidated HTTP session") {
+        val wsSession = mockk<Session>(relaxed = true)
+        val endpointConfig = mockk<EndpointConfig>()
+        val httpSession = mockk<HttpSession>()
+        every { endpointConfig.userProperties } returns mutableMapOf<String, Any>(HTTP_SESSION to httpSession)
+        every { httpSession.getAttribute(LOGGED_IN_USER_SESSION_ATTRIBUTE) } throws IllegalStateException("session invalidated")
+
+        When("open is called") {
+            endpoint.open(wsSession, endpointConfig)
+
+            Then("access is denied and the WebSocket session is closed with VIOLATED_POLICY") {
+                verify(exactly = 1) {
+                    wsSession.close(match { it.closeCode.code == CloseReason.CloseCodes.VIOLATED_POLICY.code })
+                }
+            }
+        }
+    }
+
     Given("a WebSocket open event with an authenticated HTTP session") {
         val wsSession = mockk<Session>(relaxed = true)
         val endpointConfig = mockk<EndpointConfig>()

--- a/src/test/kotlin/nl/info/client/brp/util/BrpClientHeadersFactoryTest.kt
+++ b/src/test/kotlin/nl/info/client/brp/util/BrpClientHeadersFactoryTest.kt
@@ -18,7 +18,7 @@ import jakarta.enterprise.inject.UnsatisfiedResolutionException
 import nl.info.client.brp.util.BrpClientHeadersFactory.Companion.MAX_HEADER_SIZE
 import nl.info.client.brp.util.BrpClientHeadersFactory.Companion.MAX_USER_HEADER_SIZE
 import nl.info.zac.authentication.LoggedInUser
-import nl.info.zac.authentication.SecurityUtil.Companion.FUNCTIONEEL_GEBRUIKER
+import nl.info.zac.authentication.LoggedInUserProvider.Companion.FUNCTIONEEL_GEBRUIKER
 import org.jboss.resteasy.core.Headers
 import java.util.Optional
 

--- a/src/test/kotlin/nl/info/zac/authentication/LoggedInUserProviderTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/LoggedInUserProviderTest.kt
@@ -14,7 +14,7 @@ import jakarta.servlet.http.HttpSession
 class LoggedInUserProviderTest : BehaviorSpec({
     val httpSession = mockk<HttpSession>()
 
-    beforeSpec {
+    beforeEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/authentication/LoggedInUserProviderTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/LoggedInUserProviderTest.kt
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+package nl.info.zac.authentication
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.checkUnnecessaryStub
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.servlet.http.HttpSession
+
+class LoggedInUserProviderTest : BehaviorSpec({
+    val httpSession = mockk<HttpSession>()
+
+    beforeSpec {
+        checkUnnecessaryStub()
+    }
+
+    Context("Get logged-in user") {
+        Given("a valid session with a logged-in user attribute") {
+            val loggedInUser = mockk<LoggedInUser>()
+            every { httpSession.getAttribute(LoggedInUserProvider.LOGGED_IN_USER_SESSION_ATTRIBUTE) } returns loggedInUser
+
+            When("getLoggedInUser is called") {
+                val result = getLoggedInUser(httpSession)
+
+                Then("it returns the logged-in user") {
+                    result shouldBe loggedInUser
+                }
+            }
+        }
+
+        Given("a valid session without a logged-in user attribute") {
+            every { httpSession.getAttribute(LoggedInUserProvider.LOGGED_IN_USER_SESSION_ATTRIBUTE) } returns null
+
+            When("getLoggedInUser is called") {
+                val result = getLoggedInUser(httpSession)
+
+                Then("it returns null") {
+                    result shouldBe null
+                }
+            }
+        }
+
+        Given("a session that has been invalidated (user logged out while request was in-flight)") {
+            every {
+                httpSession.getAttribute(LoggedInUserProvider.LOGGED_IN_USER_SESSION_ATTRIBUTE)
+            } throws IllegalStateException("UT000010: Session is invalid")
+
+            When("getLoggedInUser is called") {
+                val result = getLoggedInUser(httpSession)
+
+                Then("it returns null instead of propagating the IllegalStateException") {
+                    result shouldBe null
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Fixed IllegalStateException when code attempts to retrieve logged-in user from HTTP session while session has been invalidated. This happens for example when a user is receiving signaleringen when zaken have been assigned to their name and at that moment the user logs out or their session times out. We also saw this happen when running our e2e tests in the past.

Solves PZ-10943