### PR TITLE
feature: add aanvullende informatie to fase check

### DIFF
--- a/src/main/kotlin/nl/info/client/zgw/zrc/util/StatusTypeUtil.kt
+++ b/src/main/kotlin/nl/info/client/zgw/zrc/util/StatusTypeUtil.kt
@@ -5,6 +5,7 @@
 package nl.info.client.zgw.zrc.util
 
 import nl.info.client.zgw.ztc.model.generated.StatusType
+import nl.info.zac.configuration.ConfigurationService.Companion.STATUSTYPE_OMSCHRIJVING_AANVULLENDE_INFORMATIE
 import nl.info.zac.configuration.ConfigurationService.Companion.STATUSTYPE_OMSCHRIJVING_HEROPEND
 import nl.info.zac.configuration.ConfigurationService.Companion.STATUSTYPE_OMSCHRIJVING_INTAKE
 
@@ -19,3 +20,10 @@ fun StatusType?.isHeropend() = this != null && STATUSTYPE_OMSCHRIJVING_HEROPEND 
  * Note that in the ZGW ZRC API a zaak status and therefore also the corresponding [StatusType] may be `null`.
  */
 fun StatusType?.isIntake() = this != null && STATUSTYPE_OMSCHRIJVING_INTAKE == this.getOmschrijving()
+
+/**
+ * Returns `true` if the [StatusType] is not `null` and equals '[STATUSTYPE_OMSCHRIJVING_AANVULLENDE_INFORMATIE]'.
+ * This status is set when an aanvullende informatie task is created during the intake phase.
+ */
+fun StatusType?.isWachtOpAanvullendeInformatie() =
+    this != null && STATUSTYPE_OMSCHRIJVING_AANVULLENDE_INFORMATIE == this.getOmschrijving()

--- a/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverter.kt
+++ b/src/main/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverter.kt
@@ -20,6 +20,7 @@ import nl.info.client.zgw.zrc.util.isIntake
 import nl.info.client.zgw.zrc.util.isOpen
 import nl.info.client.zgw.zrc.util.isOpgeschort
 import nl.info.client.zgw.zrc.util.isVerlengd
+import nl.info.client.zgw.zrc.util.isWachtOpAanvullendeInformatie
 import nl.info.client.zgw.ztc.ZtcClientService
 import nl.info.client.zgw.ztc.model.generated.StatusType
 import nl.info.client.zgw.ztc.model.generated.ZaakType
@@ -143,7 +144,7 @@ class RestZaakConverter @Inject constructor(
             isDeelzaak = zaak.isDeelzaak(),
             isOpen = zaak.isOpen(),
             isHeropend = statustype.isHeropend(),
-            isInIntakeFase = statustype.isIntake(),
+            isInIntakeFase = statustype.isIntake() || statustype.isWachtOpAanvullendeInformatie(),
             isBesluittypeAanwezig = zaakType.besluittypen?.isNotEmpty() ?: false,
             isProcesGestuurd = bpmnProcessDefinition != null,
             bpmnProcessDefinition = bpmnProcessDefinition?.toRestZaakBpmnProcessDefinition(),

--- a/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverterTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/zaak/converter/RestZaakConverterTest.kt
@@ -43,8 +43,10 @@ import nl.info.zac.app.zaak.model.createRestGroup
 import nl.info.zac.app.zaak.model.createRestUser
 import nl.info.zac.app.zaak.model.createRestZaaktype
 import nl.info.zac.authentication.createLoggedInUser
+import nl.info.zac.configuration.ConfigurationService.Companion.STATUSTYPE_OMSCHRIJVING_AANVULLENDE_INFORMATIE
 import nl.info.zac.configuration.ConfigurationService.Companion.STATUSTYPE_OMSCHRIJVING_AFGEROND
 import nl.info.zac.configuration.ConfigurationService.Companion.STATUSTYPE_OMSCHRIJVING_HEROPEND
+import nl.info.zac.configuration.ConfigurationService.Companion.STATUSTYPE_OMSCHRIJVING_INTAKE
 import nl.info.zac.flowable.bpmn.BpmnService
 import nl.info.zac.identification.IdentificationService
 import nl.info.zac.policy.output.createZaakRechten
@@ -475,6 +477,50 @@ class RestZaakConverterTest : BehaviorSpec({
                         restZaak.indicaties shouldNotContain ONTVANGSTBEVESTIGING_NIET_VERSTUURD
                     }
                 }
+            }
+        }
+    }
+
+    Given("A zaak with an intake-related status type") {
+        val zaak = createZaak()
+        val zaakType = createZaakType()
+        val status = createZaakStatus().apply { statustoelichting = "fake status" }
+        val restZaakType = createRestZaaktype()
+        val zaakRechten = createZaakRechten()
+        val loggedInUser = createLoggedInUser()
+        val zaakdata = mapOf("fakeKey" to "fakeValue")
+
+        with(zgwApiService) {
+            every { findGroepForZaak(zaak) } returns null
+            every { findBehandelaarMedewerkerRoleForZaak(zaak) } returns null
+            every { findInitiatorRoleForZaak(zaak) } returns null
+        }
+        with(zaakVariabelenService) {
+            every { findOntvangstbevestigingVerstuurd(zaak.uuid) } returns true
+            every { readZaakdata(zaak.uuid) } returns zaakdata
+        }
+        every { brcClientService.listBesluiten(zaak) } returns emptyList()
+        every { restZaaktypeConverter.convert(zaakType) } returns restZaakType
+        every { bpmnService.findProcessDefinitionByZaak(zaak.uuid) } returns null
+        every { klantClientService.findZaakSpecificContactDetails(zaak.uuid) } returns null
+
+        When("converting a zaak with the 'Intake' status") {
+            val statusType = createStatusType().apply { omschrijving = STATUSTYPE_OMSCHRIJVING_INTAKE }
+            val restZaak = restZaakConverter.toRestZaak(zaak, zaakType, zaakRechten, loggedInUser, status, statusType)
+
+            Then("isInIntakeFase should be true") {
+                restZaak.isInIntakeFase shouldBe true
+            }
+        }
+
+        When("converting a zaak with the 'Wacht op aanvullende informatie' status") {
+            val statusType = createStatusType().apply {
+                omschrijving = STATUSTYPE_OMSCHRIJVING_AANVULLENDE_INFORMATIE
+            }
+            val restZaak = restZaakConverter.toRestZaak(zaak, zaakType, zaakRechten, loggedInUser, status, statusType)
+
+            Then("isInIntakeFase should be true") {
+                restZaak.isInIntakeFase shouldBe true
             }
         }
     }


### PR DESCRIPTION
This PR fixes the bug that the Besluit Vastleggen button was visible while the zaak had the status 'Intake'. This was caused because when a task was created the zaak was still in the intake fase but with the status 'Wacht op aanvullende informatie'. This status type has now been included in the check for the intake fase

Solves PZ-11311