### PR TITLE
fix: set profile null when initiator is changed

### DIFF
--- a/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfgegevens.component.spec.ts
+++ b/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfgegevens.component.spec.ts
@@ -662,6 +662,5 @@ describe(BedrijfsgegevensComponent.name, () => {
 
       expect(component["profiel"]()).toBeNull();
     });
-
   });
 });

--- a/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfgegevens.component.spec.ts
+++ b/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfgegevens.component.spec.ts
@@ -625,4 +625,43 @@ describe(BedrijfsgegevensComponent.name, () => {
       });
     });
   });
+
+  describe("when initiatorIdentificatie changes after profiel is loaded", () => {
+    beforeEach(async () => {
+      notifyManager.setScheduler((fn) => fn());
+      const request = httpController.expectOne(vestigingUrl);
+      request.flush(testBedrijf);
+      await sleep();
+      fixture.detectChanges();
+
+      jest
+        .spyOn(klantenService, "readVestigingsprofiel")
+        .mockReturnValue(of(makeBedrijfsprofiel()));
+      component["ophalenProfiel"]();
+    });
+
+    afterEach(() => {
+      notifyManager.setScheduler(queueMicrotask);
+    });
+
+    it("clears profiel signal", () => {
+      expect(component["profiel"]()).not.toBeNull();
+
+      componentRef.setInput(
+        "zaak",
+        fromPartial<GeneratedType<"RestZaak">>({
+          ...testZaak,
+          initiatorIdentificatie: fromPartial<BetrokkeneIdentificatie>({
+            type: "VN",
+            kvkNummer: "99999999",
+            vestigingsnummer: "99999999",
+          }),
+        }),
+      );
+      fixture.detectChanges();
+
+      expect(component["profiel"]()).toBeNull();
+    });
+
+  });
 });

--- a/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfsgegevens.component.ts
+++ b/src/main/app/src/app/klanten/bedrijfsgegevens/bedrijfsgegevens.component.ts
@@ -7,10 +7,12 @@ import { NgFor, NgIf } from "@angular/common";
 import {
   Component,
   computed,
+  effect,
   inject,
   input,
   output,
   signal,
+  untracked,
 } from "@angular/core";
 import { MatButtonModule } from "@angular/material/button";
 import { MatExpansionModule } from "@angular/material/expansion";
@@ -69,6 +71,23 @@ export class BedrijfsgegevensComponent {
   });
 
   protected profiel = signal<GeneratedType<"RestBedrijfsprofiel"> | null>(null);
+
+  private _prevIdentificatie: string | null = null;
+
+  constructor() {
+    effect(() => {
+      const currentId = JSON.stringify(this.initiatorIdentificatie());
+      untracked(() => {
+        if (
+          this._prevIdentificatie !== null &&
+          this._prevIdentificatie !== currentId
+        ) {
+          this.profiel.set(null);
+        }
+        this._prevIdentificatie = currentId;
+      });
+    });
+  }
 
   protected warningIcon = new TextIcon(
     () => true,


### PR DESCRIPTION
This PR fixes a small bug that when you have the profile opened of a bedrijf in the zaak-view page and you link a new bedrijf to the case the old data is still there. Now the profile fields are cleared and must be refetched when this change happens

Solves PZ-11350