### PR TITLE
feat(dashboard): show spinner instead of empty message while cards load

### DIFF
--- a/src/main/app/src/app/dashboard/dashboard-card/dashboard-card.component.less
+++ b/src/main/app/src/app/dashboard/dashboard-card/dashboard-card.component.less
@@ -20,6 +20,12 @@
 
   .dashboard-empty-cell {
     vertical-align: middle;
+    text-align: center;
+
+    mat-progress-spinner {
+      display: inline-block;
+      margin: 16px 0;
+    }
   }
 }
 

--- a/src/main/app/src/app/dashboard/informatieobjecten-card/informatieobjecten-card.component.html
+++ b/src/main/app/src/app/dashboard/informatieobjecten-card/informatieobjecten-card.component.html
@@ -63,7 +63,14 @@
     <tr mat-row *matRowDef="let row; columns: columns"></tr>
     <tr class="mat-row" *matNoDataRow>
       <td class="mat-cell dashboard-empty-cell" colspan="5">
-        <p>{{ "msg.geen.gegevens.gevonden" | translate }}</p>
+        <mat-progress-spinner
+          *ngIf="ioQuery.isLoading()"
+          mode="indeterminate"
+          diameter="32"
+        ></mat-progress-spinner>
+        <p *ngIf="!ioQuery.isLoading()">
+          {{ "msg.geen.gegevens.gevonden" | translate }}
+        </p>
       </td>
     </tr>
   </table>

--- a/src/main/app/src/app/dashboard/informatieobjecten-card/informatieobjecten-card.component.html
+++ b/src/main/app/src/app/dashboard/informatieobjecten-card/informatieobjecten-card.component.html
@@ -67,6 +67,7 @@
           *ngIf="ioQuery.isLoading()"
           mode="indeterminate"
           diameter="32"
+          [attr.aria-label]="'msg.loading' | translate"
         ></mat-progress-spinner>
         <p *ngIf="!ioQuery.isLoading()">
           {{ "msg.geen.gegevens.gevonden" | translate }}

--- a/src/main/app/src/app/dashboard/taak-zoeken-card/taak-zoeken-card.component.html
+++ b/src/main/app/src/app/dashboard/taak-zoeken-card/taak-zoeken-card.component.html
@@ -55,6 +55,7 @@
           *ngIf="zoekQuery.isLoading()"
           mode="indeterminate"
           diameter="32"
+          [attr.aria-label]="'msg.loading' | translate"
         ></mat-progress-spinner>
         <p *ngIf="!zoekQuery.isLoading()">
           {{ "msg.geen.gegevens.gevonden" | translate }}

--- a/src/main/app/src/app/dashboard/taak-zoeken-card/taak-zoeken-card.component.html
+++ b/src/main/app/src/app/dashboard/taak-zoeken-card/taak-zoeken-card.component.html
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-<div class="table-wrapper" [ngClass]="{ loading: zoekQuery.isLoading() }">
+<div class="table-wrapper">
   <table mat-table matSort [dataSource]="dataSource">
     <ng-container matColumnDef="naam">
       <th mat-header-cell *matHeaderCellDef mat-sort-header="TAAK_NAAM">
@@ -51,7 +51,11 @@
     <tr mat-row *matRowDef="let row; columns: columns"></tr>
     <tr class="mat-row" *matNoDataRow>
       <td class="mat-cell dashboard-empty-cell" colspan="5">
-        <p *ngIf="zoekQuery.isLoading()">{{ "msg.loading" | translate }}</p>
+        <mat-progress-spinner
+          *ngIf="zoekQuery.isLoading()"
+          mode="indeterminate"
+          diameter="32"
+        ></mat-progress-spinner>
         <p *ngIf="!zoekQuery.isLoading()">
           {{ "msg.geen.gegevens.gevonden" | translate }}
         </p>

--- a/src/main/app/src/app/dashboard/taken-card/taken-card.component.html
+++ b/src/main/app/src/app/dashboard/taken-card/taken-card.component.html
@@ -55,7 +55,14 @@
     <tr mat-row *matRowDef="let row; columns: columns"></tr>
     <tr class="mat-row" *matNoDataRow>
       <td class="mat-cell dashboard-empty-cell" colspan="5">
-        <p>{{ "msg.geen.gegevens.gevonden" | translate }}</p>
+        <mat-progress-spinner
+          *ngIf="takenQuery.isLoading()"
+          mode="indeterminate"
+          diameter="32"
+        ></mat-progress-spinner>
+        <p *ngIf="!takenQuery.isLoading()">
+          {{ "msg.geen.gegevens.gevonden" | translate }}
+        </p>
       </td>
     </tr>
   </table>

--- a/src/main/app/src/app/dashboard/taken-card/taken-card.component.html
+++ b/src/main/app/src/app/dashboard/taken-card/taken-card.component.html
@@ -59,6 +59,7 @@
           *ngIf="takenQuery.isLoading()"
           mode="indeterminate"
           diameter="32"
+          [attr.aria-label]="'msg.loading' | translate"
         ></mat-progress-spinner>
         <p *ngIf="!takenQuery.isLoading()">
           {{ "msg.geen.gegevens.gevonden" | translate }}

--- a/src/main/app/src/app/dashboard/taken-card/taken-card.component.ts
+++ b/src/main/app/src/app/dashboard/taken-card/taken-card.component.ts
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
+import { NgIf } from "@angular/common";
 import { Component, computed, effect } from "@angular/core";
 import { MatIconAnchor } from "@angular/material/button";
 import { MatIcon } from "@angular/material/icon";
 import { MatPaginator } from "@angular/material/paginator";
+import { MatProgressSpinner } from "@angular/material/progress-spinner";
 import { MatSort, MatSortHeader } from "@angular/material/sort";
 import {
   MatCell,
@@ -42,6 +44,7 @@ import { DashboardCardComponent } from "../dashboard-card/dashboard-card.compone
   ],
   standalone: true,
   imports: [
+    NgIf,
     MatTable,
     MatSort,
     MatColumnDef,
@@ -56,6 +59,7 @@ import { DashboardCardComponent } from "../dashboard-card/dashboard-card.compone
     MatRow,
     MatNoDataRow,
     MatPaginator,
+    MatProgressSpinner,
     MatIconAnchor,
     MatIcon,
     RouterLink,

--- a/src/main/app/src/app/dashboard/zaak-waarschuwingen-card/zaak-waarschuwingen-card.component.html
+++ b/src/main/app/src/app/dashboard/zaak-waarschuwingen-card/zaak-waarschuwingen-card.component.html
@@ -83,7 +83,14 @@
     <tr mat-row *matRowDef="let row; columns: columns"></tr>
     <tr class="mat-row" *matNoDataRow>
       <td class="mat-cell dashboard-empty-cell" colspan="6">
-        <p>{{ "msg.geen.gegevens.gevonden" | translate }}</p>
+        <mat-progress-spinner
+          *ngIf="zakenQuery.isLoading()"
+          mode="indeterminate"
+          diameter="32"
+        ></mat-progress-spinner>
+        <p *ngIf="!zakenQuery.isLoading()">
+          {{ "msg.geen.gegevens.gevonden" | translate }}
+        </p>
       </td>
     </tr>
   </table>

--- a/src/main/app/src/app/dashboard/zaak-waarschuwingen-card/zaak-waarschuwingen-card.component.html
+++ b/src/main/app/src/app/dashboard/zaak-waarschuwingen-card/zaak-waarschuwingen-card.component.html
@@ -87,6 +87,7 @@
           *ngIf="zakenQuery.isLoading()"
           mode="indeterminate"
           diameter="32"
+          [attr.aria-label]="'msg.loading' | translate"
         ></mat-progress-spinner>
         <p *ngIf="!zakenQuery.isLoading()">
           {{ "msg.geen.gegevens.gevonden" | translate }}

--- a/src/main/app/src/app/dashboard/zaak-zoeken-card/zaak-zoeken-card.component.html
+++ b/src/main/app/src/app/dashboard/zaak-zoeken-card/zaak-zoeken-card.component.html
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-<div class="table-wrapper" [ngClass]="{ loading: zoekQuery.isLoading() }">
+<div class="table-wrapper">
   <table mat-table matSort [dataSource]="dataSource">
     <ng-container matColumnDef="identificatie">
       <th
@@ -59,7 +59,11 @@
     <tr mat-row *matRowDef="let row; columns: columns"></tr>
     <tr class="mat-row" *matNoDataRow>
       <td class="mat-cell dashboard-empty-cell" colspan="5">
-        <p *ngIf="zoekQuery.isLoading()">{{ "msg.loading" | translate }}</p>
+        <mat-progress-spinner
+          *ngIf="zoekQuery.isLoading()"
+          mode="indeterminate"
+          diameter="32"
+        ></mat-progress-spinner>
         <p *ngIf="!zoekQuery.isLoading()">
           {{ "msg.geen.gegevens.gevonden" | translate }}
         </p>

--- a/src/main/app/src/app/dashboard/zaak-zoeken-card/zaak-zoeken-card.component.html
+++ b/src/main/app/src/app/dashboard/zaak-zoeken-card/zaak-zoeken-card.component.html
@@ -63,6 +63,7 @@
           *ngIf="zoekQuery.isLoading()"
           mode="indeterminate"
           diameter="32"
+          [attr.aria-label]="'msg.loading' | translate"
         ></mat-progress-spinner>
         <p *ngIf="!zoekQuery.isLoading()">
           {{ "msg.geen.gegevens.gevonden" | translate }}

--- a/src/main/app/src/app/dashboard/zaken-card/zaken-card.component.html
+++ b/src/main/app/src/app/dashboard/zaken-card/zaken-card.component.html
@@ -57,6 +57,7 @@
           *ngIf="zakenQuery.isLoading()"
           mode="indeterminate"
           diameter="32"
+          [attr.aria-label]="'msg.loading' | translate"
         ></mat-progress-spinner>
         <p *ngIf="!zakenQuery.isLoading()">
           {{ "msg.geen.gegevens.gevonden" | translate }}

--- a/src/main/app/src/app/dashboard/zaken-card/zaken-card.component.html
+++ b/src/main/app/src/app/dashboard/zaken-card/zaken-card.component.html
@@ -53,7 +53,14 @@
     <tr mat-row *matRowDef="let row; columns: columns"></tr>
     <tr class="mat-row" *matNoDataRow>
       <td class="mat-cell dashboard-empty-cell" colspan="5">
-        <p>{{ "msg.geen.gegevens.gevonden" | translate }}</p>
+        <mat-progress-spinner
+          *ngIf="zakenQuery.isLoading()"
+          mode="indeterminate"
+          diameter="32"
+        ></mat-progress-spinner>
+        <p *ngIf="!zakenQuery.isLoading()">
+          {{ "msg.geen.gegevens.gevonden" | translate }}
+        </p>
       </td>
     </tr>
   </table>


### PR DESCRIPTION
Card tables previously rendered "Geen gegevens gevonden" the moment the table was empty, including during the initial fetch, making loading look indistinguishable from a genuinely empty result. Each card now shows a mat-progress-spinner in the matNoDataRow while its query isLoading(), and only falls back to the empty-state text once the first fetch has completed.

The two zoeken cards already had a text-based loading indicator; they're converted to the same spinner for consistency, and their dead [ngClass]="{ loading: ... }" binding (no CSS targeted it) is removed.

Solves PZ-11242