### PR TITLE
chore: revert RabbitMQ upgrade in Docker Compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -482,7 +482,7 @@ services:
     profiles: [ "itest" ]
 
   rabbitmq:
-    image: rabbitmq:4.3.0-alpine@sha256:1d6746873c3cc0691f4884d7ac8f8e1a456ee9d9c1599a114599bc2fb4b26d7b
+    image: rabbitmq:4.2.5-alpine@sha256:d4a3806070111cc69130a6542aa4049b612789852ef11fc3862abc94631b2572
     healthcheck:
       test: rabbitmq-diagnostics -q ping
       interval: 10s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -482,6 +482,7 @@ services:
     profiles: [ "itest" ]
 
   rabbitmq:
+    # note: RabbitMQ 4.3.0 breaks Open Notificaties 1.13.0
     image: rabbitmq:4.2.5-alpine@sha256:d4a3806070111cc69130a6542aa4049b612789852ef11fc3862abc94631b2572
     healthcheck:
       test: rabbitmq-diagnostics -q ping


### PR DESCRIPTION
Revert RabbitMQ upgrade to 4.2.5-alpine@sha256:d4a3806070111cc69130a6542aa4049 in Docker Compose because it breaks Open Notificaties

Solves PZ-10991