### PR TITLE
chore: make 1password opt-out in docker compose script

### DIFF
--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -11,10 +11,11 @@ help()
 {
    echo "Starts the ZAC Docker Compose environment using the 1Password CLI tools to retrieve secrets."
    echo
-   echo "Syntax: $0 [-d|h|z|b|l|m|t|o|n|a|f]"
+   echo "Syntax: $0 [-d|e|h|z|b|l|m|t|o|n|a|f]"
    echo
    echo "General:"
    echo "   -d     Delete local Docker volume data before starting Docker Compose."
+   echo "   -e     Run Docker Compose without using the 1Password CLI tools to retrieve secrets (instead, environment variables must be set manually)."
    echo "   -h     Print this Help."
    echo
    echo "ZAC options:"
@@ -43,11 +44,12 @@ pullZac=false
 buildZac=false
 localZac=false
 disableZacOpenTelemetry=true
+disableOnePassword=false
 profiles=()
 
 [ -f fix-permissions.sh ] && ./fix-permissions.sh
 
-while getopts ':dhzblmtonaf' OPTION; do
+while getopts ':dhzblmtonafe' OPTION; do
   case $OPTION in
     d)
       echo "Deleting local Docker volume data folder: '$volumeDataFolder'.."
@@ -85,6 +87,10 @@ while getopts ':dhzblmtonaf' OPTION; do
       ;;
     a)
       profiles+=("openarchiefbeheer")
+      ;;
+    e)
+      echo "Running without 1Password CLI tools to retrieve secrets. Make sure to set environment variables manually."
+      disableOnePassword=true
       ;;
     f)
       profiles+=("openformulieren")
@@ -146,6 +152,7 @@ fi
 # Uses the 1Password CLI tools to set up the environment variables for running Docker Compose and ZAC in IntelliJ.
 # Please see docs/INSTALL.md for details on how to use this script.
 echo "Starting Docker Compose environment with profiles [$profilesList] ..."
+compose_files=""
 if [ -n "${DOCKER_USE_ARM64_CONTAINERS:-}" ]; then
   echo "Using arm64 containers ..."
   compose_files="-f docker-compose.yaml"
@@ -153,7 +160,18 @@ if [ -n "${DOCKER_USE_ARM64_CONTAINERS:-}" ]; then
     compose_files="$compose_files -f docker-compose.override.yml"
   fi
   compose_files="$compose_files -f docker-compose.arm64-override.yaml"
-  export APP_ENV=devlocal && export COMPOSE_PROFILES=$profilesList && export OTEL_SDK_DISABLED=$disableZacOpenTelemetry && op run --env-file="./.env.tpl" --no-masking -- docker compose $compose_files --project-name zac up -d
-else
-  export APP_ENV=devlocal && export COMPOSE_PROFILES=$profilesList && export OTEL_SDK_DISABLED=$disableZacOpenTelemetry && op run --env-file="./.env.tpl" --no-masking -- docker compose --project-name zac up -d
 fi
+
+op_script=""
+if [ "$disableOnePassword" = "false" ]; then
+  if ! command -v op >/dev/null 2>&1; then
+    echo "1Password CLI ('op') not found. Only using environment variables set manually."
+  elif op vault get Dimpact; then
+    echo "Using 1Password CLI tools to retrieve secrets from vault 'Dimpact'..."
+    op_script='op run --env-file=./.env.tpl --no-masking --'
+  else
+    echo "No access to 1Password vault 'Dimpact'. Only using environment variables set manually."
+  fi
+fi
+
+export APP_ENV=devlocal && export COMPOSE_PROFILES=$profilesList && export OTEL_SDK_DISABLED=$disableZacOpenTelemetry && $op_script docker compose $compose_files --project-name zac up -d


### PR DESCRIPTION
Makes 1password opt-out in the docker compose script. If you don't opt out, but the op cli is not installed or you don't have access to the correct vault, you get a message and the op cli is bypassed.

Solves PZ-11351