### PR TITLE
chore: configure unique node identifier for WildFly transactions to prevent WFLYTX0013 warning

### DIFF
--- a/src/main/resources/wildfly/configure-wildfly.cli
+++ b/src/main/resources/wildfly/configure-wildfly.cli
@@ -7,9 +7,11 @@
 
 # Transaction configuration
 
-# Set a unique node identifier to avoid WFLYTX0013 warning in multi-server environments.
-# Override by setting the JBOSS_NODE_NAME environment variable.
-/subsystem=transactions:write-attribute(name=node-identifier,value=${env.JBOSS_NODE_NAME:zac})
+# Set a unique node identifier to avoid WFLYTX0013 warning and transaction/XID collisions
+# in multi-server environments. Override by setting the JBOSS_NODE_NAME environment
+# variable; otherwise fall back to HOSTNAME, which should be unique per instance and
+# valid for WildFly's node-identifier constraints.
+/subsystem=transactions:write-attribute(name=node-identifier,value=${env.JBOSS_NODE_NAME:${env.HOSTNAME}})
 
 # Datasource configuration
 

--- a/src/main/resources/wildfly/configure-wildfly.cli
+++ b/src/main/resources/wildfly/configure-wildfly.cli
@@ -5,6 +5,12 @@
 
 # WildFly configuration script to configure WildFly for the Zaakafhandelcomponent
 
+# Transaction configuration
+
+# Set a unique node identifier to avoid WFLYTX0013 warning in multi-server environments.
+# Override by setting the JBOSS_NODE_NAME environment variable.
+/subsystem=transactions:write-attribute(name=node-identifier,value=${env.JBOSS_NODE_NAME:zac})
+
 # Datasource configuration
 
 ## Add zaakafhandelcomponent datasource


### PR DESCRIPTION
Configure unique node identifier for WildFly transactions to prevent WFLYTX0013 warning.

Solves PZ-11161