### PR TITLE
chore: remove unit test step from merge queue workflow

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -301,7 +301,7 @@ jobs:
 
   run-unit-tests:
     needs: [build, paths-filter]
-    if: ${{ needs.paths-filter.outputs.changes-requiring-build == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'hotfix/') }}
+    if: ${{ (github.event_name != 'merge_group' && needs.paths-filter.outputs.changes-requiring-build == 'true') || github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'hotfix/') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -340,8 +340,7 @@ jobs:
             src/generated
           key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
-      - name: Run unit tests and generate test coverage reports when not in merge queue
-        if: ${{ github.event_name != 'merge_group' }}
+      - name: Run unit tests and generate test coverage reports
         run: ./gradlew -x processResources -x classes test npmRunTestCoverage jacocoTestReport --info --rerun-tasks
 
       - name: Publish unit test results
@@ -355,13 +354,12 @@ jobs:
 
       - name: Upload unit test results to CodeCov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        if: ${{ github.event_name != 'merge_group' && !cancelled() }}
+        if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: "test_results"
 
       - name: Upload backend unit test coverage report to Codecov
-        if: ${{ github.event_name != 'merge_group' }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -369,7 +367,6 @@ jobs:
           directory: ./build/reports/jacoco/test
 
       - name: Upload frontend unit test coverage report to Codecov
-        if: ${{ github.event_name != 'merge_group' }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -340,10 +340,6 @@ jobs:
             src/generated
           key: generated-java-clients-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
-      - name: Run unit tests when in merge queue
-        if: ${{ github.event_name == 'merge_group' }}
-        run: ./gradlew -x processResources -x classes test --info --rerun-tasks
-
       - name: Run unit tests and generate test coverage reports when not in merge queue
         if: ${{ github.event_name != 'merge_group' }}
         run: ./gradlew -x processResources -x classes test npmRunTestCoverage jacocoTestReport --info --rerun-tasks


### PR DESCRIPTION
Remove unit test step from merge queue workflow because we already run unit tests for all pull requests and also after merging a pull request to the main branch. Also running the unit tests inside the merge queue slows down our pipeline substantially and does not provide enough added value.

Solves PZ-11115