### PR TITLE
chore: update allowed Open Zaak Renovate Docker version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -524,7 +524,7 @@
       "matchDatasources": [
         "docker"
       ],
-      "allowedVersions": "< 1.27.0",
+      "allowedVersions": "< 1.28.0",
       "description": [
         "Pinned by the next Dimpact PodiumD release"
       ]


### PR DESCRIPTION
Update allowed Open Zaak Docker version to < 1.28.0 in Renovate config.

Solves PZ-11018