### PR TITLE
fix: required bug and refactored taken-vrijgeven-dialog.component.ts…

### DIFF
--- a/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.html
+++ b/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.html
@@ -21,7 +21,9 @@
         <zac-input class="col-12" [form]="form" key="reden"></zac-input>
       </section>
     </fieldset>
-    <p *ngIf="data.taken.length === 1">{{ "msg.vrijgeven.taak" | translate }}</p>
+    <p *ngIf="data.taken.length === 1">
+      {{ "msg.vrijgeven.taak" | translate }}
+    </p>
     <p *ngIf="data.taken.length !== 1">
       {{ "msg.vrijgeven.taken" | translate: { aantal: data.taken.length } }}
     </p>

--- a/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.html
+++ b/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.html
@@ -14,38 +14,22 @@
 </mat-toolbar>
 <mat-divider></mat-divider>
 
-<mat-dialog-content>
-  <form [formGroup]="form">
+<form [formGroup]="form" (submit)="vrijgeven()" (cancel)="close()">
+  <mat-dialog-content>
     <fieldset class="p-0">
       <section class="row">
         <zac-input class="col-12" [form]="form" key="reden"></zac-input>
       </section>
     </fieldset>
-  </form>
-  <p *ngIf="data.taken.length === 1">{{ "msg.vrijgeven.taak" | translate }}</p>
-  <p *ngIf="data.taken.length !== 1">
-    {{ "msg.vrijgeven.taken" | translate: { aantal: data.taken.length } }}
-  </p>
-</mat-dialog-content>
-<mat-dialog-actions>
-  <button
-    [disabled]="loading || !data.taken.length"
-    mat-raised-button
-    color="primary"
-    (click)="vrijgeven()"
-    id="taakVrijgeven_button"
-  >
-    <mat-icon *ngIf="loading">
-      <mat-spinner diameter="18"></mat-spinner>
-    </mat-icon>
-    {{ "actie.vrijgeven" | translate }}
-  </button>
-  <button
-    [disabled]="loading"
-    mat-raised-button
-    (click)="close()"
-    id="dialogClose_button"
-  >
-    {{ "actie.annuleren" | translate }}
-  </button>
-</mat-dialog-actions>
+    <p *ngIf="data.taken.length === 1">{{ "msg.vrijgeven.taak" | translate }}</p>
+    <p *ngIf="data.taken.length !== 1">
+      {{ "msg.vrijgeven.taken" | translate: { aantal: data.taken.length } }}
+    </p>
+  </mat-dialog-content>
+  <zac-form-actions
+    [form]="form"
+    [mutation]="mutation"
+    wrapper="dialog"
+    submitLabel="actie.vrijgeven"
+  />
+</form>

--- a/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.spec.ts
+++ b/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.spec.ts
@@ -3,15 +3,23 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
-import { provideHttpClient } from "@angular/common/http";
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from "@angular/common/http";
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from "@angular/common/http/testing";
+import { provideExperimentalZonelessChangeDetection } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { provideRouter } from "@angular/router";
 import { TranslateModule } from "@ngx-translate/core";
-import { of } from "rxjs";
+import { provideTanStackQuery } from "@tanstack/angular-query-experimental";
+import { sleep, testQueryClient } from "../../../../setupJest";
 import { TaakZoekObject } from "../../zoeken/model/taken/taak-zoek-object";
-import { TakenService } from "../taken.service";
 import { TakenVrijgevenDialogComponent } from "./taken-vrijgeven-dialog.component";
 
 const makeTaak = (fields: Partial<TaakZoekObject> = {}): TaakZoekObject =>
@@ -31,8 +39,11 @@ const setup = (taken: TaakZoekObject[] = [makeTaak()]) => {
       TranslateModule.forRoot(),
     ],
     providers: [
-      provideHttpClient(),
+      provideExperimentalZonelessChangeDetection(),
+      provideHttpClient(withInterceptorsFromDi()),
+      provideHttpClientTesting(),
       provideRouter([]),
+      provideTanStackQuery(testQueryClient),
       {
         provide: MAT_DIALOG_DATA,
         useValue: { taken, screenEventResourceId: "screen-resource-id" },
@@ -40,22 +51,23 @@ const setup = (taken: TaakZoekObject[] = [makeTaak()]) => {
       { provide: MatDialogRef, useValue: dialogRefMock },
     ],
   });
-  const takenService = TestBed.inject(TakenService);
-  jest
-    .spyOn(takenService, "vrijgevenVanuitLijst")
-    .mockReturnValue(of(undefined) as never);
   const fixture: ComponentFixture<TakenVrijgevenDialogComponent> =
     TestBed.createComponent(TakenVrijgevenDialogComponent);
   fixture.detectChanges();
   return {
     fixture,
     component: fixture.componentInstance,
-    takenService,
+    httpTestingController: TestBed.inject(HttpTestingController),
     dialogRefMock,
   };
 };
 
 describe(TakenVrijgevenDialogComponent.name, () => {
+  afterEach(() => {
+    testQueryClient.clear();
+    jest.clearAllMocks();
+  });
+
   describe("with a single taak", () => {
     it("shows singular message", () => {
       const { fixture } = setup([makeTaak()]);
@@ -94,77 +106,51 @@ describe(TakenVrijgevenDialogComponent.name, () => {
     });
   });
 
-  describe("vrijgeven button", () => {
-    it("is disabled when there are no taken", () => {
-      const { fixture } = setup([]);
-      const button: HTMLButtonElement = fixture.nativeElement.querySelector(
-        "#taakVrijgeven_button",
-      );
-      expect(button.disabled).toBe(true);
-    });
+  describe("vrijgeven()", () => {
+    it("passes reden and filtered taken to the API", async () => {
+      const taken = [
+        makeTaak({ id: "t1", zaakUuid: "uuid-1", behandelaarGebruikersnaam: "user1" }),
+        makeTaak({ id: "t2", zaakUuid: "uuid-2", behandelaarGebruikersnaam: undefined }),
+      ];
+      const { component, httpTestingController } = setup(taken);
 
-    it("is disabled when loading", () => {
-      const { fixture, component } = setup();
-      component["loading"] = true;
-      fixture.detectChanges();
-      const button: HTMLButtonElement = fixture.nativeElement.querySelector(
-        "#taakVrijgeven_button",
-      );
-      expect(button.disabled).toBe(true);
-    });
-  });
-
-  describe("annuleren button", () => {
-    it("is disabled when loading", () => {
-      const { fixture, component } = setup();
-      component["loading"] = true;
-      fixture.detectChanges();
-      const button: HTMLButtonElement = fixture.nativeElement.querySelector(
-        "#dialogClose_button",
-      );
-      expect(button.disabled).toBe(true);
-    });
-  });
-
-  describe("vrijgeven() — reden", () => {
-    it("passes reden from form to service", () => {
-      const { component, takenService } = setup([makeTaak()]);
       component["form"].controls.reden.setValue("testopmerking");
       component["vrijgeven"]();
-      expect(takenService.vrijgevenVanuitLijst).toHaveBeenCalledWith(
-        expect.objectContaining({ reden: "testopmerking" }),
-      );
-    });
-  });
+      await new Promise(requestAnimationFrame);
 
-  describe("vrijgeven()", () => {
-    it("calls vrijgevenVanuitLijst only with taken that have a behandelaarGebruikersnaam", () => {
-      const taken = [
-        makeTaak({
-          id: "t1",
-          zaakUuid: "uuid-1",
-          behandelaarGebruikersnaam: "user1",
-        }),
-        makeTaak({
-          id: "t2",
-          zaakUuid: "uuid-2",
-          behandelaarGebruikersnaam: undefined,
-        }),
-      ];
-      const { component, takenService } = setup(taken);
-      component["vrijgeven"]();
-      expect(takenService.vrijgevenVanuitLijst).toHaveBeenCalledWith(
+      const req = httpTestingController.expectOne("/rest/taken/lijst/vrijgeven");
+      expect(req.request.method).toBe("PUT");
+      expect(req.request.body).toEqual(
         expect.objectContaining({
-          taken: [{ taakId: "t1", zaakUuid: "uuid-1" }],
+          reden: "testopmerking",
           screenEventResourceId: "screen-resource-id",
+          taken: [{ taakId: "t1", zaakUuid: "uuid-1" }],
         }),
       );
     });
 
-    it("closes the dialog with true on success", () => {
-      const { component, dialogRefMock } = setup();
+    it("closes the dialog with true on success", async () => {
+      const { component, httpTestingController, dialogRefMock } = setup();
+
+      component["form"].controls.reden.setValue("reden");
       component["vrijgeven"]();
+      await new Promise(requestAnimationFrame);
+
+      httpTestingController.expectOne("/rest/taken/lijst/vrijgeven").flush(null);
+      await sleep();
+
       expect(dialogRefMock.close).toHaveBeenCalledWith(true);
+    });
+
+    it("sets disableClose on the dialog when mutation starts", async () => {
+      const { component, httpTestingController, dialogRefMock } = setup();
+
+      component["form"].controls.reden.setValue("reden");
+      component["vrijgeven"]();
+      await new Promise(requestAnimationFrame);
+
+      expect(dialogRefMock.disableClose).toBe(true);
+      httpTestingController.expectOne("/rest/taken/lijst/vrijgeven").flush(null);
     });
   });
 });

--- a/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.spec.ts
+++ b/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.spec.ts
@@ -109,8 +109,16 @@ describe(TakenVrijgevenDialogComponent.name, () => {
   describe("vrijgeven()", () => {
     it("passes reden and filtered taken to the API", async () => {
       const taken = [
-        makeTaak({ id: "t1", zaakUuid: "uuid-1", behandelaarGebruikersnaam: "user1" }),
-        makeTaak({ id: "t2", zaakUuid: "uuid-2", behandelaarGebruikersnaam: undefined }),
+        makeTaak({
+          id: "t1",
+          zaakUuid: "uuid-1",
+          behandelaarGebruikersnaam: "user1",
+        }),
+        makeTaak({
+          id: "t2",
+          zaakUuid: "uuid-2",
+          behandelaarGebruikersnaam: undefined,
+        }),
       ];
       const { component, httpTestingController } = setup(taken);
 
@@ -118,7 +126,9 @@ describe(TakenVrijgevenDialogComponent.name, () => {
       component["vrijgeven"]();
       await new Promise(requestAnimationFrame);
 
-      const req = httpTestingController.expectOne("/rest/taken/lijst/vrijgeven");
+      const req = httpTestingController.expectOne(
+        "/rest/taken/lijst/vrijgeven",
+      );
       expect(req.request.method).toBe("PUT");
       expect(req.request.body).toEqual(
         expect.objectContaining({
@@ -136,7 +146,9 @@ describe(TakenVrijgevenDialogComponent.name, () => {
       component["vrijgeven"]();
       await new Promise(requestAnimationFrame);
 
-      httpTestingController.expectOne("/rest/taken/lijst/vrijgeven").flush(null);
+      httpTestingController
+        .expectOne("/rest/taken/lijst/vrijgeven")
+        .flush(null);
       await sleep();
 
       expect(dialogRefMock.close).toHaveBeenCalledWith(true);
@@ -150,7 +162,9 @@ describe(TakenVrijgevenDialogComponent.name, () => {
       await new Promise(requestAnimationFrame);
 
       expect(dialogRefMock.disableClose).toBe(true);
-      httpTestingController.expectOne("/rest/taken/lijst/vrijgeven").flush(null);
+      httpTestingController
+        .expectOne("/rest/taken/lijst/vrijgeven")
+        .flush(null);
     });
   });
 });

--- a/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.spec.ts
+++ b/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.spec.ts
@@ -137,6 +137,7 @@ describe(TakenVrijgevenDialogComponent.name, () => {
           taken: [{ taakId: "t1", zaakUuid: "uuid-1" }],
         }),
       );
+      req.flush(null);
     });
 
     it("closes the dialog with true on success", async () => {

--- a/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.spec.ts
+++ b/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.spec.ts
@@ -98,6 +98,13 @@ describe(TakenVrijgevenDialogComponent.name, () => {
     });
   });
 
+  describe("with no taken", () => {
+    it("disables the form", () => {
+      const { component } = setup([]);
+      expect(component["form"].disabled).toBe(true);
+    });
+  });
+
   describe("close()", () => {
     it("closes the dialog with false", () => {
       const { component, dialogRefMock } = setup();

--- a/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.ts
+++ b/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.ts
@@ -53,6 +53,9 @@ export class TakenVrijgevenDialogComponent {
     onMutate: () => {
       this.dialogRef.disableClose = true;
     },
+    onSettled: () => {
+      this.dialogRef.disableClose = false;
+    },
   }));
 
   protected readonly form = this.formBuilder.group({

--- a/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.ts
+++ b/src/main/app/src/app/taken/taken-vrijgeven-dialog/taken-vrijgeven-dialog.component.ts
@@ -4,22 +4,20 @@
  */
 
 import { NgIf } from "@angular/common";
-import { Component, Inject } from "@angular/core";
+import { Component, inject } from "@angular/core";
 import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
-import { MatButtonModule } from "@angular/material/button";
 import {
   MAT_DIALOG_DATA,
-  MatDialogActions,
-  MatDialogContent,
+  MatDialogModule,
   MatDialogRef,
-  MatDialogTitle,
 } from "@angular/material/dialog";
 import { MatDividerModule } from "@angular/material/divider";
 import { MatIconModule } from "@angular/material/icon";
-import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { TranslateModule } from "@ngx-translate/core";
-import { MaterialFormBuilderModule } from "../../shared/material-form-builder/material-form-builder.module";
+import { injectMutation } from "@tanstack/angular-query-experimental";
+import { ZacFormActions } from "../../shared/form/form-actions/form-actions.component";
+import { ZacInput } from "../../shared/form/input/input";
 import { TaakZoekObject } from "../../zoeken/model/taken/taak-zoek-object";
 import { TakenService } from "../taken.service";
 
@@ -32,59 +30,57 @@ import { TakenService } from "../taken.service";
     NgIf,
     ReactiveFormsModule,
     MatToolbarModule,
-    MatDialogTitle,
-    MatDialogContent,
-    MatDialogActions,
-    MatDividerModule,
     MatIconModule,
-    MatButtonModule,
-    MatProgressSpinnerModule,
+    MatDialogModule,
+    MatDividerModule,
     TranslateModule,
-    MaterialFormBuilderModule,
+    ZacInput,
+    ZacFormActions,
   ],
 })
 export class TakenVrijgevenDialogComponent {
-  protected loading = false;
+  private readonly dialogRef = inject(MatDialogRef);
+  private readonly takenService = inject(TakenService);
+  private readonly formBuilder = inject(FormBuilder);
+  protected readonly data = inject<{
+    taken: TaakZoekObject[];
+    screenEventResourceId: string;
+  }>(MAT_DIALOG_DATA);
+
+  protected readonly mutation = injectMutation(() => ({
+    ...this.takenService.vrijgevenVanuitLijst(),
+    onSuccess: () => this.dialogRef.close(true),
+    onMutate: () => {
+      this.dialogRef.disableClose = true;
+    },
+  }));
 
   protected readonly form = this.formBuilder.group({
     reden: this.formBuilder.control<string | null>(null, [
       Validators.maxLength(100),
+      Validators.required,
     ]),
   });
 
-  constructor(
-    private readonly dialogRef: MatDialogRef<TakenVrijgevenDialogComponent>,
-    @Inject(MAT_DIALOG_DATA)
-    protected readonly data: {
-      taken: TaakZoekObject[];
-      screenEventResourceId: string;
-    },
-    private readonly takenService: TakenService,
-    private readonly formBuilder: FormBuilder,
-  ) {}
+  constructor() {
+    if (this.data.taken.length) return;
+    this.form.disable();
+  }
 
   protected close() {
     this.dialogRef.close(false);
   }
 
   protected vrijgeven() {
-    this.dialogRef.disableClose = true;
-    this.loading = true;
-    this.takenService
-      .vrijgevenVanuitLijst({
-        reden: this.form.value.reden,
-        screenEventResourceId: this.data.screenEventResourceId,
-        taken: this.data.taken
-          .filter(
-            ({ behandelaarGebruikersnaam }) => !!behandelaarGebruikersnaam,
-          )
-          .map(({ zaakUuid, id }) => ({
-            taakId: id,
-            zaakUuid,
-          })),
-      })
-      .subscribe(() => {
-        this.dialogRef.close(true);
-      });
+    this.mutation.mutate({
+      reden: this.form.value.reden,
+      screenEventResourceId: this.data.screenEventResourceId,
+      taken: this.data.taken
+        .filter(({ behandelaarGebruikersnaam }) => !!behandelaarGebruikersnaam)
+        .map(({ zaakUuid, id }) => ({
+          taakId: id,
+          zaakUuid,
+        })),
+    });
   }
 }

--- a/src/main/app/src/app/taken/taken.service.spec.ts
+++ b/src/main/app/src/app/taken/taken.service.spec.ts
@@ -145,14 +145,10 @@ describe(TakenService.name, () => {
   });
 
   describe("vrijgevenVanuitLijst", () => {
-    it("puts with the given body", () => {
-      const body = {
-        taken: [{ taakId: "taak-1", zaakUuid: "zaak-uuid-1" }],
-        reden: "test",
-      };
-      jest.spyOn(zacHttpClient, "PUT").mockReturnValue(of([] as never));
-      service.vrijgevenVanuitLijst(body).subscribe();
-      expect(zacHttpClient.PUT).toHaveBeenCalledWith(expect.any(String), body);
+    it("builds mutation options for vrijgeven", () => {
+      jest.spyOn(zacQueryClient, "PUT");
+      service.vrijgevenVanuitLijst();
+      expect(zacQueryClient.PUT).toHaveBeenCalledWith(expect.any(String));
     });
   });
 });

--- a/src/main/app/src/app/taken/taken.service.ts
+++ b/src/main/app/src/app/taken/taken.service.ts
@@ -4,7 +4,7 @@
  */
 
 import { inject, Injectable } from "@angular/core";
-import { PatchBody, PutBody } from "../shared/http/http-client";
+import { PatchBody } from "../shared/http/http-client";
 import { ZacHttpClient } from "../shared/http/zac-http-client";
 import { ZacQueryClient } from "../shared/http/zac-query-client";
 
@@ -67,7 +67,7 @@ export class TakenService {
     return this.zacQueryClient.PUT("/rest/taken/lijst/verdelen");
   }
 
-  vrijgevenVanuitLijst(body: PutBody<"/rest/taken/lijst/vrijgeven">) {
-    return this.zacHttpClient.PUT("/rest/taken/lijst/vrijgeven", body);
+  vrijgevenVanuitLijst() {
+    return this.zacQueryClient.PUT("/rest/taken/lijst/vrijgeven");
   }
 }

--- a/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.spec.ts
@@ -104,6 +104,13 @@ describe(ZakenVrijgevenDialogComponent.name, () => {
     expect(fixture.nativeElement.textContent).toContain("msg.vrijgeven.zaken");
   });
 
+    describe("with no taken", () => {
+        it("disables the form", () => {
+            const { component } = setup([]);
+            expect(component["form"].disabled).toBe(true);
+        });
+    });
+
   it("vrijgeven filters zaken without behandelaar", () => {
     const { component } = setup([
       makeZaakZoekObject({ id: "a", behandelaarGebruikersnaam: "user1" }),

--- a/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.spec.ts
+++ b/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.spec.ts
@@ -104,12 +104,12 @@ describe(ZakenVrijgevenDialogComponent.name, () => {
     expect(fixture.nativeElement.textContent).toContain("msg.vrijgeven.zaken");
   });
 
-    describe("with no taken", () => {
-        it("disables the form", () => {
-            const { component } = setup([]);
-            expect(component["form"].disabled).toBe(true);
-        });
+  describe("with no taken", () => {
+    it("disables the form", () => {
+      const { component } = setup([]);
+      expect(component["form"].disabled).toBe(true);
     });
+  });
 
   it("vrijgeven filters zaken without behandelaar", () => {
     const { component } = setup([

--- a/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.ts
@@ -49,6 +49,9 @@ export class ZakenVrijgevenDialogComponent {
     onMutate: () => {
       this.dialogRef.disableClose = true;
     },
+    onSettled: () => {
+      this.dialogRef.disableClose = false;
+    },
   }));
 
   constructor() {

--- a/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.ts
+++ b/src/main/app/src/app/zaken/zaken-vrijgeven-dialog/zaken-vrijgeven-dialog.component.ts
@@ -59,6 +59,7 @@ export class ZakenVrijgevenDialogComponent {
   protected readonly form = this.formBuilder.group({
     reden: this.formBuilder.control<string | null>(null, [
       Validators.maxLength(100),
+      Validators.required,
     ]),
   });
 


### PR DESCRIPTION
This PR fixes the bug that the reden field is no longer required to be filled in when releasing taken or zaken. The bug was caused because the required validator was not set on the field. This was fixed alongside a different side effect where the form could still be sent even without entering a reden when releasing taken in the `taken-vrijgeven-component`. This was functional in the `zaken-vrijgeven-component` which used tanstack and custom components so therefor this component has been refactored to use `zac` components and use tanstack mutations. Further tests have been added/altered to test this refactor and bugfix

Solves PZ-11169