### PR TITLE
chore: revert making npmInstall Gradle task cacheable because it causes failed builds sometimes

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -260,15 +260,12 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
-      # The Gradle build also executes a Maven command to build the WildFly bootable JAR.
-      # Disable the Gradle Configuration Cache for now because we sometimes run into a similar issue to:
-      # https://github.com/diffplug/spotless/issues/651
       - name: Gradle build
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            ./gradlew clean build -x test --info --no-configuration-cache
+            ./gradlew clean build -x test --info
           else
-            ./gradlew build -x test --info --no-configuration-cache
+            ./gradlew build -x test --info
           fi
 
       - name: Cache Gradle build artefacts

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -260,6 +260,10 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
+      - name: Clean npm cache to prevent stale node_modules
+        run: npm cache clean --force
+        working-directory: src/main/app
+
       - name: Gradle build
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -261,14 +261,12 @@ jobs:
         uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       # The Gradle build also executes a Maven command to build the WildFly bootable JAR.
-      # Disable the Gradle Configuration Cache for now because we sometimes run into a similar issue to:
-      # https://github.com/diffplug/spotless/issues/651
       - name: Gradle build
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            ./gradlew clean build -x test --info --no-configuration-cache
+            ./gradlew clean build -x test --info
           else
-            ./gradlew build -x test --info --no-configuration-cache
+            ./gradlew build -x test --info
           fi
 
       - name: Cache Gradle build artefacts

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -260,16 +260,15 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
-      - name: Clean npm cache to prevent stale node_modules
-        run: npm cache clean --force
-        working-directory: src/main/app
-
+      # The Gradle build also executes a Maven command to build the WildFly bootable JAR.
+      # Disable the Gradle Configuration Cache for now because we sometimes run into a similar issue to:
+      # https://github.com/diffplug/spotless/issues/651
       - name: Gradle build
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            ./gradlew clean build -x test --info
+            ./gradlew clean build -x test --info --no-configuration-cache
           else
-            ./gradlew build -x test --info
+            ./gradlew build -x test --info --no-configuration-cache
           fi
 
       - name: Cache Gradle build artefacts

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -750,7 +750,6 @@ tasks {
         group = "build"
         inputs.file("$appPath/package.json")
         outputs.dir("$appPath/node_modules")
-        outputs.cacheIf { true }
     }
 
     register<NpmTask>("npmRunLint") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -762,8 +762,6 @@ tasks {
 
         inputs.files(fileTree("$appPath/node_modules"))
         inputs.files(fileTree("$appPath/src"))
-        outputs.files(fileTree("$appPath/src"))
-        outputs.cacheIf { true }
     }
 
     register<NpmTask>("npmRunBuild") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # configure Gradle JVM memory for better build performance
 # see: https://kotlinlang.org/docs/native-improving-compilation-time.html#gradle-configuration
 # and: https://docs.gradle.org/current/userguide/config_gradle.html#sec:configuring_jvm_memory
-org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 # enable Gradle build cache
 org.gradle.caching=true
 # enable Gradle configuration cache


### PR DESCRIPTION
Revert making npmInstall Gradle task cacheable because it causes failed builds sometimes. Remove Gradle configuration cache flag from build workflow steps. Increase Gradle JVM memory settings because this is advised for Kotlin monorepos.

Solves PZ-11234