### PR TITLE
chore: disable Docker image pre-pulling in integration test setup to improve efficiency

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
@@ -326,8 +326,7 @@ class ZacItestProjectConfig : AbstractProjectConfig() {
             )
             .waitingFor(
                 "greenmail",
-                Wait.forHttp("/api/service")
-                    .forPort(8080)
+                Wait.forLogMessage(".*Starting GreenMail API server.*", 1)
                     .withStartupTimeout(2.minutes.toJavaDuration())
             )
     }

--- a/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
@@ -272,6 +272,9 @@ class ZacItestProjectConfig : AbstractProjectConfig() {
 
         return ComposeContainer("zac-itest-", composeFiles)
             .withEnv(dockerComposeOverrideEnvironment)
+            // do not pull images first because this will cause _all_ Docker images to be pulled,
+            // and not just the ones we need for our profiles
+            .withPull(false)
             .withOptions(
                 "--profile zac",
                 "--profile itest",

--- a/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/config/ZacItestProjectConfig.kt
@@ -324,6 +324,12 @@ class ZacItestProjectConfig : AbstractProjectConfig() {
                 Wait.forLogMessage(".* WildFly .* started .*", 1)
                     .withStartupTimeout(3.minutes.toJavaDuration())
             )
+            .waitingFor(
+                "greenmail",
+                Wait.forHttp("/api/service")
+                    .forPort(8080)
+                    .withStartupTimeout(2.minutes.toJavaDuration())
+            )
     }
 
     /**


### PR DESCRIPTION
Disable Docker image pre-pulling in integration test setup to improve efficiency.

Solves PZ-11267