### PR TITLE
fix(task-forms): fix ExternAdviesMail verzender serialization and harden taak form specs

### DIFF
--- a/.claude/commands/audit-ng-spec-skill.md
+++ b/.claude/commands/audit-ng-spec-skill.md
@@ -34,10 +34,23 @@ For each item, mark **PASS** or **FAIL** with a one-line reason and the exact li
 **Spec structure**
 - [ ] `describe(ClassName.name, ...)` — class name reference, not a string literal
 - [ ] `declarations: [Component]` used (component is `standalone: false`), OR `imports: [Component]` if already standalone
-- [ ] Services mocked via `TestBed.inject()` + `jest.spyOn()` — NOT `useValue: mockObject` (exception: `MAT_DIALOG_DATA`, `LOCALE_ID`, and other Angular built-in tokens)
-- [ ] `provideHttpClient()` present if any service uses `ZacHttpClient`
-- [ ] `provideRouter([])` present if any service uses `Router`
-- [ ] Factory helpers use `as Partial<T> as unknown as T` — never bare `as unknown as T` on an object literal
+- [ ] **Services should use `TestBed.inject()` + `jest.spyOn()` — avoid `useValue: mockObject`.**
+  - **Reason: type safety.** `useValue` accepts any object — typos, missing methods, wrong return types all silently pass. `jest.spyOn` is checked against the real service type, so the compiler catches mismatches.
+  - Strongly preferred pattern:
+    ```typescript
+    providers: [provideHttpClient(), provideRouter([]), MyService],
+    // ...
+    myService = TestBed.inject(MyService);
+    jest.spyOn(myService, "someMethod").mockReturnValue(of(result));
+    ```
+  - `useValue` is acceptable when genuinely difficult to avoid (e.g. a service with a deeply complex DI tree that cannot be satisfied without significant setup). Flag it with a comment explaining why.
+  - **Always acceptable exceptions**: Angular built-in injection tokens (`MAT_DIALOG_DATA`, `LOCALE_ID`, `APP_BASE_HREF`, etc.) where no real class exists to inject.
+  - `TranslateService` → use `TranslateModule.forRoot()` in `imports`, then `TestBed.inject(TranslateService)` + `jest.spyOn`.
+  - Services using `ZacHttpClient` → add `provideHttpClient()` to providers.
+  - Services using `Router` → add `provideRouter([])` to providers.
+- [ ] `provideHttpClient()` present if any service in the tree uses `ZacHttpClient`
+- [ ] `provideRouter([])` present if any service in the tree uses `Router`
+- [ ] Factory helpers use `fromPartial<T>(obj)` — never bare `{ ... } as unknown as T` on an object literal (non-literal re-casts like `mockVar as unknown as T` are OK)
 
 **Coverage**
 - [ ] Every test asserts meaningful behaviour

--- a/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie-task-form.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/aanvullende-informatie-task-form.spec.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
+import { provideHttpClient } from "@angular/common/http";
 import { TestBed } from "@angular/core/testing";
-import { TranslateService } from "@ngx-translate/core";
+import { provideRouter } from "@angular/router";
+import { TranslateModule } from "@ngx-translate/core";
 import moment from "moment";
 import { of } from "rxjs";
-import { FoutAfhandelingService } from "src/app/fout-afhandeling/fout-afhandeling.service";
 import { fromPartial } from "../../../../test-helpers";
 import { InformatieObjectenService } from "../../../informatie-objecten/informatie-objecten.service";
 import { KlantenService } from "../../../klanten/klanten.service";
@@ -16,14 +17,12 @@ import { GeneratedType } from "../../../shared/utils/generated-types";
 import { ZakenService } from "../../../zaken/zaken.service";
 import { AanvullendeInformatieTaskForm } from "./aanvullende-informatie-task-form";
 
-describe("AanvullendeInformatieTaskForm", () => {
+describe(AanvullendeInformatieTaskForm.name, () => {
   let formulier: AanvullendeInformatieTaskForm;
-  let zakenService: { listAfzendersVoorZaak: jest.Mock };
-  let mailtemplateService: { findMailtemplate: jest.Mock };
-  let informatieObjectenService: {
-    listEnkelvoudigInformatieobjecten: jest.Mock;
-  };
-  let klantenService: { getContactDetailsForPerson: jest.Mock };
+  let listAfzendersVoorZaakSpy: jest.SpyInstance;
+  let findMailtemplateSpy: jest.SpyInstance;
+  let listEnkelvoudigInformatieobjectenSpy: jest.SpyInstance;
+  let getContactDetailsForPersonSpy: jest.SpyInstance;
 
   const mockZaak = fromPartial<GeneratedType<"RestZaak">>({
     uuid: "zaak-uuid",
@@ -48,34 +47,33 @@ describe("AanvullendeInformatieTaskForm", () => {
   });
 
   beforeEach(() => {
-    zakenService = {
-      listAfzendersVoorZaak: jest.fn().mockReturnValue(of([])),
-    };
-    mailtemplateService = {
-      findMailtemplate: jest
-        .fn()
-        .mockReturnValue(of({ body: "template body", variabelen: [] })),
-    };
-    informatieObjectenService = {
-      listEnkelvoudigInformatieobjecten: jest.fn().mockReturnValue(of([])),
-    };
-    klantenService = {
-      getContactDetailsForPerson: jest.fn().mockReturnValue(of({})),
-    };
-
     TestBed.configureTestingModule({
-      providers: [
-        { provide: FoutAfhandelingService, useValue: {} },
-        { provide: TranslateService, useValue: { instant: jest.fn() } },
-        { provide: ZakenService, useValue: zakenService },
-        { provide: MailtemplateService, useValue: mailtemplateService },
-        {
-          provide: InformatieObjectenService,
-          useValue: informatieObjectenService,
-        },
-        { provide: KlantenService, useValue: klantenService },
-      ],
+      imports: [TranslateModule.forRoot()],
+      providers: [provideHttpClient(), provideRouter([])],
     });
+
+    listAfzendersVoorZaakSpy = jest
+      .spyOn(TestBed.inject(ZakenService), "listAfzendersVoorZaak")
+      .mockReturnValue(of([]));
+    findMailtemplateSpy = jest
+      .spyOn(TestBed.inject(MailtemplateService), "findMailtemplate")
+      .mockReturnValue(
+        of(
+          fromPartial<GeneratedType<"RESTMailtemplate">>({
+            body: "template body",
+            variabelen: [],
+          }),
+        ),
+      );
+    listEnkelvoudigInformatieobjectenSpy = jest
+      .spyOn(
+        TestBed.inject(InformatieObjectenService),
+        "listEnkelvoudigInformatieobjecten",
+      )
+      .mockReturnValue(of([]));
+    getContactDetailsForPersonSpy = jest
+      .spyOn(TestBed.inject(KlantenService), "getContactDetailsForPerson")
+      .mockReturnValue(of({}));
 
     formulier = TestBed.inject(AanvullendeInformatieTaskForm);
   });
@@ -163,7 +161,7 @@ describe("AanvullendeInformatieTaskForm", () => {
       it("should call findMailtemplate with TAAK_AANVULLENDE_INFORMATIE and zaak uuid", async () => {
         await formulier.requestForm(mockZaak);
 
-        expect(mailtemplateService.findMailtemplate).toHaveBeenCalledWith(
+        expect(findMailtemplateSpy).toHaveBeenCalledWith(
           "TAAK_AANVULLENDE_INFORMATIE",
           "zaak-uuid",
         );
@@ -172,14 +170,19 @@ describe("AanvullendeInformatieTaskForm", () => {
       it("should call listEnkelvoudigInformatieobjecten with zaak uuid for bijlagen", async () => {
         await formulier.requestForm(mockZaak);
 
-        expect(
-          informatieObjectenService.listEnkelvoudigInformatieobjecten,
-        ).toHaveBeenCalledWith({ zaakUUID: "zaak-uuid" });
+        expect(listEnkelvoudigInformatieobjectenSpy).toHaveBeenCalledWith({
+          zaakUUID: "zaak-uuid",
+        });
       });
 
       it("should use empty array for body variables when mailtemplate variabelen is null", async () => {
-        mailtemplateService.findMailtemplate.mockReturnValue(
-          of({ body: "template body", variabelen: null }),
+        findMailtemplateSpy.mockReturnValue(
+          of(
+            fromPartial<GeneratedType<"RESTMailtemplate">>({
+              body: "template body",
+              variabelen: null,
+            }),
+          ),
         );
 
         const fields = await formulier.requestForm(mockZaak);
@@ -191,7 +194,7 @@ describe("AanvullendeInformatieTaskForm", () => {
 
     describe("verzender", () => {
       it("should set verzender options from listAfzendersVoorZaak", async () => {
-        zakenService.listAfzendersVoorZaak.mockReturnValue(
+        listAfzendersVoorZaakSpy.mockReturnValue(
           of([mockAfzender, mockDefaultAfzender]),
         );
 
@@ -204,7 +207,7 @@ describe("AanvullendeInformatieTaskForm", () => {
       });
 
       it("should pre-select the default afzender", async () => {
-        zakenService.listAfzendersVoorZaak.mockReturnValue(
+        listAfzendersVoorZaakSpy.mockReturnValue(
           of([mockAfzender, mockDefaultAfzender]),
         );
 
@@ -217,7 +220,7 @@ describe("AanvullendeInformatieTaskForm", () => {
       });
 
       it("should set verzender to null when no default afzender exists", async () => {
-        zakenService.listAfzendersVoorZaak.mockReturnValue(of([mockAfzender]));
+        listAfzendersVoorZaakSpy.mockReturnValue(of([mockAfzender]));
 
         const fields = await formulier.requestForm(mockZaak);
 
@@ -226,7 +229,7 @@ describe("AanvullendeInformatieTaskForm", () => {
       });
 
       it("should update replyTo when verzender changes", async () => {
-        zakenService.listAfzendersVoorZaak.mockReturnValue(
+        listAfzendersVoorZaakSpy.mockReturnValue(
           of([mockAfzender, mockDefaultAfzender]),
         );
 
@@ -245,9 +248,7 @@ describe("AanvullendeInformatieTaskForm", () => {
       });
 
       it("should set replyTo to null when verzender is cleared", async () => {
-        zakenService.listAfzendersVoorZaak.mockReturnValue(
-          of([mockDefaultAfzender]),
-        );
+        listAfzendersVoorZaakSpy.mockReturnValue(of([mockDefaultAfzender]));
 
         const fields = await formulier.requestForm(mockZaak);
 
@@ -394,7 +395,7 @@ describe("AanvullendeInformatieTaskForm", () => {
       });
 
       it("should pre-fill the email from initiatorIdentificatie when both type and temporaryPersonId are set", async () => {
-        klantenService.getContactDetailsForPerson.mockReturnValue(
+        getContactDetailsForPersonSpy.mockReturnValue(
           of(
             fromPartial<GeneratedType<"RestContactDetails">>({
               emailadres: "test@example.com",
@@ -411,7 +412,7 @@ describe("AanvullendeInformatieTaskForm", () => {
 
         const fields = await formulier.requestForm(zaakWithInitiator);
 
-        expect(klantenService.getContactDetailsForPerson).toHaveBeenCalledWith(
+        expect(getContactDetailsForPersonSpy).toHaveBeenCalledWith(
           "person-123",
         );
         const emailField = fields.find((f) => f.key === "emailadres");
@@ -421,13 +422,11 @@ describe("AanvullendeInformatieTaskForm", () => {
       it("should not call getContactDetailsForPerson when initiatorIdentificatie is absent", async () => {
         await formulier.requestForm(mockZaak);
 
-        expect(
-          klantenService.getContactDetailsForPerson,
-        ).not.toHaveBeenCalled();
+        expect(getContactDetailsForPersonSpy).not.toHaveBeenCalled();
       });
 
       it("should not set email when getContactDetailsForPerson returns no emailadres", async () => {
-        klantenService.getContactDetailsForPerson.mockReturnValue(
+        getContactDetailsForPersonSpy.mockReturnValue(
           of(fromPartial<GeneratedType<"RestContactDetails">>({})),
         );
         const zaakWithInitiator = fromPartial<GeneratedType<"RestZaak">>({

--- a/src/main/app/src/app/formulieren/taken/model/abstract-taak-formulier.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/abstract-taak-formulier.spec.ts
@@ -20,9 +20,10 @@ import { MatInputHarness } from "@angular/material/input/testing";
 import { MatRadioGroupHarness } from "@angular/material/radio/testing";
 import { MatSelectHarness } from "@angular/material/select/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { RouterModule } from "@angular/router";
+import { provideRouter } from "@angular/router";
 import { TranslateModule } from "@ngx-translate/core";
 import { of } from "rxjs";
+import { fromPartial } from "../../../../test-helpers";
 import { FormField, ZacForm } from "../../../shared/form/form";
 import { MaterialFormBuilderModule } from "../../../shared/material-form-builder/material-form-builder.module";
 import { GeneratedType } from "../../../shared/utils/generated-types";
@@ -129,10 +130,9 @@ describe(AbstractTaskForm.name, () => {
         ReactiveFormsModule,
         NoopAnimationsModule,
         TranslateModule.forRoot(),
-        RouterModule.forRoot([]),
         MaterialFormBuilderModule,
       ],
-      providers: [FormBuilder],
+      providers: [FormBuilder, provideRouter([])],
     }).compileComponents();
 
     formulier = TestBed.runInInjectionContext(() => new TestForm());
@@ -140,9 +140,9 @@ describe(AbstractTaskForm.name, () => {
 
   describe("requestForm rendering", () => {
     beforeEach(async () => {
-      const fields = await formulier.requestForm({
-        uuid: "zaak-uuid",
-      } as GeneratedType<"RestZaak">);
+      const fields = await formulier.requestForm(
+        fromPartial<GeneratedType<"RestZaak">>({ uuid: "zaak-uuid" }),
+      );
 
       formGroup = new FormGroup({});
       for (const field of fields) {

--- a/src/main/app/src/app/formulieren/taken/model/abstract-task-form.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/abstract-task-form.spec.ts
@@ -142,7 +142,9 @@ describe(AbstractTaskForm.name, () => {
     beforeEach(async () => {
       const fields = await formulier.requestForm({
         uuid: "zaak-uuid",
-      } as GeneratedType<"RestZaak">);
+      } as Partial<
+        GeneratedType<"RestZaak">
+      > as unknown as GeneratedType<"RestZaak">);
 
       formGroup = new FormGroup({});
       for (const field of fields) {

--- a/src/main/app/src/app/formulieren/taken/model/abstract-task-form.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/abstract-task-form.spec.ts
@@ -23,6 +23,7 @@ import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterModule } from "@angular/router";
 import { TranslateModule } from "@ngx-translate/core";
 import { of } from "rxjs";
+import { fromPartial } from "../../../../test-helpers";
 import { FormField, ZacForm } from "../../../shared/form/form";
 import { MaterialFormBuilderModule } from "../../../shared/material-form-builder/material-form-builder.module";
 import { GeneratedType } from "../../../shared/utils/generated-types";
@@ -140,11 +141,9 @@ describe(AbstractTaskForm.name, () => {
 
   describe("requestForm rendering", () => {
     beforeEach(async () => {
-      const fields = await formulier.requestForm({
-        uuid: "zaak-uuid",
-      } as Partial<
-        GeneratedType<"RestZaak">
-      > as unknown as GeneratedType<"RestZaak">);
+      const fields = await formulier.requestForm(
+        fromPartial<GeneratedType<"RestZaak">>({ uuid: "zaak-uuid" }),
+      );
 
       formGroup = new FormGroup({});
       for (const field of fields) {

--- a/src/main/app/src/app/formulieren/taken/model/advies-task-form.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/advies-task-form.spec.ts
@@ -126,7 +126,9 @@ describe(AdviesTaskForm.name, () => {
       });
 
       it("should pass fetched documents as options", async () => {
-        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument]));
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(
+          of([mockDocument]),
+        );
 
         const fields = await formulier.requestForm(mockZaak);
 

--- a/src/main/app/src/app/formulieren/taken/model/advies-task-form.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/advies-task-form.spec.ts
@@ -3,20 +3,19 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
+import { provideHttpClient } from "@angular/common/http";
 import { TestBed } from "@angular/core/testing";
-import { TranslateService } from "@ngx-translate/core";
+import { provideRouter } from "@angular/router";
+import { TranslateModule } from "@ngx-translate/core";
 import { of } from "rxjs";
-import { FoutAfhandelingService } from "src/app/fout-afhandeling/fout-afhandeling.service";
 import { fromPartial } from "../../../../test-helpers";
 import { InformatieObjectenService } from "../../../informatie-objecten/informatie-objecten.service";
 import { GeneratedType } from "../../../shared/utils/generated-types";
 import { AdviesTaskForm } from "./advies-task-form";
 
-describe("AdviesTaskForm", () => {
+describe(AdviesTaskForm.name, () => {
   let formulier: AdviesTaskForm;
-  let informatieObjectenService: {
-    listEnkelvoudigInformatieobjecten: jest.Mock;
-  };
+  let informatieObjectenService: InformatieObjectenService;
   const mockZaak = fromPartial<GeneratedType<"RestZaak">>({
     uuid: "zaak-uuid",
   });
@@ -26,20 +25,15 @@ describe("AdviesTaskForm", () => {
   >({ uuid: "doc-uuid-1", titel: "Document 1" });
 
   beforeEach(() => {
-    informatieObjectenService = {
-      listEnkelvoudigInformatieobjecten: jest.fn().mockReturnValue(of([])),
-    };
-
     TestBed.configureTestingModule({
-      providers: [
-        { provide: FoutAfhandelingService, useValue: {} },
-        { provide: TranslateService, useValue: {} },
-        {
-          provide: InformatieObjectenService,
-          useValue: informatieObjectenService,
-        },
-      ],
+      imports: [TranslateModule.forRoot()],
+      providers: [provideHttpClient(), provideRouter([])],
     });
+
+    informatieObjectenService = TestBed.inject(InformatieObjectenService);
+    jest
+      .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
+      .mockReturnValue(of([]));
 
     formulier = TestBed.inject(AdviesTaskForm);
   });
@@ -131,9 +125,9 @@ describe("AdviesTaskForm", () => {
       });
 
       it("should pass fetched documents as options", async () => {
-        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
-          of([mockDocument]),
-        );
+        jest
+          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
+          .mockReturnValue(of([mockDocument]));
 
         const fields = await formulier.requestForm(mockZaak);
 

--- a/src/main/app/src/app/formulieren/taken/model/advies-task-form.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/advies-task-form.spec.ts
@@ -16,6 +16,7 @@ import { AdviesTaskForm } from "./advies-task-form";
 describe(AdviesTaskForm.name, () => {
   let formulier: AdviesTaskForm;
   let informatieObjectenService: InformatieObjectenService;
+  let listEnkelvoudigInformatieobjectenSpy: jest.SpyInstance;
   const mockZaak = fromPartial<GeneratedType<"RestZaak">>({
     uuid: "zaak-uuid",
   });
@@ -31,7 +32,7 @@ describe(AdviesTaskForm.name, () => {
     });
 
     informatieObjectenService = TestBed.inject(InformatieObjectenService);
-    jest
+    listEnkelvoudigInformatieobjectenSpy = jest
       .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
       .mockReturnValue(of([]));
 
@@ -125,9 +126,7 @@ describe(AdviesTaskForm.name, () => {
       });
 
       it("should pass fetched documents as options", async () => {
-        jest
-          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
-          .mockReturnValue(of([mockDocument]));
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument]));
 
         const fields = await formulier.requestForm(mockZaak);
 

--- a/src/main/app/src/app/formulieren/taken/model/extern-advies-mail.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/extern-advies-mail.spec.ts
@@ -1,0 +1,437 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import { provideHttpClient } from "@angular/common/http";
+import { TestBed } from "@angular/core/testing";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
+import { of } from "rxjs";
+import { fromPartial } from "../../../../test-helpers";
+import { InformatieObjectenService } from "../../../informatie-objecten/informatie-objecten.service";
+import { MailtemplateService } from "../../../mailtemplate/mailtemplate.service";
+import { SelectFormField } from "../../../shared/material-form-builder/form-components/select/select-form-field";
+import { FieldType } from "../../../shared/material-form-builder/model/field-type.enum";
+import { GeneratedType } from "../../../shared/utils/generated-types";
+import { TakenService } from "../../../taken/taken.service";
+import { ZakenService } from "../../../zaken/zaken.service";
+import { ExternAdviesMail } from "./extern-advies-mail";
+
+describe(ExternAdviesMail.name, () => {
+  let formulier: ExternAdviesMail;
+  let translateService: TranslateService;
+  let zakenService: ZakenService;
+  let mailtemplateService: MailtemplateService;
+  let informatieObjectenService: InformatieObjectenService;
+
+  const mockZaak = fromPartial<GeneratedType<"RestZaak">>({
+    uuid: "zaak-uuid",
+  });
+
+  const mockTaak = fromPartial<GeneratedType<"RestTask">>({
+    toelichting: undefined,
+    taakdocumenten: [],
+  });
+
+  const mockAfzender = fromPartial<GeneratedType<"RestZaakAfzender">>({
+    mail: "afzender@example.com",
+    replyTo: "reply@example.com",
+    suffix: "Afdeling X",
+  });
+
+  const mockDefaultAfzender = fromPartial<GeneratedType<"RestZaakAfzender">>({
+    mail: "default@example.com",
+    replyTo: "default-reply@example.com",
+    suffix: "Default afdeling",
+    defaultMail: true,
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        provideHttpClient(),
+        TakenService,
+        ZakenService,
+        MailtemplateService,
+        InformatieObjectenService,
+      ],
+    });
+
+    translateService = TestBed.inject(TranslateService);
+    zakenService = TestBed.inject(ZakenService);
+    mailtemplateService = TestBed.inject(MailtemplateService);
+    informatieObjectenService = TestBed.inject(InformatieObjectenService);
+
+    jest.spyOn(translateService, "instant").mockReturnValue("translated-value");
+    jest.spyOn(zakenService, "listAfzendersVoorZaak").mockReturnValue(of([]));
+    jest
+      .spyOn(zakenService, "readDefaultAfzenderVoorZaak")
+      .mockReturnValue(of(null));
+    jest.spyOn(mailtemplateService, "findMailtemplate").mockReturnValue(
+      of(
+        fromPartial<GeneratedType<"RESTMailtemplate">>({
+          body: "mail-template-body",
+          variabelen: [],
+        }),
+      ),
+    );
+    jest
+      .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
+      .mockReturnValue(of([]));
+
+    formulier = new ExternAdviesMail(
+      translateService,
+      TestBed.inject(TakenService),
+      informatieObjectenService,
+      mailtemplateService,
+      zakenService,
+    );
+
+    formulier.zaak = mockZaak;
+    formulier.taak = mockTaak;
+    formulier.humanTaskData = {};
+    formulier.dataElementen = {};
+  });
+
+  describe("taakinformatieMapping", () => {
+    it("should map uitkomst to the externAdvies field key", () => {
+      expect(formulier.taakinformatieMapping.uitkomst).toBe("externAdvies");
+    });
+  });
+
+  describe("getBehandelTitel", () => {
+    it("should call translate.instant with the extern advies behandel title key", () => {
+      formulier.getBehandelTitel();
+
+      expect(translateService.instant).toHaveBeenCalledWith(
+        "title.taak.extern-advies.verwerken",
+      );
+    });
+
+    it("should return the translated title", () => {
+      const result = formulier.getBehandelTitel();
+
+      expect(result).toBe("translated-value");
+    });
+  });
+
+  describe("initStartForm (_initStartForm)", () => {
+    beforeEach(() => {
+      formulier.initStartForm();
+    });
+
+    describe("taakStuurGegevens", () => {
+      it("should set sendMail to true", () => {
+        expect(formulier.humanTaskData.taakStuurGegevens?.sendMail).toBe(true);
+      });
+
+      it("should set mail to TAAK_ADVIES_EXTERN", () => {
+        expect(formulier.humanTaskData.taakStuurGegevens?.mail).toBe(
+          "TAAK_ADVIES_EXTERN",
+        );
+      });
+    });
+
+    describe("service calls", () => {
+      it("should call listAfzendersVoorZaak with the zaak uuid", () => {
+        expect(zakenService.listAfzendersVoorZaak).toHaveBeenCalledWith(
+          "zaak-uuid",
+        );
+      });
+
+      it("should call readDefaultAfzenderVoorZaak with the zaak uuid", () => {
+        expect(zakenService.readDefaultAfzenderVoorZaak).toHaveBeenCalledWith(
+          "zaak-uuid",
+        );
+      });
+
+      it("should call findMailtemplate with TAAK_ADVIES_EXTERN and the zaak uuid", () => {
+        expect(mailtemplateService.findMailtemplate).toHaveBeenCalledWith(
+          "TAAK_ADVIES_EXTERN",
+          "zaak-uuid",
+        );
+      });
+
+      it("should call listEnkelvoudigInformatieobjecten with the zaak uuid for bijlagen", () => {
+        expect(
+          informatieObjectenService.listEnkelvoudigInformatieobjecten,
+        ).toHaveBeenCalledWith({ zaakUUID: "zaak-uuid" });
+      });
+    });
+
+    describe("adviseur field", () => {
+      it("should exist in the form", () => {
+        expect(() => formulier.getFormField("adviseur")).not.toThrow();
+      });
+
+      it("should be required", () => {
+        const field = formulier.getFormField("adviseur");
+        field.formControl.setValue("");
+        field.formControl.markAsTouched();
+
+        expect(field.formControl.errors?.["required"]).toBeDefined();
+      });
+
+      it("should enforce maxlength of 1000", () => {
+        const field = formulier.getFormField("adviseur") as unknown as {
+          maxlength: number;
+        };
+
+        expect(field.maxlength).toBe(1000);
+      });
+    });
+
+    describe("verzender field", () => {
+      it("should exist in the form", () => {
+        expect(() => formulier.getFormField("verzender")).not.toThrow();
+      });
+
+      it("should be required", () => {
+        const field = formulier.getFormField("verzender");
+        field.formControl.setValue(null);
+        field.formControl.markAsTouched();
+
+        expect(field.formControl.errors?.["required"]).toBeDefined();
+      });
+
+      it("should pre-fill with the default afzender mail string from readDefaultAfzenderVoorZaak", () => {
+        formulier.humanTaskData = {};
+        jest
+          .spyOn(zakenService, "readDefaultAfzenderVoorZaak")
+          .mockReturnValue(of(mockDefaultAfzender));
+        formulier.initStartForm();
+
+        const field = formulier.getFormField("verzender");
+
+        expect(field.formControl.value).toBe(mockDefaultAfzender.mail);
+      });
+
+      it("should remain null when readDefaultAfzenderVoorZaak emits null", () => {
+        const field = formulier.getFormField("verzender");
+
+        expect(field.formControl.value).toBeNull();
+      });
+
+      it("should have options from listAfzendersVoorZaak", () => {
+        formulier.humanTaskData = {};
+        jest
+          .spyOn(zakenService, "listAfzendersVoorZaak")
+          .mockReturnValue(of([mockAfzender, mockDefaultAfzender]));
+        formulier.initStartForm();
+
+        const field = formulier.getFormField("verzender") as SelectFormField<
+          GeneratedType<"RestZaakAfzender">
+        >;
+        let emittedOptions: GeneratedType<"RestZaakAfzender">[] = [];
+        field.options.subscribe((opts) => (emittedOptions = opts));
+
+        expect(emittedOptions.length).toBe(2);
+      });
+    });
+
+    describe("replyTo field", () => {
+      it("should exist in the form", () => {
+        expect(() => formulier.getFormField("replyTo")).not.toThrow();
+      });
+
+      it("should not be required", () => {
+        const field = formulier.getFormField("replyTo");
+        field.formControl.setValue(null);
+        field.formControl.markAsTouched();
+
+        expect(field.formControl.errors?.["required"]).toBeUndefined();
+      });
+    });
+
+    describe("emailadres field", () => {
+      it("should exist in the form", () => {
+        expect(() => formulier.getFormField("emailadres")).not.toThrow();
+      });
+
+      it("should be required", () => {
+        const field = formulier.getFormField("emailadres");
+        field.formControl.setValue("");
+        field.formControl.markAsTouched();
+
+        expect(field.formControl.errors?.["required"]).toBeDefined();
+      });
+
+      it("should reject an invalid email address", () => {
+        const field = formulier.getFormField("emailadres");
+        field.formControl.setValue("not-an-email");
+
+        expect(field.formControl.errors?.["email"]).toBeDefined();
+      });
+
+      it("should accept a valid email address", () => {
+        const field = formulier.getFormField("emailadres");
+        field.formControl.setValue("valid@example.com");
+
+        expect(field.formControl.errors).toBeNull();
+      });
+    });
+
+    describe("body field", () => {
+      it("should be an html-editor field", () => {
+        expect(formulier.getFormField("body").fieldType).toBe(
+          FieldType.HTML_EDITOR,
+        );
+      });
+
+      it("should be required", () => {
+        const field = formulier.getFormField("body");
+        field.formControl.setValue("");
+        field.formControl.markAsTouched();
+
+        expect(field.formControl.errors?.["required"]).toBeDefined();
+      });
+
+      it("should wire the mailtemplate observable to the body field", () => {
+        const field = formulier.getFormField("body") as unknown as {
+          mailtemplateBody$: unknown;
+        };
+
+        expect(field.mailtemplateBody$).toBeDefined();
+      });
+    });
+
+    describe("bijlagen field", () => {
+      it("should be a documenten-lijst field", () => {
+        expect(formulier.getFormField("bijlagen").fieldType).toBe(
+          FieldType.DOCUMENTEN_LIJST,
+        );
+      });
+    });
+
+    describe("verzender → replyTo subscription", () => {
+      it("should update replyTo when verzender changes to a known afzender", () => {
+        formulier.humanTaskData = {};
+        jest
+          .spyOn(zakenService, "listAfzendersVoorZaak")
+          .mockReturnValue(of([mockAfzender, mockDefaultAfzender]));
+        formulier.initStartForm();
+
+        const verzenderField = formulier.getFormField(
+          "verzender",
+        ) as SelectFormField<GeneratedType<"RestZaakAfzender">>;
+        const replyToField = formulier.getFormField("replyTo");
+
+        // Subscribing to options causes the tap to fire, populating valueOptions
+        verzenderField.options.subscribe();
+
+        verzenderField.formControl.setValue(
+          mockAfzender as unknown as GeneratedType<"RestZaakAfzender">,
+        );
+
+        expect(replyToField.formControl.value).toBe("reply@example.com");
+      });
+
+      it("should set replyTo to undefined when verzender changes to an unknown value", () => {
+        formulier.humanTaskData = {};
+        jest
+          .spyOn(zakenService, "listAfzendersVoorZaak")
+          .mockReturnValue(of([mockAfzender]));
+        formulier.initStartForm();
+
+        const verzenderField = formulier.getFormField(
+          "verzender",
+        ) as SelectFormField<GeneratedType<"RestZaakAfzender">>;
+        const replyToField = formulier.getFormField("replyTo");
+
+        verzenderField.options.subscribe();
+
+        verzenderField.formControl.setValue(
+          fromPartial<GeneratedType<"RestZaakAfzender">>({
+            mail: "unknown@example.com",
+          }),
+        );
+
+        expect(replyToField.formControl.value).toBeUndefined();
+      });
+    });
+  });
+
+  describe("initBehandelForm (_initBehandelForm)", () => {
+    describe("field types and readonly state (editable mode)", () => {
+      beforeEach(() => {
+        formulier.initBehandelForm(false);
+      });
+
+      it("should render adviseur as a ReadonlyFormField", () => {
+        expect(formulier.getFormField("adviseur").fieldType).toBe(
+          FieldType.READONLY,
+        );
+      });
+
+      it("should render verzender as a ReadonlyFormField", () => {
+        expect(formulier.getFormField("verzender").fieldType).toBe(
+          FieldType.READONLY,
+        );
+      });
+
+      it("should render emailadres as a ReadonlyFormField", () => {
+        expect(formulier.getFormField("emailadres").fieldType).toBe(
+          FieldType.READONLY,
+        );
+      });
+
+      it("should render body as a ReadonlyFormField", () => {
+        expect(formulier.getFormField("body").fieldType).toBe(
+          FieldType.READONLY,
+        );
+      });
+
+      it("should render externAdvies as a textarea (not readonly)", () => {
+        expect(formulier.getFormField("externAdvies").fieldType).toBe(
+          FieldType.TEXTAREA,
+        );
+        expect(formulier.getFormField("externAdvies").readonly).toBe(false);
+      });
+
+      it("should require externAdvies", () => {
+        const field = formulier.getFormField("externAdvies");
+        field.formControl.setValue("");
+        field.formControl.markAsTouched();
+
+        expect(field.formControl.errors?.["required"]).toBeDefined();
+      });
+
+      it("should enforce maxlength of 1000 on externAdvies", () => {
+        const field = formulier.getFormField("externAdvies") as unknown as {
+          maxlength: number;
+        };
+
+        expect(field.maxlength).toBe(1000);
+      });
+    });
+
+    describe("externAdvies pre-fill from dataElementen", () => {
+      it("should pre-fill externAdvies when dataElementen contains a previously saved value", () => {
+        formulier.dataElementen = { externAdvies: "eerder opgeslagen advies" };
+
+        formulier.initBehandelForm(false);
+
+        expect(formulier.getFormField("externAdvies").formControl.value).toBe(
+          "eerder opgeslagen advies",
+        );
+      });
+
+      it("should initialize externAdvies as null when dataElementen is empty", () => {
+        formulier.initBehandelForm(false);
+
+        expect(
+          formulier.getFormField("externAdvies").formControl.value,
+        ).toBeNull();
+      });
+    });
+
+    describe("readonly mode", () => {
+      it("should render externAdvies as readonly when initBehandelForm is called with readonly=true", () => {
+        formulier.initBehandelForm(true);
+
+        expect(formulier.getFormField("externAdvies").readonly).toBe(true);
+      });
+    });
+  });
+});

--- a/src/main/app/src/app/formulieren/taken/model/extern-advies-mail.ts
+++ b/src/main/app/src/app/formulieren/taken/model/extern-advies-mail.ts
@@ -112,14 +112,32 @@ export class ExternAdviesMail extends AbstractTaakFormulier {
 
     this.getFormField(fields.VERZENDER).formControl.valueChanges.subscribe(
       (afzender) => {
+        if (!afzender || typeof afzender !== "object") return;
+        const typed = afzender as Record<string, unknown>;
         const verzender = this.getFormField(
           fields.VERZENDER,
         ) as SelectFormField;
         this.getFormField(fields.REPLYTO).formControl.setValue(
-          verzender.getOption(afzender as Record<string, unknown>)?.replyTo,
+          verzender.getOption(typed)?.replyTo,
+        );
+        // Normalize to mail string so taakdata serializes as Map<String,String>
+        this.getFormField(fields.VERZENDER).formControl.setValue(
+          typed["mail"] as never,
+          { emitEvent: false },
         );
       },
     );
+
+    // value$() fires before the subscription above; normalize the initial value now
+    const initial = this.getFormField(fields.VERZENDER).formControl.value;
+    if (initial && typeof initial === "object") {
+      const typed = initial as Record<string, unknown>;
+      this.getFormField(fields.REPLYTO).formControl.setValue(typed["replyTo"]);
+      this.getFormField(fields.VERZENDER).formControl.setValue(
+        typed["mail"] as never,
+        { emitEvent: false },
+      );
+    }
   }
 
   _initBehandelForm() {

--- a/src/main/app/src/app/formulieren/taken/model/extern-advies-vastleggen-task-form.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/extern-advies-vastleggen-task-form.spec.ts
@@ -4,13 +4,12 @@
  */
 
 import { TestBed } from "@angular/core/testing";
-import { TranslateService } from "@ngx-translate/core";
-import { FoutAfhandelingService } from "src/app/fout-afhandeling/fout-afhandeling.service";
+import { TranslateModule } from "@ngx-translate/core";
 import { fromPartial } from "../../../../test-helpers";
 import { GeneratedType } from "../../../shared/utils/generated-types";
 import { ExternAdviesVastleggenTaskForm } from "./extern-advies-vastleggen-task-form";
 
-describe("ExternAdviesVastleggenTaskForm", () => {
+describe(ExternAdviesVastleggenTaskForm.name, () => {
   let formulier: ExternAdviesVastleggenTaskForm;
 
   const mockZaak = fromPartial<GeneratedType<"RestZaak">>({
@@ -19,10 +18,7 @@ describe("ExternAdviesVastleggenTaskForm", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        { provide: FoutAfhandelingService, useValue: {} },
-        { provide: TranslateService, useValue: {} },
-      ],
+      imports: [TranslateModule.forRoot()],
     });
 
     formulier = TestBed.inject(ExternAdviesVastleggenTaskForm);

--- a/src/main/app/src/app/formulieren/taken/model/goedkeuren-task-form.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/goedkeuren-task-form.spec.ts
@@ -17,6 +17,7 @@ import { GoedkeurenTaskForm } from "./goedkeuren-task-form";
 describe(GoedkeurenTaskForm.name, () => {
   let formulier: GoedkeurenTaskForm;
   let informatieObjectenService: InformatieObjectenService;
+  let listEnkelvoudigInformatieobjectenSpy: jest.SpyInstance;
   let translateService: TranslateService;
 
   const mockZaak = fromPartial<GeneratedType<"RestZaak">>({
@@ -38,7 +39,7 @@ describe(GoedkeurenTaskForm.name, () => {
     });
 
     informatieObjectenService = TestBed.inject(InformatieObjectenService);
-    jest
+    listEnkelvoudigInformatieobjectenSpy = jest
       .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
       .mockReturnValue(of([]));
 
@@ -127,9 +128,8 @@ describe(GoedkeurenTaskForm.name, () => {
 
       it("should pass the Observable directly as options without resolving it", async () => {
         const documentsObservable = of([mockDocument1]);
-        jest
-          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
-          .mockReturnValue(documentsObservable);
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(documentsObservable);
+
 
         const fields = await formulier.requestForm(mockZaak);
 
@@ -275,8 +275,7 @@ describe(GoedkeurenTaskForm.name, () => {
 
       it("should set ondertekenen options to fetched documents", async () => {
         jest
-          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
-          .mockReturnValue(of([mockDocument1, mockDocument2]));
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
 
         const fields = await formulier.handleForm(mockTaak);
 
@@ -289,8 +288,7 @@ describe(GoedkeurenTaskForm.name, () => {
 
       it("should pre-check documents that were previously signed (ondertekenen taakdata)", async () => {
         jest
-          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
-          .mockReturnValue(of([mockDocument1, mockDocument2]));
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
         const taakWithSigned = fromPartial<GeneratedType<"RestTask">>({
           ...mockTaak,
           taakdata: { ondertekenen: "doc-uuid-1" },
@@ -304,8 +302,7 @@ describe(GoedkeurenTaskForm.name, () => {
 
       it("should not pre-check documents that were not previously signed", async () => {
         jest
-          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
-          .mockReturnValue(of([mockDocument1, mockDocument2]));
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
         const taakWithSigned = fromPartial<GeneratedType<"RestTask">>({
           ...mockTaak,
           taakdata: { ondertekenen: "doc-uuid-1" },
@@ -319,8 +316,7 @@ describe(GoedkeurenTaskForm.name, () => {
 
       it("should initialize ondertekenen as empty when no documents were previously signed", async () => {
         jest
-          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
-          .mockReturnValue(of([mockDocument1, mockDocument2]));
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
 
         const fields = await formulier.handleForm(mockTaak);
 

--- a/src/main/app/src/app/formulieren/taken/model/goedkeuren-task-form.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/goedkeuren-task-form.spec.ts
@@ -274,7 +274,6 @@ describe(GoedkeurenTaskForm.name, () => {
       });
 
       it("should set ondertekenen options to fetched documents", async () => {
-        jest
         listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
 
         const fields = await formulier.handleForm(mockTaak);
@@ -287,7 +286,6 @@ describe(GoedkeurenTaskForm.name, () => {
       });
 
       it("should pre-check documents that were previously signed (ondertekenen taakdata)", async () => {
-        jest
         listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
         const taakWithSigned = fromPartial<GeneratedType<"RestTask">>({
           ...mockTaak,
@@ -301,7 +299,6 @@ describe(GoedkeurenTaskForm.name, () => {
       });
 
       it("should not pre-check documents that were not previously signed", async () => {
-        jest
         listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
         const taakWithSigned = fromPartial<GeneratedType<"RestTask">>({
           ...mockTaak,
@@ -315,7 +312,6 @@ describe(GoedkeurenTaskForm.name, () => {
       });
 
       it("should initialize ondertekenen as empty when no documents were previously signed", async () => {
-        jest
         listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
 
         const fields = await formulier.handleForm(mockTaak);

--- a/src/main/app/src/app/formulieren/taken/model/goedkeuren-task-form.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/goedkeuren-task-form.spec.ts
@@ -3,22 +3,21 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
+import { provideHttpClient } from "@angular/common/http";
 import { TestBed } from "@angular/core/testing";
-import { TranslateService } from "@ngx-translate/core";
+import { provideRouter } from "@angular/router";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { of } from "rxjs";
-import { FoutAfhandelingService } from "src/app/fout-afhandeling/fout-afhandeling.service";
 import { fromPartial } from "../../../../test-helpers";
 import { InformatieObjectenService } from "../../../informatie-objecten/informatie-objecten.service";
 import { GeneratedType } from "../../../shared/utils/generated-types";
 import { Goedkeuring } from "../goedkeuring.enum";
 import { GoedkeurenTaskForm } from "./goedkeuren-task-form";
 
-describe("GoedkeurenTaskForm", () => {
+describe(GoedkeurenTaskForm.name, () => {
   let formulier: GoedkeurenTaskForm;
-  let informatieObjectenService: {
-    listEnkelvoudigInformatieobjecten: jest.Mock;
-  };
-  let translateService: { instant: jest.Mock };
+  let informatieObjectenService: InformatieObjectenService;
+  let translateService: TranslateService;
 
   const mockZaak = fromPartial<GeneratedType<"RestZaak">>({
     uuid: "zaak-uuid",
@@ -33,23 +32,18 @@ describe("GoedkeurenTaskForm", () => {
   >({ uuid: "doc-uuid-2", titel: "Document 2" });
 
   beforeEach(() => {
-    informatieObjectenService = {
-      listEnkelvoudigInformatieobjecten: jest.fn().mockReturnValue(of([])),
-    };
-    translateService = {
-      instant: jest.fn().mockReturnValue("translated-value"),
-    };
-
     TestBed.configureTestingModule({
-      providers: [
-        { provide: FoutAfhandelingService, useValue: {} },
-        { provide: TranslateService, useValue: translateService },
-        {
-          provide: InformatieObjectenService,
-          useValue: informatieObjectenService,
-        },
-      ],
+      imports: [TranslateModule.forRoot()],
+      providers: [provideHttpClient(), provideRouter([])],
     });
+
+    informatieObjectenService = TestBed.inject(InformatieObjectenService);
+    jest
+      .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
+      .mockReturnValue(of([]));
+
+    translateService = TestBed.inject(TranslateService);
+    jest.spyOn(translateService, "instant").mockReturnValue("translated-value");
 
     formulier = TestBed.inject(GoedkeurenTaskForm);
   });
@@ -133,9 +127,9 @@ describe("GoedkeurenTaskForm", () => {
 
       it("should pass the Observable directly as options without resolving it", async () => {
         const documentsObservable = of([mockDocument1]);
-        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
-          documentsObservable,
-        );
+        jest
+          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
+          .mockReturnValue(documentsObservable);
 
         const fields = await formulier.requestForm(mockZaak);
 
@@ -280,9 +274,9 @@ describe("GoedkeurenTaskForm", () => {
       });
 
       it("should set ondertekenen options to fetched documents", async () => {
-        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
-          of([mockDocument1, mockDocument2]),
-        );
+        jest
+          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
+          .mockReturnValue(of([mockDocument1, mockDocument2]));
 
         const fields = await formulier.handleForm(mockTaak);
 
@@ -294,9 +288,9 @@ describe("GoedkeurenTaskForm", () => {
       });
 
       it("should pre-check documents that were previously signed (ondertekenen taakdata)", async () => {
-        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
-          of([mockDocument1, mockDocument2]),
-        );
+        jest
+          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
+          .mockReturnValue(of([mockDocument1, mockDocument2]));
         const taakWithSigned = fromPartial<GeneratedType<"RestTask">>({
           ...mockTaak,
           taakdata: { ondertekenen: "doc-uuid-1" },
@@ -309,9 +303,9 @@ describe("GoedkeurenTaskForm", () => {
       });
 
       it("should not pre-check documents that were not previously signed", async () => {
-        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
-          of([mockDocument1, mockDocument2]),
-        );
+        jest
+          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
+          .mockReturnValue(of([mockDocument1, mockDocument2]));
         const taakWithSigned = fromPartial<GeneratedType<"RestTask">>({
           ...mockTaak,
           taakdata: { ondertekenen: "doc-uuid-1" },
@@ -324,9 +318,9 @@ describe("GoedkeurenTaskForm", () => {
       });
 
       it("should initialize ondertekenen as empty when no documents were previously signed", async () => {
-        informatieObjectenService.listEnkelvoudigInformatieobjecten.mockReturnValue(
-          of([mockDocument1, mockDocument2]),
-        );
+        jest
+          .spyOn(informatieObjectenService, "listEnkelvoudigInformatieobjecten")
+          .mockReturnValue(of([mockDocument1, mockDocument2]));
 
         const fields = await formulier.handleForm(mockTaak);
 

--- a/src/main/app/src/app/formulieren/taken/model/goedkeuren-task-form.spec.ts
+++ b/src/main/app/src/app/formulieren/taken/model/goedkeuren-task-form.spec.ts
@@ -128,8 +128,9 @@ describe(GoedkeurenTaskForm.name, () => {
 
       it("should pass the Observable directly as options without resolving it", async () => {
         const documentsObservable = of([mockDocument1]);
-        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(documentsObservable);
-
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(
+          documentsObservable,
+        );
 
         const fields = await formulier.requestForm(mockZaak);
 
@@ -274,7 +275,9 @@ describe(GoedkeurenTaskForm.name, () => {
       });
 
       it("should set ondertekenen options to fetched documents", async () => {
-        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(
+          of([mockDocument1, mockDocument2]),
+        );
 
         const fields = await formulier.handleForm(mockTaak);
 
@@ -286,7 +289,9 @@ describe(GoedkeurenTaskForm.name, () => {
       });
 
       it("should pre-check documents that were previously signed (ondertekenen taakdata)", async () => {
-        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(
+          of([mockDocument1, mockDocument2]),
+        );
         const taakWithSigned = fromPartial<GeneratedType<"RestTask">>({
           ...mockTaak,
           taakdata: { ondertekenen: "doc-uuid-1" },
@@ -299,7 +304,9 @@ describe(GoedkeurenTaskForm.name, () => {
       });
 
       it("should not pre-check documents that were not previously signed", async () => {
-        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(
+          of([mockDocument1, mockDocument2]),
+        );
         const taakWithSigned = fromPartial<GeneratedType<"RestTask">>({
           ...mockTaak,
           taakdata: { ondertekenen: "doc-uuid-1" },
@@ -312,7 +319,9 @@ describe(GoedkeurenTaskForm.name, () => {
       });
 
       it("should initialize ondertekenen as empty when no documents were previously signed", async () => {
-        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(of([mockDocument1, mockDocument2]));
+        listEnkelvoudigInformatieobjectenSpy.mockReturnValue(
+          of([mockDocument1, mockDocument2]),
+        );
 
         const fields = await formulier.handleForm(mockTaak);
 


### PR DESCRIPTION
FE - Task Forms - fix ExternAdviesMail verzender serialization and harden taak form specs

## Summary
- Fixes `ExternAdviesMail` frontend bug where the full `RestZaakAfzender` object was stored
  in `taakdata.verzender` instead of the mail string, causing a backend `Map<String,String>`
  deserialization error on form submit
- Adds full spec coverage for `ExternAdviesMail` (ATOS pattern) to prepare for the refactoring
- Hardens all taak form specs: `describe(ClassName.name)`, `TestBed.inject` + `jest.spyOn`
  instead of `useValue`, `provideHttpClient()`, `provideRouter([])`, `fromPartial` for typed
  fixtures
- Updates `audit-ng-spec-skill` to enforce the `jest.spyOn` pattern with type-safety rationale

## Test plan
- [ ] `npx ng test --test-path-pattern="formulieren/taken/model"` — all tests green
- [ ] Manually test `EXTERN_ADVIES_MAIL` taak form submit — no backend 500 error

Solves PZ-10947
