### PR TITLE
chore: fix flaky KlantRestServiceTest unit test

### DIFF
--- a/src/main/kotlin/nl/info/zac/app/klant/KlantRestService.kt
+++ b/src/main/kotlin/nl/info/zac/app/klant/KlantRestService.kt
@@ -18,6 +18,7 @@ import jakarta.ws.rs.core.MediaType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
 import net.atos.zac.app.shared.RESTResultaat
 import nl.info.client.brp.BrpClientService
@@ -89,18 +90,20 @@ class KlantRestService @Inject constructor(
         // run the two client calls concurrently in a coroutine scope,
         // so we do not need to wait for the first call to complete
         withContext(Dispatchers.IO) {
-            val klantPersoonDigitalAddresses =
-                async { klantClientService.findDigitalAddressesForNaturalPerson(bsn) }
-            val brpPersoon = async {
-                brpClientService.retrievePersoon(bsn, zaaktypeUuid, username)
-            }
-            val restPersoon = brpPersoon.await()?.toRestPersoon()
-                ?: throw BrpPersonNotFoundException("Geen persoon gevonden voor BSN '$bsn'")
-            klantPersoonDigitalAddresses.await().toContactDetails().let { contactDetails ->
-                restPersoon.apply {
-                    telefoonnummer = contactDetails.telephoneNumber
-                    emailadres = contactDetails.emailAddress
-                    temporaryPersonId = requestedTemporaryPersonId
+            supervisorScope {
+                val klantPersoonDigitalAddresses =
+                    async { klantClientService.findDigitalAddressesForNaturalPerson(bsn) }
+                val brpPersoon = async {
+                    brpClientService.retrievePersoon(bsn, zaaktypeUuid, username)
+                }
+                val restPersoon = brpPersoon.await()?.toRestPersoon()
+                    ?: throw BrpPersonNotFoundException("Geen persoon gevonden voor BSN '$bsn'")
+                klantPersoonDigitalAddresses.await().toContactDetails().let { contactDetails ->
+                    restPersoon.apply {
+                        telefoonnummer = contactDetails.telephoneNumber
+                        emailadres = contactDetails.emailAddress
+                        temporaryPersonId = requestedTemporaryPersonId
+                    }
                 }
             }
         }
@@ -158,15 +161,17 @@ class KlantRestService @Inject constructor(
             // run the two client calls concurrently in a coroutine scope,
             // so we do not need to wait for the first call to complete
             withContext(Dispatchers.IO) {
-                val klantRechtspersoonDigitalAddresses =
-                    async { klantClientService.findDigitalAddressesForNonNaturalPerson(kvkNummer) }
-                val rechtspersoon = async { kvkClientService.findRechtspersoonByKvkNummer(kvkNummer) }
-                val restBedrijf = rechtspersoon.await()?.toRestBedrijf()
-                    ?: throw RechtspersoonNotFoundException("Geen rechtspersoon gevonden voor KVK nummer '$kvkNummer'")
-                klantRechtspersoonDigitalAddresses.await().toContactDetails().let { contactDetails ->
-                    restBedrijf.apply {
-                        emailadres = contactDetails.emailAddress
-                        telefoonnummer = contactDetails.telephoneNumber
+                supervisorScope {
+                    val klantRechtspersoonDigitalAddresses =
+                        async { klantClientService.findDigitalAddressesForNonNaturalPerson(kvkNummer) }
+                    val rechtspersoon = async { kvkClientService.findRechtspersoonByKvkNummer(kvkNummer) }
+                    val restBedrijf = rechtspersoon.await()?.toRestBedrijf()
+                        ?: throw RechtspersoonNotFoundException("Geen rechtspersoon gevonden voor KVK nummer '$kvkNummer'")
+                    klantRechtspersoonDigitalAddresses.await().toContactDetails().let { contactDetails ->
+                        restBedrijf.apply {
+                            emailadres = contactDetails.emailAddress
+                            telefoonnummer = contactDetails.telephoneNumber
+                        }
                     }
                 }
             }
@@ -247,22 +252,24 @@ class KlantRestService @Inject constructor(
         // run the two client calls concurrently in a coroutine scope,
         // so we do not need to wait for the first call to complete
         withContext(Dispatchers.IO) {
-            val klantVestigingDigitalAddresses =
-                async {
-                    // we do not support retrieving contact details for a vestiging if no KVK number was provided
-                    kvkNummer?.let { klantClientService.findDigitalAddressesForVestiging(vestigingsnummer, it) }
-                        ?: emptyList()
-                }
-            val vestiging = async { kvkClientService.findVestiging(vestigingsnummer, kvkNummer) }
-            val restBedrijf = vestiging.await()?.toRestBedrijf()?.apply { if (kvkNummer == null) this.kvkNummer = null }
-                ?: throw VestigingNotFoundException(
-                    "Geen vestiging gevonden voor vestiging met vestigingsnummer '$vestigingsnummer'" +
-                        (kvkNummer?.let { " en KVK nummer '$it'" } ?: "")
-                )
-            klantVestigingDigitalAddresses.await().toContactDetails().let { contactDetails ->
-                restBedrijf.apply {
-                    emailadres = contactDetails.emailAddress
-                    telefoonnummer = contactDetails.telephoneNumber
+            supervisorScope {
+                val klantVestigingDigitalAddresses =
+                    async {
+                        // we do not support retrieving contact details for a vestiging if no KVK number was provided
+                        kvkNummer?.let { klantClientService.findDigitalAddressesForVestiging(vestigingsnummer, it) }
+                            ?: emptyList()
+                    }
+                val vestiging = async { kvkClientService.findVestiging(vestigingsnummer, kvkNummer) }
+                val restBedrijf = vestiging.await()?.toRestBedrijf()?.apply { if (kvkNummer == null) this.kvkNummer = null }
+                    ?: throw VestigingNotFoundException(
+                        "Geen vestiging gevonden voor vestiging met vestigingsnummer '$vestigingsnummer'" +
+                            (kvkNummer?.let { " en KVK nummer '$it'" } ?: "")
+                    )
+                klantVestigingDigitalAddresses.await().toContactDetails().let { contactDetails ->
+                    restBedrijf.apply {
+                        emailadres = contactDetails.emailAddress
+                        telefoonnummer = contactDetails.telephoneNumber
+                    }
                 }
             }
         }

--- a/src/test/kotlin/net/atos/zac/app/admin/MailtemplateBeheerRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/admin/MailtemplateBeheerRestServiceTest.kt
@@ -30,7 +30,7 @@ class MailtemplateBeheerRestServiceTest : BehaviorSpec({
         policyService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/app/bag/BagRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/bag/BagRestServiceTest.kt
@@ -32,7 +32,7 @@ class BagRestServiceTest : BehaviorSpec({
         loggedInUserInstance
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/app/bag/converter/RESTAdresseerbaarObjectConverterTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/bag/converter/RESTAdresseerbaarObjectConverterTest.kt
@@ -16,7 +16,7 @@ import nl.info.client.bag.model.generated.StatusVerblijfsobject
 import nl.info.client.bag.model.generated.TypeAdresseerbaarObject
 
 class RESTAdresseerbaarObjectConverterTest : BehaviorSpec({
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/app/flowable/cmmn/ZacCmmnAdminUtilRestServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/app/flowable/cmmn/ZacCmmnAdminUtilRestServiceTest.kt
@@ -27,7 +27,7 @@ class ZacCmmnAdminUtilRestServiceTest : BehaviorSpec({
         policyService = policyService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/flowable/ZaakVariabelenServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/ZaakVariabelenServiceTest.kt
@@ -40,7 +40,7 @@ class ZaakVariabelenServiceTest : BehaviorSpec({
     )
     val zaakUuid = UUID.randomUUID()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/flowable/bpmn/function/TaskFunctionsTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/bpmn/function/TaskFunctionsTest.kt
@@ -21,7 +21,7 @@ import org.flowable.task.api.history.HistoricTaskInstance
 
 class TaskFunctionsTest : BehaviorSpec({
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/flowable/cmmn/CMMNServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/cmmn/CMMNServiceTest.kt
@@ -37,7 +37,7 @@ class CMMNServiceTest : BehaviorSpec({
         loggedInUserInstance
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/flowable/delegate/ExtendZaakDelegateTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/delegate/ExtendZaakDelegateTest.kt
@@ -39,7 +39,7 @@ class ExtendZaakDelegateTest : BehaviorSpec({
     val suspensionZaakHelper = mockk<SuspensionZaakHelper>()
     val eventingService = mockk<EventingService>()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/flowable/delegate/ResumeZaakDelegateTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/delegate/ResumeZaakDelegateTest.kt
@@ -29,7 +29,7 @@ class ResumeZaakDelegateTest : BehaviorSpec({
     val reason = "test"
     val date = ZonedDateTime.now()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/flowable/delegate/SendEmailDelegateTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/delegate/SendEmailDelegateTest.kt
@@ -38,7 +38,7 @@ class SendEmailDelegateTest : BehaviorSpec({
     val templateName = "fakeTemplate"
     val mailTemplate = createMailTemplate()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/flowable/delegate/SignDocumentDelegateTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/delegate/SignDocumentDelegateTest.kt
@@ -41,7 +41,7 @@ class SignDocumentDelegateTest : BehaviorSpec({
         unmockkStatic(CDI::class)
     }
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/flowable/delegate/SuspendZaakDelegateTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/delegate/SuspendZaakDelegateTest.kt
@@ -29,7 +29,7 @@ class SuspendZaakDelegateTest : BehaviorSpec({
     val numberOfDays = 10L
     val reason = "test"
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/flowable/delegate/UpdateZaakAssignmentDelegateTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/delegate/UpdateZaakAssignmentDelegateTest.kt
@@ -31,7 +31,7 @@ class UpdateZaakAssignmentDelegateTest : BehaviorSpec({
     val userId = "fakeUserId"
     val reason = "fakeReason"
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/flowable/delegate/UpdateZaakJavaDelegateTest.kt
+++ b/src/test/kotlin/net/atos/zac/flowable/delegate/UpdateZaakJavaDelegateTest.kt
@@ -41,7 +41,7 @@ class UpdateZaakJavaDelegateTest : BehaviorSpec({
     val zaakStatusName = "fakeStatus"
     val zaakStatus = createZaakStatusSub()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/gebruikersvoorkeuren/GebruikersvoorkeurenServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/gebruikersvoorkeuren/GebruikersvoorkeurenServiceTest.kt
@@ -19,7 +19,7 @@ class GebruikersvoorkeurenServiceTest : BehaviorSpec({
     val signaleringService = mockk<SignaleringService>()
     val gebruikersvoorkeurenService = GebruikersvoorkeurenService(entityManager, signaleringService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/solr/SolrDeployerServiceTest.kt
+++ b/src/test/kotlin/net/atos/zac/solr/SolrDeployerServiceTest.kt
@@ -31,7 +31,7 @@ class SolrDeployerServiceTest : BehaviorSpec({
         indexingService,
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/util/JsonbConfigurationTest.kt
+++ b/src/test/kotlin/net/atos/zac/util/JsonbConfigurationTest.kt
@@ -20,7 +20,7 @@ class JsonbConfigurationTest : BehaviorSpec({
     val jsonbConfiguration = JsonbConfiguration()
     val contextResolver = jsonbConfiguration.getContext(JsonbConfiguration::class.java)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/websocket/SessionRegistryTest.kt
+++ b/src/test/kotlin/net/atos/zac/websocket/SessionRegistryTest.kt
@@ -21,7 +21,7 @@ class SessionRegistryTest : BehaviorSpec({
     val screenEventCreatedZaak = createScreenEvent(opcode = Opcode.CREATED, screenEventType = ScreenEventType.ZAAK)
     val screenEventAnyAny = createScreenEvent(opcode = Opcode.ANY, screenEventType = ScreenEventType.ANY)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/net/atos/zac/websocket/WebSocketServerEndPointTest.kt
+++ b/src/test/kotlin/net/atos/zac/websocket/WebSocketServerEndPointTest.kt
@@ -25,7 +25,7 @@ class WebSocketServerEndPointTest : BehaviorSpec({
     val registry = mockk<SessionRegistry>()
     val endpoint = WebSocketServerEndPoint(registry)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/bag/BagClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/bag/BagClientServiceTest.kt
@@ -37,7 +37,7 @@ class BagClientServiceTest : BehaviorSpec({
         openbareRuimteApi
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/brp/BrpClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/brp/BrpClientServiceTest.kt
@@ -39,7 +39,7 @@ class BrpClientServiceTest : BehaviorSpec({
         brpConfiguration = brpConfiguration,
         zaaktypeCmmnConfigurationService = zaaktypeCmmnConfigurationService
     )
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/brp/util/BrpClientHeadersFactoryTest.kt
+++ b/src/test/kotlin/nl/info/client/brp/util/BrpClientHeadersFactoryTest.kt
@@ -28,7 +28,7 @@ class BrpClientHeadersFactoryTest : BehaviorSpec({
     val purpose = "fakePurpose"
     val loggedInUserInstance = mockk<Instance<LoggedInUser>>()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/klant/KlantClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/klant/KlantClientServiceTest.kt
@@ -28,7 +28,7 @@ class KlantClientServiceTest : BehaviorSpec({
     val klantClient = mockk<KlantClient>()
     val klantClientService = KlantClientService(klantClient)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/kvk/KvkClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/kvk/KvkClientServiceTest.kt
@@ -23,7 +23,7 @@ class KvkClientServiceTest : BehaviorSpec({
         kvkVestigingsprofielClient = kvkVestigingsprofielClient
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/or/object/ObjectsClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/or/object/ObjectsClientServiceTest.kt
@@ -17,7 +17,7 @@ class ObjectsClientServiceTest : BehaviorSpec({
     val objectsClient = mockk<ObjectsClient>()
     val service = ObjectsClientService(objectsClient)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/pabc/PabcClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/pabc/PabcClientServiceTest.kt
@@ -20,7 +20,7 @@ class PabcClientServiceTest : BehaviorSpec({
     val pabcClient = mockk<PabcClient>()
     val pabcClientService = PabcClientService(pabcClient)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/zgw/brc/BrcClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/brc/BrcClientServiceTest.kt
@@ -27,7 +27,7 @@ class BrcClientServiceTest : BehaviorSpec({
         zgwClientHeadersFactory = zgwClientHeadersFactory
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/zgw/drc/DrcClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/drc/DrcClientServiceTest.kt
@@ -37,11 +37,8 @@ class DrcClientServiceTest : BehaviorSpec({
         configurationService
     )
 
-    beforeEach {
-        checkUnnecessaryStub()
-    }
-
     afterEach {
+        checkUnnecessaryStub()
         clearAllMocks()
     }
 

--- a/src/test/kotlin/nl/info/client/zgw/shared/ZgwApiServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/shared/ZgwApiServiceTest.kt
@@ -55,7 +55,7 @@ class ZgwApiServiceTest : BehaviorSpec({
         drcClientService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/zgw/shared/util/AuditWijzigingJsonbDeserializerTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/shared/util/AuditWijzigingJsonbDeserializerTest.kt
@@ -23,7 +23,7 @@ class AuditWijzigingJsonbDeserializerTest : BehaviorSpec({
     val deserializationContext = mockk<DeserializationContext>()
     val runtimeType = mockk<Type>()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/zgw/util/ZgwClientHeadersFactoryTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/util/ZgwClientHeadersFactoryTest.kt
@@ -26,7 +26,7 @@ class ZgwClientHeadersFactoryTest : BehaviorSpec({
         zgwApiSecret
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/zgw/util/ZgwJwtTokenUtilsTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/util/ZgwJwtTokenUtilsTest.kt
@@ -15,7 +15,7 @@ import nl.info.zac.authentication.LoggedInUser
 import nl.info.zac.identity.model.getFullName
 
 class ZgwJwtTokenUtilsTest : BehaviorSpec({
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/zgw/zrc/ZrcClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/zrc/ZrcClientServiceTest.kt
@@ -34,7 +34,7 @@ class ZrcClientServiceTest : BehaviorSpec({
         configurationService = configurationService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/zgw/zrc/jsonb/DeleteGeoJSONGeometryJsonbSerializerTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/zrc/jsonb/DeleteGeoJSONGeometryJsonbSerializerTest.kt
@@ -18,7 +18,7 @@ class DeleteGeoJSONGeometryJsonbSerializerTest : BehaviorSpec({
     val jsonGenerator = mockk<JsonGenerator>()
     val serializationContext = mockk<SerializationContext>()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/client/zgw/ztc/ZtcClientServiceTest.kt
+++ b/src/test/kotlin/nl/info/client/zgw/ztc/ZtcClientServiceTest.kt
@@ -34,7 +34,7 @@ class ZtcClientServiceTest : BehaviorSpec({
     val testStartDateTime = ZonedDateTime.now()
     lateinit var initialDateTime: ZonedDateTime
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/admin/ReferenceTableAdminServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/admin/ReferenceTableAdminServiceTest.kt
@@ -35,7 +35,7 @@ class ReferenceTableAdminServiceTest : BehaviorSpec({
         referenceTableService = referenceTableService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/admin/ReferenceTableServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/admin/ReferenceTableServiceTest.kt
@@ -20,7 +20,7 @@ class ReferenceTableServiceTest : BehaviorSpec({
     val entityManager = mockk<EntityManager>()
     val referenceTableService = ReferenceTableService(entityManager)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/admin/SignaleringAdminRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/admin/SignaleringAdminRestServiceTest.kt
@@ -36,7 +36,7 @@ class SignaleringAdminRestServiceTest : BehaviorSpec({
         deleteOlderThanDays = deleteOlderThanDays
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/admin/ZaaktypeBpmnConfigurationBeheerServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/admin/ZaaktypeBpmnConfigurationBeheerServiceTest.kt
@@ -40,7 +40,7 @@ class ZaaktypeBpmnConfigurationBeheerServiceTest : BehaviorSpec({
         smartDocumentsTemplatesService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/admin/ZaaktypeCmmnConfigurationBeheerServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/admin/ZaaktypeCmmnConfigurationBeheerServiceTest.kt
@@ -68,7 +68,7 @@ class ZaaktypeCmmnConfigurationBeheerServiceTest : BehaviorSpec({
         zaaktypeHelperService = ZaaktypeHelperService(ztcClientService)
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/admin/ZaaktypeConfigurationServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/admin/ZaaktypeConfigurationServiceTest.kt
@@ -38,7 +38,7 @@ class ZaaktypeConfigurationServiceTest : BehaviorSpec({
         zaaktypeBpmnConfigurationBeheerService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/admin/HealthCheckRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/HealthCheckRestServiceTest.kt
@@ -37,7 +37,7 @@ class HealthCheckRestServiceTest : BehaviorSpec({
         policyService = policyService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/admin/ReferenceTableRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/ReferenceTableRestServiceTest.kt
@@ -33,7 +33,7 @@ class ReferenceTableRestServiceTest : BehaviorSpec({
         policyService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/admin/ZaaktypeBpmnConfigurationRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/ZaaktypeBpmnConfigurationRestServiceTest.kt
@@ -57,7 +57,7 @@ class ZaaktypeBpmnConfigurationRestServiceTest : BehaviorSpec({
             smartDocumentsService
         )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/admin/ZaaktypeCmmnConfigurationRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/ZaaktypeCmmnConfigurationRestServiceTest.kt
@@ -71,7 +71,7 @@ class ZaaktypeCmmnConfigurationRestServiceTest : BehaviorSpec({
         identityService = identityService,
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/admin/ZaaktypeHelperServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/admin/ZaaktypeHelperServiceTest.kt
@@ -23,7 +23,7 @@ class ZaaktypeHelperServiceTest : BehaviorSpec({
     val ztcClientService = mockk<ZtcClientService>()
     val zaaktypeHelperService = ZaaktypeHelperService(ztcClientService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/csv/CsvRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/csv/CsvRestServiceTest.kt
@@ -30,7 +30,7 @@ class CsvRestServiceTest : BehaviorSpec({
         policyService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/decision/DecisionServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/decision/DecisionServiceTest.kt
@@ -54,7 +54,7 @@ class DecisionServiceTest : BehaviorSpec({
     val enkelvoudigInformatieObject = createEnkelvoudigInformatieObject()
     val besluitInformatieObject = createBesluitInformatieObject()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/detacheddocuments/DetachedDocumentRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/detacheddocuments/DetachedDocumentRestServiceTest.kt
@@ -54,7 +54,7 @@ class DetachedDocumentRestServiceTest : BehaviorSpec({
         policyService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/detacheddocuments/converter/RestDetachedDocumentConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/detacheddocuments/converter/RestDetachedDocumentConverterTest.kt
@@ -26,7 +26,7 @@ class RestDetachedDocumentConverterTest : BehaviorSpec({
 
     val converter = RestDetachedDocumentConverter(userConverter, lockService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/inboxdocument/converter/RestInboxDocumentConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/inboxdocument/converter/RestInboxDocumentConverterTest.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 
 class RestInboxDocumentConverterTest : BehaviorSpec({
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectConvertServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectConvertServiceTest.kt
@@ -32,7 +32,7 @@ class EnkelvoudigInformatieObjectConvertServiceTest : BehaviorSpec({
         enkelvoudigInformatieObjectUpdateService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectDownloadServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectDownloadServiceTest.kt
@@ -31,7 +31,7 @@ class EnkelvoudigInformatieObjectDownloadServiceTest : BehaviorSpec({
     val zrcClientService = mockk<ZrcClientService>()
     val service = EnkelvoudigInformatieObjectDownloadService(drcClientService, zrcClientService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectUpdateServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/EnkelvoudigInformatieObjectUpdateServiceTest.kt
@@ -61,7 +61,7 @@ class EnkelvoudigInformatieObjectUpdateServiceTest : BehaviorSpec({
     val taskId = "1234"
     val task = createTestTask()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/converter/RestInformatieobjectConverterTest.kt
@@ -66,7 +66,7 @@ class RestInformatieobjectConverterTest : BehaviorSpec({
         ztcClientService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/klant/KlantRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/klant/KlantRestServiceTest.kt
@@ -45,7 +45,7 @@ class KlantRestServiceTest : BehaviorSpec({
     val brpClientService = mockk<BrpClientService>()
     val kvkClientService = mockk<KvkClientService>()
     val ztcClientService = mockk<ZtcClientService>()
-    val klantClientService = mockk<KlantClientService>(relaxed = true)
+    val klantClientService = mockk<KlantClientService>()
     val identificationService = mockk<IdentificationService>()
     val loggedInUserInstance = mockk<Instance<LoggedInUser>>()
     val klantRestService = KlantRestService(
@@ -180,6 +180,9 @@ class KlantRestServiceTest : BehaviorSpec({
             every {
                 kvkClientService.findVestiging(vestigingsnummer, kvkNummer)
             } returns null
+            every {
+                klantClientService.findDigitalAddressesForVestiging(vestigingsnummer, kvkNummer)
+            } returns emptyList()
 
             When("a request is made to get the vestiging") {
                 val exception =
@@ -239,6 +242,7 @@ class KlantRestServiceTest : BehaviorSpec({
             val persoon = createPersoon(bsn = bsn)
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, zaaktypeUuid, userName) } returns persoon
+            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -262,6 +266,7 @@ class KlantRestServiceTest : BehaviorSpec({
             val userName = "fakeUserName"
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, zaaktypeUuid, userName) } returns null
+            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -281,6 +286,7 @@ class KlantRestServiceTest : BehaviorSpec({
             val temporaryPersonId = UUID.randomUUID()
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns null
+            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -350,6 +356,7 @@ class KlantRestServiceTest : BehaviorSpec({
             val persoon = createPersoon(bsn = bsn)
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns persoon
+            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -373,6 +380,7 @@ class KlantRestServiceTest : BehaviorSpec({
             val userName = "fakeUserName"
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns null
+            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -392,6 +400,7 @@ class KlantRestServiceTest : BehaviorSpec({
             val userName = "fakeUserName"
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, zaaktypeUuid, userName) } returns null
+            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -487,6 +496,7 @@ class KlantRestServiceTest : BehaviorSpec({
             val persoon = createPersoon(bsn = bsn)
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns persoon
+            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -510,6 +520,7 @@ class KlantRestServiceTest : BehaviorSpec({
             val userName = "fakeUserName"
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, zaaktypeUuid, userName) } returns null
+            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -529,6 +540,7 @@ class KlantRestServiceTest : BehaviorSpec({
             val userName = "fakeUserName"
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns null
+            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {

--- a/src/test/kotlin/nl/info/zac/app/klant/KlantRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/klant/KlantRestServiceTest.kt
@@ -45,7 +45,7 @@ class KlantRestServiceTest : BehaviorSpec({
     val brpClientService = mockk<BrpClientService>()
     val kvkClientService = mockk<KvkClientService>()
     val ztcClientService = mockk<ZtcClientService>()
-    val klantClientService = mockk<KlantClientService>()
+    val klantClientService = mockk<KlantClientService>(relaxed = true)
     val identificationService = mockk<IdentificationService>()
     val loggedInUserInstance = mockk<Instance<LoggedInUser>>()
     val klantRestService = KlantRestService(
@@ -57,8 +57,9 @@ class KlantRestServiceTest : BehaviorSpec({
         loggedInUserInstance
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
+        clearAllMocks()
     }
 
     Context("Read vestiging by vestigingsnummer but without KVK nummer") {
@@ -102,7 +103,6 @@ class KlantRestServiceTest : BehaviorSpec({
         }
 
         Given("a vestiging by vestigingsnummer which does not exist in the KVK client") {
-            clearAllMocks()
             val vestigingsnummer = "fakeVestigingsnummer"
             every {
                 kvkClientService.findVestiging(vestigingsnummer)
@@ -175,15 +175,11 @@ class KlantRestServiceTest : BehaviorSpec({
         Given(
             "a vestiging which does not exist in the KVK client nor in in the klanten client"
         ) {
-            clearAllMocks()
             val vestigingsnummer = "fakeVestigingsnummer"
             val kvkNummer = "fakeKvkNummer"
             every {
                 kvkClientService.findVestiging(vestigingsnummer, kvkNummer)
             } returns null
-            every {
-                klantClientService.findDigitalAddressesForVestiging(vestigingsnummer, kvkNummer)
-            } returns emptyList()
 
             When("a request is made to get the vestiging") {
                 val exception =
@@ -241,9 +237,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val temporaryPersonId = UUID.randomUUID()
             val userName = "fakeUserName"
             val persoon = createPersoon(bsn = bsn)
-            every {
-                klantClientService.findDigitalAddressesForNaturalPerson(bsn)
-            } returns emptyList()
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, zaaktypeUuid, userName) } returns persoon
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
@@ -266,16 +259,7 @@ class KlantRestServiceTest : BehaviorSpec({
         Given("A person with a BSN which exists in the klanten client but not in the BRP client") {
             val bsn = "123456789"
             val temporaryPersonId = UUID.randomUUID()
-            val telephoneNumber = "0612345678"
-            val emailAddress = "test@example.com"
             val userName = "fakeUserName"
-            val digitaalAdresses = createDigitalAddresses(
-                phone = telephoneNumber,
-                email = emailAddress
-            )
-            every {
-                klantClientService.findDigitalAddressesForNaturalPerson(bsn)
-            } returns digitaalAdresses
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, zaaktypeUuid, userName) } returns null
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
@@ -295,9 +279,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val bsn = "123456789"
             val userName = "fakeUserName"
             val temporaryPersonId = UUID.randomUUID()
-            every {
-                klantClientService.findDigitalAddressesForNaturalPerson(bsn)
-            } returns emptyList()
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns null
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
@@ -367,9 +348,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val temporaryPersonId = UUID.randomUUID()
             val userName = "fakeUserName"
             val persoon = createPersoon(bsn = bsn)
-            every {
-                klantClientService.findDigitalAddressesForNaturalPerson(bsn)
-            } returns emptyList()
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns persoon
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
@@ -392,16 +370,7 @@ class KlantRestServiceTest : BehaviorSpec({
         Given("A person with a BSN which exists in the klanten client but not in the BRP client") {
             val bsn = "123456789"
             val temporaryPersonId = UUID.randomUUID()
-            val telephoneNumber = "0612345678"
-            val emailAddress = "test@example.com"
             val userName = "fakeUserName"
-            val digitaalAdresses = createDigitalAddresses(
-                phone = telephoneNumber,
-                email = emailAddress
-            )
-            every {
-                klantClientService.findDigitalAddressesForNaturalPerson(bsn)
-            } returns digitaalAdresses
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns null
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
@@ -421,9 +390,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val bsn = "123456789"
             val temporaryPersonId = UUID.randomUUID()
             val userName = "fakeUserName"
-            every {
-                klantClientService.findDigitalAddressesForNaturalPerson(bsn)
-            } returns emptyList()
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, zaaktypeUuid, userName) } returns null
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
@@ -519,9 +485,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val temporaryPersonId = UUID.randomUUID()
             val userName = "fakeUserName"
             val persoon = createPersoon(bsn = bsn)
-            every {
-                klantClientService.findDigitalAddressesForNaturalPerson(bsn)
-            } returns emptyList()
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns persoon
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
@@ -544,16 +507,7 @@ class KlantRestServiceTest : BehaviorSpec({
         Given("A person with a BSN which exists in the klanten client but not in the BRP client") {
             val bsn = "123456789"
             val temporaryPersonId = UUID.randomUUID()
-            val telephoneNumber = "0612345678"
-            val emailAddress = "test@example.com"
             val userName = "fakeUserName"
-            val digitaalAdresses = createDigitalAddresses(
-                phone = telephoneNumber,
-                email = emailAddress
-            )
-            every {
-                klantClientService.findDigitalAddressesForNaturalPerson(bsn)
-            } returns digitaalAdresses
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, zaaktypeUuid, userName) } returns null
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
@@ -573,9 +527,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val bsn = "123456789"
             val temporaryPersonId = UUID.randomUUID()
             val userName = "fakeUserName"
-            every {
-                klantClientService.findDigitalAddressesForNaturalPerson(bsn)
-            } returns emptyList()
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns null
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
@@ -841,7 +792,6 @@ class KlantRestServiceTest : BehaviorSpec({
         }
 
         Given("No person exists for a given BSN") {
-            clearAllMocks()
             val bsn = "123456789"
             val restListPersonenParameters = RestListPersonenParameters(bsn = bsn)
 
@@ -859,7 +809,6 @@ class KlantRestServiceTest : BehaviorSpec({
         }
 
         Given("Persons are queried using search parameters (no BSN)") {
-            clearAllMocks()
             val restListPersonenParameters = RestListPersonenParameters(
                 geslachtsnaam = "Jansen",
                 geboortedatum = LocalDate.of(1990, 1, 1)

--- a/src/test/kotlin/nl/info/zac/app/klant/KlantRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/klant/KlantRestServiceTest.kt
@@ -180,9 +180,6 @@ class KlantRestServiceTest : BehaviorSpec({
             every {
                 kvkClientService.findVestiging(vestigingsnummer, kvkNummer)
             } returns null
-            every {
-                klantClientService.findDigitalAddressesForVestiging(vestigingsnummer, kvkNummer)
-            } returns emptyList()
 
             When("a request is made to get the vestiging") {
                 val exception =
@@ -266,7 +263,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val userName = "fakeUserName"
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, zaaktypeUuid, userName) } returns null
-            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -286,7 +282,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val temporaryPersonId = UUID.randomUUID()
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns null
-            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -380,7 +375,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val userName = "fakeUserName"
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns null
-            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -400,7 +394,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val userName = "fakeUserName"
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, zaaktypeUuid, userName) } returns null
-            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -520,7 +513,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val userName = "fakeUserName"
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, zaaktypeUuid, userName) } returns null
-            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {
@@ -540,7 +532,6 @@ class KlantRestServiceTest : BehaviorSpec({
             val userName = "fakeUserName"
             every { loggedInUserInstance.get().id } returns userName
             every { brpClientService.retrievePersoon(bsn, null, userName) } returns null
-            every { klantClientService.findDigitalAddressesForNaturalPerson(bsn) } returns emptyList()
             every { identificationService.replaceKeyWithBsn(temporaryPersonId) } returns bsn
 
             When("when the person is retrieved") {

--- a/src/test/kotlin/nl/info/zac/app/note/NoteRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/note/NoteRestServiceTest.kt
@@ -31,7 +31,7 @@ class NoteRestServiceTest : BehaviorSpec({
         policyService = policyService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/planitems/PlanItemsRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/planitems/PlanItemsRestServiceTest.kt
@@ -99,7 +99,7 @@ class PlanItemsRestServiceTest : BehaviorSpec({
         zaaktypeUUID = zaakTypeUUID
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/search/SearchRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/search/SearchRestServiceTest.kt
@@ -59,7 +59,7 @@ class SearchRestServiceTest : BehaviorSpec({
         ztcClientService = ztcClientService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/signalering/SignaleringRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/signalering/SignaleringRestServiceTest.kt
@@ -42,7 +42,7 @@ class SignaleringRestServiceTest : BehaviorSpec({
         loggedInUserInstance = loggedInUserInstance
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/signalering/converter/RESTSignaleringTaakConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/signalering/converter/RESTSignaleringTaakConverterTest.kt
@@ -14,7 +14,7 @@ import java.time.Month
 import java.util.Calendar
 
 class RESTSignaleringTaakConverterTest : BehaviorSpec({
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/task/TaskRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/task/TaskRestServiceTest.kt
@@ -114,7 +114,7 @@ class TaskRestServiceTest : BehaviorSpec({
     )
     val loggedInUser = createLoggedInUser()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/task/converter/RestTaskHistoryConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/task/converter/RestTaskHistoryConverterTest.kt
@@ -18,7 +18,7 @@ class RestTaskHistoryConverterTest : BehaviorSpec({
     val identityService = mockk<IdentityService>()
     val restTaskHistoryConverter = RestTaskHistoryConverter(identityService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/util/UtilRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/util/UtilRestServiceTest.kt
@@ -34,7 +34,7 @@ class UtilRestServiceTest : BehaviorSpec({
         policyService = policyService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/util/interceptor/NullFilteringReaderInterceptorTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/util/interceptor/NullFilteringReaderInterceptorTest.kt
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 class NullFilteringReaderInterceptorTest : BehaviorSpec({
     val interceptor = NullFilteringReaderInterceptor()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceAssignTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceAssignTest.kt
@@ -137,7 +137,7 @@ class ZaakRestServiceAssignTest : BehaviorSpec({
         identificationService = identificationService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceCreateTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceCreateTest.kt
@@ -159,7 +159,7 @@ class ZaakRestServiceCreateTest : BehaviorSpec({
         identificationService = identificationService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceDeleteTerminateCloseTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceDeleteTerminateCloseTest.kt
@@ -10,7 +10,6 @@ import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
-import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -237,16 +236,22 @@ class ZaakRestServiceDeleteTerminateCloseTest : BehaviorSpec({
             every { policyService.readZaakRechten(zaak, zaakType, loggedInUser) } returns createZaakRechten(afbreken = true)
             every { loggedInUserInstance.get() } returns loggedInUser
 
-            shouldThrow<ZaakWithADecisionCannotBeTerminatedException> {
-                zaakRestService.terminateZaak(
-                    zaakUuid,
-                    RESTZaakAfbrekenGegevens(zaakbeeindigRedenId = INADMISSIBLE_TERMINATION_ID)
-                )
-            }
+            When("trying to terminate the zaak") {
+                shouldThrow<ZaakWithADecisionCannotBeTerminatedException> {
+                    zaakRestService.terminateZaak(
+                        zaakUuid,
+                        RESTZaakAfbrekenGegevens(zaakbeeindigRedenId = INADMISSIBLE_TERMINATION_ID)
+                    )
+                }
 
-            verify(exactly = 0) {
-                zgwApiService.closeZaak(any<Zaak>(), any<UUID>(), any())
-                cmmnService.terminateCase(any())
+                Then(
+                    "it throws ZaakWithADecisionCannotBeTerminatedException and no close or terminate calls are made"
+                ) {
+                    verify(exactly = 0) {
+                        zgwApiService.closeZaak(any<Zaak>(), any<UUID>(), any())
+                        cmmnService.terminateCase(any())
+                    }
+                }
             }
         }
 
@@ -269,16 +274,15 @@ class ZaakRestServiceDeleteTerminateCloseTest : BehaviorSpec({
             )
             val loggedInUser = createLoggedInUser()
 
-            every { zaakService.readZaakAndZaakTypeByZaakUUID(zaak.uuid) } returns Pair(zaak, zaakType)
-            every { policyService.readZaakRechten(zaak, zaakType, loggedInUser) } returns createZaakRechten(afbreken = true)
-            every {
-                zaaktypeConfigurationService.readZaaktypeConfiguration(zaakTypeUUID)
-            } returns zaaktypeCmmnConfiguration
-            every { zgwApiService.closeZaak(zaak, resultTypeUUID, "-2 name") } just runs
-            every { cmmnService.terminateCase(zaak.uuid) } returns Unit
-            every { loggedInUserInstance.get() } returns loggedInUser
-
             When("aborted with managed zaakbeeindigreden") {
+                every { zaakService.readZaakAndZaakTypeByZaakUUID(zaak.uuid) } returns Pair(zaak, zaakType)
+                every { policyService.readZaakRechten(zaak, zaakType, loggedInUser) } returns createZaakRechten(afbreken = true)
+                every {
+                    zaaktypeConfigurationService.readZaaktypeConfiguration(zaakTypeUUID)
+                } returns zaaktypeCmmnConfiguration
+                every { zgwApiService.closeZaak(zaak, resultTypeUUID, "-2 name") } just runs
+                every { cmmnService.terminateCase(zaak.uuid) } returns Unit
+                every { loggedInUserInstance.get() } returns loggedInUser
                 zaakRestService.terminateZaak(zaak.uuid, RESTZaakAfbrekenGegevens(zaakbeeindigRedenId = "-2"))
 
                 Then("it is ended with result") {
@@ -290,7 +294,12 @@ class ZaakRestServiceDeleteTerminateCloseTest : BehaviorSpec({
             }
 
             When("aborted with invalid zaakbeeindigreden id") {
-                clearMocks(zgwApiService, cmmnService)
+                every { zaakService.readZaakAndZaakTypeByZaakUUID(zaak.uuid) } returns Pair(zaak, zaakType)
+                every { policyService.readZaakRechten(zaak, zaakType, loggedInUser) } returns createZaakRechten(afbreken = true)
+                every {
+                    zaaktypeConfigurationService.readZaaktypeConfiguration(zaakTypeUUID)
+                } returns zaaktypeCmmnConfiguration
+                every { loggedInUserInstance.get() } returns loggedInUser
                 val exception = shouldThrow<IllegalArgumentException> {
                     zaakRestService.terminateZaak(
                         zaak.uuid,

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceDeleteTerminateCloseTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceDeleteTerminateCloseTest.kt
@@ -152,6 +152,7 @@ class ZaakRestServiceDeleteTerminateCloseTest : BehaviorSpec({
 
     afterEach {
         checkUnnecessaryStub()
+        clearAllMocks()
     }
 
     Context("Deleting an initiator") {
@@ -223,7 +224,6 @@ class ZaakRestServiceDeleteTerminateCloseTest : BehaviorSpec({
         }
 
         Given("A zaak with a decision cannot be terminated. A bad request is returned") {
-            clearAllMocks()
             val zaakUuid = UUID.randomUUID()
             val zaakType = createZaakType(omschrijving = ZAAK_TYPE_1_OMSCHRIJVING)
             val zaak = createZaak(
@@ -251,7 +251,6 @@ class ZaakRestServiceDeleteTerminateCloseTest : BehaviorSpec({
         }
 
         Given("A zaak and managed zaakbeeindigreden") {
-            clearAllMocks()
             val zaakType = createZaakType(omschrijving = ZAAK_TYPE_1_OMSCHRIJVING)
             val zaakTypeUUID = zaakType.url.extractUuid()
             val zaak = createZaak(zaaktypeUri = zaakType.url)

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceDeleteTerminateCloseTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceDeleteTerminateCloseTest.kt
@@ -150,7 +150,7 @@ class ZaakRestServiceDeleteTerminateCloseTest : BehaviorSpec({
         identificationService = identificationService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceLinkUnlinkTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceLinkUnlinkTest.kt
@@ -134,7 +134,7 @@ class ZaakRestServiceLinkUnlinkTest : BehaviorSpec({
         identificationService = identificationService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceReadDownloadListTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceReadDownloadListTest.kt
@@ -146,7 +146,7 @@ class ZaakRestServiceReadDownloadListTest : BehaviorSpec({
         identificationService = identificationService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceUpdateTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakRestServiceUpdateTest.kt
@@ -151,7 +151,7 @@ class ZaakRestServiceUpdateTest : BehaviorSpec({
         identificationService = identificationService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/ZaakSuspendRestServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/ZaakSuspendRestServiceTest.kt
@@ -44,7 +44,7 @@ class ZaakSuspendRestServiceTest : BehaviorSpec({
         zaakVariabelenService = zaakVariabelenService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/converter/RestDecisionConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/converter/RestDecisionConverterTest.kt
@@ -41,7 +41,7 @@ class RestDecisionConverterTest : BehaviorSpec({
         configurationService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverterTest.kt
@@ -91,7 +91,7 @@ class RestZaakConverterTest : BehaviorSpec({
         klantClientService = klantClientService,
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakOverzichtConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakOverzichtConverterTest.kt
@@ -41,7 +41,7 @@ class RestZaakOverzichtConverterTest : BehaviorSpec({
         zrcClientService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakResultaatConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakResultaatConverterTest.kt
@@ -23,7 +23,7 @@ class RestZaakResultaatConverterTest : BehaviorSpec({
     val ztcClientService = mockk<ZtcClientService>()
     val converter = RestZaakResultaatConverter(zrcClientService, ztcClientService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/authentication/LoggedInUserAuthorisationTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/LoggedInUserAuthorisationTest.kt
@@ -13,7 +13,7 @@ import nl.info.zac.app.zaak.model.ZAAK_TYPE_2_OMSCHRIJVING
 
 class LoggedInUserAuthorisationTest : BehaviorSpec({
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/authentication/LoggedInUserProviderTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/LoggedInUserProviderTest.kt
@@ -14,7 +14,7 @@ import jakarta.servlet.http.HttpSession
 class LoggedInUserProviderTest : BehaviorSpec({
     val httpSession = mockk<HttpSession>()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/authentication/RequestAuthorizationFilterTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/RequestAuthorizationFilterTest.kt
@@ -23,7 +23,7 @@ class RequestAuthorizationFilterTest : BehaviorSpec({
     val filterChain = mockk<FilterChain>()
     val httpSession = mockk<HttpSession>(relaxed = true)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/authentication/UserPrincipalFilterTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/UserPrincipalFilterTest.kt
@@ -43,7 +43,7 @@ class UserPrincipalFilterTest : BehaviorSpec({
     val httpSession = mockk<HttpSession>()
     val newHttpSession = mockk<HttpSession>()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/authentication/ZacApiKeyAuthFilterTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/ZacApiKeyAuthFilterTest.kt
@@ -21,7 +21,7 @@ class ZacApiKeyAuthFilterTest : BehaviorSpec({
     )
     val containerRequestContext = mockk<ContainerRequestContext>()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/configuratie/ConfiguratieServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/configuratie/ConfiguratieServiceTest.kt
@@ -31,7 +31,7 @@ class ConfiguratieServiceTest : BehaviorSpec({
     val gemeenteNaam = "Gemeente Name"
     val gemeenteMail = "gemeente@example.com"
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/database/flyway/FlywayIntegratorTest.kt
+++ b/src/test/kotlin/nl/info/zac/database/flyway/FlywayIntegratorTest.kt
@@ -12,7 +12,7 @@ import nl.info.zac.database.flyway.exception.DatabaseConfigurationException
 class FlywayIntegratorTest : BehaviorSpec({
     val flywayIntegrator = FlywayIntegrator()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/document/detacheddocument/DetachedDocumentServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/document/detacheddocument/DetachedDocumentServiceTest.kt
@@ -35,7 +35,7 @@ class DetachedDocumentServiceTest : BehaviorSpec({
         loggedInUserInstance = loggedInUserInstance
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/document/detacheddocument/repository/DetachedDocumentRepositoryTest.kt
+++ b/src/test/kotlin/nl/info/zac/document/detacheddocument/repository/DetachedDocumentRepositoryTest.kt
@@ -22,7 +22,7 @@ class DetachedDocumentRepositoryTest : BehaviorSpec({
     val entityManager = mockk<EntityManager>(relaxed = true)
     val detachedDocumentRepository = DetachedDocumentRepository(entityManager)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/document/inboxdocument/InboxDocumentServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/document/inboxdocument/InboxDocumentServiceTest.kt
@@ -34,7 +34,7 @@ class InboxDocumentServiceTest : BehaviorSpec({
 
     val inboxDocumentService = InboxDocumentService(inboxDocumentRepository, zrcClientService, drcClientService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/document/inboxdocument/repository/InboxDocumentRepositoryTest.kt
+++ b/src/test/kotlin/nl/info/zac/document/inboxdocument/repository/InboxDocumentRepositoryTest.kt
@@ -28,7 +28,7 @@ class InboxDocumentRepositoryTest : BehaviorSpec({
     val entityManager = mockk<EntityManager>(relaxed = true)
     val inboxDocumentRepository = InboxDocumentRepository(entityManager)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/documentcreation/DocumentCreationServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/documentcreation/DocumentCreationServiceTest.kt
@@ -51,7 +51,7 @@ class DocumentCreationServiceTest : BehaviorSpec({
         loggedInUserInstance = loggedInUserInstance
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/documentcreation/converter/DocumentCreationDataConverterTest.kt
@@ -63,7 +63,7 @@ class DocumentCreationDataConverterTest : BehaviorSpec({
         configurationService = configurationService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/flowable/bpmn/ZaaktypeBpmnConfigurationBeheerServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/flowable/bpmn/ZaaktypeBpmnConfigurationBeheerServiceTest.kt
@@ -49,7 +49,7 @@ class ZaaktypeBpmnConfigurationBeheerServiceTest : BehaviorSpec({
     val zaaktypeBpmnConfigurationBeheerService =
         ZaaktypeBpmnConfigurationBeheerService(entityManager, smartDocumentsTemplatesService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/flowable/bpmn/ZaaktypeBpmnConfigurationServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/flowable/bpmn/ZaaktypeBpmnConfigurationServiceTest.kt
@@ -19,7 +19,7 @@ class ZaaktypeBpmnConfigurationServiceTest : BehaviorSpec({
     val zaaktypeBpmnConfigurationBeheerService = mockk<ZaaktypeBpmnConfigurationBeheerService>()
     val zaaktypeBpmnConfigurationService = ZaaktypeBpmnConfigurationService(zaaktypeBpmnConfigurationBeheerService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/flowable/bpmn/delegate/SendConfirmationEmailDelegateTest.kt
+++ b/src/test/kotlin/nl/info/zac/flowable/bpmn/delegate/SendConfirmationEmailDelegateTest.kt
@@ -58,7 +58,7 @@ class SendConfirmationEmailDelegateTest : BehaviorSpec({
 
     val capturedMailGegevens = mutableListOf<MailGegevens>()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/health/PabcReadinessHealthCheckTest.kt
+++ b/src/test/kotlin/nl/info/zac/health/PabcReadinessHealthCheckTest.kt
@@ -20,7 +20,7 @@ class PabcReadinessHealthCheckTest : BehaviorSpec({
     val configurationService = mockk<ConfigurationService>()
     val pabcReadinessHealthCheck = PabcReadinessHealthCheck(pabcClientService, configurationService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/health/SolrReadinessHealthCheckTest.kt
+++ b/src/test/kotlin/nl/info/zac/health/SolrReadinessHealthCheckTest.kt
@@ -6,7 +6,6 @@ package nl.info.zac.health
 
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/kotlin/nl/info/zac/health/SolrReadinessHealthCheckTest.kt
+++ b/src/test/kotlin/nl/info/zac/health/SolrReadinessHealthCheckTest.kt
@@ -6,6 +6,7 @@ package nl.info.zac.health
 
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/kotlin/nl/info/zac/healthcheck/model/ZaaktypeInrichtingscheckTest.kt
+++ b/src/test/kotlin/nl/info/zac/healthcheck/model/ZaaktypeInrichtingscheckTest.kt
@@ -11,7 +11,7 @@ import nl.info.zac.healthcheck.createZaaktypeInrichtingscheck
 
 class ZaaktypeInrichtingscheckTest : BehaviorSpec({
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/helper/SuspensionZaakHelperTest.kt
+++ b/src/test/kotlin/nl/info/zac/helper/SuspensionZaakHelperTest.kt
@@ -55,7 +55,7 @@ class SuspensionZaakHelperTest : BehaviorSpec({
     val tomorrow = today.plusDays(1)
     val numberOfDays = 2L
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/history/ZaakHistoryServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/history/ZaakHistoryServiceTest.kt
@@ -37,7 +37,7 @@ class ZaakHistoryServiceTest : BehaviorSpec({
         ZaakHistoryPartialUpdateConverter(zrcClientService)
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/history/converter/ZaakHistoryPartialUpdateConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/history/converter/ZaakHistoryPartialUpdateConverterTest.kt
@@ -25,7 +25,7 @@ class ZaakHistoryPartialUpdateConverterTest : BehaviorSpec({
     val description = "description"
     val zaakHistoryPartialUpdateConverter = ZaakHistoryPartialUpdateConverter(zrcClientService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/identity/IdentityServiceTest.kt
@@ -42,7 +42,7 @@ class IdentityServiceTest : BehaviorSpec({
         ztcClientService = ztcClientService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/mail/MailServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/mail/MailServiceTest.kt
@@ -55,7 +55,7 @@ class MailServiceTest : BehaviorSpec({
         loggedInUserInstance
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/mailtemplates/MailTemplateServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/mailtemplates/MailTemplateServiceTest.kt
@@ -35,7 +35,7 @@ class MailTemplateServiceTest : BehaviorSpec({
     val typedQuery = mockk<TypedQuery<MailTemplate>>()
     val mailTemplateService = MailTemplateService(entityManager)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/note/NoteServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/note/NoteServiceTest.kt
@@ -21,7 +21,7 @@ class NoteServiceTest : BehaviorSpec({
     val entityManager = mockk<EntityManager>()
     val noteService = NoteService(entityManager)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/notification/NotificationReceiverTest.kt
+++ b/src/test/kotlin/nl/info/zac/notification/NotificationReceiverTest.kt
@@ -64,7 +64,7 @@ class NotificationReceiverTest : BehaviorSpec({
         httpSession = httpSessionInstance
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/policy/PolicyServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/policy/PolicyServiceTest.kt
@@ -70,7 +70,7 @@ class PolicyServiceTest : BehaviorSpec({
         configurationService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/productaanvraag/InboxProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/InboxProductaanvraagServiceTest.kt
@@ -27,7 +27,7 @@ class InboxProductaanvraagServiceTest : BehaviorSpec({
     val entityManager = mockk<EntityManager>(relaxed = true)
     val service = InboxProductaanvraagService(entityManager)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagEmailServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagEmailServiceTest.kt
@@ -44,7 +44,7 @@ class ProductaanvraagEmailServiceTest : BehaviorSpec({
         mailTemplateService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -8,6 +8,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -531,6 +532,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             has the BRP and KVK koppelingen disabled
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -653,6 +655,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             and zaaktypeCmmnConfiguration that have the KVK koppeling enabled 
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -753,6 +756,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             containing a betrokkene with initiator role that's not supported by the zaaktype
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -854,6 +858,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             containing a betrokkene with role initiator but no supported initiator identification
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -941,6 +946,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             not containing any betrokkenen
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -1021,6 +1027,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             containing a list of supported betrokkenen including behandelaar but no initiator
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -1253,6 +1260,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             with a default group, but an exception occurs when adding a zaakinformatieobject
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -1326,6 +1334,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
         }
 
         Given("a productaanvraag-dimpact object registration object missing required aanvraaggegevens") {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
             val formulierBron = createBron()
@@ -1367,6 +1376,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             and for which no zaaktype exists in the ZTC catalogus
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
             val zaakType = createZaakType()
@@ -1437,6 +1447,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             A productaanvraag-dimpact object that cannot be read from the objects client service
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             every { objectsClientService.readObject(productAanvraagObjectUUID) } throws RuntimeException("Failed")
 
@@ -1465,6 +1476,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             but a BPMN definition for the productaanvraagtype
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
             val zaakType = createZaakType()
@@ -1598,6 +1610,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             A productaanvraag-dimpact object where both a CMMN mapping and a BPMN mapping exist for the productaanvraagtype
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
             val zaakTypeUUID = UUID.randomUUID()
@@ -1659,6 +1672,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             and for which application-specific contact details are available
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -1735,6 +1749,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             a BPMN definition for the productaanvraagtype, and application-specific contact details
             """
         ) {
+            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
             val zaakType = createZaakType()

--- a/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/productaanvraag/ProductaanvraagServiceTest.kt
@@ -8,7 +8,6 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.checkUnnecessaryStub
-import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -109,7 +108,7 @@ class ProductaanvraagServiceTest : BehaviorSpec({
         productaanvraagDocumentService = productaanvraagDocumentService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 
@@ -532,7 +531,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             has the BRP and KVK koppelingen disabled
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -655,7 +653,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             and zaaktypeCmmnConfiguration that have the KVK koppeling enabled 
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -756,7 +753,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             containing a betrokkene with initiator role that's not supported by the zaaktype
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -858,7 +854,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             containing a betrokkene with role initiator but no supported initiator identification
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -946,7 +941,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             not containing any betrokkenen
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -1027,7 +1021,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             containing a list of supported betrokkenen including behandelaar but no initiator
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -1260,7 +1253,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             with a default group, but an exception occurs when adding a zaakinformatieobject
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -1334,7 +1326,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
         }
 
         Given("a productaanvraag-dimpact object registration object missing required aanvraaggegevens") {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
             val formulierBron = createBron()
@@ -1376,7 +1367,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             and for which no zaaktype exists in the ZTC catalogus
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
             val zaakType = createZaakType()
@@ -1447,7 +1437,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             A productaanvraag-dimpact object that cannot be read from the objects client service
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             every { objectsClientService.readObject(productAanvraagObjectUUID) } throws RuntimeException("Failed")
 
@@ -1476,7 +1465,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             but a BPMN definition for the productaanvraagtype
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
             val zaakType = createZaakType()
@@ -1610,7 +1598,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             A productaanvraag-dimpact object where both a CMMN mapping and a BPMN mapping exist for the productaanvraagtype
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
             val zaakTypeUUID = UUID.randomUUID()
@@ -1672,7 +1659,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             and for which application-specific contact details are available
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val zaakTypeUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
@@ -1749,7 +1735,6 @@ class ProductaanvraagServiceTest : BehaviorSpec({
             a BPMN definition for the productaanvraagtype, and application-specific contact details
             """
         ) {
-            clearAllMocks()
             val productAanvraagObjectUUID = UUID.randomUUID()
             val productAanvraagType = "productaanvraag"
             val zaakType = createZaakType()

--- a/src/test/kotlin/nl/info/zac/search/IndexingServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/IndexingServiceTest.kt
@@ -88,7 +88,7 @@ private fun setupContext(): TestContext {
 }
 
 class IndexingServiceTest : BehaviorSpec({
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/search/SearchServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/SearchServiceTest.kt
@@ -59,7 +59,7 @@ class SearchServiceTest : BehaviorSpec({
     val loggedInUser = mockk<LoggedInUser>()
     val zoekService = SearchService(loggedInUserInstance, configurationService)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/converter/DocumentZoekObjectConverterTest.kt
@@ -41,7 +41,7 @@ class DocumentZoekObjectConverterTest : BehaviorSpec({
         enkelvoudigInformatieObjectLockService = enkelvoudigInformatieObjectLockService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/search/converter/ZaakZoekObjectConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/search/converter/ZaakZoekObjectConverterTest.kt
@@ -54,7 +54,7 @@ class ZaakZoekObjectConverterTest : BehaviorSpec({
         flowableTaskService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/signalering/SignaleringServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/signalering/SignaleringServiceTest.kt
@@ -87,7 +87,7 @@ class SignaleringServiceTest : BehaviorSpec({
         loggedInUserInstance = loggedInUserInstance
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/signalering/ZaakTaskDueDateEmailNotificationServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/signalering/ZaakTaskDueDateEmailNotificationServiceTest.kt
@@ -48,7 +48,7 @@ class ZaakTaskDueDateEmailNotificationServiceTest : BehaviorSpec({
         flowableTaskService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/smartdocuments/SmartDocumentsServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/smartdocuments/SmartDocumentsServiceTest.kt
@@ -33,7 +33,7 @@ class SmartDocumentsServiceTest : BehaviorSpec({
     val loggedInUserInstance = mockk<Instance<LoggedInUser>>()
     val smartDocumentsClient = mockk<Instance<SmartDocumentsClient>>()
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/smartdocuments/SmartDocumentsTemplatesServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/smartdocuments/SmartDocumentsTemplatesServiceTest.kt
@@ -38,7 +38,7 @@ class SmartDocumentsTemplatesServiceTest : BehaviorSpec({
         zaaktypeConfigurationService = zaaktypeConfigurationService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/task/BpmnTaskFormRuntimeServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/task/BpmnTaskFormRuntimeServiceTest.kt
@@ -58,7 +58,7 @@ class BpmnTaskFormRuntimeServiceTest : BehaviorSpec({
         flowableTaskService = flowableTaskService
     )
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/task/TaskServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/task/TaskServiceTest.kt
@@ -47,7 +47,7 @@ class TaskServiceTest : BehaviorSpec({
     val taskId1 = "fakeTaskId1"
     val taskId2 = "fakeTaskId2"
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/test/util/Base64ConvertersTest.kt
+++ b/src/test/kotlin/nl/info/zac/test/util/Base64ConvertersTest.kt
@@ -13,7 +13,7 @@ import java.util.Base64
 
 class Base64ConvertersTest : BehaviorSpec({
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/util/BSNValidatorTest.kt
+++ b/src/test/kotlin/nl/info/zac/util/BSNValidatorTest.kt
@@ -12,7 +12,7 @@ import java.lang.IllegalArgumentException
 
 class BSNValidatorTest : BehaviorSpec({
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/webdav/WebdavHelperTest.kt
+++ b/src/test/kotlin/nl/info/zac/webdav/WebdavHelperTest.kt
@@ -31,7 +31,7 @@ class WebdavHelperTest : BehaviorSpec({
 
     val webdavHelper = WebdavHelper(drcClientService, loggedInUserInstance)
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/webdav/WebdavStoreTest.kt
+++ b/src/test/kotlin/nl/info/zac/webdav/WebdavStoreTest.kt
@@ -59,7 +59,7 @@ class WebdavStoreTest : BehaviorSpec({
         }
     }
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 

--- a/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
+++ b/src/test/kotlin/nl/info/zac/zaak/ZaakServiceTest.kt
@@ -95,7 +95,7 @@ class ZaakServiceTest : BehaviorSpec({
     val explanation = "fakeExplanation"
     val screenEventResourceId = "fakeResourceId"
 
-    beforeEach {
+    afterEach {
         checkUnnecessaryStub()
     }
 


### PR DESCRIPTION
Fix flaky KlantRestServiceTest unit test because of async refactorings in KlantRestService. Refactor test cases to move `checkUnnecessaryStub` to `afterEach` and improve mock handling.

Solves PZ-11232