### PR TITLE
chore: remove unused ZAC application role enums

### DIFF
--- a/src/main/kotlin/nl/info/zac/authentication/RequestAuthorizationFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/RequestAuthorizationFilter.kt
@@ -84,17 +84,23 @@ class RequestAuthorizationFilter @Inject constructor() : Filter {
         val path = request.requestURI.removePrefix(request.contextPath)
         val isAdmin = ADMIN_URI_PREFIXES.any(path::startsWith)
         return if (isAdmin) {
-            // access allowed if the user has the 'beheerder' application role for at least one zaaktype
             hasBeheerderApplicationRole(user)
         } else {
-            // access allowed if the user has at least one application role for at least one zaaktype
             hasAnyApplicationRole(user)
         }
     }
 
+    /**
+     * Checks if the user has at least one application role for at least one zaaktype,
+     * or if the user has any overall roles.
+     */
     private fun hasAnyApplicationRole(user: LoggedInUser): Boolean =
         user.applicationRolesPerZaaktype.values.any { it.isNotEmpty() } || user.overallRoles.isNotEmpty()
 
+    /**
+     * Checks if the user has the 'beheerder' role for at least one zaaktype,
+     * or if the user has the 'beheerder' role for at least one of the overall roles.
+     */
     private fun hasBeheerderApplicationRole(user: LoggedInUser): Boolean =
         user.applicationRolesPerZaaktype.values.any { roles ->
             roles.any { it == ZacApplicationRole.BEHEERDER.value }

--- a/src/main/kotlin/nl/info/zac/authentication/RequestAuthorizationFilter.kt
+++ b/src/main/kotlin/nl/info/zac/authentication/RequestAuthorizationFilter.kt
@@ -85,17 +85,17 @@ class RequestAuthorizationFilter @Inject constructor() : Filter {
         val isAdmin = ADMIN_URI_PREFIXES.any(path::startsWith)
         return if (isAdmin) {
             // access allowed if the user has the 'beheerder' application role for at least one zaaktype
-            hasAnyBeheerderApplicationRole(user)
+            hasBeheerderApplicationRole(user)
         } else {
             // access allowed if the user has at least one application role for at least one zaaktype
-            hasAnyPabcApplicationRole(user)
+            hasAnyApplicationRole(user)
         }
     }
 
-    private fun hasAnyPabcApplicationRole(user: LoggedInUser): Boolean =
+    private fun hasAnyApplicationRole(user: LoggedInUser): Boolean =
         user.applicationRolesPerZaaktype.values.any { it.isNotEmpty() } || user.overallRoles.isNotEmpty()
 
-    private fun hasAnyBeheerderApplicationRole(user: LoggedInUser): Boolean =
+    private fun hasBeheerderApplicationRole(user: LoggedInUser): Boolean =
         user.applicationRolesPerZaaktype.values.any { roles ->
             roles.any { it == ZacApplicationRole.BEHEERDER.value }
         } || user.overallRoles.contains(ZacApplicationRole.BEHEERDER.value)

--- a/src/main/kotlin/nl/info/zac/identity/model/ZacApplicationRole.kt
+++ b/src/main/kotlin/nl/info/zac/identity/model/ZacApplicationRole.kt
@@ -8,7 +8,7 @@ package nl.info.zac.identity.model
  * Defines those ZAC application roles that require specific handling in the application code.
  * ZAC defines other application roles that are not listed here, but those roles do not require
  * specific handling in the application code.
- * For an overview of all ZAC application roles, see: [rollen.rego](../../../../resources/policies/rollen.rego).
+ * For an overview of all ZAC application roles, see: [rollen.rego](/src/main/resources/policies/rollen.rego).
  */
 enum class ZacApplicationRole(val value: String) {
     BEHEERDER("beheerder"),

--- a/src/main/kotlin/nl/info/zac/identity/model/ZacApplicationRole.kt
+++ b/src/main/kotlin/nl/info/zac/identity/model/ZacApplicationRole.kt
@@ -4,13 +4,13 @@
  */
 package nl.info.zac.identity.model
 
+/**
+ * Defines those ZAC application roles that require specific handling in the application code.
+ * ZAC defines other application roles that are not listed here, but those roles do not require
+ * specific handling in the application code.
+ * For an overview of all ZAC application roles, see: [rollen.rego](../../../../resources/policies/rollen.rego).
+ */
 enum class ZacApplicationRole(val value: String) {
-    @Deprecated(
-        message = "Not used in new PABC based IAM architecture"
-    )
     BEHEERDER("beheerder"),
-    BEHANDELAAR("behandelaar"),
-    COORDINATOR("coordinator"),
-    RAADPLEGER("raadpleger"),
-    RECORDMANAGER("recordmanager"),
+    BEHANDELAAR("behandelaar")
 }

--- a/src/test/kotlin/nl/info/zac/authentication/RequestAuthorizationFilterTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/RequestAuthorizationFilterTest.kt
@@ -311,7 +311,7 @@ class RequestAuthorizationFilterTest : BehaviorSpec({
         Given("An authenticated beheerder accesses '/rest/admin/*'") {
             val filter = RequestAuthorizationFilter()
             val user = createLoggedInUser(
-                applicationRolesPerZaaktype = mapOf("zt2" to setOf(ZacApplicationRole.BEHEERDER.value))
+                applicationRolesPerZaaktype = mapOf("fakeZaaktypeDescription" to setOf(ZacApplicationRole.BEHEERDER.value))
             )
             setSessionUser(user)
             every { httpServletRequest.requestURI } returns "/rest/admin/util/health"
@@ -333,7 +333,7 @@ class RequestAuthorizationFilterTest : BehaviorSpec({
         Given("A non-beheerder user accesses '/admin/settings'") {
             val filter = RequestAuthorizationFilter()
             val user = createLoggedInUser(
-                applicationRolesPerZaaktype = mapOf("zt-3" to setOf("fakeApplicationRole"))
+                applicationRolesPerZaaktype = mapOf("fakeZaakTypeDescription" to setOf("fakeApplicationRole"))
             )
             setSessionUser(user)
             every { httpServletRequest.requestURI } returns "/admin/settings"

--- a/src/test/kotlin/nl/info/zac/authentication/RequestAuthorizationFilterTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/RequestAuthorizationFilterTest.kt
@@ -333,7 +333,7 @@ class RequestAuthorizationFilterTest : BehaviorSpec({
         Given("A non-beheerder user accesses '/admin/settings'") {
             val filter = RequestAuthorizationFilter()
             val user = createLoggedInUser(
-                applicationRolesPerZaaktype = mapOf("zt-3" to setOf(ZacApplicationRole.RAADPLEGER.value))
+                applicationRolesPerZaaktype = mapOf("zt-3" to setOf("fakeApplicationRole"))
             )
             setSessionUser(user)
             every { httpServletRequest.requestURI } returns "/admin/settings"
@@ -356,7 +356,7 @@ class RequestAuthorizationFilterTest : BehaviorSpec({
             val filter = RequestAuthorizationFilter()
             val user = createLoggedInUser(
                 applicationRolesPerZaaktype = emptyMap(),
-                overallRoles = setOf(ZacApplicationRole.RAADPLEGER.value)
+                overallRoles = setOf("fakeApplicationRole")
             )
             setSessionUser(user)
             every { httpServletRequest.requestURI } returns "/app/home"
@@ -404,7 +404,7 @@ class RequestAuthorizationFilterTest : BehaviorSpec({
             val filter = RequestAuthorizationFilter()
             val user = createLoggedInUser(
                 applicationRolesPerZaaktype = emptyMap(),
-                overallRoles = setOf(ZacApplicationRole.RAADPLEGER.value)
+                overallRoles = setOf("fakeApplicationRole")
             )
             setSessionUser(user)
             every { httpServletRequest.requestURI } returns "/rest/admin/util/health"

--- a/src/test/kotlin/nl/info/zac/authentication/RequestAuthorizationFilterTest.kt
+++ b/src/test/kotlin/nl/info/zac/authentication/RequestAuthorizationFilterTest.kt
@@ -311,7 +311,9 @@ class RequestAuthorizationFilterTest : BehaviorSpec({
         Given("An authenticated beheerder accesses '/rest/admin/*'") {
             val filter = RequestAuthorizationFilter()
             val user = createLoggedInUser(
-                applicationRolesPerZaaktype = mapOf("fakeZaaktypeDescription" to setOf(ZacApplicationRole.BEHEERDER.value))
+                applicationRolesPerZaaktype = mapOf(
+                    "fakeZaaktypeDescription" to setOf(ZacApplicationRole.BEHEERDER.value)
+                )
             )
             setSessionUser(user)
             every { httpServletRequest.requestURI } returns "/rest/admin/util/health"


### PR DESCRIPTION
Remove unused ZAC application role enums and refactor related unit tests. No functional changes.

Solves PZ-11287