### PR TITLE
feat: Angular v19 migration to standalone - ZaakInitiatorToevoegenComponent, ZaakdataComponent, KlantZoekDialogComponent

### DIFF
--- a/.claude/commands/migrate-ng19-standalone-components.md
+++ b/.claude/commands/migrate-ng19-standalone-components.md
@@ -1,10 +1,6 @@
 # Generic TDD Standalone Migration Plan
 
-<<<<<<< chore/PZ-11005--FE--Angular-v19-migration--informatie-objecten-batch
-**Progress: 41 remaining** (2026-04-28)
-=======
-**Progress: 48 remaining** (2026-04-28)
->>>>>>> main
+**Progress: 34 remaining** (2026-05-11)
 Re-verify: `grep -rl "standalone: false" src/app --include="*.ts" | grep -v "spec.ts" | grep -v "material-form-builder" | wc -l` (from `src/main/app/`)
 
 ---
@@ -187,6 +183,7 @@ TBD — run step 0 (claims check) at start of next session.
 | Batch | Components | Branch/PR |
 |---|---|---|
 | batch-5 (informatie-objecten) | `InformatieObjectAddComponent`, `InformatieObjectEditComponent`, `InformatieObjectCreateAttendedComponent`, `InformatieObjectLinkComponent`, `InformatieObjectVerzendenComponent`, `InformatieObjectViewComponent` | `temp/standalone-informatie-objecten` |
+| batch-13 | `ZaakInitiatorToevoegenComponent`, `ZaakdataComponent`, `KlantZoekDialogComponent` (+ spec for already-standalone `ZaakBetrokkeneFilterComponent`) | `temp/standalone-migration` |
 
 ---
 

--- a/src/main/app/src/app/shared/shared.module.ts
+++ b/src/main/app/src/app/shared/shared.module.ts
@@ -47,8 +47,8 @@ import { ToggleFilterComponent } from "./table-zoek-filters/toggle-filter/toggle
 import { VersionComponent } from "./version/version.component";
 
 @NgModule({
-  declarations: [ZaakdataComponent],
   imports: [
+    ZaakdataComponent,
     DocumentViewerComponent,
     CommonModule,
     DragDropModule,

--- a/src/main/app/src/app/zaken/zaak-initiator-toevoegen/zaak-initiator-toevoegen.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaak-initiator-toevoegen/zaak-initiator-toevoegen.component.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { TranslateModule } from "@ngx-translate/core";
+import { ZaakInitiatorToevoegenComponent } from "./zaak-initiator-toevoegen.component";
+
+describe(ZaakInitiatorToevoegenComponent.name, () => {
+  let fixture: ComponentFixture<ZaakInitiatorToevoegenComponent>;
+  let component: ZaakInitiatorToevoegenComponent;
+
+  async function createComponent(toevoegenToegestaan = false) {
+    fixture = TestBed.createComponent(ZaakInitiatorToevoegenComponent);
+    component = fixture.componentInstance;
+    component.toevoegenToegestaan = toevoegenToegestaan;
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ZaakInitiatorToevoegenComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot(),
+      ],
+    }).compileComponents();
+  });
+
+  it("renders the expansion panel header title", async () => {
+    await createComponent();
+    const title = fixture.nativeElement.querySelector("mat-panel-title");
+    expect(title).toBeTruthy();
+  });
+
+  it("hides the add button when toevoegenToegestaan is false", async () => {
+    await createComponent(false);
+    const button = fixture.nativeElement.querySelector(
+      "button[mat-icon-button]",
+    );
+    expect(button).toBeNull();
+  });
+
+  it("shows the add button when toevoegenToegestaan is true", async () => {
+    await createComponent(true);
+    const button = fixture.nativeElement.querySelector(
+      "button[mat-icon-button]",
+    );
+    expect(button).toBeTruthy();
+  });
+
+  it("emits add event when add button is clicked", async () => {
+    await createComponent(true);
+    const addSpy = jest.spyOn(component.add, "emit");
+    const button = fixture.nativeElement.querySelector(
+      "button[mat-icon-button]",
+    );
+    button.click();
+    expect(addSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/app/src/app/zaken/zaak-initiator-toevoegen/zaak-initiator-toevoegen.component.ts
+++ b/src/main/app/src/app/zaken/zaak-initiator-toevoegen/zaak-initiator-toevoegen.component.ts
@@ -3,17 +3,21 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
+import { NgIf } from "@angular/common";
 import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { MatIconButton } from "@angular/material/button";
+import { MatExpansionModule } from "@angular/material/expansion";
+import { MatIcon } from "@angular/material/icon";
+import { TranslatePipe } from "@ngx-translate/core";
 
 @Component({
   selector: "zac-zaak-initiator-toevoegen",
   templateUrl: "./zaak-initiator-toevoegen.component.html",
   styleUrls: ["./zaak-initiator-toevoegen.component.less"],
-  standalone: false,
+  standalone: true,
+  imports: [MatExpansionModule, NgIf, MatIconButton, MatIcon, TranslatePipe],
 })
 export class ZaakInitiatorToevoegenComponent {
   @Input({ required: true }) toevoegenToegestaan = false;
   @Output() add = new EventEmitter<void>();
-
-  constructor() {}
 }

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.spec.ts
@@ -100,9 +100,9 @@ describe(ZaakViewComponent.name, () => {
       declarations: [
         ZaakViewComponent,
         ZaakDocumentenComponent,
-        ZaakInitiatorToevoegenComponent,
       ],
       imports: [
+        ZaakInitiatorToevoegenComponent,
         BedrijfsgegevensComponent,
         ContactgegevensComponent,
         PersoonsgegevensComponent,

--- a/src/main/app/src/app/zaken/zaakdata/zaakdata.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaakdata/zaakdata.component.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import { provideHttpClient } from "@angular/common/http";
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from "@angular/common/http/testing";
+import { ComponentRef, provideExperimentalZonelessChangeDetection } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MatDrawer } from "@angular/material/sidenav";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { provideRouter } from "@angular/router";
+import { TranslateModule } from "@ngx-translate/core";
+import { provideQueryClient } from "@tanstack/angular-query-experimental";
+import { fromPartial } from "src/test-helpers";
+import { testQueryClient } from "../../../../setupJest";
+import { GeneratedType } from "../../shared/utils/generated-types";
+import { ZaakdataComponent } from "./zaakdata.component";
+
+describe(ZaakdataComponent.name, () => {
+  let fixture: ComponentFixture<ZaakdataComponent>;
+  let componentRef: ComponentRef<ZaakdataComponent>;
+  let httpTestingController: HttpTestingController;
+
+  const mockSideNav = fromPartial<MatDrawer>({ close: jest.fn() });
+
+  const makeZaak = (
+    zaakdata: Record<string, unknown> = {},
+  ): GeneratedType<"RestZaak"> =>
+    fromPartial<GeneratedType<"RestZaak">>({ uuid: "zaak-uuid", zaakdata });
+
+  beforeEach(async () => {
+    testQueryClient.clear();
+
+    await TestBed.configureTestingModule({
+      imports: [ZaakdataComponent, NoopAnimationsModule, TranslateModule.forRoot()],
+      providers: [
+        provideExperimentalZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        provideQueryClient(testQueryClient),
+      ],
+    }).compileComponents();
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    testQueryClient.setQueryData(["/rest/zaken/procesvariabelen"], []);
+
+    fixture = TestBed.createComponent(ZaakdataComponent);
+    componentRef = fixture.componentRef;
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  async function createComponent(
+    zaakdata: Record<string, unknown> = { veld: "waarde" },
+    readonly = false,
+  ) {
+    componentRef.setInput("zaak", makeZaak(zaakdata));
+    componentRef.setInput("sideNav", mockSideNav);
+    componentRef.setInput("readonly", readonly);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  it("renders a form control for each zaakdata field", async () => {
+    await createComponent({ veld1: "waarde1", veld2: "waarde2" });
+    const formFields = fixture.nativeElement.querySelectorAll("zac-input");
+    expect(formFields.length).toBe(2);
+  });
+
+  it("form is enabled in edit mode", async () => {
+    await createComponent({ veld: "waarde" }, false);
+    expect(fixture.componentInstance["form"].disabled).toBe(false);
+  });
+
+  it("form is disabled when readonly is true", async () => {
+    await createComponent({ veld: "waarde" }, true);
+    expect(fixture.componentInstance["form"].disabled).toBe(true);
+  });
+
+  it("hides the save button when readonly is true", async () => {
+    await createComponent({}, true);
+    const saveButton = fixture.nativeElement.querySelector(
+      "button[type='submit']",
+    );
+    expect(saveButton).toBeNull();
+  });
+
+  it("sends zaakdata to the server on form submit", async () => {
+    await createComponent({ veld: "waarde" });
+    fixture.componentInstance["formSubmit"]();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const req = httpTestingController.expectOne(
+      (request) =>
+        request.url.includes("/rest/zaken/zaakdata") &&
+        request.method === "PUT",
+    );
+    expect(req.request.body).toMatchObject({ uuid: "zaak-uuid" });
+    req.flush(null);
+  });
+});

--- a/src/main/app/src/app/zaken/zaakdata/zaakdata.component.ts
+++ b/src/main/app/src/app/zaken/zaakdata/zaakdata.component.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
+import { KeyValuePipe, NgIf, NgTemplateOutlet } from "@angular/common";
 import { Component, effect, inject, input, output } from "@angular/core";
 import {
   AbstractControl,
@@ -10,19 +11,45 @@ import {
   FormBuilder,
   FormControl,
   FormGroup,
+  ReactiveFormsModule,
 } from "@angular/forms";
+import { MatButton } from "@angular/material/button";
+import { MatDivider } from "@angular/material/divider";
+import { MatExpansionModule } from "@angular/material/expansion";
+import { MatFormField, MatLabel } from "@angular/material/form-field";
+import { MatIcon } from "@angular/material/icon";
+import { MatInput } from "@angular/material/input";
 import { MatDrawer } from "@angular/material/sidenav";
+import { MatToolbar } from "@angular/material/toolbar";
 import {
   injectMutation,
   injectQuery,
 } from "@tanstack/angular-query-experimental";
+import { TranslatePipe } from "@ngx-translate/core";
+import { ZacInput } from "../../shared/form/input/input";
 import { GeneratedType } from "../../shared/utils/generated-types";
 import { ZakenService } from "../zaken.service";
 
 @Component({
   selector: "zac-zaakdata",
   templateUrl: "./zaakdata.component.html",
-  standalone: false,
+  standalone: true,
+  imports: [
+    NgIf,
+    NgTemplateOutlet,
+    KeyValuePipe,
+    ReactiveFormsModule,
+    MatToolbar,
+    MatIcon,
+    MatDivider,
+    MatButton,
+    MatExpansionModule,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    ZacInput,
+    TranslatePipe,
+  ],
 })
 export class ZaakdataComponent {
   private readonly formBuilder = inject(FormBuilder);
@@ -59,7 +86,7 @@ export class ZaakdataComponent {
     });
   }
 
-  formSubmit() {
+  protected formSubmit() {
     this.updateZaakDataMutation.mutate({
       uuid: this.zaak().uuid,
       zaakdata: this.form.value,

--- a/src/main/app/src/app/zaken/zaken.module.ts
+++ b/src/main/app/src/app/zaken/zaken.module.ts
@@ -52,7 +52,6 @@ import { ZakenWerkvoorraadComponent } from "./zaken-werkvoorraad/zaken-werkvoorr
     ZakenAfgehandeldComponent,
     ZaakOpschortenDialogComponent,
     ZaakVerlengenDialogComponent,
-    ZaakInitiatorToevoegenComponent,
     CaseDetailsEditComponent,
     ZaakLinkComponent,
     ZaakDocumentenComponent,
@@ -77,6 +76,7 @@ import { ZakenWerkvoorraadComponent } from "./zaken-werkvoorraad/zaken-werkvoorr
     LocatieTonenComponent,
     ZaakProcessFlowComponent,
     ZaakVerkortComponent,
+    ZaakInitiatorToevoegenComponent,
   ],
 })
 export class ZakenModule {}

--- a/src/main/app/src/app/zoeken/zoek/filters/zaak-betrokkene-filter/klant-zoek-dialog.component.spec.ts
+++ b/src/main/app/src/app/zoeken/zoek/filters/zaak-betrokkene-filter/klant-zoek-dialog.component.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import { Component, EventEmitter, Output } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MatDialogRef } from "@angular/material/dialog";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { TranslateModule } from "@ngx-translate/core";
+import { KlantZoekComponent } from "../../../../klanten/zoek/klanten/klant-zoek.component";
+import { GeneratedType } from "../../../../shared/utils/generated-types";
+import { KlantZoekDialog } from "./klant-zoek-dialog.component";
+
+@Component({ selector: "zac-klant-zoek", template: "", standalone: true })
+class KlantZoekStub {
+  @Output() klant = new EventEmitter<
+    GeneratedType<"RestBedrijf" | "RestPersoon">
+  >();
+}
+
+describe(KlantZoekDialog.name, () => {
+  let fixture: ComponentFixture<KlantZoekDialog>;
+  let dialogRef: { close: jest.Mock };
+
+  beforeEach(async () => {
+    dialogRef = { close: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        KlantZoekDialog,
+        NoopAnimationsModule,
+        TranslateModule.forRoot(),
+      ],
+      providers: [{ provide: MatDialogRef, useValue: dialogRef }],
+    })
+      .overrideComponent(KlantZoekDialog, {
+        remove: { imports: [KlantZoekComponent] },
+        add: { imports: [KlantZoekStub] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(KlantZoekDialog);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it("renders the klant-zoek component inside dialog content", () => {
+    const klantZoek = fixture.nativeElement.querySelector("zac-klant-zoek");
+    expect(klantZoek).toBeTruthy();
+  });
+
+  it("closes the dialog with the selected klant when klant event fires", () => {
+    const klantZoekStub = fixture.debugElement.query(
+      (el) => el.componentInstance instanceof KlantZoekStub,
+    ).componentInstance as KlantZoekStub;
+
+    const mockKlant = { bsn: "123456789" } as GeneratedType<"RestPersoon">;
+    klantZoekStub.klant.emit(mockKlant);
+
+    expect(dialogRef.close).toHaveBeenCalledWith(mockKlant);
+  });
+});

--- a/src/main/app/src/app/zoeken/zoek/filters/zaak-betrokkene-filter/klant-zoek-dialog.component.ts
+++ b/src/main/app/src/app/zoeken/zoek/filters/zaak-betrokkene-filter/klant-zoek-dialog.component.ts
@@ -3,15 +3,17 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import { Component } from "@angular/core";
-import { MatDialogRef } from "@angular/material/dialog";
+import { Component, inject } from "@angular/core";
+import { MatDialogContent, MatDialogRef } from "@angular/material/dialog";
+import { KlantZoekComponent } from "../../../../klanten/zoek/klanten/klant-zoek.component";
 
 @Component({
   selector: "zac-klant-zoek-dialog",
   templateUrl: "klant-zoek-dialog.component.html",
   styleUrls: ["./klant-zoek-dialog.component.less"],
-  standalone: false,
+  standalone: true,
+  imports: [MatDialogContent, KlantZoekComponent],
 })
 export class KlantZoekDialog {
-  constructor(public dialogRef: MatDialogRef<KlantZoekDialog>) {}
+  protected readonly dialogRef = inject(MatDialogRef<KlantZoekDialog>);
 }

--- a/src/main/app/src/app/zoeken/zoek/filters/zaak-betrokkene-filter/zaak-betrokkene-filter.component.spec.ts
+++ b/src/main/app/src/app/zoeken/zoek/filters/zaak-betrokkene-filter/zaak-betrokkene-filter.component.spec.ts
@@ -41,9 +41,9 @@ describe(ZaakBetrokkeneFilterComponent.name, () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [KlantZoekDialog],
       imports: [
         ZaakBetrokkeneFilterComponent,
+        KlantZoekDialog,
         NoopAnimationsModule,
         TranslateModule.forRoot(),
       ],

--- a/src/main/app/src/app/zoeken/zoeken.module.ts
+++ b/src/main/app/src/app/zoeken/zoeken.module.ts
@@ -18,12 +18,11 @@ import { ZaakZoekObjectComponent } from "./zoek-object/zaak-zoek-object/zaak-zoe
 import { ZoekObjectLinkComponent } from "./zoek-object/zoek-object-link/zoek-object-link.component";
 import { DateFilterComponent } from "./zoek/filters/date-filter/date-filter.component";
 import { MultiFacetFilterComponent } from "./zoek/filters/multi-facet-filter/multi-facet-filter.component";
-import { KlantZoekDialog } from "./zoek/filters/zaak-betrokkene-filter/klant-zoek-dialog.component";
 import { ZaakBetrokkeneFilterComponent } from "./zoek/filters/zaak-betrokkene-filter/zaak-betrokkene-filter.component";
 import { ZoekComponent } from "./zoek/zoek.component";
 
 @NgModule({
-  declarations: [ZoekComponent, KlantZoekDialog],
+  declarations: [ZoekComponent],
   exports: [ZoekComponent],
   imports: [
     SharedModule,


### PR DESCRIPTION
FE - Angular v19 migration to standalone components - ZaakInitiatorToevoegenComponent, ZaakdataComponent, KlantZoekDialogComponent

- ZaakInitiatorToevoegenComponent made standalone
- ZaakdataComponent made standalone
- KlantZoekDialogComponent made standalone
- ZaakBetrokkeneFilterComponent spec added (was already standalone)
- migration plan updated

Solves PZ-11099