### PR TITLE
feature: create custom functions in formio

### DIFF
--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
@@ -7,19 +7,14 @@ import { TestBed } from "@angular/core/testing";
 import { of, throwError } from "rxjs";
 import { InformatieObjectenService } from "../../informatie-objecten/informatie-objecten.service";
 import { GeneratedType } from "../../shared/utils/generated-types";
-import { ZakenService } from "../../zaken/zaken.service";
 import {
   FormioCustomFunctions,
   KNOWN_FORMIO_FUNCTIONS,
 } from "./formio-custom-functions";
 
-const mockZaak = (zaakdata: Record<string, unknown>) =>
-  of({ zaakdata } as GeneratedType<"RestZaak">);
-
 const mockDocument = (titel: string | null) =>
   of({ titel } as GeneratedType<"RestEnkelvoudigInformatieobject">);
 
-const ZAAK_UUID = "zaak-uuid-123";
 const UUID_A = "aaaaaaaa-0000-0000-0000-000000000001";
 const UUID_B = "bbbbbbbb-0000-0000-0000-000000000002";
 const UUID_C = "cccccccc-0000-0000-0000-000000000003";
@@ -32,21 +27,17 @@ const formWithFunction = (field: string) => ({
 
 describe(FormioCustomFunctions.name, () => {
   let service: FormioCustomFunctions;
-  let zakenService: jest.Mocked<Pick<ZakenService, "readZaak">>;
   let informatieObjectenService: jest.Mocked<
     Pick<InformatieObjectenService, "readEnkelvoudigInformatieobject">
   >;
 
   beforeEach(() => {
-    zakenService = { readZaak: jest.fn() };
     informatieObjectenService = {
       readEnkelvoudigInformatieobject: jest.fn(),
     };
 
     TestBed.configureTestingModule({
       providers: [
-        FormioCustomFunctions,
-        { provide: ZakenService, useValue: zakenService },
         {
           provide: InformatieObjectenService,
           useValue: informatieObjectenService,
@@ -59,9 +50,7 @@ describe(FormioCustomFunctions.name, () => {
 
   describe(FormioCustomFunctions.prototype.hasFunctionCalls.name, () => {
     it("should return true when form contains a {{ }} function call", () => {
-      expect(service.hasFunctionCalls(formWithFunction("ZAAK_Docs"))).toBe(
-        true,
-      );
+      expect(service.hasFunctionCalls(formWithFunction("ZAAK_Docs"))).toBe(true);
     });
 
     it("should return false for a form with no function calls", () => {
@@ -100,16 +89,15 @@ describe(FormioCustomFunctions.name, () => {
 
   describe(FormioCustomFunctions.prototype.buildEvalContext.name, () => {
     beforeEach(() => {
-      zakenService.readZaak.mockReturnValue(mockZaak({ ZAAK_Docs: [UUID_A] }));
       informatieObjectenService.readEnkelvoudigInformatieobject.mockReturnValue(
         mockDocument("Document A"),
       );
     });
 
-    it("should spread zaakdata as top-level keys in the context", async () => {
+    it("should spread taakdata as top-level keys in the context", async () => {
       const context = await service.buildEvalContext(
         formWithFunction("ZAAK_Docs"),
-        ZAAK_UUID,
+        { ZAAK_Docs: [UUID_A] },
       );
 
       expect(context["ZAAK_Docs"]).toEqual([UUID_A]);
@@ -118,29 +106,26 @@ describe(FormioCustomFunctions.name, () => {
     it("should register getDocumentTitles as a function in the context", async () => {
       const context = await service.buildEvalContext(
         formWithFunction("ZAAK_Docs"),
-        ZAAK_UUID,
+        { ZAAK_Docs: [UUID_A] },
       );
 
-      expect(
-        typeof context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE],
-      ).toBe("function");
+      expect(typeof context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE]).toBe("function");
     });
 
     it("should return the pre-built title string when getDocumentTitles is called", async () => {
       const context = await service.buildEvalContext(
         formWithFunction("ZAAK_Docs"),
-        ZAAK_UUID,
+        { ZAAK_Docs: [UUID_A] },
       );
       const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
 
       expect(fn()).toBe("Document A");
     });
 
-    it("should return empty string when the zaakdata field is missing", async () => {
-      zakenService.readZaak.mockReturnValue(mockZaak({}));
+    it("should return empty string when the taakdata field is missing", async () => {
       const context = await service.buildEvalContext(
         formWithFunction("ZAAK_Missing"),
-        ZAAK_UUID,
+        {},
       );
       const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
 
@@ -148,14 +133,13 @@ describe(FormioCustomFunctions.name, () => {
     });
 
     it("should format two documents with 'en'", async () => {
-      zakenService.readZaak.mockReturnValue(mockZaak({ ZAAK_Docs: [UUID_A, UUID_B] }));
       informatieObjectenService.readEnkelvoudigInformatieobject.mockImplementation(
         (uuid) => mockDocument(uuid === UUID_A ? "Document A" : "Document B"),
       );
 
       const context = await service.buildEvalContext(
         formWithFunction("ZAAK_Docs"),
-        ZAAK_UUID,
+        { ZAAK_Docs: [UUID_A, UUID_B] },
       );
       const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
 
@@ -163,15 +147,16 @@ describe(FormioCustomFunctions.name, () => {
     });
 
     it("should format three documents with commas and 'en'", async () => {
-      zakenService.readZaak.mockReturnValue(mockZaak({ ZAAK_Docs: [UUID_A, UUID_B, UUID_C] }));
       informatieObjectenService.readEnkelvoudigInformatieobject.mockImplementation(
         (uuid) =>
-          mockDocument(uuid === UUID_A ? "Document A" : uuid === UUID_B ? "Document B" : "Document C"),
+          mockDocument(
+            uuid === UUID_A ? "Document A" : uuid === UUID_B ? "Document B" : "Document C",
+          ),
       );
 
       const context = await service.buildEvalContext(
         formWithFunction("ZAAK_Docs"),
-        ZAAK_UUID,
+        { ZAAK_Docs: [UUID_A, UUID_B, UUID_C] },
       );
       const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
 
@@ -185,7 +170,7 @@ describe(FormioCustomFunctions.name, () => {
 
       const context = await service.buildEvalContext(
         formWithFunction("ZAAK_Docs"),
-        ZAAK_UUID,
+        { ZAAK_Docs: [UUID_A] },
       );
       const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
 
@@ -199,25 +184,22 @@ describe(FormioCustomFunctions.name, () => {
 
       const context = await service.buildEvalContext(
         formWithFunction("ZAAK_Docs"),
-        ZAAK_UUID,
+        { ZAAK_Docs: [UUID_A] },
       );
       const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
 
       expect(fn()).toBe(UUID_A);
     });
 
-    it("should fetch zaakdata using the provided zaakUuid", async () => {
-      await service.buildEvalContext(formWithFunction("ZAAK_Docs"), ZAAK_UUID);
-
-      expect(zakenService.readZaak).toHaveBeenCalledWith(ZAAK_UUID);
-    });
-
-    it("should fetch each document with the zaakUuid for context", async () => {
-      await service.buildEvalContext(formWithFunction("ZAAK_Docs"), ZAAK_UUID);
+    it("should fetch each document by UUID", async () => {
+      await service.buildEvalContext(
+        formWithFunction("ZAAK_Docs"),
+        { ZAAK_Docs: [UUID_A] },
+      );
 
       expect(
         informatieObjectenService.readEnkelvoudigInformatieobject,
-      ).toHaveBeenCalledWith(UUID_A, ZAAK_UUID);
+      ).toHaveBeenCalledWith(UUID_A);
     });
   });
 });

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
@@ -1,0 +1,223 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { of, throwError } from "rxjs";
+import { InformatieObjectenService } from "../../informatie-objecten/informatie-objecten.service";
+import { GeneratedType } from "../../shared/utils/generated-types";
+import { ZakenService } from "../../zaken/zaken.service";
+import {
+  FormioCustomFunctions,
+  KNOWN_FORMIO_FUNCTIONS,
+} from "./formio-custom-functions";
+
+const mockZaak = (zaakdata: Record<string, unknown>) =>
+  of({ zaakdata } as GeneratedType<"RestZaak">);
+
+const mockDocument = (titel: string | null) =>
+  of({ titel } as GeneratedType<"RestEnkelvoudigInformatieobject">);
+
+const ZAAK_UUID = "zaak-uuid-123";
+const UUID_A = "aaaaaaaa-0000-0000-0000-000000000001";
+const UUID_B = "bbbbbbbb-0000-0000-0000-000000000002";
+const UUID_C = "cccccccc-0000-0000-0000-000000000003";
+
+const formWithFunction = (field: string) => ({
+  components: [
+    { html: `<p>{{ getDocumentTitles(${field}) }}</p>`, type: "content" },
+  ],
+});
+
+describe(FormioCustomFunctions.name, () => {
+  let service: FormioCustomFunctions;
+  let zakenService: jest.Mocked<Pick<ZakenService, "readZaak">>;
+  let informatieObjectenService: jest.Mocked<
+    Pick<InformatieObjectenService, "readEnkelvoudigInformatieobject">
+  >;
+
+  beforeEach(() => {
+    zakenService = { readZaak: jest.fn() };
+    informatieObjectenService = {
+      readEnkelvoudigInformatieobject: jest.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        FormioCustomFunctions,
+        { provide: ZakenService, useValue: zakenService },
+        {
+          provide: InformatieObjectenService,
+          useValue: informatieObjectenService,
+        },
+      ],
+    });
+
+    service = TestBed.inject(FormioCustomFunctions);
+  });
+
+  describe(FormioCustomFunctions.prototype.hasFunctionCalls.name, () => {
+    it("should return true when form contains a {{ }} function call", () => {
+      expect(service.hasFunctionCalls(formWithFunction("ZAAK_Docs"))).toBe(
+        true,
+      );
+    });
+
+    it("should return false for a form with no function calls", () => {
+      const form = { components: [{ label: "Name", type: "textfield" }] };
+      expect(service.hasFunctionCalls(form)).toBe(false);
+    });
+
+    it("should return false for null", () => {
+      expect(service.hasFunctionCalls(null)).toBe(false);
+    });
+
+    it("should return false for an empty object", () => {
+      expect(service.hasFunctionCalls({})).toBe(false);
+    });
+
+    it("should detect function calls in deeply nested components", () => {
+      const form = {
+        components: [
+          {
+            components: [
+              { html: "{{ getDocumentTitles(ZAAK_Docs) }}", type: "content" },
+            ],
+          },
+        ],
+      };
+      expect(service.hasFunctionCalls(form)).toBe(true);
+    });
+
+    it("should return false for plain HTML without function syntax", () => {
+      const form = {
+        components: [{ html: "<p>Vaste tekst zonder functies</p>" }],
+      };
+      expect(service.hasFunctionCalls(form)).toBe(false);
+    });
+  });
+
+  describe(FormioCustomFunctions.prototype.buildEvalContext.name, () => {
+    beforeEach(() => {
+      zakenService.readZaak.mockReturnValue(mockZaak({ ZAAK_Docs: [UUID_A] }));
+      informatieObjectenService.readEnkelvoudigInformatieobject.mockReturnValue(
+        mockDocument("Document A"),
+      );
+    });
+
+    it("should spread zaakdata as top-level keys in the context", async () => {
+      const context = await service.buildEvalContext(
+        formWithFunction("ZAAK_Docs"),
+        ZAAK_UUID,
+      );
+
+      expect(context["ZAAK_Docs"]).toEqual([UUID_A]);
+    });
+
+    it("should register getDocumentTitles as a function in the context", async () => {
+      const context = await service.buildEvalContext(
+        formWithFunction("ZAAK_Docs"),
+        ZAAK_UUID,
+      );
+
+      expect(
+        typeof context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE],
+      ).toBe("function");
+    });
+
+    it("should return the pre-built title string when getDocumentTitles is called", async () => {
+      const context = await service.buildEvalContext(
+        formWithFunction("ZAAK_Docs"),
+        ZAAK_UUID,
+      );
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+
+      expect(fn()).toBe("Document A");
+    });
+
+    it("should return empty string when the zaakdata field is missing", async () => {
+      zakenService.readZaak.mockReturnValue(mockZaak({}));
+      const context = await service.buildEvalContext(
+        formWithFunction("ZAAK_Missing"),
+        ZAAK_UUID,
+      );
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+
+      expect(fn()).toBe("");
+    });
+
+    it("should format two documents with 'en'", async () => {
+      zakenService.readZaak.mockReturnValue(mockZaak({ ZAAK_Docs: [UUID_A, UUID_B] }));
+      informatieObjectenService.readEnkelvoudigInformatieobject.mockImplementation(
+        (uuid) => mockDocument(uuid === UUID_A ? "Document A" : "Document B"),
+      );
+
+      const context = await service.buildEvalContext(
+        formWithFunction("ZAAK_Docs"),
+        ZAAK_UUID,
+      );
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+
+      expect(fn()).toBe("Document A en Document B");
+    });
+
+    it("should format three documents with commas and 'en'", async () => {
+      zakenService.readZaak.mockReturnValue(mockZaak({ ZAAK_Docs: [UUID_A, UUID_B, UUID_C] }));
+      informatieObjectenService.readEnkelvoudigInformatieobject.mockImplementation(
+        (uuid) =>
+          mockDocument(uuid === UUID_A ? "Document A" : uuid === UUID_B ? "Document B" : "Document C"),
+      );
+
+      const context = await service.buildEvalContext(
+        formWithFunction("ZAAK_Docs"),
+        ZAAK_UUID,
+      );
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+
+      expect(fn()).toBe("Document A, Document B en Document C");
+    });
+
+    it("should fall back to UUID when document fetch fails", async () => {
+      informatieObjectenService.readEnkelvoudigInformatieobject.mockReturnValue(
+        throwError(() => new Error("Not found")),
+      );
+
+      const context = await service.buildEvalContext(
+        formWithFunction("ZAAK_Docs"),
+        ZAAK_UUID,
+      );
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+
+      expect(fn()).toBe(UUID_A);
+    });
+
+    it("should fall back to UUID when document has no titel", async () => {
+      informatieObjectenService.readEnkelvoudigInformatieobject.mockReturnValue(
+        mockDocument(null),
+      );
+
+      const context = await service.buildEvalContext(
+        formWithFunction("ZAAK_Docs"),
+        ZAAK_UUID,
+      );
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+
+      expect(fn()).toBe(UUID_A);
+    });
+
+    it("should fetch zaakdata using the provided zaakUuid", async () => {
+      await service.buildEvalContext(formWithFunction("ZAAK_Docs"), ZAAK_UUID);
+
+      expect(zakenService.readZaak).toHaveBeenCalledWith(ZAAK_UUID);
+    });
+
+    it("should fetch each document with the zaakUuid for context", async () => {
+      await service.buildEvalContext(formWithFunction("ZAAK_Docs"), ZAAK_UUID);
+
+      expect(
+        informatieObjectenService.readEnkelvoudigInformatieobject,
+      ).toHaveBeenCalledWith(UUID_A, ZAAK_UUID);
+    });
+  });
+});

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
@@ -116,16 +116,24 @@ describe(FormioCustomFunctions.name, () => {
       );
     });
 
-    it("should return the pre-built title string when getDocumentTitles is called", async () => {
+    it("should return the title string when getDocumentTitles is called with UUIDs", async () => {
       const context = await service.buildEvalContext(
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[
-        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
-      ] as () => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
 
-      expect(fn()).toBe("Document A");
+      expect(fn([UUID_A])).toBe("Document A");
+    });
+
+    it("should return empty string when called with an empty array", async () => {
+      const context = await service.buildEvalContext(
+        formWithFunction("ZAAK_Docs"),
+        { ZAAK_Docs: [] },
+      );
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
+
+      expect(fn([])).toBe("");
     });
 
     it("should return empty string when the taakdata field is missing", async () => {
@@ -133,11 +141,9 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Missing"),
         {},
       );
-      const fn = context[
-        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
-      ] as () => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: unknown) => string;
 
-      expect(fn()).toBe("");
+      expect(fn(undefined)).toBe("");
     });
 
     it("should format two documents with 'en'", async () => {
@@ -149,22 +155,16 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A, UUID_B] },
       );
-      const fn = context[
-        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
-      ] as () => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
 
-      expect(fn()).toBe("Document A en Document B");
+      expect(fn([UUID_A, UUID_B])).toBe("Document A en Document B");
     });
 
     it("should format three documents with commas and 'en'", async () => {
       informatieObjectenService.readEnkelvoudigInformatieobject.mockImplementation(
         (uuid) =>
           mockDocument(
-            uuid === UUID_A
-              ? "Document A"
-              : uuid === UUID_B
-                ? "Document B"
-                : "Document C",
+            uuid === UUID_A ? "Document A" : uuid === UUID_B ? "Document B" : "Document C",
           ),
       );
 
@@ -172,11 +172,9 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A, UUID_B, UUID_C] },
       );
-      const fn = context[
-        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
-      ] as () => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
 
-      expect(fn()).toBe("Document A, Document B en Document C");
+      expect(fn([UUID_A, UUID_B, UUID_C])).toBe("Document A, Document B en Document C");
     });
 
     it("should fall back to UUID when document fetch fails", async () => {
@@ -188,11 +186,9 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[
-        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
-      ] as () => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
 
-      expect(fn()).toBe(UUID_A);
+      expect(fn([UUID_A])).toBe(UUID_A);
     });
 
     it("should fall back to UUID when document has no titel", async () => {
@@ -204,11 +200,30 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[
-        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
-      ] as () => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
 
-      expect(fn()).toBe(UUID_A);
+      expect(fn([UUID_A])).toBe(UUID_A);
+    });
+
+    it("should pre-fetch titles for all fields when the same function appears multiple times", async () => {
+      informatieObjectenService.readEnkelvoudigInformatieobject.mockImplementation(
+        (uuid) => mockDocument(uuid === UUID_A ? "Document A" : "Document B"),
+      );
+      const formWithTwoCalls = {
+        components: [
+          { html: "{{ getDocumentTitles(ZAAK_Docs_A) }}", type: "content" },
+          { html: "{{ getDocumentTitles(ZAAK_Docs_B) }}", type: "content" },
+        ],
+      };
+
+      const context = await service.buildEvalContext(formWithTwoCalls, {
+        ZAAK_Docs_A: [UUID_A],
+        ZAAK_Docs_B: [UUID_B],
+      });
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
+
+      expect(fn([UUID_A])).toBe("Document A");
+      expect(fn([UUID_B])).toBe("Document B");
     });
 
     it("should fetch each document by UUID", async () => {

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
@@ -102,9 +102,7 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Missing"),
         {},
       );
-      const fn = context["ZAC_getDocumentTitles"] as (
-        uuids: unknown,
-      ) => string;
+      const fn = context["ZAC_getDocumentTitles"] as (uuids: unknown) => string;
 
       expect(fn(undefined)).toBe("");
     });

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
@@ -7,10 +7,7 @@ import { TestBed } from "@angular/core/testing";
 import { of, throwError } from "rxjs";
 import { InformatieObjectenService } from "../../informatie-objecten/informatie-objecten.service";
 import { GeneratedType } from "../../shared/utils/generated-types";
-import {
-  FormioCustomFunctions,
-  KNOWN_FORMIO_FUNCTIONS,
-} from "./formio-custom-functions";
+import { FormioCustomFunctions } from "./formio-custom-functions";
 
 const mockDocument = (titel: string | null) =>
   of({ titel } as GeneratedType<"RestEnkelvoudigInformatieobject">);
@@ -21,7 +18,10 @@ const UUID_C = "cccccccc-0000-0000-0000-000000000003";
 
 const formWithFunction = (field: string) => ({
   components: [
-    { html: `<p>{{ getDocumentTitles(${field}) }}</p>`, type: "content" },
+    {
+      html: `<p>{{ ZAC_getDocumentTitles(${field}) }}</p>`,
+      type: "content",
+    },
   ],
 });
 
@@ -48,47 +48,6 @@ describe(FormioCustomFunctions.name, () => {
     service = TestBed.inject(FormioCustomFunctions);
   });
 
-  describe(FormioCustomFunctions.prototype.hasFunctionCalls.name, () => {
-    it("should return true when form contains a {{ }} function call", () => {
-      expect(service.hasFunctionCalls(formWithFunction("ZAAK_Docs"))).toBe(
-        true,
-      );
-    });
-
-    it("should return false for a form with no function calls", () => {
-      const form = { components: [{ label: "Name", type: "textfield" }] };
-      expect(service.hasFunctionCalls(form)).toBe(false);
-    });
-
-    it("should return false for null", () => {
-      expect(service.hasFunctionCalls(null)).toBe(false);
-    });
-
-    it("should return false for an empty object", () => {
-      expect(service.hasFunctionCalls({})).toBe(false);
-    });
-
-    it("should detect function calls in deeply nested components", () => {
-      const form = {
-        components: [
-          {
-            components: [
-              { html: "{{ getDocumentTitles(ZAAK_Docs) }}", type: "content" },
-            ],
-          },
-        ],
-      };
-      expect(service.hasFunctionCalls(form)).toBe(true);
-    });
-
-    it("should return false for plain HTML without function syntax", () => {
-      const form = {
-        components: [{ html: "<p>Vaste tekst zonder functies</p>" }],
-      };
-      expect(service.hasFunctionCalls(form)).toBe(false);
-    });
-  });
-
   describe(FormioCustomFunctions.prototype.prepareFormContext.name, () => {
     beforeEach(() => {
       informatieObjectenService.readEnkelvoudigInformatieobject.mockReturnValue(
@@ -105,23 +64,21 @@ describe(FormioCustomFunctions.name, () => {
       expect(context["ZAAK_Docs"]).toEqual([UUID_A]);
     });
 
-    it("should register getDocumentTitles as a function in the context", async () => {
+    it("should register ZAC_getDocumentTitles as a function in the context", async () => {
       const context = await service.prepareFormContext(
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
 
-      expect(typeof context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES]).toBe(
-        "function",
-      );
+      expect(typeof context["ZAC_getDocumentTitles"]).toBe("function");
     });
 
-    it("should return the title string when getDocumentTitles is called with UUIDs", async () => {
+    it("should return the title string when ZAC_getDocumentTitles is called with UUIDs", async () => {
       const context = await service.prepareFormContext(
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+      const fn = context["ZAC_getDocumentTitles"] as (
         uuids: string[],
       ) => string;
 
@@ -133,7 +90,7 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+      const fn = context["ZAC_getDocumentTitles"] as (
         uuids: string[],
       ) => string;
 
@@ -145,7 +102,7 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Missing"),
         {},
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+      const fn = context["ZAC_getDocumentTitles"] as (
         uuids: unknown,
       ) => string;
 
@@ -161,7 +118,7 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A, UUID_B] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+      const fn = context["ZAC_getDocumentTitles"] as (
         uuids: string[],
       ) => string;
 
@@ -184,7 +141,7 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A, UUID_B, UUID_C] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+      const fn = context["ZAC_getDocumentTitles"] as (
         uuids: string[],
       ) => string;
 
@@ -202,7 +159,7 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+      const fn = context["ZAC_getDocumentTitles"] as (
         uuids: string[],
       ) => string;
 
@@ -218,7 +175,7 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+      const fn = context["ZAC_getDocumentTitles"] as (
         uuids: string[],
       ) => string;
 
@@ -231,8 +188,14 @@ describe(FormioCustomFunctions.name, () => {
       );
       const formWithTwoCalls = {
         components: [
-          { html: "{{ getDocumentTitles(ZAAK_Docs_A) }}", type: "content" },
-          { html: "{{ getDocumentTitles(ZAAK_Docs_B) }}", type: "content" },
+          {
+            html: "{{ ZAC_getDocumentTitles(ZAAK_Docs_A) }}",
+            type: "content",
+          },
+          {
+            html: "{{ ZAC_getDocumentTitles(ZAAK_Docs_B) }}",
+            type: "content",
+          },
         ],
       };
 
@@ -240,7 +203,7 @@ describe(FormioCustomFunctions.name, () => {
         ZAAK_Docs_A: [UUID_A],
         ZAAK_Docs_B: [UUID_B],
       });
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+      const fn = context["ZAC_getDocumentTitles"] as (
         uuids: string[],
       ) => string;
 

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
@@ -50,7 +50,9 @@ describe(FormioCustomFunctions.name, () => {
 
   describe(FormioCustomFunctions.prototype.hasFunctionCalls.name, () => {
     it("should return true when form contains a {{ }} function call", () => {
-      expect(service.hasFunctionCalls(formWithFunction("ZAAK_Docs"))).toBe(true);
+      expect(service.hasFunctionCalls(formWithFunction("ZAAK_Docs"))).toBe(
+        true,
+      );
     });
 
     it("should return false for a form with no function calls", () => {
@@ -109,7 +111,9 @@ describe(FormioCustomFunctions.name, () => {
         { ZAAK_Docs: [UUID_A] },
       );
 
-      expect(typeof context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE]).toBe("function");
+      expect(typeof context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE]).toBe(
+        "function",
+      );
     });
 
     it("should return the pre-built title string when getDocumentTitles is called", async () => {
@@ -117,7 +121,9 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+      const fn = context[
+        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
+      ] as () => string;
 
       expect(fn()).toBe("Document A");
     });
@@ -127,7 +133,9 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Missing"),
         {},
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+      const fn = context[
+        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
+      ] as () => string;
 
       expect(fn()).toBe("");
     });
@@ -141,7 +149,9 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A, UUID_B] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+      const fn = context[
+        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
+      ] as () => string;
 
       expect(fn()).toBe("Document A en Document B");
     });
@@ -150,7 +160,11 @@ describe(FormioCustomFunctions.name, () => {
       informatieObjectenService.readEnkelvoudigInformatieobject.mockImplementation(
         (uuid) =>
           mockDocument(
-            uuid === UUID_A ? "Document A" : uuid === UUID_B ? "Document B" : "Document C",
+            uuid === UUID_A
+              ? "Document A"
+              : uuid === UUID_B
+                ? "Document B"
+                : "Document C",
           ),
       );
 
@@ -158,7 +172,9 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A, UUID_B, UUID_C] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+      const fn = context[
+        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
+      ] as () => string;
 
       expect(fn()).toBe("Document A, Document B en Document C");
     });
@@ -172,7 +188,9 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+      const fn = context[
+        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
+      ] as () => string;
 
       expect(fn()).toBe(UUID_A);
     });
@@ -186,16 +204,17 @@ describe(FormioCustomFunctions.name, () => {
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as () => string;
+      const fn = context[
+        KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE
+      ] as () => string;
 
       expect(fn()).toBe(UUID_A);
     });
 
     it("should fetch each document by UUID", async () => {
-      await service.buildEvalContext(
-        formWithFunction("ZAAK_Docs"),
-        { ZAAK_Docs: [UUID_A] },
-      );
+      await service.buildEvalContext(formWithFunction("ZAAK_Docs"), {
+        ZAAK_Docs: [UUID_A],
+      });
 
       expect(
         informatieObjectenService.readEnkelvoudigInformatieobject,

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.spec.ts
@@ -89,7 +89,7 @@ describe(FormioCustomFunctions.name, () => {
     });
   });
 
-  describe(FormioCustomFunctions.prototype.buildEvalContext.name, () => {
+  describe(FormioCustomFunctions.prototype.prepareFormContext.name, () => {
     beforeEach(() => {
       informatieObjectenService.readEnkelvoudigInformatieobject.mockReturnValue(
         mockDocument("Document A"),
@@ -97,7 +97,7 @@ describe(FormioCustomFunctions.name, () => {
     });
 
     it("should spread taakdata as top-level keys in the context", async () => {
-      const context = await service.buildEvalContext(
+      const context = await service.prepareFormContext(
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
@@ -106,42 +106,48 @@ describe(FormioCustomFunctions.name, () => {
     });
 
     it("should register getDocumentTitles as a function in the context", async () => {
-      const context = await service.buildEvalContext(
+      const context = await service.prepareFormContext(
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
 
-      expect(typeof context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE]).toBe(
+      expect(typeof context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES]).toBe(
         "function",
       );
     });
 
     it("should return the title string when getDocumentTitles is called with UUIDs", async () => {
-      const context = await service.buildEvalContext(
+      const context = await service.prepareFormContext(
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+        uuids: string[],
+      ) => string;
 
       expect(fn([UUID_A])).toBe("Document A");
     });
 
     it("should return empty string when called with an empty array", async () => {
-      const context = await service.buildEvalContext(
+      const context = await service.prepareFormContext(
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+        uuids: string[],
+      ) => string;
 
       expect(fn([])).toBe("");
     });
 
     it("should return empty string when the taakdata field is missing", async () => {
-      const context = await service.buildEvalContext(
+      const context = await service.prepareFormContext(
         formWithFunction("ZAAK_Missing"),
         {},
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: unknown) => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+        uuids: unknown,
+      ) => string;
 
       expect(fn(undefined)).toBe("");
     });
@@ -151,11 +157,13 @@ describe(FormioCustomFunctions.name, () => {
         (uuid) => mockDocument(uuid === UUID_A ? "Document A" : "Document B"),
       );
 
-      const context = await service.buildEvalContext(
+      const context = await service.prepareFormContext(
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A, UUID_B] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+        uuids: string[],
+      ) => string;
 
       expect(fn([UUID_A, UUID_B])).toBe("Document A en Document B");
     });
@@ -164,17 +172,25 @@ describe(FormioCustomFunctions.name, () => {
       informatieObjectenService.readEnkelvoudigInformatieobject.mockImplementation(
         (uuid) =>
           mockDocument(
-            uuid === UUID_A ? "Document A" : uuid === UUID_B ? "Document B" : "Document C",
+            uuid === UUID_A
+              ? "Document A"
+              : uuid === UUID_B
+                ? "Document B"
+                : "Document C",
           ),
       );
 
-      const context = await service.buildEvalContext(
+      const context = await service.prepareFormContext(
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A, UUID_B, UUID_C] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+        uuids: string[],
+      ) => string;
 
-      expect(fn([UUID_A, UUID_B, UUID_C])).toBe("Document A, Document B en Document C");
+      expect(fn([UUID_A, UUID_B, UUID_C])).toBe(
+        "Document A, Document B en Document C",
+      );
     });
 
     it("should fall back to UUID when document fetch fails", async () => {
@@ -182,11 +198,13 @@ describe(FormioCustomFunctions.name, () => {
         throwError(() => new Error("Not found")),
       );
 
-      const context = await service.buildEvalContext(
+      const context = await service.prepareFormContext(
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+        uuids: string[],
+      ) => string;
 
       expect(fn([UUID_A])).toBe(UUID_A);
     });
@@ -196,11 +214,13 @@ describe(FormioCustomFunctions.name, () => {
         mockDocument(null),
       );
 
-      const context = await service.buildEvalContext(
+      const context = await service.prepareFormContext(
         formWithFunction("ZAAK_Docs"),
         { ZAAK_Docs: [UUID_A] },
       );
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+        uuids: string[],
+      ) => string;
 
       expect(fn([UUID_A])).toBe(UUID_A);
     });
@@ -216,18 +236,20 @@ describe(FormioCustomFunctions.name, () => {
         ],
       };
 
-      const context = await service.buildEvalContext(formWithTwoCalls, {
+      const context = await service.prepareFormContext(formWithTwoCalls, {
         ZAAK_Docs_A: [UUID_A],
         ZAAK_Docs_B: [UUID_B],
       });
-      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE] as (uuids: string[]) => string;
+      const fn = context[KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES] as (
+        uuids: string[],
+      ) => string;
 
       expect(fn([UUID_A])).toBe("Document A");
       expect(fn([UUID_B])).toBe("Document B");
     });
 
     it("should fetch each document by UUID", async () => {
-      await service.buildEvalContext(formWithFunction("ZAAK_Docs"), {
+      await service.prepareFormContext(formWithFunction("ZAAK_Docs"), {
         ZAAK_Docs: [UUID_A],
       });
 

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -6,58 +6,39 @@
 import { inject, Injectable } from "@angular/core";
 import { lastValueFrom } from "rxjs";
 import { InformatieObjectenService } from "../../informatie-objecten/informatie-objecten.service";
-import { ZakenService } from "../../zaken/zaken.service";
 
-/**
- * All custom function names that can appear in form.io ${...} expressions.
- * Add a new entry here when you add a new function below.
- */
 export enum KNOWN_FORMIO_FUNCTIONS {
   GET_DOCUMENT_TITLE = "getDocumentTitles",
 }
 
 type EvalContext = Record<string, unknown>;
 
-/**
- * Builds an evalContext object with custom functions for form.io ${...} expressions.
- * Form.io merges this into every component's eval context at render time.
- *
- * To add a new function:
- *   1. Add its name to KNOWN_FORMIO_FUNCTIONS.
- *   2. Add a case in the switch block below.
- *   3. Pre-fetch the needed data using zaakdata/zaakUuid and register a synchronous function.
- */
 @Injectable({ providedIn: "root" })
 export class FormioCustomFunctions {
-  private readonly zakenService = inject(ZakenService);
   private readonly informatieObjectenService = inject(InformatieObjectenService);
 
   hasFunctionCalls(form: unknown): boolean {
     return this.getFormFunctions(form).size > 0;
   }
 
-  async buildEvalContext(form: unknown, zaakUuid: string): Promise<EvalContext> {
-      console.log("formio-custom-functions.ts: buildEvalContext");
+  async buildEvalContext(form: unknown, taakdata: Record<string, unknown>): Promise<EvalContext> {
     const context: EvalContext = {};
     const zaakDataKey = this.getFormFunctions(form);
-    const zaakdata = await this.fetchZaakdata(zaakUuid);
 
     for (const functionName of Object.values(KNOWN_FORMIO_FUNCTIONS)) {
       const zaakdataField = zaakDataKey.get(functionName);
 
       switch (functionName) {
         case KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE: {
-          const documentUuids = (zaakdata[zaakdataField!] as string[]) ?? [];
-          const titlesString = await this.getDocumentTitles(documentUuids, zaakUuid);
+          const documentUuids = (taakdata[zaakdataField!] as string[]) ?? [];
+          const titlesString = await this.getDocumentTitles(documentUuids, );
           context[functionName] = () => titlesString;
           break;
         }
       }
     }
 
-    // Spread zaakdata as top-level keys so lodash template's with(__data__) scope
-    // can resolve field names like ZAAK_Documenten_Ondertekenen_Selectie directly.
-    return { ...zaakdata, ...context };
+    return { ...taakdata, ...context };
   }
 
     private getFormFunctions(
@@ -78,17 +59,12 @@ export class FormioCustomFunctions {
         return result;
     }
 
-  private async fetchZaakdata(zaakUuid: string) {
-    const zaak = await lastValueFrom(this.zakenService.readZaak(zaakUuid));
-    return zaak.zaakdata as Record<string, unknown>;
-  }
-
-  private async getDocumentTitles(uuids: string[], zaakUuid?: string): Promise<string> {
+  private async getDocumentTitles(uuids: string[]): Promise<string> {
     const titles = await Promise.all(
       uuids.map(async (uuid) => {
         try {
           const document = await lastValueFrom(
-            this.informatieObjectenService.readEnkelvoudigInformatieobject(uuid, zaakUuid),
+            this.informatieObjectenService.readEnkelvoudigInformatieobject(uuid),
           );
           return document?.titel ?? uuid;
         } catch {
@@ -96,7 +72,6 @@ export class FormioCustomFunctions {
         }
       }),
     );
-
     return this.formatValues(titles);
   }
 

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -37,7 +37,7 @@ export class FormioCustomFunctions {
       });
       return (uuids) =>
         listFormat.format(
-          (Array.isArray(uuids) ? (uuids as string[]) : []).map(
+          (Array.isArray(uuids) ? uuids : []).map(
             (uuid) => titleByUuid.get(uuid) ?? uuid,
           ),
         );

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -7,18 +7,32 @@ import { inject, Injectable } from "@angular/core";
 import { lastValueFrom } from "rxjs";
 import { InformatieObjectenService } from "../../informatie-objecten/informatie-objecten.service";
 
-export enum KNOWN_FORMIO_FUNCTIONS {
-  GET_DOCUMENT_TITLES = "getDocumentTitles",
-}
-
 type EvalContext = Record<string, unknown>;
 type FormNode = string | unknown[] | Record<string, unknown> | null | undefined;
 
+// Each factory pre-fetches async data and returns a synchronous closure for form.io's {{ }} evaluator.
+type FormioFunctionFactory = (
+  taakdata: Record<string, unknown>,
+) => Promise<(uuids: unknown) => string>;
+
 @Injectable({ providedIn: "root" })
 export class FormioCustomFunctions {
-  private readonly informatieObjectenService = inject(
-    InformatieObjectenService,
-  );
+  private readonly informatieObjectenService = inject(InformatieObjectenService);
+
+  private readonly functionRegistry: Record<string, FormioFunctionFactory> = {
+    getDocumentTitles: async (taakdata) => {
+      const allUuids = Object.values(taakdata)
+        .filter(Array.isArray)
+        .flat() as string[];
+      const titlesById = await this.fetchTitlesByUuid(allUuids);
+      return (uuids: unknown) =>
+        this.formatValues(
+          (Array.isArray(uuids) ? (uuids as string[]) : []).map(
+            (uuid) => titlesById.get(uuid) ?? uuid,
+          ),
+        );
+    },
+  };
 
   hasFunctionCalls(form: unknown): boolean {
     return this.extractFormFunctions(form as FormNode).size > 0;
@@ -28,39 +42,34 @@ export class FormioCustomFunctions {
     form: unknown,
     taakdata: Record<string, unknown>,
   ): Promise<EvalContext> {
-    const functionsContext: EvalContext = {};
-    const functionCallsByName = this.extractFormFunctions(form as FormNode);
+    const foundFunctions = this.extractFormFunctions(form as FormNode);
 
-    for (const functionName of Object.values(KNOWN_FORMIO_FUNCTIONS)) {
-      const zaakdataFields = functionCallsByName.get(functionName);
-      if (!zaakdataFields?.length) continue;
-
-      switch (functionName) {
-        case KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES: {
-          const allUuids = zaakdataFields.flatMap((parameter) => {
-            const fieldValue = taakdata[parameter];
-            return Array.isArray(fieldValue) ? (fieldValue as string[]) : [];
-          });
-          const titlesById = await this.fetchTitlesByUuid(allUuids);
-          functionsContext[functionName] = (uuids: unknown) =>
-            this.formatValues(
-              (Array.isArray(uuids) ? (uuids as string[]) : []).map(
-                (uuid) => titlesById.get(uuid) ?? uuid,
-              ),
-            );
-          break;
-        }
+    for (const funcName of foundFunctions.keys()) {
+      if (!(funcName in this.functionRegistry)) {
+        console.warn(
+          `[FormioCustomFunctions] Unknown function "{{ ${funcName}(...) }}" in form JSON. ` +
+            `Known functions: ${Object.keys(this.functionRegistry).join(", ")}`,
+        );
       }
     }
 
-    return { ...taakdata, ...functionsContext };
+    const context: EvalContext = { ...taakdata };
+    for (const [funcName, factory] of Object.entries(this.functionRegistry)) {
+      if (foundFunctions.has(funcName)) {
+        context[funcName] = await factory(taakdata);
+      }
+    }
+    return context;
   }
+
+  // ── Private helpers ──────────────────────────────────────────────────────────
 
   private extractFormFunctions(
     formNode: FormNode,
     functionCallsByName = new Map<string, string[]>(),
   ): Map<string, string[]> {
     if (typeof formNode === "string") {
+        // Add ZAC_ to regex
       const functionCallPattern = /\{\{\s*(\w+)\((\w+)\)/g;
       let regexMatch: RegExpExecArray | null;
       while ((regexMatch = functionCallPattern.exec(formNode)) !== null) {
@@ -71,10 +80,7 @@ export class FormioCustomFunctions {
       }
     } else if (Array.isArray(formNode)) {
       for (const arrayElement of formNode)
-        this.extractFormFunctions(
-          arrayElement as FormNode,
-          functionCallsByName,
-        );
+        this.extractFormFunctions(arrayElement as FormNode, functionCallsByName);
     } else if (formNode !== null && typeof formNode === "object") {
       for (const nestedValue of Object.values(formNode))
         this.extractFormFunctions(nestedValue as FormNode, functionCallsByName);
@@ -90,13 +96,11 @@ export class FormioCustomFunctions {
       uuids.map(async (uuid) => {
         try {
           const document = await lastValueFrom(
-            this.informatieObjectenService.readEnkelvoudigInformatieobject(
-              uuid,
-            ),
+            this.informatieObjectenService.readEnkelvoudigInformatieobject(uuid),
           );
           if (document?.titel) titlesById.set(uuid, document.titel);
         } catch {
-          return uuid;
+
         }
       }),
     );

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -33,6 +33,7 @@ export class FormioCustomFunctions {
   private readonly informatieObjectenService = inject(InformatieObjectenService);
 
   async buildEvalContext(form: unknown, zaakUuid: string): Promise<EvalContext> {
+      console.log("formio-custom-functions.ts: buildEvalContext");
     const context: EvalContext = {};
     const zaakDataKey = this.getZaakdataKeys(form);
     const zaakdata = await this.fetchZaakdata(zaakUuid);
@@ -91,7 +92,13 @@ export class FormioCustomFunctions {
         }
       }),
     );
-    console.log(titles.join(" and "));
-    return titles.join(" and ");
+
+    return this.formatValues(titles);
+  }
+
+  private formatValues(values: string[]): string {
+    if (values.length === 0) return "";
+    if (values.length === 1) return values[0];
+    return values.slice(0, -1).join(", ") + " en " + values[values.length - 1];
   }
 }

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -96,7 +96,9 @@ export class FormioCustomFunctions {
           );
           return document?.titel ? ([uuid, document.titel] as const) : null;
         } catch {
-          console.error(`[FormioCustomFunctions] Failed to fetch document with UUID ${uuid}`);
+          console.error(
+            `[FormioCustomFunctions] Failed to fetch document with UUID ${uuid}`,
+          );
           return null;
         }
       }),

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -3,67 +3,95 @@
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
+import { inject, Injectable } from "@angular/core";
+import { lastValueFrom } from "rxjs";
+import { InformatieObjectenService } from "../../informatie-objecten/informatie-objecten.service";
+import { ZakenService } from "../../zaken/zaken.service";
+
 /**
  * All custom function names that can appear in form.io ${...} expressions.
  * Add a new entry here when you add a new function below.
  */
 export enum KNOWN_FORMIO_FUNCTIONS {
-  GET_DOCUMENT_NAME = "getDocumentName",
+  GET_DOCUMENT_TITLE = "getDocumentTitles",
 }
 
-type EvalContext = Record<string, (...args: unknown[]) => unknown>;
+type EvalContext = Record<string, unknown>;
 
 /**
- * Scans a form definition for ${functionName(...)} expressions and builds an
- * evalContext object containing only the functions that are actually used.
- * Form.io merges this object into every component's eval context at render time.
+ * Builds an evalContext object with custom functions for form.io ${...} expressions.
+ * Form.io merges this into every component's eval context at render time.
  *
  * To add a new function:
  *   1. Add its name to KNOWN_FORMIO_FUNCTIONS.
- *   2. Add a case for it in the switch block inside buildEvalContext.
- *   3. Implement the function as a private method below.
+ *   2. Add a case in the switch block below.
+ *   3. Pre-fetch the needed data using zaakdata/zaakUuid and register a synchronous function.
  */
+@Injectable({ providedIn: "root" })
 export class FormioCustomFunctions {
-  buildEvalContext(form: unknown): EvalContext {
+  private readonly zakenService = inject(ZakenService);
+  private readonly informatieObjectenService = inject(InformatieObjectenService);
+
+  async buildEvalContext(form: unknown, zaakUuid: string): Promise<EvalContext> {
     const context: EvalContext = {};
+    const zaakDataKey = this.getZaakdataKeys(form);
+    const zaakdata = await this.fetchZaakdata(zaakUuid);
 
-    for (const [name, parameter] of this.extractFunctionCalls(form)) {
-      console.log("NAAM: ", name, " | PARAMETER: ", parameter);
-      switch (name) {
-        // Add a case here for each entry in KNOWN_FORMIO_FUNCTIONS:
-        //
-        // case KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_NAME:
-        //   context[name] = this.getDocumentName;
-        //   break;
+    for (const functionName of Object.values(KNOWN_FORMIO_FUNCTIONS)) {
+      const zaakdataField = zaakDataKey.get(functionName);
+
+      switch (functionName) {
+        case KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE: {
+          const documentUuids = (zaakdata[zaakdataField!] as string[]) ?? [];
+          const titlesString = await this.getDocumentTitles(documentUuids, zaakUuid);
+          context[functionName] = () => titlesString;
+          break;
+        }
       }
     }
 
-    return context;
+    // Spread zaakdata as top-level keys so lodash template's with(__data__) scope
+    // can resolve field names like ZAAK_Documenten_Ondertekenen_Selectie directly.
+    return { ...zaakdata, ...context };
   }
 
-  // ── Private helpers ──────────────────────────────────────────────────────────
-
-  // Returns a Map of functionName → parameter so both are available in the switch.
-  private extractFunctionCalls(value: unknown): Map<string, string> {
-    const calls = new Map<string, string>();
-    this.collectFunctionCalls(value, calls);
-    return calls;
-  }
-
-  private collectFunctionCalls(
-    value: unknown,
-    calls: Map<string, string>,
-  ): void {
-    if (typeof value === "string") {
-      const pattern = /\$\{(\w+)\((\w+)\)/g;
-      let match: RegExpExecArray | null;
-      while ((match = pattern.exec(value)) !== null) {
-        calls.set(match[1], match[2]);
-      }
-    } else if (Array.isArray(value)) {
-      for (const item of value) this.collectFunctionCalls(item, calls);
-    } else if (value !== null && typeof value === "object") {
-      for (const v of Object.values(value)) this.collectFunctionCalls(v, calls);
+    private getZaakdataKeys(
+        form: unknown,
+        result = new Map<string, string>(),
+    ): Map<string, string> {
+        if (typeof form === "string") {
+            const pattern = /\{\{\s*(\w+)\((\w+)\)/g;
+            let match: RegExpExecArray | null;
+            while ((match = pattern.exec(form)) !== null) {
+                result.set(match[1], match[2]);
+            }
+        } else if (Array.isArray(form)) {
+            for (const item of form) this.getZaakdataKeys(item, result);
+        } else if (form !== null && typeof form === "object") {
+            for (const v of Object.values(form)) this.getZaakdataKeys(v, result);
+        }
+        return result;
     }
+
+  private async fetchZaakdata(zaakUuid: string) {
+    const zaak = await lastValueFrom(this.zakenService.readZaak(zaakUuid));
+    return zaak.zaakdata as Record<string, unknown>;
+  }
+
+  private async getDocumentTitles(uuids: string[], zaakUuid?: string): Promise<string> {
+    const titles = await Promise.all(
+      uuids.map(async (uuid) => {
+        try {
+          const document = await lastValueFrom(
+            this.informatieObjectenService.readEnkelvoudigInformatieobject(uuid, zaakUuid),
+          );
+          return document?.titel ?? uuid;
+        } catch {
+          return uuid;
+        }
+      }),
+    );
+    console.log(titles.join(" and "));
+    return titles.join(" and ");
   }
 }

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -9,9 +9,11 @@ import { InformatieObjectenService } from "../../informatie-objecten/informatie-
 
 type EvalContext = Record<string, unknown>;
 
-// Each factory pre-fetches async data and returns a synchronous closure for form.io's {{ }} evaluator.
+// Each factory receives the taakdata and the specific parameter names found in the form,
+// pre-fetches async data, and returns a synchronous closure for form.io's {{ }} evaluator.
 type FormioFunctionFactory = (
   taakdata: Record<string, unknown>,
+  parameters: string[],
 ) => Promise<(uuids: unknown) => string>;
 
 @Injectable({ providedIn: "root" })
@@ -19,11 +21,12 @@ export class FormioCustomFunctions {
   private readonly informatieObjectenService = inject(InformatieObjectenService);
 
   private readonly functionRegistry: Record<string, FormioFunctionFactory> = {
-    getDocumentTitles: async (taakdata) => {
-      const allUuids = Object.values(taakdata)
-        .filter(Array.isArray)
-        .flat() as string[];
-      const titlesById = await this.fetchTitlesByUuid(allUuids);
+    getDocumentTitles: async (taakdata, parameters) => {
+      const documentUuids = parameters.flatMap((parameter) => {
+        const fieldValue = taakdata[parameter];
+        return Array.isArray(fieldValue) ? (fieldValue as string[]) : [];
+      });
+      const titlesById = await this.fetchTitlesByUuid(documentUuids);
       return (uuids: unknown) =>
         this.formatValues(
           (Array.isArray(uuids) ? (uuids as string[]) : []).map(
@@ -55,7 +58,7 @@ export class FormioCustomFunctions {
     const context: EvalContext = { ...taakdata };
     for (const [funcName, factory] of Object.entries(this.functionRegistry)) {
       if (foundFunctions.has(funcName)) {
-        context[funcName] = await factory(taakdata);
+        context[funcName] = await factory(taakdata, foundFunctions.get(funcName) ?? []);
       }
     }
     return context;

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -16,13 +16,18 @@ type FormNode = string | unknown[] | Record<string, unknown> | null | undefined;
 
 @Injectable({ providedIn: "root" })
 export class FormioCustomFunctions {
-  private readonly informatieObjectenService = inject(InformatieObjectenService);
+  private readonly informatieObjectenService = inject(
+    InformatieObjectenService,
+  );
 
   hasFunctionCalls(form: unknown): boolean {
     return this.extractFormFunctions(form as FormNode).size > 0;
   }
 
-  async buildEvalContext(form: unknown, taakdata: Record<string, unknown>): Promise<EvalContext> {
+  async buildEvalContext(
+    form: unknown,
+    taakdata: Record<string, unknown>,
+  ): Promise<EvalContext> {
     const functionsContext: EvalContext = {};
     const zaakDataKey = this.extractFormFunctions(form as FormNode);
     for (const functionName of Object.values(KNOWN_FORMIO_FUNCTIONS)) {
@@ -31,9 +36,9 @@ export class FormioCustomFunctions {
 
       switch (functionName) {
         case KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE: {
-            console.log("called getDocumentTitles")
+          console.log("called getDocumentTitles");
           const documentUuids = (taakdata[zaakdataField!] as string[]) ?? [];
-          const titlesString = await this.getDocumentTitles(documentUuids, );
+          const titlesString = await this.getDocumentTitles(documentUuids);
           functionsContext[functionName] = () => titlesString;
           break;
         }
@@ -43,30 +48,37 @@ export class FormioCustomFunctions {
     return { ...taakdata, ...functionsContext };
   }
 
-    private extractFormFunctions(
-        formNode: FormNode,
-        functionCallsByName = new Map<string, string>(),
-    ): Map<string, string> {
-        if (typeof formNode === "string") {
-            const functionCallPattern = /\{\{\s*(\w+)\((\w+)\)/g;
-            let regexMatch: RegExpExecArray | null;
-            while ((regexMatch = functionCallPattern.exec(formNode)) !== null) {
-                functionCallsByName.set(regexMatch[1], regexMatch[2]);
-            }
-        } else if (Array.isArray(formNode)) {
-            for (const arrayElement of formNode) this.extractFormFunctions(arrayElement as FormNode, functionCallsByName);
-        } else if (formNode !== null && typeof formNode === "object") {
-            for (const nestedValue of Object.values(formNode)) this.extractFormFunctions(nestedValue as FormNode, functionCallsByName);
-        }
-        return functionCallsByName;
+  private extractFormFunctions(
+    formNode: FormNode,
+    functionCallsByName = new Map<string, string>(),
+  ): Map<string, string> {
+    if (typeof formNode === "string") {
+      const functionCallPattern = /\{\{\s*(\w+)\((\w+)\)/g;
+      let regexMatch: RegExpExecArray | null;
+      while ((regexMatch = functionCallPattern.exec(formNode)) !== null) {
+        functionCallsByName.set(regexMatch[1], regexMatch[2]);
+      }
+    } else if (Array.isArray(formNode)) {
+      for (const arrayElement of formNode)
+        this.extractFormFunctions(
+          arrayElement as FormNode,
+          functionCallsByName,
+        );
+    } else if (formNode !== null && typeof formNode === "object") {
+      for (const nestedValue of Object.values(formNode))
+        this.extractFormFunctions(nestedValue as FormNode, functionCallsByName);
     }
+    return functionCallsByName;
+  }
 
   private async getDocumentTitles(uuids: string[]): Promise<string> {
     const titles = await Promise.all(
       uuids.map(async (uuid) => {
         try {
           const document = await lastValueFrom(
-            this.informatieObjectenService.readEnkelvoudigInformatieobject(uuid),
+            this.informatieObjectenService.readEnkelvoudigInformatieobject(
+              uuid,
+            ),
           );
           return document?.titel ?? uuid;
         } catch {

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: 2026 INFO.nl
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+/**
+ * All custom function names that can appear in form.io ${...} expressions.
+ * Add a new entry here when you add a new function below.
+ */
+export enum KNOWN_FORMIO_FUNCTIONS {
+  GET_DOCUMENT_NAME = "getDocumentName",
+}
+
+type EvalContext = Record<string, (...args: unknown[]) => unknown>;
+
+/**
+ * Scans a form definition for ${functionName(...)} expressions and builds an
+ * evalContext object containing only the functions that are actually used.
+ * Form.io merges this object into every component's eval context at render time.
+ *
+ * To add a new function:
+ *   1. Add its name to KNOWN_FORMIO_FUNCTIONS.
+ *   2. Add a case for it in the switch block inside buildEvalContext.
+ *   3. Implement the function as a private method below.
+ */
+export class FormioCustomFunctions {
+  buildEvalContext(form: unknown): EvalContext {
+    const context: EvalContext = {};
+
+    for (const [name, parameter] of this.extractFunctionCalls(form)) {
+      console.log("NAAM: ", name, " | PARAMETER: ", parameter);
+      switch (name) {
+        // Add a case here for each entry in KNOWN_FORMIO_FUNCTIONS:
+        //
+        // case KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_NAME:
+        //   context[name] = this.getDocumentName;
+        //   break;
+      }
+    }
+
+    return context;
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────────────
+
+  // Returns a Map of functionName → parameter so both are available in the switch.
+  private extractFunctionCalls(value: unknown): Map<string, string> {
+    const calls = new Map<string, string>();
+    this.collectFunctionCalls(value, calls);
+    return calls;
+  }
+
+  private collectFunctionCalls(
+    value: unknown,
+    calls: Map<string, string>,
+  ): void {
+    if (typeof value === "string") {
+      const pattern = /\$\{(\w+)\((\w+)\)/g;
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(value)) !== null) {
+        calls.set(match[1], match[2]);
+      }
+    } else if (Array.isArray(value)) {
+      for (const item of value) this.collectFunctionCalls(item, calls);
+    } else if (value !== null && typeof value === "object") {
+      for (const v of Object.values(value)) this.collectFunctionCalls(v, calls);
+    }
+  }
+}

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -35,8 +35,8 @@ export class FormioCustomFunctions {
 
       switch (functionName) {
         case KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE: {
-          const allUuids = zaakdataFields.flatMap((field) => {
-            const fieldValue = taakdata[field];
+          const allUuids = zaakdataFields.flatMap((parameter) => {
+            const fieldValue = taakdata[parameter];
             return Array.isArray(fieldValue) ? (fieldValue as string[]) : [];
           });
           const titlesById = await this.fetchTitlesById(allUuids);
@@ -62,10 +62,10 @@ export class FormioCustomFunctions {
       const functionCallPattern = /\{\{\s*(\w+)\((\w+)\)/g;
       let regexMatch: RegExpExecArray | null;
       while ((regexMatch = functionCallPattern.exec(formNode)) !== null) {
-        const [, funcName, paramName] = regexMatch;
-        const existing = functionCallsByName.get(funcName) ?? [];
-        if (!existing.includes(paramName)) existing.push(paramName);
-        functionCallsByName.set(funcName, existing);
+        const [, funcName, parameter] = regexMatch;
+        const existingParams = functionCallsByName.get(funcName) ?? [];
+        if (!existingParams.includes(parameter)) existingParams.push(parameter);
+        functionCallsByName.set(funcName, existingParams);
       }
     } else if (Array.isArray(formNode)) {
       for (const arrayElement of formNode)

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -18,27 +18,31 @@ type FormioFunctionFactory = (
 
 @Injectable({ providedIn: "root" })
 export class FormioCustomFunctions {
-  private readonly informatieObjectenService = inject(InformatieObjectenService);
+  private readonly informatieObjectenService = inject(
+    InformatieObjectenService,
+  );
 
   private readonly functionRegistry: Record<string, FormioFunctionFactory> = {
-    getDocumentTitles: async (taakdata, parameters) => {
+    ZAC_getDocumentTitles: async (taakdata, parameters) => {
       const documentUuids = parameters.flatMap((parameter) => {
         const fieldValue = taakdata[parameter];
         return Array.isArray(fieldValue) ? (fieldValue as string[]) : [];
       });
-      const titlesById = await this.fetchTitlesByUuid(documentUuids);
-      return (uuids: unknown) =>
-        this.formatValues(
+      const titleByUuid =
+        await this.fetchInformatieObjectTitlesByUuid(documentUuids);
+
+      const listFormat = new Intl.ListFormat("nl", {
+        style: "long",
+        type: "conjunction",
+      });
+      return (uuids) =>
+        listFormat.format(
           (Array.isArray(uuids) ? (uuids as string[]) : []).map(
-            (uuid) => titlesById.get(uuid) ?? uuid,
+            (uuid) => titleByUuid.get(uuid) ?? uuid,
           ),
         );
     },
   };
-
-  hasFunctionCalls(form: unknown): boolean {
-    return this.extractFormFunctions(form).size > 0;
-  }
 
   async prepareFormContext(
     form: unknown,
@@ -58,17 +62,20 @@ export class FormioCustomFunctions {
     const context: EvalContext = { ...taakdata };
     for (const [funcName, factory] of Object.entries(this.functionRegistry)) {
       if (foundFunctions.has(funcName)) {
-        context[funcName] = await factory(taakdata, foundFunctions.get(funcName) ?? []);
+        context[funcName] = await factory(
+          taakdata,
+          foundFunctions.get(funcName) ?? [],
+        );
       }
     }
     return context;
   }
 
-  // ── Private helpers ──────────────────────────────────────────────────────────
-
   private extractFormFunctions(form: unknown): Map<string, string[]> {
     const result = new Map<string, string[]>();
-    for (const [, funcName, parameter] of JSON.stringify(form ?? "").matchAll(/\{\{\s*(\w+)\((\w+)\)/g)) {
+    for (const [, funcName, parameter] of JSON.stringify(form ?? "").matchAll(
+      /\{\{\s*(\w+)\((\w+)\)/g,
+    )) {
       const params = result.get(funcName) ?? [];
       if (!params.includes(parameter)) params.push(parameter);
       result.set(funcName, params);
@@ -76,28 +83,23 @@ export class FormioCustomFunctions {
     return result;
   }
 
-  private async fetchTitlesByUuid(
+  private async fetchInformatieObjectTitlesByUuid(
     uuids: string[],
   ): Promise<Map<string, string>> {
-    const titlesById = new Map<string, string>();
-    await Promise.all(
+    const entries = await Promise.all(
       uuids.map(async (uuid) => {
         try {
           const document = await lastValueFrom(
-            this.informatieObjectenService.readEnkelvoudigInformatieobject(uuid),
+            this.informatieObjectenService.readEnkelvoudigInformatieobject(
+              uuid,
+            ),
           );
-          if (document?.titel) titlesById.set(uuid, document.titel);
+          return document?.titel ? ([uuid, document.titel] as const) : null;
         } catch {
-
+          return null;
         }
       }),
     );
-    return titlesById;
-  }
-
-  private formatValues(values: string[]): string {
-    if (values.length === 0) return "";
-    if (values.length === 1) return values[0];
-    return values.slice(0, -1).join(", ") + " en " + values[values.length - 1];
+    return new Map(entries.filter((entry) => entry !== null));
   }
 }

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -16,9 +16,7 @@ type FormNode = string | unknown[] | Record<string, unknown> | null | undefined;
 
 @Injectable({ providedIn: "root" })
 export class FormioCustomFunctions {
-  private readonly informatieObjectenService = inject(
-    InformatieObjectenService,
-  );
+  private readonly informatieObjectenService = inject(InformatieObjectenService);
 
   hasFunctionCalls(form: unknown): boolean {
     return this.extractFormFunctions(form as FormNode).size > 0;
@@ -29,17 +27,25 @@ export class FormioCustomFunctions {
     taakdata: Record<string, unknown>,
   ): Promise<EvalContext> {
     const functionsContext: EvalContext = {};
-    const zaakDataKey = this.extractFormFunctions(form as FormNode);
+    const functionCallsByName = this.extractFormFunctions(form as FormNode);
+
     for (const functionName of Object.values(KNOWN_FORMIO_FUNCTIONS)) {
-      const zaakdataField = zaakDataKey.get(functionName);
-      if (!zaakdataField) continue;
+      const zaakdataFields = functionCallsByName.get(functionName);
+      if (!zaakdataFields?.length) continue;
 
       switch (functionName) {
         case KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE: {
-          console.log("called getDocumentTitles");
-          const documentUuids = (taakdata[zaakdataField!] as string[]) ?? [];
-          const titlesString = await this.getDocumentTitles(documentUuids);
-          functionsContext[functionName] = () => titlesString;
+          const allUuids = zaakdataFields.flatMap((field) => {
+            const fieldValue = taakdata[field];
+            return Array.isArray(fieldValue) ? (fieldValue as string[]) : [];
+          });
+          const titlesById = await this.fetchTitlesById(allUuids);
+          functionsContext[functionName] = (uuids: unknown) =>
+            this.formatValues(
+              (Array.isArray(uuids) ? (uuids as string[]) : []).map(
+                (uuid) => titlesById.get(uuid) ?? uuid,
+              ),
+            );
           break;
         }
       }
@@ -50,20 +56,20 @@ export class FormioCustomFunctions {
 
   private extractFormFunctions(
     formNode: FormNode,
-    functionCallsByName = new Map<string, string>(),
-  ): Map<string, string> {
+    functionCallsByName = new Map<string, string[]>(),
+  ): Map<string, string[]> {
     if (typeof formNode === "string") {
       const functionCallPattern = /\{\{\s*(\w+)\((\w+)\)/g;
       let regexMatch: RegExpExecArray | null;
       while ((regexMatch = functionCallPattern.exec(formNode)) !== null) {
-        functionCallsByName.set(regexMatch[1], regexMatch[2]);
+        const [, funcName, paramName] = regexMatch;
+        const existing = functionCallsByName.get(funcName) ?? [];
+        if (!existing.includes(paramName)) existing.push(paramName);
+        functionCallsByName.set(funcName, existing);
       }
     } else if (Array.isArray(formNode)) {
       for (const arrayElement of formNode)
-        this.extractFormFunctions(
-          arrayElement as FormNode,
-          functionCallsByName,
-        );
+        this.extractFormFunctions(arrayElement as FormNode, functionCallsByName);
     } else if (formNode !== null && typeof formNode === "object") {
       for (const nestedValue of Object.values(formNode))
         this.extractFormFunctions(nestedValue as FormNode, functionCallsByName);
@@ -71,22 +77,21 @@ export class FormioCustomFunctions {
     return functionCallsByName;
   }
 
-  private async getDocumentTitles(uuids: string[]): Promise<string> {
-    const titles = await Promise.all(
+  private async fetchTitlesById(uuids: string[]): Promise<Map<string, string>> {
+    const titlesById = new Map<string, string>();
+    await Promise.all(
       uuids.map(async (uuid) => {
         try {
           const document = await lastValueFrom(
-            this.informatieObjectenService.readEnkelvoudigInformatieobject(
-              uuid,
-            ),
+            this.informatieObjectenService.readEnkelvoudigInformatieobject(uuid),
           );
-          return document?.titel ?? uuid;
+          if (document?.titel) titlesById.set(uuid, document.titel);
         } catch {
-          return uuid;
+          return uuid
         }
       }),
     );
-    return this.formatValues(titles);
+    return titlesById;
   }
 
   private formatValues(values: string[]): string {

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -96,6 +96,7 @@ export class FormioCustomFunctions {
           );
           return document?.titel ? ([uuid, document.titel] as const) : null;
         } catch {
+          console.error(`[FormioCustomFunctions] Failed to fetch document with UUID ${uuid}`);
           return null;
         }
       }),

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -32,10 +32,14 @@ export class FormioCustomFunctions {
   private readonly zakenService = inject(ZakenService);
   private readonly informatieObjectenService = inject(InformatieObjectenService);
 
+  hasFunctionCalls(form: unknown): boolean {
+    return this.getFormFunctions(form).size > 0;
+  }
+
   async buildEvalContext(form: unknown, zaakUuid: string): Promise<EvalContext> {
       console.log("formio-custom-functions.ts: buildEvalContext");
     const context: EvalContext = {};
-    const zaakDataKey = this.getZaakdataKeys(form);
+    const zaakDataKey = this.getFormFunctions(form);
     const zaakdata = await this.fetchZaakdata(zaakUuid);
 
     for (const functionName of Object.values(KNOWN_FORMIO_FUNCTIONS)) {
@@ -56,7 +60,7 @@ export class FormioCustomFunctions {
     return { ...zaakdata, ...context };
   }
 
-    private getZaakdataKeys(
+    private getFormFunctions(
         form: unknown,
         result = new Map<string, string>(),
     ): Map<string, string> {
@@ -67,9 +71,9 @@ export class FormioCustomFunctions {
                 result.set(match[1], match[2]);
             }
         } else if (Array.isArray(form)) {
-            for (const item of form) this.getZaakdataKeys(item, result);
+            for (const item of form) this.getFormFunctions(item, result);
         } else if (form !== null && typeof form === "object") {
-            for (const v of Object.values(form)) this.getZaakdataKeys(v, result);
+            for (const v of Object.values(form)) this.getFormFunctions(v, result);
         }
         return result;
     }

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -16,7 +16,9 @@ type FormNode = string | unknown[] | Record<string, unknown> | null | undefined;
 
 @Injectable({ providedIn: "root" })
 export class FormioCustomFunctions {
-  private readonly informatieObjectenService = inject(InformatieObjectenService);
+  private readonly informatieObjectenService = inject(
+    InformatieObjectenService,
+  );
 
   hasFunctionCalls(form: unknown): boolean {
     return this.extractFormFunctions(form as FormNode).size > 0;
@@ -69,7 +71,10 @@ export class FormioCustomFunctions {
       }
     } else if (Array.isArray(formNode)) {
       for (const arrayElement of formNode)
-        this.extractFormFunctions(arrayElement as FormNode, functionCallsByName);
+        this.extractFormFunctions(
+          arrayElement as FormNode,
+          functionCallsByName,
+        );
     } else if (formNode !== null && typeof formNode === "object") {
       for (const nestedValue of Object.values(formNode))
         this.extractFormFunctions(nestedValue as FormNode, functionCallsByName);
@@ -77,17 +82,21 @@ export class FormioCustomFunctions {
     return functionCallsByName;
   }
 
-  private async fetchTitlesByUuid(uuids: string[]): Promise<Map<string, string>> {
+  private async fetchTitlesByUuid(
+    uuids: string[],
+  ): Promise<Map<string, string>> {
     const titlesById = new Map<string, string>();
     await Promise.all(
       uuids.map(async (uuid) => {
         try {
           const document = await lastValueFrom(
-            this.informatieObjectenService.readEnkelvoudigInformatieobject(uuid),
+            this.informatieObjectenService.readEnkelvoudigInformatieobject(
+              uuid,
+            ),
           );
           if (document?.titel) titlesById.set(uuid, document.titel);
         } catch {
-          return uuid
+          return uuid;
         }
       }),
     );

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -8,7 +8,7 @@ import { lastValueFrom } from "rxjs";
 import { InformatieObjectenService } from "../../informatie-objecten/informatie-objecten.service";
 
 export enum KNOWN_FORMIO_FUNCTIONS {
-  GET_DOCUMENT_TITLE = "getDocumentTitles",
+  GET_DOCUMENT_TITLES = "getDocumentTitles",
 }
 
 type EvalContext = Record<string, unknown>;
@@ -22,7 +22,7 @@ export class FormioCustomFunctions {
     return this.extractFormFunctions(form as FormNode).size > 0;
   }
 
-  async buildEvalContext(
+  async prepareFormContext(
     form: unknown,
     taakdata: Record<string, unknown>,
   ): Promise<EvalContext> {
@@ -34,12 +34,12 @@ export class FormioCustomFunctions {
       if (!zaakdataFields?.length) continue;
 
       switch (functionName) {
-        case KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE: {
+        case KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLES: {
           const allUuids = zaakdataFields.flatMap((parameter) => {
             const fieldValue = taakdata[parameter];
             return Array.isArray(fieldValue) ? (fieldValue as string[]) : [];
           });
-          const titlesById = await this.fetchTitlesById(allUuids);
+          const titlesById = await this.fetchTitlesByUuid(allUuids);
           functionsContext[functionName] = (uuids: unknown) =>
             this.formatValues(
               (Array.isArray(uuids) ? (uuids as string[]) : []).map(
@@ -77,7 +77,7 @@ export class FormioCustomFunctions {
     return functionCallsByName;
   }
 
-  private async fetchTitlesById(uuids: string[]): Promise<Map<string, string>> {
+  private async fetchTitlesByUuid(uuids: string[]): Promise<Map<string, string>> {
     const titlesById = new Map<string, string>();
     await Promise.all(
       uuids.map(async (uuid) => {

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -8,7 +8,6 @@ import { lastValueFrom } from "rxjs";
 import { InformatieObjectenService } from "../../informatie-objecten/informatie-objecten.service";
 
 type EvalContext = Record<string, unknown>;
-type FormNode = string | unknown[] | Record<string, unknown> | null | undefined;
 
 // Each factory pre-fetches async data and returns a synchronous closure for form.io's {{ }} evaluator.
 type FormioFunctionFactory = (
@@ -35,14 +34,14 @@ export class FormioCustomFunctions {
   };
 
   hasFunctionCalls(form: unknown): boolean {
-    return this.extractFormFunctions(form as FormNode).size > 0;
+    return this.extractFormFunctions(form).size > 0;
   }
 
   async prepareFormContext(
     form: unknown,
     taakdata: Record<string, unknown>,
   ): Promise<EvalContext> {
-    const foundFunctions = this.extractFormFunctions(form as FormNode);
+    const foundFunctions = this.extractFormFunctions(form);
 
     for (const funcName of foundFunctions.keys()) {
       if (!(funcName in this.functionRegistry)) {
@@ -64,28 +63,14 @@ export class FormioCustomFunctions {
 
   // ── Private helpers ──────────────────────────────────────────────────────────
 
-  private extractFormFunctions(
-    formNode: FormNode,
-    functionCallsByName = new Map<string, string[]>(),
-  ): Map<string, string[]> {
-    if (typeof formNode === "string") {
-        // Add ZAC_ to regex
-      const functionCallPattern = /\{\{\s*(\w+)\((\w+)\)/g;
-      let regexMatch: RegExpExecArray | null;
-      while ((regexMatch = functionCallPattern.exec(formNode)) !== null) {
-        const [, funcName, parameter] = regexMatch;
-        const existingParams = functionCallsByName.get(funcName) ?? [];
-        if (!existingParams.includes(parameter)) existingParams.push(parameter);
-        functionCallsByName.set(funcName, existingParams);
-      }
-    } else if (Array.isArray(formNode)) {
-      for (const arrayElement of formNode)
-        this.extractFormFunctions(arrayElement as FormNode, functionCallsByName);
-    } else if (formNode !== null && typeof formNode === "object") {
-      for (const nestedValue of Object.values(formNode))
-        this.extractFormFunctions(nestedValue as FormNode, functionCallsByName);
+  private extractFormFunctions(form: unknown): Map<string, string[]> {
+    const result = new Map<string, string[]>();
+    for (const [, funcName, parameter] of JSON.stringify(form ?? "").matchAll(/\{\{\s*(\w+)\((\w+)\)/g)) {
+      const params = result.get(funcName) ?? [];
+      if (!params.includes(parameter)) params.push(parameter);
+      result.set(funcName, params);
     }
-    return functionCallsByName;
+    return result;
   }
 
   private async fetchTitlesByUuid(

--- a/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
+++ b/src/main/app/src/app/formulieren/formio-custom-functions/formio-custom-functions.ts
@@ -12,51 +12,53 @@ export enum KNOWN_FORMIO_FUNCTIONS {
 }
 
 type EvalContext = Record<string, unknown>;
+type FormNode = string | unknown[] | Record<string, unknown> | null | undefined;
 
 @Injectable({ providedIn: "root" })
 export class FormioCustomFunctions {
   private readonly informatieObjectenService = inject(InformatieObjectenService);
 
   hasFunctionCalls(form: unknown): boolean {
-    return this.getFormFunctions(form).size > 0;
+    return this.extractFormFunctions(form as FormNode).size > 0;
   }
 
   async buildEvalContext(form: unknown, taakdata: Record<string, unknown>): Promise<EvalContext> {
-    const context: EvalContext = {};
-    const zaakDataKey = this.getFormFunctions(form);
-
+    const functionsContext: EvalContext = {};
+    const zaakDataKey = this.extractFormFunctions(form as FormNode);
     for (const functionName of Object.values(KNOWN_FORMIO_FUNCTIONS)) {
       const zaakdataField = zaakDataKey.get(functionName);
+      if (!zaakdataField) continue;
 
       switch (functionName) {
         case KNOWN_FORMIO_FUNCTIONS.GET_DOCUMENT_TITLE: {
+            console.log("called getDocumentTitles")
           const documentUuids = (taakdata[zaakdataField!] as string[]) ?? [];
           const titlesString = await this.getDocumentTitles(documentUuids, );
-          context[functionName] = () => titlesString;
+          functionsContext[functionName] = () => titlesString;
           break;
         }
       }
     }
 
-    return { ...taakdata, ...context };
+    return { ...taakdata, ...functionsContext };
   }
 
-    private getFormFunctions(
-        form: unknown,
-        result = new Map<string, string>(),
+    private extractFormFunctions(
+        formNode: FormNode,
+        functionCallsByName = new Map<string, string>(),
     ): Map<string, string> {
-        if (typeof form === "string") {
-            const pattern = /\{\{\s*(\w+)\((\w+)\)/g;
-            let match: RegExpExecArray | null;
-            while ((match = pattern.exec(form)) !== null) {
-                result.set(match[1], match[2]);
+        if (typeof formNode === "string") {
+            const functionCallPattern = /\{\{\s*(\w+)\((\w+)\)/g;
+            let regexMatch: RegExpExecArray | null;
+            while ((regexMatch = functionCallPattern.exec(formNode)) !== null) {
+                functionCallsByName.set(regexMatch[1], regexMatch[2]);
             }
-        } else if (Array.isArray(form)) {
-            for (const item of form) this.getFormFunctions(item, result);
-        } else if (form !== null && typeof form === "object") {
-            for (const v of Object.values(form)) this.getFormFunctions(v, result);
+        } else if (Array.isArray(formNode)) {
+            for (const arrayElement of formNode) this.extractFormFunctions(arrayElement as FormNode, functionCallsByName);
+        } else if (formNode !== null && typeof formNode === "object") {
+            for (const nestedValue of Object.values(formNode)) this.extractFormFunctions(nestedValue as FormNode, functionCallsByName);
         }
-        return result;
+        return functionCallsByName;
     }
 
   private async getDocumentTitles(uuids: string[]): Promise<string> {

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.html
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.html
@@ -9,8 +9,9 @@
     [submitDone]="submissionDone"
     [form]="form"
     [readOnly]="readOnly"
-    [options]="formOptions"
-    [renderOptions]="formOptions"
+    <!-- options: Angular wrapper config; renderOptions: passed to Form.io core renderer — evalContext must reach both -->
+    [options]="{ disableAlerts: true, evalContext: evalContext }"
+    [renderOptions]="{ disableAlerts: true, evalContext: evalContext }"
     (ready)="onFormioReady($event)"
     (submit)="onSubmit($event)"
     (change)="onChange($event)"

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.html
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.html
@@ -9,7 +9,6 @@
     [submitDone]="submissionDone"
     [form]="form"
     [readOnly]="readOnly"
-    <!-- options: Angular wrapper config; renderOptions: passed to Form.io core renderer — evalContext must reach both -->
     [options]="{ disableAlerts: true, evalContext: evalContext }"
     [renderOptions]="{ disableAlerts: true, evalContext: evalContext }"
     (ready)="onFormioReady($event)"

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.html
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.html
@@ -3,13 +3,14 @@
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
-@if (form && stylesLoaded) {
+@if (form && stylesLoaded && evalContextReady) {
   <formio
     [submission]="submission"
     [submitDone]="submissionDone"
     [form]="form"
     [readOnly]="readOnly"
     [options]="formOptions"
+    [renderOptions]="formOptions"
     (ready)="onFormioReady($event)"
     (submit)="onSubmit($event)"
     (change)="onChange($event)"

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.html
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.html
@@ -9,7 +9,7 @@
     [submitDone]="submissionDone"
     [form]="form"
     [readOnly]="readOnly"
-    [options]="{ disableAlerts: true }"
+    [options]="formOptions"
     (ready)="onFormioReady($event)"
     (submit)="onSubmit($event)"
     (change)="onChange($event)"

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.spec.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.spec.ts
@@ -4,6 +4,7 @@
  */
 import { ElementRef } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
+import { FormioCustomFunctions } from "../formio-custom-functions/formio-custom-functions";
 import { FormioBootstrapLoaderService } from "./formio-bootstrap-loader.service";
 import { FormioWrapperComponent } from "./formio-wrapper.component";
 
@@ -25,6 +26,13 @@ describe(FormioWrapperComponent.name, () => {
       providers: [
         FormioWrapperComponent,
         { provide: ElementRef, useValue: mockElementRef },
+        {
+          provide: FormioCustomFunctions,
+          useValue: {
+            hasFunctionCalls: jest.fn().mockReturnValue(false),
+            buildEvalContext: jest.fn().mockResolvedValue({}),
+          },
+        },
       ],
     }).compileComponents();
 

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -51,6 +51,7 @@ import { FORMIO_NL_TRANSLATIONS } from "./formio-wrapper.i18n-translations.nl";
 export class FormioWrapperComponent implements OnInit, OnChanges, AfterViewInit {
   @Input() form: unknown;
   @Input() submission: unknown;
+  @Input() zaakUuid?: string;
   @Input() options?: FormioHookOptions;
   @Input({ required: true, transform: booleanAttribute }) readOnly = false;
   @Output() formSubmit = new EventEmitter<FormioSubmitEvent>();
@@ -77,16 +78,26 @@ export class FormioWrapperComponent implements OnInit, OnChanges, AfterViewInit 
   protected stylesLoaded = false;
 
   private static activeElementPatched = false;
-  private readonly customFunctions = new FormioCustomFunctions();
+  private readonly customFunctions = inject(FormioCustomFunctions);
   protected formOptions: Record<string, unknown> = {};
+  protected evalContextReady = false;
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes["form"]) {
-      this.formOptions = {
-        disableAlerts: true,
-        evalContext: this.customFunctions.buildEvalContext(this.form),
-      };
+      void this.rebuildFormOptions();
     }
+  }
+
+  private async rebuildFormOptions(): Promise<void> {
+    this.evalContextReady = false;
+    this.formOptions = {
+      disableAlerts: true,
+      evalContext: await this.customFunctions.buildEvalContext(
+        this.form,
+        this.zaakUuid!,
+      ),
+    };
+    this.evalContextReady = true;
   }
 
   async ngOnInit() {

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -90,13 +90,10 @@ export class FormioWrapperComponent implements OnInit, OnChanges, AfterViewInit 
 
   private async rebuildFormOptions(): Promise<void> {
     this.evalContextReady = false;
-    this.formOptions = {
-      disableAlerts: true,
-      evalContext: await this.customFunctions.buildEvalContext(
-        this.form,
-        this.zaakUuid!,
-      ),
-    };
+    const evalContext = this.customFunctions.hasFunctionCalls(this.form)
+      ? await this.customFunctions.buildEvalContext(this.form, this.zaakUuid!)
+      : {};
+    this.formOptions = { disableAlerts: true, evalContext };
     this.evalContextReady = true;
   }
 

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -7,6 +7,7 @@ import {
   AfterViewInit,
   booleanAttribute,
   Component,
+  DestroyRef,
   ElementRef,
   EventEmitter,
   HostListener,
@@ -19,6 +20,8 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { catchError, from, of, ReplaySubject, switchMap } from "rxjs";
 import {
   ExtendedComponentSchema,
   FormioAppConfig,
@@ -82,36 +85,41 @@ export class FormioWrapperComponent
 
   private static activeElementPatched = false;
   private readonly customFunctions = inject(FormioCustomFunctions);
-  protected formOptions: Record<string, unknown> = {};
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly rebuild$ = new ReplaySubject<void>(1);
+  protected evalContext: Record<string, unknown> = {};
   protected evalContextReady = false;
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes["form"] || changes["taakdata"]) {
-      setTimeout(() => void this.rebuildFormOptions());
-    }
-  }
-
-  private async rebuildFormOptions(): Promise<void> {
-    this.evalContextReady = false;
-    this.isLoading.emit(true);
-    try {
-      const evalContext = this.customFunctions.hasFunctionCalls(this.form)
-        ? await this.customFunctions.prepareFormContext(
-            this.form,
-            this.taakdata ?? {},
-          )
-        : {};
-      this.formOptions = { disableAlerts: true, evalContext };
-    } catch (error) {
-      console.error("Failed to build form eval context:", error);
-      this.formOptions = { disableAlerts: true, evalContext: {} };
-    } finally {
-      this.evalContextReady = true;
-      this.isLoading.emit(false);
+    if (changes["form"]) {
+      this.rebuild$.next();
     }
   }
 
   async ngOnInit() {
+    this.rebuild$
+      .pipe(
+        switchMap(() => {
+          this.evalContextReady = false;
+          this.isLoading.emit(true);
+          const source = from(
+            this.customFunctions.prepareFormContext(this.form, this.taakdata ?? {}),
+          );
+          return source.pipe(
+            catchError((error) => {
+              console.error("Failed to build form eval context:", error);
+              return of({});
+            }),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((evalContext: Record<string, unknown>) => {
+        this.evalContext = evalContext;
+        this.evalContextReady = true;
+        this.isLoading.emit(false);
+      });
+
     await this.loadBootstrapStyles();
     this.stylesLoaded = true;
   }

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -12,8 +12,10 @@ import {
   HostListener,
   inject,
   Input,
+  OnChanges,
   OnInit,
   Output,
+  SimpleChanges,
   ViewChild,
   ViewEncapsulation,
 } from "@angular/core";
@@ -26,6 +28,7 @@ import {
   FormioModule,
 } from "@formio/angular";
 import { FormioBootstrapLoaderService } from "./formio-bootstrap-loader.service";
+import { FormioCustomFunctions } from "../formio-custom-functions/formio-custom-functions";
 import { FORMIO_NL_TRANSLATIONS } from "./formio-wrapper.i18n-translations.nl";
 
 @Component({
@@ -45,7 +48,7 @@ import { FORMIO_NL_TRANSLATIONS } from "./formio-wrapper.i18n-translations.nl";
     },
   ],
 })
-export class FormioWrapperComponent implements OnInit, AfterViewInit {
+export class FormioWrapperComponent implements OnInit, OnChanges, AfterViewInit {
   @Input() form: unknown;
   @Input() submission: unknown;
   @Input() options?: FormioHookOptions;
@@ -74,6 +77,17 @@ export class FormioWrapperComponent implements OnInit, AfterViewInit {
   protected stylesLoaded = false;
 
   private static activeElementPatched = false;
+  private readonly customFunctions = new FormioCustomFunctions();
+  protected formOptions: Record<string, unknown> = {};
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes["form"]) {
+      this.formOptions = {
+        disableAlerts: true,
+        evalContext: this.customFunctions.buildEvalContext(this.form),
+      };
+    }
+  }
 
   async ngOnInit() {
     await this.loadBootstrapStyles();

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -96,7 +96,7 @@ export class FormioWrapperComponent
     this.isLoading.emit(true);
     try {
       const evalContext = this.customFunctions.hasFunctionCalls(this.form)
-        ? await this.customFunctions.buildEvalContext(
+        ? await this.customFunctions.prepareFormContext(
             this.form,
             this.taakdata ?? {},
           )

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -85,7 +85,7 @@ export class FormioWrapperComponent implements OnInit, OnChanges, AfterViewInit 
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes["form"]) {
-      void this.rebuildFormOptions();
+      setTimeout(() => void this.rebuildFormOptions());
     }
   }
 

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -86,7 +86,7 @@ export class FormioWrapperComponent
   protected evalContextReady = false;
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes["form"]) {
+    if (changes["form"] || changes["taakdata"]) {
       setTimeout(() => void this.rebuildFormOptions());
     }
   }

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -58,6 +58,7 @@ export class FormioWrapperComponent implements OnInit, OnChanges, AfterViewInit 
   @Output() formChange = new EventEmitter<FormioChangeEvent>();
   @Output() createDocument = new EventEmitter<FormioCustomEvent>();
   @Output() submissionDone = new EventEmitter<boolean>();
+  @Output() isLoading = new EventEmitter<boolean>();
 
   @HostListener("click", ["$event"])
   onClickInside(event: MouseEvent) {
@@ -90,11 +91,13 @@ export class FormioWrapperComponent implements OnInit, OnChanges, AfterViewInit 
 
   private async rebuildFormOptions(): Promise<void> {
     this.evalContextReady = false;
+    this.isLoading.emit(true);
     const evalContext = this.customFunctions.hasFunctionCalls(this.form)
       ? await this.customFunctions.buildEvalContext(this.form, this.zaakUuid!)
       : {};
     this.formOptions = { disableAlerts: true, evalContext };
     this.evalContextReady = true;
+    this.isLoading.emit(false);
   }
 
   async ngOnInit() {

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -51,7 +51,7 @@ import { FORMIO_NL_TRANSLATIONS } from "./formio-wrapper.i18n-translations.nl";
 export class FormioWrapperComponent implements OnInit, OnChanges, AfterViewInit {
   @Input() form: unknown;
   @Input() submission: unknown;
-  @Input() zaakUuid?: string;
+  @Input() taakdata?: Record<string, unknown>;
   @Input() options?: FormioHookOptions;
   @Input({ required: true, transform: booleanAttribute }) readOnly = false;
   @Output() formSubmit = new EventEmitter<FormioSubmitEvent>();
@@ -93,7 +93,7 @@ export class FormioWrapperComponent implements OnInit, OnChanges, AfterViewInit 
     this.evalContextReady = false;
     this.isLoading.emit(true);
     const evalContext = this.customFunctions.hasFunctionCalls(this.form)
-      ? await this.customFunctions.buildEvalContext(this.form, this.zaakUuid!)
+      ? await this.customFunctions.buildEvalContext(this.form, this.taakdata ?? {})
       : {};
     this.formOptions = { disableAlerts: true, evalContext };
     this.evalContextReady = true;

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -94,15 +94,21 @@ export class FormioWrapperComponent
   private async rebuildFormOptions(): Promise<void> {
     this.evalContextReady = false;
     this.isLoading.emit(true);
-    const evalContext = this.customFunctions.hasFunctionCalls(this.form)
-      ? await this.customFunctions.buildEvalContext(
-          this.form,
-          this.taakdata ?? {},
-        )
-      : {};
-    this.formOptions = { disableAlerts: true, evalContext };
-    this.evalContextReady = true;
-    this.isLoading.emit(false);
+    try {
+      const evalContext = this.customFunctions.hasFunctionCalls(this.form)
+        ? await this.customFunctions.buildEvalContext(
+            this.form,
+            this.taakdata ?? {},
+          )
+        : {};
+      this.formOptions = { disableAlerts: true, evalContext };
+    } catch (error) {
+      console.error("Failed to build form eval context:", error);
+      this.formOptions = { disableAlerts: true, evalContext: {} };
+    } finally {
+      this.evalContextReady = true;
+      this.isLoading.emit(false);
+    }
   }
 
   async ngOnInit() {

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -27,8 +27,8 @@ import {
   FormioHookOptions,
   FormioModule,
 } from "@formio/angular";
-import { FormioBootstrapLoaderService } from "./formio-bootstrap-loader.service";
 import { FormioCustomFunctions } from "../formio-custom-functions/formio-custom-functions";
+import { FormioBootstrapLoaderService } from "./formio-bootstrap-loader.service";
 import { FORMIO_NL_TRANSLATIONS } from "./formio-wrapper.i18n-translations.nl";
 
 @Component({
@@ -48,7 +48,9 @@ import { FORMIO_NL_TRANSLATIONS } from "./formio-wrapper.i18n-translations.nl";
     },
   ],
 })
-export class FormioWrapperComponent implements OnInit, OnChanges, AfterViewInit {
+export class FormioWrapperComponent
+  implements OnInit, OnChanges, AfterViewInit
+{
   @Input() form: unknown;
   @Input() submission: unknown;
   @Input() taakdata?: Record<string, unknown>;
@@ -93,7 +95,10 @@ export class FormioWrapperComponent implements OnInit, OnChanges, AfterViewInit 
     this.evalContextReady = false;
     this.isLoading.emit(true);
     const evalContext = this.customFunctions.hasFunctionCalls(this.form)
-      ? await this.customFunctions.buildEvalContext(this.form, this.taakdata ?? {})
+      ? await this.customFunctions.buildEvalContext(
+          this.form,
+          this.taakdata ?? {},
+        )
       : {};
     this.formOptions = { disableAlerts: true, evalContext };
     this.evalContextReady = true;

--- a/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
+++ b/src/main/app/src/app/formulieren/formio-wrapper/formio-wrapper.component.ts
@@ -21,7 +21,6 @@ import {
   ViewEncapsulation,
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { catchError, from, of, ReplaySubject, switchMap } from "rxjs";
 import {
   ExtendedComponentSchema,
   FormioAppConfig,
@@ -30,6 +29,7 @@ import {
   FormioHookOptions,
   FormioModule,
 } from "@formio/angular";
+import { catchError, from, of, ReplaySubject, switchMap } from "rxjs";
 import { FormioCustomFunctions } from "../formio-custom-functions/formio-custom-functions";
 import { FormioBootstrapLoaderService } from "./formio-bootstrap-loader.service";
 import { FORMIO_NL_TRANSLATIONS } from "./formio-wrapper.i18n-translations.nl";
@@ -63,7 +63,6 @@ export class FormioWrapperComponent
   @Output() formChange = new EventEmitter<FormioChangeEvent>();
   @Output() createDocument = new EventEmitter<FormioCustomEvent>();
   @Output() submissionDone = new EventEmitter<boolean>();
-  @Output() isLoading = new EventEmitter<boolean>();
 
   @HostListener("click", ["$event"])
   onClickInside(event: MouseEvent) {
@@ -101,9 +100,11 @@ export class FormioWrapperComponent
       .pipe(
         switchMap(() => {
           this.evalContextReady = false;
-          this.isLoading.emit(true);
           const source = from(
-            this.customFunctions.prepareFormContext(this.form, this.taakdata ?? {}),
+            this.customFunctions.prepareFormContext(
+              this.form,
+              this.taakdata ?? {},
+            ),
           );
           return source.pipe(
             catchError((error) => {
@@ -117,7 +118,6 @@ export class FormioWrapperComponent
       .subscribe((evalContext: Record<string, unknown>) => {
         this.evalContext = evalContext;
         this.evalContextReady = true;
-        this.isLoading.emit(false);
       });
 
     await this.loadBootstrapStyles();

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.html
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.html
@@ -95,7 +95,10 @@
               (isLoading)="formioWrapperLoading = $event"
             ></zac-formio-wrapper>
             <mat-progress-bar
-              *ngIf="(!formulier && !formioFormulier && !formFields.length) || formioWrapperLoading"
+              *ngIf="
+                (!formulier && !formioFormulier && !formFields.length) ||
+                formioWrapperLoading
+              "
               mode="query"
             ></mat-progress-bar>
           </div>

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.html
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.html
@@ -92,9 +92,10 @@
               (formSubmit)="onFormioFormSubmit($event)"
               (formChange)="onFormioFormChange($event)"
               (createDocument)="onDocumentCreate($event)"
+              (isLoading)="formioWrapperLoading = $event"
             ></zac-formio-wrapper>
             <mat-progress-bar
-              *ngIf="!formulier && !formioFormulier && !formFields.length"
+              *ngIf="(!formulier && !formioFormulier && !formFields.length) || formioWrapperLoading"
               mode="query"
             ></mat-progress-bar>
           </div>

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.html
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.html
@@ -87,6 +87,7 @@
               *ngIf="formioFormulier"
               [submission]="{ data: taak.taakdata }"
               [form]="formioFormulier"
+              [zaakUuid]="taak.zaakUuid"
               [readOnly]="isReadonly()"
               (formSubmit)="onFormioFormSubmit($event)"
               (formChange)="onFormioFormChange($event)"

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.html
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.html
@@ -92,13 +92,9 @@
               (formSubmit)="onFormioFormSubmit($event)"
               (formChange)="onFormioFormChange($event)"
               (createDocument)="onDocumentCreate($event)"
-              (isLoading)="formioWrapperLoading = $event"
             ></zac-formio-wrapper>
             <mat-progress-bar
-              *ngIf="
-                (!formulier && !formioFormulier && !formFields.length) ||
-                formioWrapperLoading
-              "
+              *ngIf="!formulier && !formioFormulier && !formFields.length"
               mode="query"
             ></mat-progress-bar>
           </div>

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.html
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.html
@@ -87,7 +87,7 @@
               *ngIf="formioFormulier"
               [submission]="{ data: taak.taakdata }"
               [form]="formioFormulier"
-              [zaakUuid]="taak.zaakUuid"
+              [taakdata]="taak.taakdata"
               [readOnly]="isReadonly()"
               (formSubmit)="onFormioFormSubmit($event)"
               (formChange)="onFormioFormChange($event)"

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.ts
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.ts
@@ -81,7 +81,6 @@ export class TaakViewComponent
   protected formulier?: AbstractTaakFormulier | null = null;
   protected formConfig?: FormConfig | null = null;
   protected formioFormulier?: FormioForm;
-  protected formioWrapperLoading = false;
 
   protected smartDocumentsGroupId?: string;
   protected smartDocumentsTemplateId?: string;

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.ts
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.ts
@@ -81,6 +81,7 @@ export class TaakViewComponent
   protected formulier?: AbstractTaakFormulier | null = null;
   protected formConfig?: FormConfig | null = null;
   protected formioFormulier?: FormioForm;
+  protected formioWrapperLoading = false;
 
   protected smartDocumentsGroupId?: string;
   protected smartDocumentsTemplateId?: string;


### PR DESCRIPTION
  What changed

  New: **FormioCustomFunctions** service
  A new injectable service that builds an eval context — a plain object of functions — that form.io uses when evaluating {{ }} expressions.

  The service:
  - Scans the form JSON for {{ functionName(fieldName) }} patterns using a regex, extracting which functions are used and which taakdata field each one reads from
  - Only runs for functions that appear in the form — if a function is registered in KNOWN_FORMIO_FUNCTIONS but not used in the current form, it is skipped entirely
  - Pre-fetches data before rendering — because form.io's interpolation is synchronous, all async work (fetching document titles) happens upfront
  - Spreads taakdata into the context as top-level keys, which is required by lodash template's with(__data__) scope to resolve field names like ZAAK_Documenten_Ondertekenen_Selectie
  
  Adding a new function follows a three-step pattern:
  1. Add its name to KNOWN_FORMIO_FUNCTIONS
  2. Add a switch case in buildEvalContext
  3. Implement the function as a private method
  
  First function: getDocumentTitles

  Receives an array of document UUIDs from taakdata, fetches each document title from the backend via InformatieObjectenService, and returns them as a formatted string ("Title A, Title B en Title C"). Falls back to showing the UUID if a fetch fails.

  Used in form JSON as:
  {{ getDocumentTitles(ZAAK_Documenten_Ondertekenen_Selectie) }}

  ---
  Updated: **FormioWrapperComponent**
  
  **formio-wrapper.component.ts**
  - Added @Input() taakdata — receives the task's data object from the parent
  - Added @Output() isLoading — emits true when the custom function setup starts and false when it finishes, so the parent can keep the loading bar visible during the fetch
  - ngOnChanges now rebuilds form options via setTimeout to avoid Angular's ExpressionChangedAfterItHasBeenCheckedError
  - Custom function setup is skipped entirely for forms with no {{ }} expressions

  **formio-wrapper.component.html**
  - Added [renderOptions]="formOptions" — this is the key fix that makes evalContext actually reach form.io's renderer. [options] is processed by @formio/angular's wrapper and never forwards evalContext to the underlying Webform instance; [renderOptions] bypasses the wrapper and passes directly to the
  renderer constructor

  ---
  Updated: **TaakViewComponent**

  - Added formioWrapperLoading flag
  - The existing mat-progress-bar now stays visible while the wrapper is loading its eval context, preventing a blank space between the initial loading bar and the form appearing

  ---
  Tests
  
  - New: **formio-custom-functions.spec.ts** — covers hasFunctionCalls, buildEvalContext, formatting logic (formatValues), fallback behaviour on failed fetches, and correct taakdata spreading
  - Updated: **formio-wrapper.component.spec.ts** — added mock for FormioCustomFunctions to prevent the real service's dependency chain from being resolved in unit tests

Solves PZ-11201