### PR TITLE
fix: fix open formulieren docker compose setup

### DIFF
--- a/docker-compose.arm64-override.yaml
+++ b/docker-compose.arm64-override.yaml
@@ -35,12 +35,6 @@ services:
     image: ghcr.io/infonl/open-archiefbeheer:1.1.1@sha256:e28956d9266e13935addf14ae772d730a22304377ee0e9f0e66ed754c0d2191d
     platform: linux/arm64
 
-  # note: do not use the current Open Formulieren ARM image because using those will result
-  # in a non-working Open Formulieren instance.
-  # using the ARM images, when you create a new form and attempt to open it, you will see this error in the browser:
-  # "Er ging helaas iets fout. Neem a.u.b. contact op met de helpdesk en informeer hen van dit probleem."
-  # This seems to have to do with missing static content (such as JS translation bundles) in the ARM image.
-
   openklant.local:
     image: ghcr.io/infonl/open-klant:2.15.0@sha256:090741b0c2211588e882dad93741e1bb6c13ce9d95ae13d1cd2ab591339b6a36
     platform: linux/arm64

--- a/docker-compose.arm64-override.yaml
+++ b/docker-compose.arm64-override.yaml
@@ -35,21 +35,11 @@ services:
     image: ghcr.io/infonl/open-archiefbeheer:1.1.1@sha256:e28956d9266e13935addf14ae772d730a22304377ee0e9f0e66ed754c0d2191d
     platform: linux/arm64
 
-  openformulieren-celery:
-    image: ghcr.io/infonl/open-formulieren:3.4.2@sha256:f35aa06833c43744a03c6397ebf6f7f23e59f67ffff1a3be017dd6c2fc4cc6f8
-    platform: linux/arm64
-
-  openformulieren-celery-beat:
-    image: ghcr.io/infonl/open-formulieren:3.4.2@sha256:f35aa06833c43744a03c6397ebf6f7f23e59f67ffff1a3be017dd6c2fc4cc6f8
-    platform: linux/arm64
-
-  openformulieren-init:
-    image: ghcr.io/infonl/open-formulieren:3.4.2@sha256:f35aa06833c43744a03c6397ebf6f7f23e59f67ffff1a3be017dd6c2fc4cc6f8
-    platform: linux/arm64
-
-  openformulieren-web:
-    image: ghcr.io/infonl/open-formulieren:3.4.2@sha256:f35aa06833c43744a03c6397ebf6f7f23e59f67ffff1a3be017dd6c2fc4cc6f8
-    platform: linux/arm64
+  # note: do not use the current Open Formulieren ARM image because using those will result
+  # in a non-working Open Formulieren instance.
+  # using the ARM images, when you create a new form and attempt to open it, you will see this error in the browser:
+  # "Er ging helaas iets fout. Neem a.u.b. contact op met de helpdesk en informeer hen van dit probleem."
+  # This seems to have to do with missing static content (such as JS translation bundles) in the ARM image.
 
   openklant.local:
     image: ghcr.io/infonl/open-klant:2.15.0@sha256:090741b0c2211588e882dad93741e1bb6c13ce9d95ae13d1cd2ab591339b6a36

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -901,7 +901,6 @@ services:
       - |
         set -e
         /setup_configuration.sh
-        OTEL_SDK_DISABLED=True src/manage.py collectstatic --no-input
         OTEL_SDK_DISABLED=True src/manage.py shell -c "
         from django.contrib.auth import get_user_model
         User = get_user_model()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -901,6 +901,7 @@ services:
       - |
         set -e
         /setup_configuration.sh
+        OTEL_SDK_DISABLED=True src/manage.py collectstatic --no-input
         OTEL_SDK_DISABLED=True src/manage.py shell -c "
         from django.contrib.auth import get_user_model
         User = get_user_model()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -926,6 +926,13 @@ services:
 
   openformulieren-web:
     image: openformulieren/open-forms:3.4.2@sha256:70574342ab610792478b38e73eecf23d5f9d91a571e48a7a9327ea6e7008bcec
+    # for now we set the platform to AMD because using the current Open Formulieren INFO.nl custom-built ARM Docker Image
+    # results in a non-working Open Formulieren instance.
+    # using the INFO.nl Open Formulieren ARM image, when you create a new form and attempt to open it, you will see this error in the browser
+    # "Er ging helaas iets fout. Neem a.u.b. contact op met de helpdesk en informeer hen van dit probleem."
+    # This seems to have to do with missing static content (such as JS translation bundles) in the ARM image.
+    # You will see a related 404 error on a JS translation bundle file in the browser when trying to open a form.
+    platform: linux/amd64
     environment: *openformulieren-env
     ports:
       - "8009:8000"
@@ -947,6 +954,13 @@ services:
 
   openformulieren-celery:
     image: openformulieren/open-forms:3.4.2@sha256:70574342ab610792478b38e73eecf23d5f9d91a571e48a7a9327ea6e7008bcec
+    # for now we set the platform to AMD because using the current Open Formulieren INFO.nl custom-built ARM Docker Image
+    # results in a non-working Open Formulieren instance.
+    # using the INFO.nl Open Formulieren ARM image, when you create a new form and attempt to open it, you will see this error in the browser
+    # "Er ging helaas iets fout. Neem a.u.b. contact op met de helpdesk en informeer hen van dit probleem."
+    # This seems to have to do with missing static content (such as JS translation bundles) in the ARM image.
+    # You will see a related 404 error on a JS translation bundle file in the browser when trying to open a form.
+    platform: linux/amd64
     environment: *openformulieren-env
     command: /celery_worker.sh
     healthcheck:
@@ -969,6 +983,13 @@ services:
 
   openformulieren-celery-beat:
     image: openformulieren/open-forms:3.4.2@sha256:70574342ab610792478b38e73eecf23d5f9d91a571e48a7a9327ea6e7008bcec
+    # for now we set the platform to AMD because using the current Open Formulieren INFO.nl custom-built ARM Docker Image
+    # results in a non-working Open Formulieren instance.
+    # using the INFO.nl Open Formulieren ARM image, when you create a new form and attempt to open it, you will see this error in the browser
+    # "Er ging helaas iets fout. Neem a.u.b. contact op met de helpdesk en informeer hen van dit probleem."
+    # This seems to have to do with missing static content (such as JS translation bundles) in the ARM image.
+    # You will see a related 404 error on a JS translation bundle file in the browser when trying to open a form.
+    platform: linux/amd64
     environment: *openformulieren-env
     command: /celery_beat.sh
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -959,6 +959,7 @@ services:
       - openformulieren-media:/app/media
       - openformulieren-private-media:/app/private_media
       - openformulieren-log:/app/log
+      - ./scripts/docker-compose/imports/openformulieren/settings/docker_local.py:/app/src/openforms/conf/docker_local.py:ro
     depends_on:
       openformulieren-database:
         condition: service_healthy
@@ -974,6 +975,7 @@ services:
       - openformulieren-media:/app/media
       - openformulieren-private-media:/app/private_media
       - openformulieren-log:/app/log
+      - ./scripts/docker-compose/imports/openformulieren/settings/docker_local.py:/app/src/openforms/conf/docker_local.py:ro
     depends_on:
       openformulieren-database:
         condition: service_healthy

--- a/scripts/docker-compose/imports/openformulieren/settings/docker_local.py
+++ b/scripts/docker-compose/imports/openformulieren/settings/docker_local.py
@@ -3,9 +3,3 @@ from openforms.conf.docker import *  # noqa
 # Disable 2FA for local development so the admin UI at http://localhost:8007/admin/
 # and http://localhost:8009/admin/ can be accessed with username/password only.
 MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
-
-# The arm64 INFO.nl repackaged image (ghcr.io/infonl/open-formulieren) is missing the UMD
-# bundle (open-forms-sdk.js) from its static files. ManifestStaticFilesStorage raises
-# ValueError for any missing manifest entry, breaking the admin login page.
-# Use StaticFilesStorage to skip manifest validation for local development.
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"

--- a/scripts/docker-compose/imports/openformulieren/settings/docker_local.py
+++ b/scripts/docker-compose/imports/openformulieren/settings/docker_local.py
@@ -3,3 +3,9 @@ from openforms.conf.docker import *  # noqa
 # Disable 2FA for local development so the admin UI at http://localhost:8007/admin/
 # and http://localhost:8009/admin/ can be accessed with username/password only.
 MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
+
+# The arm64 INFO.nl repackaged image (ghcr.io/infonl/open-formulieren) is missing the UMD
+# bundle (open-forms-sdk.js) from its static files. ManifestStaticFilesStorage raises
+# ValueError for any missing manifest entry, breaking the admin login page.
+# Use StaticFilesStorage to skip manifest validation for local development.
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"


### PR DESCRIPTION
Fix open formulieren docker compose setup. The current Open Formulieren ARM Docker Image cannot be used because it will cause errors when trying to open any form. Something to do with missing static content (e.g. translation JS bundle files) in this image. Reverting to the AMD image does work. Also fixed other configuration to allow form submissions to work.

Solves PZ-11288