### PR TITLE
chore: Reschedule e2e-tests to run at 1:00h UTC

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -5,7 +5,7 @@
 name: Playwright Tests
 on:
   schedule:
-    # Runs at 9:00 PM UTC from Monday to Friday
+    # Runs at 1:00 AM UTC from Monday to Friday
     - cron: "0 1 * * 1-5"
   workflow_dispatch:
 

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -6,7 +6,7 @@ name: Playwright Tests
 on:
   schedule:
     # Runs at 9:00 PM UTC from Monday to Friday
-    - cron: "0 21 * * 1-5"
+    - cron: "0 1 * * 1-5"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Rescheduled the end-to-end tests to run at 1:00h UTC to prevent issues with date/time based tests. GitHub seems a little flexible in adhering to the schedule.

Solves [PZ-11371]