### PR TITLE
chore: fix lint sentinel file created in project root instead of build dir

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -751,7 +751,7 @@ tasks {
         dependsOn("generateOpenApiSpec")
         npmCommand.set(listOf("run", "lint"))
 
-        val sentinelFile = file("${layout.buildDirectory}/.lint-sentinel")
+        val sentinelFile = layout.buildDirectory.file(".lint-sentinel").get().asFile
 
         inputs.files(fileTree("$appPath/src"))
         inputs.files(


### PR DESCRIPTION
- `layout.buildDirectory` is a Gradle `DirectoryProperty`; using it in a
  Kotlin string interpolation (`"${layout.buildDirectory}"`) calls `.toString()`
  on the property object, resolving to the literal string `property 'buildDir'/`
  instead of the actual `build/` directory
- This caused `npmRunLint` to create `./property 'buildDir'/.lint-sentinel` in
  the project root, which showed up as an untracked file in `git status` after
  every build
- Bug was introduced in PR #6069 (_feat(brp): make BRP protocollering headers
  fully configurable_, merged 2026-05-26, Jira PZ-7850)
- Fixed by using the Gradle API correctly: `layout.buildDirectory.file(".lint-sentinel").get().asFile`