### PR TITLE
feature: (doc) create documentation for new sendConfirmationEmailDelegate

### DIFF
--- a/docs/manuals/bpmn-guide/README.md
+++ b/docs/manuals/bpmn-guide/README.md
@@ -312,9 +312,9 @@ To store a Form.io field value as zaakdata, use the `ZAC_process_data` type (see
 }
 ```
 
-### Send automatische ontvangstbevestiging
+### Send confirmation email (automatische ontvangstbevestiging)
 
-To automatically send a confirmation email to the zaak initiator or zaak-specific contact:
+To send a confirmation email to the zaak initiator or zaak-specific contact email address from a BPMN process:
 * create a service task
 * set class `nl.info.zac.flowable.bpmn.delegate.SendConfirmationEmailDelegate`
 * add fields:
@@ -324,10 +324,10 @@ To automatically send a confirmation email to the zaak initiator or zaak-specifi
 
 Unlike `SendEmailDelegate`, the recipient address is resolved automatically from the zaak:
 1. The email address from the zaak-specific contact details is used if available.
-2. Otherwise, the email address of the zaak's initiator role is used.
-3. If no address can be found, no email is sent and the process continues.
+2. Otherwise, the default email address of the initiator of zaak is used. Or if the initiator does not have a default email address, the first email address of the initiator is used3. If no address can be found, no email is sent and the process continues.
+3. If no email address could be found, no email is sent and the process continues.
 
-The email is stored as a document on the zaak.
+The email is stored as a document attached to the zaak.
 
 For example:
 ```xml

--- a/docs/manuals/bpmn-guide/README.md
+++ b/docs/manuals/bpmn-guide/README.md
@@ -312,7 +312,7 @@ To store a Form.io field value as zaakdata, use the `ZAC_process_data` type (see
 }
 ```
 
-#### Send automatische ontvangstbevestiging
+### Send automatische ontvangstbevestiging
 
 To automatically send a confirmation email to the zaak initiator or zaak-specific contact:
 * create a service task
@@ -320,7 +320,7 @@ To automatically send a confirmation email to the zaak initiator or zaak-specifi
 * add fields:
   * `from` - the sender's email address
   * `replyTo` - the reply-to email address (optional)
-  * `template` - the name of the mail template to use
+  * `template` - the name of the email template to use
 
 Unlike `SendEmailDelegate`, the recipient address is resolved automatically from the zaak:
 1. The email address from the zaak-specific contact details is used if available.

--- a/docs/manuals/bpmn-guide/README.md
+++ b/docs/manuals/bpmn-guide/README.md
@@ -81,6 +81,7 @@ The following functionality is supported by the BPMN process definition:
    * resuming
    * extending
 * Send email
+* Send automatische ontvangstbevestiging
 * User/group
    * listing groups/users
    * assigning a group/user to a zaak
@@ -309,6 +310,42 @@ To store a Form.io field value as zaakdata, use the `ZAC_process_data` type (see
     "ZAC_TYPE": "ZAC_process_data"
   }
 }
+```
+
+#### Send automatische ontvangstbevestiging
+
+To automatically send a confirmation email to the zaak initiator or zaak-specific contact:
+* create a service task
+* set class `nl.info.zac.flowable.bpmn.delegate.SendConfirmationEmailDelegate`
+* add fields:
+  * `from` - the sender's email address
+  * `replyTo` - the reply-to email address (optional)
+  * `template` - the name of the mail template to use
+
+Unlike `SendEmailDelegate`, the recipient address is resolved automatically from the zaak:
+1. The email address from the zaak-specific contact details is used if available.
+2. Otherwise, the email address of the zaak's initiator role is used.
+3. If no address can be found, no email is sent and the process continues.
+
+The email is stored as a document on the zaak.
+
+For example:
+```xml
+    <serviceTask id="ServiceTask_359" name="Send confirmation email" flowable:class="nl.info.zac.flowable.bpmn.delegate.SendConfirmationEmailDelegate">
+      <extensionElements>
+        <flowable:field name="from">
+          <flowable:string><![CDATA[noreply@example.nl]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="replyTo">
+          <flowable:string><![CDATA[contact@example.nl]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="template">
+          <flowable:string><![CDATA[Ontvangstbevestiging]]></flowable:string>
+        </flowable:field>
+        <design:stencilid><![CDATA[ServiceTask]]></design:stencilid>
+        <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+      </extensionElements>
+    </serviceTask>
 ```
 
 ### User/group


### PR DESCRIPTION
This PR adds documentation for using the new sendConfirmationEmailDelegate in the BPMN manual.

Must wait for [the functional PR to be merged](https://github.com/infonl/dimpact-zaakafhandelcomponent/pull/5866)

Solves PZ-10609