### PR TITLE
feat: remove spotless version restriction from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -643,15 +643,6 @@
     },
     {
       "matchPackageNames": [
-        "com.diffplug.spotless"
-      ],
-      "allowedVersions": "< 7",
-      "description": [
-        "Pinned - version 7 causes Connection refused and node/npm discovery issues"
-      ]
-    },
-    {
-      "matchPackageNames": [
         "eclipse-temurin"
       ],
       "matchDatasources": [


### PR DESCRIPTION
Remove spotless allowedVersions restriction from renovate config. If we're still having issues with newer versions we should close the PR. At least keep it in view

Solves PZ-11272