### PR TITLE
fix(ci): restore --helm-extra-args in helm-chart-testing install step

### DIFF
--- a/.github/workflows/helm-chart-testing.yml
+++ b/.github/workflows/helm-chart-testing.yml
@@ -102,7 +102,9 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
 
       - name: Run chart-testing (install)
-        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        run: |
+          ct install --target-branch ${{ github.event.repository.default_branch }} \
+          --helm-extra-args "--values=charts/zac/ci/zac-chart-test-values.yaml"
 
   bump-chart:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The symlink charts/zac/ci/helm-testing-values.yaml resolves to values.yaml which has all required fields empty. Without --helm-extra-args, ct install fails when iterating over that values file. Restore the argument so the test values are layered on top of every install run.

Solves PZ-7836