### PR TITLE
fix: use disabled fields values for creating documents

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.spec.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.spec.ts
@@ -334,8 +334,6 @@ describe(InformatieObjectAddComponent.name, () => {
         vertrouwelijkheidaanduiding: { label: "Intern", value: "intern" },
         auteur: "Test Author",
       });
-      // Setting ontvangstdatum triggers valueChanges, which disables the status control
-      // and auto-sets it to DEFINITIEF. Without getRawValue(), form.value would omit it.
       component["form"].controls.ontvangstdatum.setValue(moment());
       component["form"].markAsDirty();
       fixture.detectChanges();

--- a/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.spec.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.spec.ts
@@ -324,6 +324,38 @@ describe(InformatieObjectAddComponent.name, () => {
     });
   });
 
+  describe("Submit when status is disabled by ontvangstdatum", () => {
+    it("should include DEFINITIEF status in FormData even when the status control is disabled", async () => {
+      component["form"].patchValue({
+        bestand: mockFile,
+        titel: "Test Title",
+        taal: mockTalen[0],
+        informatieobjectType: mockInformatieObjectTypes[0],
+        vertrouwelijkheidaanduiding: { label: "Intern", value: "intern" },
+        auteur: "Test Author",
+      });
+      // Setting ontvangstdatum triggers valueChanges, which disables the status control
+      // and auto-sets it to DEFINITIEF. Without getRawValue(), form.value would omit it.
+      component["form"].controls.ontvangstdatum.setValue(moment());
+      component["form"].markAsDirty();
+      fixture.detectChanges();
+
+      const submitButton = await loader.getHarness(
+        MatButtonHarness.with({ text: "actie.toevoegen" }),
+      );
+      await submitButton.click();
+      await new Promise(requestAnimationFrame);
+
+      const req = httpTestingController.expectOne(
+        `/rest/informatieobjecten/informatieobject/${mockZaak.uuid}/${mockZaak.uuid}?taakObject=false`,
+      );
+      const formData = Object.fromEntries(
+        (req.request.body as FormData).entries(),
+      );
+      expect(formData.status).toBe("DEFINITIEF");
+    });
+  });
+
   describe("EML file upload handling", () => {
     it("should convert .eml file to Blob with application/octet-stream and append to FormData", async () => {
       const emlFile = new File(

--- a/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.ts
@@ -276,7 +276,7 @@ export class InformatieObjectAddComponent {
   }
 
   protected submit() {
-    const { value } = this.form;
+    const value = this.form.getRawValue();
     const payload = {
       bestand: value.bestand!,
       bestandsnaam: value.bestand?.name,

--- a/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.spec.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.spec.ts
@@ -298,8 +298,6 @@ describe(InformatieObjectEditComponent.name, () => {
     });
 
     it("should include status in payload when status control is disabled due to ontvangstdatum", async () => {
-      // enkelvoudigInformatieObjectVersieGegevens has ontvangstdatum set, so initForm
-      // disables the status control. Without getRawValue(), form.value omits disabled controls.
       component["form"].patchValue({
         bestand: mockFile,
         titel: "Test Title",

--- a/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.spec.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.spec.ts
@@ -297,6 +297,34 @@ describe(InformatieObjectEditComponent.name, () => {
       );
     });
 
+    it("should include status in payload when status control is disabled due to ontvangstdatum", async () => {
+      // enkelvoudigInformatieObjectVersieGegevens has ontvangstdatum set, so initForm
+      // disables the status control. Without getRawValue(), form.value omits disabled controls.
+      component["form"].patchValue({
+        bestand: mockFile,
+        titel: "Test Title",
+        taal: mockTalen[0],
+        informatieobjectType: mockInformatieObjectTypes[0],
+        vertrouwelijkheidaanduiding: { label: "Intern", value: "intern" },
+        auteur: "Test Author",
+      });
+      component["form"].markAsDirty();
+      fixture.detectChanges();
+
+      const submitButton = await loader.getHarness(
+        MatButtonHarness.with({ text: "actie.toevoegen" }),
+      );
+      await submitButton.click();
+
+      expect(
+        informatieObjectenService.updateEnkelvoudigInformatieobject,
+      ).toHaveBeenCalledWith(
+        enkelvoudigInformatieObjectVersieGegevens.uuid,
+        "test-zaak-uuid",
+        expect.objectContaining({ status: "IN_BEWERKING" }),
+      );
+    });
+
     it("should emit document event after successful update", async () => {
       const emitSpy = jest.spyOn(component.document, "emit");
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
@@ -245,7 +245,7 @@ export class InformatieObjectEditComponent implements OnChanges {
   }
 
   protected submit() {
-    const { value } = this.form;
+    const value = this.form.getRawValue();
     this.informatieObjectenService
       .updateEnkelvoudigInformatieobject(
         this.infoObject!.uuid!,


### PR DESCRIPTION
This PR fixes the bug that no status is set when saving or editing a informatieobject(document). The bug happened because ontvangstdatum sets the status field to definitief and disables it. Because it was disabled when the form was saved the value of that field was ignored. Added getRawValue() to still retrieve the values from that disabled field and created tests

Solves PZ-11296