### PR TITLE
chore: update openspec commands and skills

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -35,13 +35,13 @@ Implement tasks from an OpenSpec change.
    ```
 
    This returns:
-   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
    - Progress (total, complete, remaining)
    - Task list with status
    - Dynamic instruction based on current state
 
    **Handle states:**
-   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
    - If `state: "all_done"`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 
@@ -60,14 +60,26 @@ Implement tasks from an OpenSpec change.
    - Remaining tasks overview
    - Dynamic instruction from CLI
 
-6. **Implement tasks (loop until done or blocked)**
+6. **Implement tasks using tracer bullets**
 
-   For each pending task:
-   - Show which task is being worked on
-   - Make the code changes required
-   - Keep changes minimal and focused
-   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
-   - Continue to next task
+   Before starting the loop, identify the **tracer bullet**: the first task that forms a minimal end-to-end slice through all relevant layers (e.g., one user action wired from UI through to backend/data layer). This is typically the first task if tasks were structured following tracer bullet principles.
+
+   **Phase 1 — Tracer bullet first (RED → GREEN → REFACTOR):**
+   - Write a failing test that describes the tracer bullet behavior — verify it fails before writing any implementation code (RED)
+   - Implement only the minimal code needed to make that test pass (GREEN)
+   - **Pause and verify**: run the test suite, confirm the test passes and the slice works end-to-end
+   - Look for quick refactor opportunities now that the path is green — extract duplication, rename for clarity — then re-run tests (REFACTOR)
+   - Mark it complete: `- [ ]` → `- [x]`
+   - Report what was validated and invite confirmation to continue
+
+   **Phase 2 — Expand from the working slice (RED → GREEN → REFACTOR per task):**
+   - Only after the tracer bullet is verified, continue with remaining tasks
+   - Each task expands or builds on top of the already-working slice
+   - For each task:
+     - Write a failing test for the behavior this task introduces (RED)
+     - Write minimal code to make it pass — no speculative additions (GREEN)
+     - Refactor if needed, run tests to confirm still green (REFACTOR)
+     - Mark complete `- [ ]` → `- [x]`, continue to next
 
    **Pause if:**
    - Task is unclear → ask for clarification
@@ -111,7 +123,7 @@ Working on task 4/7: <task description>
 - [x] Task 2
 ...
 
-All tasks complete! You can archive this change with `/opsx:archive`.
+All tasks complete! Ready to archive this change.
 ```
 
 **Output On Pause (Issue Encountered)**

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -30,7 +30,7 @@ Archive a completed change in the experimental workflow.
 
    **If any artifacts are not `done`:**
    - Display warning listing incomplete artifacts
-   - Prompt user for confirmation to continue
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
    - Proceed if user confirms
 
 3. **Check task completion status**
@@ -41,7 +41,7 @@ Archive a completed change in the experimental workflow.
 
    **If incomplete tasks found:**
    - Display warning showing count of incomplete tasks
-   - Prompt user for confirmation to continue
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
    - Proceed if user confirms
 
    **If no tasks file exists:** Proceed without task-related warning.
@@ -84,7 +84,7 @@ Archive a completed change in the experimental workflow.
    - Change name
    - Schema that was used
    - Archive location
-   - Spec sync status (synced / sync skipped / no delta specs)
+   - Whether specs were synced (if applicable)
    - Note about any warnings (incomplete artifacts/tasks)
 
 **Output On Success**
@@ -95,56 +95,9 @@ Archive a completed change in the experimental workflow.
 **Change:** <change-name>
 **Schema:** <schema-name>
 **Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
-**Specs:** ✓ Synced to main specs
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
 
 All artifacts complete. All tasks complete.
-```
-
-**Output On Success (No Delta Specs)**
-
-```
-## Archive Complete
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
-**Specs:** No delta specs
-
-All artifacts complete. All tasks complete.
-```
-
-**Output On Success With Warnings**
-
-```
-## Archive Complete (with warnings)
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
-**Specs:** Sync skipped (user chose to skip)
-
-**Warnings:**
-- Archived with 2 incomplete artifacts
-- Archived with 3 incomplete tasks
-- Delta spec sync was skipped (user chose to skip)
-
-Review the archive if this was not intentional.
-```
-
-**Output On Error (Archive Exists)**
-
-```
-## Archive Failed
-
-**Change:** <change-name>
-**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
-
-Target archive directory already exists.
-
-**Options:**
-1. Rename the existing archive
-2. Delete the existing archive if it's a duplicate
-3. Wait until a different date to archive
 ```
 
 **Guardrails**
@@ -153,5 +106,5 @@ Target archive directory already exists.
 - Don't block archive on warnings - just inform and confirm
 - Preserve .openspec.yaml when moving to archive (it moves with the directory)
 - Show clear summary of what happened
-- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
 - If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -148,6 +148,110 @@ If the user mentions a change or you detect one is relevant:
 
 ---
 
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
 ## Ending Discovery
 
 There's no required ending. Discovery might:
@@ -157,7 +261,23 @@ There's no required ending. Discovery might:
 - **Just provide clarity**: User has what they need, moves on
 - **Continue later**: "We can pick this up anytime"
 
-When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
 
 ---
 

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -86,7 +86,7 @@ After completing all artifacts, summarize:
 - Change name and location
 - List of artifacts created with brief descriptions
 - What's ready: "All artifacts created! Ready for implementation."
-- Prompt: "Run `/opsx:apply` to start implementing."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
 
 **Artifact Creation Guidelines**
 
@@ -97,6 +97,9 @@ After completing all artifacts, summarize:
 - **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
   - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
   - These guide what you write, but should never appear in the output
+
+- **When writing tasks, structure them as tracer bullets**: the first task must be a minimal end-to-end slice that touches all relevant layers (e.g., one UI action wired to one backend endpoint). Subsequent tasks expand outward from that working slice. This avoids building horizontal layers in isolation and ensures the critical path is validated early.
+- **Write tasks as behaviors to verify, not implementation steps**: each task title should describe what the system does from the outside (e.g., "user can submit form with valid input" not "add POST handler"). This makes each task directly testable and ensures the implementation is driven by observable behavior. Phrase tasks so that a failing test for that behavior can be written before any code exists.
 
 **Guardrails**
 - Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -64,14 +64,26 @@ Implement tasks from an OpenSpec change.
    - Remaining tasks overview
    - Dynamic instruction from CLI
 
-6. **Implement tasks (loop until done or blocked)**
+6. **Implement tasks using tracer bullets**
 
-   For each pending task:
-   - Show which task is being worked on
-   - Make the code changes required
-   - Keep changes minimal and focused
-   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
-   - Continue to next task
+   Before starting the loop, identify the **tracer bullet**: the first task that forms a minimal end-to-end slice through all relevant layers (e.g., one user action wired from UI through to backend/data layer). This is typically the first task if tasks were structured following tracer bullet principles.
+
+   **Phase 1 — Tracer bullet first (RED → GREEN → REFACTOR):**
+   - Write a failing test that describes the tracer bullet behavior — verify it fails before writing any implementation code (RED)
+   - Implement only the minimal code needed to make that test pass (GREEN)
+   - **Pause and verify**: run the test suite, confirm the test passes and the slice works end-to-end
+   - Look for quick refactor opportunities now that the path is green — extract duplication, rename for clarity — then re-run tests (REFACTOR)
+   - Mark it complete: `- [ ]` → `- [x]`
+   - Report what was validated and invite confirmation to continue
+
+   **Phase 2 — Expand from the working slice (RED → GREEN → REFACTOR per task):**
+   - Only after the tracer bullet is verified, continue with remaining tasks
+   - Each task expands or builds on top of the already-working slice
+   - For each task:
+     - Write a failing test for the behavior this task introduces (RED)
+     - Write minimal code to make it pass — no speculative additions (GREEN)
+     - Refactor if needed, run tests to confirm still green (REFACTOR)
+     - Mark complete `- [ ]` → `- [x]`, continue to next
 
    **Pause if:**
    - Task is unclear → ask for clarification

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -101,6 +101,8 @@ After completing all artifacts, summarize:
 - **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
   - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
   - These guide what you write, but should never appear in the output
+- **When writing tasks, structure them as tracer bullets**: the first task must be a minimal end-to-end slice that touches all relevant layers (e.g., one UI action wired to one backend endpoint). Subsequent tasks expand outward from that working slice. This avoids building horizontal layers in isolation and ensures the critical path is validated early.
+- **Write tasks as behaviors to verify, not implementation steps**: each task title should describe what the system does from the outside (e.g., "user can submit form with valid input" not "add POST handler"). This makes each task directly testable and ensures the implementation is driven by observable behavior. Phrase tasks so that a failing test for that behavior can be written before any code exists.
 
 **Guardrails**
 - Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)


### PR DESCRIPTION
Add the ideas of tracer bullets and tdd into openspec skills and commands.

Tracer Bullets (from The Pragmatic Programmer) are the idea to build functional, end-to-end connections early.

TDD is the idea to write failing tests (red) first before implementing the feature to pass the tests (green).


See also https://youtu.be/v4F1gFy-hqg?si=HJ_numoZyigqYvNO