### PR TITLE
chore: fix flaky KlantRestServiceTest

### DIFF
--- a/src/itest/kotlin/nl/info/zac/itest/KlantRestServiceTest.kt
+++ b/src/itest/kotlin/nl/info/zac/itest/KlantRestServiceTest.kt
@@ -100,11 +100,7 @@ class KlantRestServiceTest : BehaviorSpec({
                     val responseBody = response.bodyAsString
                     logger.info { "Response: $responseBody" }
                     response.code shouldBe HTTP_OK
-                    JSONObject(responseBody).run {
-                        getJSONObject("zaakdata").run {
-                            zaakUuid = getString("zaakUUID").run(UUID::fromString)
-                        }
-                    }
+                    zaakUuid = JSONObject(responseBody).getString("uuid").let(UUID::fromString)
                 }
             }
 


### PR DESCRIPTION
Fix flaky KlantRestServiceTest by not relying on the zaakdata because the zaakdata may not be available yet when the zaak has just been started. This can take some time.

Solves PZ-11274