### PR TITLE
fix: Unlinked documents can now be unlocked

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.spec.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.spec.ts
@@ -271,4 +271,116 @@ describe(InformatieObjectViewComponent.name, () => {
       expect(button).toBeNull();
     });
   });
+
+  describe("actie.unlock", () => {
+    it("should not have a button when the document is not locked", async () => {
+      jest
+        .spyOn(informatieObjectenService, "readEnkelvoudigInformatieobject")
+        .mockReturnValue(
+          of({
+            ...enkelvoudigInformatieobject,
+            gelockedDoor: undefined,
+            rechten: fromPartial<GeneratedType<"RestDocumentRechten">>({
+              ontgrendelen: true,
+            }),
+          }),
+        );
+      mockActivatedRoute.data.next({
+        zaak,
+        informatieObject: enkelvoudigInformatieobject,
+      });
+
+      const button = await loader.getHarnessOrNull(
+        MatNavListItemHarness.with({ title: "actie.unlock" }),
+      );
+
+      expect(button).toBeNull();
+    });
+
+    it("should not have a button when the document is locked but the user does not have the right to unlock", async () => {
+      jest
+        .spyOn(informatieObjectenService, "readEnkelvoudigInformatieobject")
+        .mockReturnValue(
+          of({
+            ...enkelvoudigInformatieobject,
+            gelockedDoor: { id: "user-001", naam: "Test User" },
+            rechten: fromPartial<GeneratedType<"RestDocumentRechten">>({
+              ontgrendelen: false,
+            }),
+          }),
+        );
+      mockActivatedRoute.data.next({
+        zaak,
+        informatieObject: enkelvoudigInformatieobject,
+      });
+
+      const button = await loader.getHarnessOrNull(
+        MatNavListItemHarness.with({ title: "actie.unlock" }),
+      );
+
+      expect(button).toBeNull();
+    });
+
+    it("should call unlockInformatieObject with zaakUuid when clicked and a zaak is present", async () => {
+      jest
+        .spyOn(informatieObjectenService, "readEnkelvoudigInformatieobject")
+        .mockReturnValue(
+          of({
+            ...enkelvoudigInformatieobject,
+            gelockedDoor: { id: "user-001", naam: "Test User" },
+            rechten: fromPartial<GeneratedType<"RestDocumentRechten">>({
+              ontgrendelen: true,
+            }),
+          }),
+        );
+      const unlockSpy = jest
+        .spyOn(informatieObjectenService, "unlockInformatieObject")
+        .mockReturnValue(of({}));
+      mockActivatedRoute.data.next({
+        zaak,
+        informatieObject: enkelvoudigInformatieobject,
+      });
+
+      const button = await loader.getHarness(
+        MatNavListItemHarness.with({ title: "actie.unlock" }),
+      );
+      await button.click();
+
+      expect(unlockSpy).toHaveBeenCalledWith(
+        enkelvoudigInformatieobject.uuid,
+        zaak.uuid,
+      );
+    });
+
+    it("should call unlockInformatieObject without zaakUuid when clicked and no zaak is present", async () => {
+      jest
+        .spyOn(informatieObjectenService, "readEnkelvoudigInformatieobject")
+        .mockReturnValue(
+          of({
+            ...enkelvoudigInformatieobject,
+            gelockedDoor: { id: "user-001", naam: "Test User" },
+            rechten: fromPartial<GeneratedType<"RestDocumentRechten">>({
+              ontgrendelen: true,
+            }),
+          }),
+        );
+      const unlockSpy = jest
+        .spyOn(informatieObjectenService, "unlockInformatieObject")
+        .mockReturnValue(of({}));
+      mockActivatedRoute.data.next({
+        zaak: undefined as unknown as GeneratedType<"RestZaak">,
+        informatieObject: enkelvoudigInformatieobject,
+      });
+
+      const button = await loader.getHarness(
+        MatNavListItemHarness.with({ title: "actie.unlock" }),
+      );
+      await button.click();
+
+      expect(unlockSpy).toHaveBeenCalledWith(
+        enkelvoudigInformatieobject.uuid,
+        undefined,
+      );
+    });
+  });
 });

--- a/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.ts
@@ -300,7 +300,7 @@ export class InformatieObjectViewComponent
         () => {
           button.disabled = true;
           this.informatieObjectenService
-            .unlockInformatieObject(this.infoObject.uuid!, this.zaak!.uuid!)
+            .unlockInformatieObject(this.infoObject.uuid!, this.zaak?.uuid)
             .pipe(
               catchError((e) => {
                 // we only need to do this on error, because on success we get a new button

--- a/src/main/app/src/app/informatie-objecten/informatie-objecten.service.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-objecten.service.ts
@@ -198,13 +198,13 @@ export class InformatieObjectenService {
     );
   }
 
-  unlockInformatieObject(uuid: string, zaakUuid: string) {
+  unlockInformatieObject(uuid: string, zaakUuid?: string) {
     return this.zacHttpClient.POST(
       "/rest/informatieobjecten/informatieobject/{uuid}/unlock",
       undefined as never,
       {
         path: { uuid },
-        query: { zaak: zaakUuid },
+        query: { zaak: zaakUuid ?? null },
       },
     );
   }


### PR DESCRIPTION
When a locked document is unlinked from a zaak, it can now be unlocked from the detail view.

Solves [PZ-11365]