### PR TITLE
chore: remove node identifier configuration for WildFly transactions

### DIFF
--- a/src/main/resources/wildfly/configure-wildfly.cli
+++ b/src/main/resources/wildfly/configure-wildfly.cli
@@ -5,14 +5,6 @@
 
 # WildFly configuration script to configure WildFly for the Zaakafhandelcomponent
 
-# Transaction configuration
-
-# Set a unique node identifier to avoid WFLYTX0013 warning and transaction/XID collisions
-# in multi-server environments. Override by setting the JBOSS_NODE_NAME environment
-# variable; otherwise fall back to HOSTNAME, which should be unique per instance and
-# valid for WildFly's node-identifier constraints.
-/subsystem=transactions:write-attribute(name=node-identifier,value=${env.JBOSS_NODE_NAME:${env.HOSTNAME}})
-
 # Datasource configuration
 
 ## Add zaakafhandelcomponent datasource


### PR DESCRIPTION
Remove node identifier configuration for WildFly transactions. It appears this causes ZAC not to startup on our test environment. Probably related is this Kubernetes message: 

>The HOSTNAME env variable used to set jboss.tx.node.id is longer than 23 bytes. jboss.tx.node.id value was adjusted to 23 bytes long string mponent-6dcf6dc6b-wsvj2 from the original value zac-dev-zaakafhandelcomponent-6dcf6dc6b-wsvj2

Solves PZ-11168