### PR TITLE
feat: Update renovate.json with the limits for arm64 images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -408,13 +408,29 @@
       "groupName": "Platform Autorisatie Beheer Component (PABC)",
       "matchPackageNames": [
         "ghcr.io/platform-autorisatie-beheer-component/pabc-migrations",
-        "ghcr.io/platform-autorisatie-beheer-component/pabc-api"
+        "ghcr.io/platform-autorisatie-beheer-component/pabc-api",
+        "ghcr.io/infonl/pabc-migrations",
+        "ghcr.io/infonl/pabc-api"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "versioning": "semver",
+      "description": [
+        "Group PABC migrations and API updates into a single PR"
+      ]
+    },
+    {
+      "groupName": "PostGIS docker image",
+      "matchPackageNames": [
+        "postgis/postgis",
+        "ghcr.io/infonl/postgis"
       ],
       "matchDatasources": [
         "docker"
       ],
       "description": [
-        "Group PABC migrations and API updates into a single PR"
+        "Group PostGIS upstream and infonl mirror updates into a single PR"
       ]
     },
     {
@@ -483,8 +499,10 @@
       ]
     },
     {
+      "groupName": "Objects-api docker image",
       "matchPackageNames": [
-        "maykinmedia/objects-api"
+        "maykinmedia/objects-api",
+        "ghcr.io/infonl/objects-api"
       ],
       "matchDatasources": [
         "docker"
@@ -495,8 +513,10 @@
       ]
     },
     {
+      "groupName": "Objecttypes-api docker image",
       "matchPackageNames": [
-        "maykinmedia/objecttypes-api"
+        "maykinmedia/objecttypes-api",
+        "ghcr.io/infonl/objecttypes-api"
       ],
       "matchDatasources": [
         "docker"
@@ -507,8 +527,10 @@
       ]
     },
     {
+      "groupName": "Open-klant docker image",
       "matchPackageNames": [
-        "maykinmedia/open-klant"
+        "maykinmedia/open-klant",
+        "ghcr.io/infonl/open-klant"
       ],
       "matchDatasources": [
         "docker"
@@ -519,8 +541,10 @@
       ]
     },
     {
+      "groupName": "Open-zaak docker image",
       "matchPackageNames": [
-        "openzaak/open-zaak"
+        "openzaak/open-zaak",
+        "ghcr.io/infonl/open-zaak"
       ],
       "matchDatasources": [
         "docker"
@@ -531,8 +555,10 @@
       ]
     },
     {
+      "groupName": "Open-notificaties docker image",
       "matchPackageNames": [
-        "openzaak/open-notificaties"
+        "openzaak/open-notificaties",
+        "ghcr.io/infonl/open-notificaties"
       ],
       "matchDatasources": [
         "docker"
@@ -555,8 +581,10 @@
       ]
     },
     {
+      "groupName": "Open-archiefbeheer docker image",
       "matchPackageNames": [
-        "maykinmedia/open-archiefbeheer"
+        "maykinmedia/open-archiefbeheer",
+        "ghcr.io/infonl/open-archiefbeheer"
       ],
       "matchDatasources": [
         "docker"
@@ -564,14 +592,6 @@
       "allowedVersions": "< 1.2.0",
       "description": [
         "Pinned by the next Dimpact PodiumD release"
-      ]
-    },
-    {
-      "matchPackageNames": [
-        "opentelemetry-collector"
-      ],
-      "matchDatasources": [
-        "helm"
       ]
     },
     {
@@ -639,24 +659,6 @@
       ],
       "versioning": "loose",
       "allowedVersions": "/jre-ubi10-minimal$/"
-    },
-    {
-      "matchPackageNames": [
-        "ghcr.io/platform-autorisatie-beheer-component/pabc-api"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "versioning": "semver"
-    },
-    {
-      "matchPackageNames": [
-        "ghcr.io/platform-autorisatie-beheer-component/pabc-migrations"
-      ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "versioning": "semver"
     },
     {
       "matchPackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -417,7 +417,7 @@
       ],
       "versioning": "semver",
       "description": [
-        "Group PABC migrations and API updates into a single PR"
+        "Group upstream and infonl mirror PABC migrations and API updates into a single PR"
       ]
     },
     {


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to improve and streamline the grouping of Docker image dependencies, particularly by consolidating upstream and mirrored images into single PRs, and by removing redundant or obsolete configuration blocks. These changes will help keep dependency updates more organized and reduce noise from multiple PRs for related images.

**Dependency grouping improvements:**

* Added new groupings for Docker images so that both upstream and `ghcr.io/infonl` mirrored images are updated together for the following services: PABC (API and migrations), PostGIS, Objects API, Objecttypes API, Open-klant, Open-zaak, Open-notificaties, and Open-archiefbeheer. This ensures related updates are bundled into single PRs for easier management. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L411-R435) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R502-R505) [[3]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R516-R519) [[4]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R530-R533) [[5]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R544-R547) [[6]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R558-R561) [[7]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R584-R587)

**Configuration cleanup:**

* Removed obsolete or redundant configuration blocks, including individual settings for PABC API/migrations and opentelemetry-collector, as these are now covered by the new grouping or are no longer needed. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L569-L576) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L643-L660)

Solves PZ-11269