### PR TITLE
feat: NVD database caching and increase rate limit

### DIFF
--- a/.github/workflows/dependency-security-scan.yml
+++ b/.github/workflows/dependency-security-scan.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Update OWASP dependency database
         run: |
           echo "🔄 Updating OWASP Dependency Check database..."
-          ./gradlew dependencyCheckUpdate --no-configuration-cache -DdependencyCheck.connectionTimeout=2400000 || true
+          ./gradlew dependencyCheckUpdate --no-configuration-cache || true
 
           # Show cache info
           if [ -d ~/.gradle/dependency-check-data ]; then

--- a/.github/workflows/dependency-security-scan.yml
+++ b/.github/workflows/dependency-security-scan.yml
@@ -141,6 +141,19 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
+      - name: Get cache date
+        id: cache_date
+        run: echo "date=$(date -u +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Cache OWASP dependency-check data
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.gradle/dependency-check-data
+          key: owasp-nvd-db-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}-${{ steps.cache_date.outputs.date }}
+          restore-keys: |
+            owasp-nvd-db-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}-
+            owasp-nvd-db-${{ runner.os }}-
+
       - name: Update OWASP dependency database
         run: |
           echo "🔄 Updating OWASP Dependency Check database..."
@@ -177,9 +190,9 @@ jobs:
 
           # Save vulnerability counts for Slack notification
           if [ -f "build/reports/dependency-check-report.json" ]; then
-            TOTAL_VULNS=$(jq '[.dependencies[].vulnerabilities] | flatten | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
-            CRITICAL_VULNS=$(jq '[.dependencies[].vulnerabilities[] | select(.severity=="CRITICAL")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
-            HIGH_VULNS=$(jq '[.dependencies[].vulnerabilities[] | select(.severity=="HIGH")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
+            TOTAL_VULNS=$(jq '[.dependencies[]?.vulnerabilities[]?] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
+            CRITICAL_VULNS=$(jq '[.dependencies[]?.vulnerabilities[]? | select(.severity=="CRITICAL")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
+            HIGH_VULNS=$(jq '[.dependencies[]?.vulnerabilities[]? | select(.severity=="HIGH")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
             echo "vuln_total=$TOTAL_VULNS" >> $GITHUB_OUTPUT
             echo "vuln_critical=$CRITICAL_VULNS" >> $GITHUB_OUTPUT
             echo "vuln_high=$HIGH_VULNS" >> $GITHUB_OUTPUT
@@ -198,11 +211,11 @@ jobs:
 
           if [ -f "build/reports/dependency-check-report.json" ]; then
             # Extract vulnerability counts from JSON report
-            TOTAL_VULNS=$(jq '[.dependencies[].vulnerabilities] | flatten | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
-            CRITICAL_VULNS=$(jq '[.dependencies[].vulnerabilities[] | select(.severity=="CRITICAL")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
-            HIGH_VULNS=$(jq '[.dependencies[].vulnerabilities[] | select(.severity=="HIGH")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
-            MEDIUM_VULNS=$(jq '[.dependencies[].vulnerabilities[] | select(.severity=="MEDIUM")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
-            LOW_VULNS=$(jq '[.dependencies[].vulnerabilities[] | select(.severity=="LOW")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
+            TOTAL_VULNS=$(jq '[.dependencies[]?.vulnerabilities[]?] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
+            CRITICAL_VULNS=$(jq '[.dependencies[]?.vulnerabilities[]? | select(.severity=="CRITICAL")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
+            HIGH_VULNS=$(jq '[.dependencies[]?.vulnerabilities[]? | select(.severity=="HIGH")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
+            MEDIUM_VULNS=$(jq '[.dependencies[]?.vulnerabilities[]? | select(.severity=="MEDIUM")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
+            LOW_VULNS=$(jq '[.dependencies[]?.vulnerabilities[]? | select(.severity=="LOW")] | length' build/reports/dependency-check-report.json 2>/dev/null || echo "0")
           fi
 
           # Write summary to GitHub Step Summary

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -907,7 +907,7 @@ dependencyCheck {
     )
 
     // Configure output formats - generates HTML, JSON, and SARIF reports
-    formats = listOf("HTML", "SARIF")
+    formats = listOf("HTML", "JSON", "SARIF")
 
     // Set severity threshold - only report HIGH and CRITICAL vulnerabilities
     failBuildOnCVSS = 7.0f
@@ -957,10 +957,14 @@ dependencyCheck {
     }
 
     // Configure NVD API settings (optional - improves performance)
+    val nvdApiKey = System.getenv("NVD_API_KEY")
+        ?.takeIf(String::isNotBlank)
+        ?: project.findProperty("nvdApiKey")?.toString()?.takeIf(String::isNotBlank)
     nvd {
-        // Read from environment variable (CI/CD) or gradle.properties (local dev)
-        apiKey = System.getenv("NVD_API_KEY") ?: project.findProperty("nvdApiKey")?.toString()
-        delay = 16000 // 16 seconds between API calls (free tier limit)
+        apiKey = nvdApiKey
+        // With an API key NVD allows 50 req/30s so 2s delay is safe;
+        // without a key the free-tier limit requires 16s between calls.
+        delay = if (nvdApiKey != null) 2000 else 16000
     }
 }
 


### PR DESCRIPTION
This pull request updates the `dependency-security-scan` GitHub Actions workflow to improve the efficiency and reliability of the OWASP dependency check process. The main changes include adding caching for the OWASP NVD database to speed up runs and making the vulnerability extraction logic more robust against missing or null data in the report.

Workflow improvements:

* Added a step to cache the OWASP dependency-check data directory using the `actions/cache` action, which should reduce scan times by reusing previously downloaded vulnerability databases.
* Introduced a step to generate a cache key based on the current date and dependency versions, ensuring the cache is refreshed daily or when dependencies change.

Vulnerability extraction robustness:

* Updated all `jq` expressions used to extract vulnerability counts from the JSON report to use safe navigation (`[]?` and `[]?`) operators, preventing errors if dependencies or vulnerabilities arrays are missing or null. This change applies to the extraction of total, critical, high, medium, and low severity vulnerabilities. [[1]](diffhunk://#diff-0388e90066e35802c447e416154fac614ea1842b939d2026c44e8eb215eeb61bL180-R195) [[2]](diffhunk://#diff-0388e90066e35802c447e416154fac614ea1842b939d2026c44e8eb215eeb61bL201-R218)

Solves PZ-11403