### PR TITLE
feat: Limit open-forms to podiumD supported versions in renovate config

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -25,6 +25,7 @@ This document lists the Docker images and versions that the corresponding versio
 - **open-zaak**: 1.27.1
 - **objects-api**: 3.3.1
 - **open-klant**: 2.15.0
+- **open-forms**: 3.4.2
 - **open-notificaties**: 1.14.0
 - **open-archiefbeheer**: 1.1.1
 - **pabc-migrations**: 1.1.0

--- a/renovate.json
+++ b/renovate.json
@@ -189,6 +189,17 @@
     {
       "customType": "regex",
       "matchStrings": [
+        "- \\*\\*open-forms\\*\\*: (?<currentValue>[^\\n]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "openformulieren/open-forms",
+      "managerFilePatterns": [
+        "/^DEPENDENCIES\\.md$/"
+      ]
+    },
+    {
+      "customType": "regex",
+      "matchStrings": [
         "- \\*\\*open-klant\\*\\*: (?<currentValue>[^\\n]+)"
       ],
       "datasourceTemplate": "docker",
@@ -530,7 +541,7 @@
       "groupName": "Open-forms docker image",
       "matchPackageNames": [
         "openformulieren/open-forms",
-        "ghcr.io/infonl/open-forms"
+        "ghcr.io/infonl/open-formulieren"
       ],
       "matchDatasources": [
         "docker"

--- a/renovate.json
+++ b/renovate.json
@@ -527,6 +527,20 @@
       ]
     },
     {
+      "groupName": "Open-forms docker image",
+      "matchPackageNames": [
+        "openformulieren/open-forms",
+        "ghcr.io/infonl/open-forms"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "allowedVersions": "< 3.5.0",
+      "description": [
+        "Pinned by the next Dimpact PodiumD release"
+      ]
+    },
+    {
       "groupName": "Open-klant docker image",
       "matchPackageNames": [
         "maykinmedia/open-klant",


### PR DESCRIPTION
This pull request adds a new configuration to the `renovate.json` file to manage updates for the Open-forms Docker image. The configuration pins updates for specific Open-forms images to versions below 3.5.0, ensuring compatibility with the next Dimpact PodiumD release.

Dependency management:

* Added a new group in `renovate.json` to pin updates for the `openformulieren/open-forms` and `ghcr.io/infonl/open-forms` Docker images to versions below 3.5.0, with a description indicating the pin is related to the next Dimpact PodiumD release.

Solves PZ-11333