### PR TITLE
chore(deps): update keycloak-admin-client to 26.5.7

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ spotless-prettier-organize-imports = "4.1.0"
 jacoco = "0.8.14"
 owasp-dependencycheck = "12.2.2"
 glassfish-expressly = "6.0.0"
-keycloak = "26.0.9"
+keycloak = "26.5.7"
 
 apache-commons-lang = "3.20.0"
 apache-commons-text = "1.15.0"


### PR DESCRIPTION
## Summary

- Bumps `keycloak-admin-client` from `26.0.9` to `26.5.7` to align with the Keycloak Docker image version already pinned in `docker-compose.yaml`
- The comment in `libs.versions.toml` explicitly requires these to stay in sync

## Test plan

- [ ] Existing CI passes
- [ ] Local Docker Compose environment starts correctly with Keycloak

🤖 Generated with [Claude Code](https://claude.com/claude-code)