### PR TITLE
chore: alter E2E test and add documentation

### DIFF
--- a/docs/manuals/bpmn-guide/README.md
+++ b/docs/manuals/bpmn-guide/README.md
@@ -674,7 +674,7 @@ Resolves a list of document UUIDs stored in a taakdata field to their human-read
 The titles are formatted as a Dutch conjunction list (e.g. `Document A, Document B en Document C`).
 
 * Use a `content` component with an `html` property containing `{{ ZAC_getDocumentTitles(<fieldKey>) }}`
-* `<fieldKey>` must match the `key` of a form field whose value is a list of document UUIDs
+* `<fieldKey>` must match the name of a taakdata field containing a list of document UUIDs (it does not need to be a component in the form)
 
 ```json
 {
@@ -686,7 +686,7 @@ The titles are formatted as a Dutch conjunction list (e.g. `Document A, Document
 }
 ```
 
- If a document cannot be fetched or has no title, the UUID is used as a fallback.
+If a document cannot be fetched or has no title, the UUID is used as a fallback.
 
 #### Supported process data variables
 * `zaakUUID` - zaak UUID

--- a/docs/manuals/bpmn-guide/README.md
+++ b/docs/manuals/bpmn-guide/README.md
@@ -663,6 +663,31 @@ Example:
 }
 ```
 
+### Custom functions
+
+ZAC supports custom functions in Form.io `content` components via the `{{ }}` template syntax.
+These functions are evaluated client-side and can be used to display dynamic data in read-only content blocks.
+
+#### ZAC_getDocumentTitles
+
+Resolves a list of document UUIDs stored in a taakdata field to their human-readable document titles.
+The titles are formatted as a Dutch conjunction list (e.g. `Document A, Document B en Document C`).
+
+* Use a `content` component with an `html` property containing `{{ ZAC_getDocumentTitles(<fieldKey>) }}`
+* `<fieldKey>` must match the `key` of a form field whose value is a list of document UUIDs
+
+```json
+{
+  "label": "Selected documents",
+  "type": "content",
+  "key": "selectedDocuments",
+  "html": "<p>Te ondertekenen documenten:</p><p>{{ ZAC_getDocumentTitles(ZAAK_Documenten_Ondertekenen_Selectie) }}</p>",
+  "input": false
+}
+```
+
+ If a document cannot be fetched or has no title, the UUID is used as a fallback.
+
 #### Supported process data variables
 * `zaakUUID` - zaak UUID
 * `zaakIdentificatie` - zaak id

--- a/src/e2e/features/9-bpmn.feature
+++ b/src/e2e/features/9-bpmn.feature
@@ -60,7 +60,8 @@ Feature: BPMN
     Given "Bob" is logged in to zac
     And Employee "Bob" is on the newly created zaak
     When "Bob" opens the active task
-    Then "Bob" sees 2 documents in the to be signed list
+    Then "Bob" sees document "file A" in the to be signed list
+    Then "Bob" sees document "file B" in the to be signed list
     When "Bob" confirms the signing of the documents
     When Employee "Bob" is on the newly created zaak
     And "Bob" sees document "file A" has been signed

--- a/src/e2e/features/9-bpmn.feature
+++ b/src/e2e/features/9-bpmn.feature
@@ -60,6 +60,7 @@ Feature: BPMN
     Given "Bob" is logged in to zac
     And Employee "Bob" is on the newly created zaak
     When "Bob" opens the active task
+    Then "Bob" sees 2 documents in the to be signed list
     Then "Bob" sees document "file A" in the to be signed list
     Then "Bob" sees document "file B" in the to be signed list
     When "Bob" confirms the signing of the documents

--- a/src/e2e/step-definitions/authentication.ts
+++ b/src/e2e/step-definitions/authentication.ts
@@ -29,7 +29,7 @@ async function loginToZac(this: CustomWorld, user: string) {
 async function waitForPage(world: CustomWorld) {
   const account_circle = world.page.getByText("account_circle");
   const loginHeader = world.page.getByText("ZAAKAFHANDELCOMPONENT");
-  return account_circle.or(loginHeader).waitFor();
+  return account_circle.or(loginHeader).nth(0).waitFor();
 }
 
 async function logout(world: CustomWorld) {

--- a/src/e2e/step-definitions/authentication.ts
+++ b/src/e2e/step-definitions/authentication.ts
@@ -29,7 +29,7 @@ async function loginToZac(this: CustomWorld, user: string) {
 async function waitForPage(world: CustomWorld) {
   const account_circle = world.page.getByText("account_circle");
   const loginHeader = world.page.getByText("ZAAKAFHANDELCOMPONENT");
-  return account_circle.or(loginHeader).nth(0).waitFor();
+  return account_circle.or(loginHeader).first().waitFor({ state: "attached" });
 }
 
 async function logout(world: CustomWorld) {

--- a/src/e2e/step-definitions/bpmn.ts
+++ b/src/e2e/step-definitions/bpmn.ts
@@ -398,6 +398,24 @@ When(
 );
 
 Then(
+    "{string} sees {int} documents in the to be signed list",
+    { timeout: FORTY_SECONDS_IN_MS },
+    async function (
+        this: CustomWorld,
+        _user: z.infer<typeof worldUsers>,
+        expectedCount: number,
+    ) {
+        const titlesParagraph = formioForm(this.page).locator(
+            ".formio-component-selectedDocuments .formio-component-htmlelement p:nth-child(2)",
+        );
+        await expect(titlesParagraph).toBeVisible({ timeout: FORTY_SECONDS_IN_MS });
+        const text = (await titlesParagraph.textContent()) ?? "";
+        const count = text.split(" en ").filter(Boolean).length;
+        expect(count).toBe(expectedCount);
+    },
+);
+
+Then(
   "{string} sees document {string} in the to be signed list",
   { timeout: FORTY_SECONDS_IN_MS },
   async function (
@@ -408,7 +426,10 @@ Then(
     const selectedDocuments = formioForm(this.page).locator(
       ".formio-component-selectedDocuments .formio-component-htmlelement",
     );
-    await expect(selectedDocuments).toContainText(fileName);
+      await waitForFormioContent(this.page, selectedDocuments);
+      await expect(selectedDocuments).toContainText(fileName, {
+          timeout: FORTY_SECONDS_IN_MS,
+      });
   },
 );
 

--- a/src/e2e/step-definitions/bpmn.ts
+++ b/src/e2e/step-definitions/bpmn.ts
@@ -398,21 +398,21 @@ When(
 );
 
 Then(
-    "{string} sees {int} documents in the to be signed list",
-    { timeout: FORTY_SECONDS_IN_MS },
-    async function (
-        this: CustomWorld,
-        _user: z.infer<typeof worldUsers>,
-        expectedCount: number,
-    ) {
-        const titlesParagraph = formioForm(this.page).locator(
-            ".formio-component-selectedDocuments .formio-component-htmlelement p:nth-child(2)",
-        );
-        await expect(titlesParagraph).toBeVisible({ timeout: FORTY_SECONDS_IN_MS });
-        const text = (await titlesParagraph.textContent()) ?? "";
-        const count = text.split(" en ").filter(Boolean).length;
-        expect(count).toBe(expectedCount);
-    },
+  "{string} sees {int} documents in the to be signed list",
+  { timeout: FORTY_SECONDS_IN_MS },
+  async function (
+    this: CustomWorld,
+    _user: z.infer<typeof worldUsers>,
+    expectedCount: number,
+  ) {
+    const titlesParagraph = formioForm(this.page).locator(
+      ".formio-component-selectedDocuments .formio-component-htmlelement p:nth-child(2)",
+    );
+    await expect(titlesParagraph).toBeVisible({ timeout: FORTY_SECONDS_IN_MS });
+    const text = (await titlesParagraph.textContent()) ?? "";
+    const count = text.split(" en ").filter(Boolean).length;
+    expect(count).toBe(expectedCount);
+  },
 );
 
 Then(
@@ -426,10 +426,10 @@ Then(
     const selectedDocuments = formioForm(this.page).locator(
       ".formio-component-selectedDocuments .formio-component-htmlelement",
     );
-      await waitForFormioContent(this.page, selectedDocuments);
-      await expect(selectedDocuments).toContainText(fileName, {
-          timeout: FORTY_SECONDS_IN_MS,
-      });
+    await waitForFormioContent(this.page, selectedDocuments);
+    await expect(selectedDocuments).toContainText(fileName, {
+      timeout: FORTY_SECONDS_IN_MS,
+    });
   },
 );
 

--- a/src/e2e/step-definitions/bpmn.ts
+++ b/src/e2e/step-definitions/bpmn.ts
@@ -398,20 +398,17 @@ When(
 );
 
 Then(
-  "{string} sees {int} documents in the to be signed list",
+  "{string} sees document {string} in the to be signed list",
   { timeout: FORTY_SECONDS_IN_MS },
   async function (
     this: CustomWorld,
     user: z.infer<typeof worldUsers>,
-    expectedCount: number,
+    fileName: string,
   ) {
-    const options = formioForm(this.page).getByRole("option", {
-      name: UUID_V4_REGEX,
-    });
-    await waitForFormioContent(this.page, options.first());
-    await expect(options).toHaveCount(expectedCount, {
-      timeout: FORTY_SECONDS_IN_MS,
-    });
+    const selectedDocuments = formioForm(this.page).locator(
+      ".formio-component-selectedDocuments .formio-component-htmlelement",
+    );
+    await expect(selectedDocuments).toContainText(fileName);
   },
 );
 

--- a/src/itest/resources/bpmn/document-sign/signDocumentsForm.json
+++ b/src/itest/resources/bpmn/document-sign/signDocumentsForm.json
@@ -1,27 +1,20 @@
 {
-  "display": "form",
-  "name": "signDocumentForm",
   "title": "signDocumentForm",
+  "type": "form",
+  "name": "signDocumentForm",
+  "path": "signDocumentForm",
+  "pdfComponents": [],
+  "display": "form",
+  "tags": [],
+  "settings": {},
   "components": [
     {
-      "label": "Document(s) to sign",
-      "widget": "choicesjs",
-      "tableView": true,
-      "validateWhenHidden": false,
-      "key": "ZAAK_Documenten_Ondertekenen_Selectie",
-      "type": "select",
-      "input": true,
-      "dataSrc": "custom",
-      "multiple": true,
-      "customOptions": {
-        "choicesOptions": {
-          "removeItemButton": true,
-          "placeholder": false,
-          "searchEnabled": true,
-          "shouldSort": false
-        }
-      },
-      "disabled": true
+      "html": "<p>Te ondertekenen documenten:</p><p>{{ZAC_getDocumentTitles(ZAAK_Documenten_Ondertekenen_Selectie)}}</p>",
+      "refreshOnChange": false,
+      "key": "selectedDocuments",
+      "type": "content",
+      "input": false,
+      "tableView": false
     },
     {
       "type": "button",


### PR DESCRIPTION
This PR adds the logic of the new custom form.io functions into the E2E tests. It now checks for actual document titles instead of the amount of documents in the list. Documentation of these functions and how they work is also added in this PR

Edit: This PR also fixes the broken E2E tests step where   `return account_circle.or(loginHeader).waitFor({ state: "attached" }); ` returned 2 elements. My best guess is that this check happened when switching from the login screen to the dashboard which results in 2 elements being selected. Now we take the first available element which is correct since we only want to check if the page is fully loaded


Solves PZ-11372 & PZ-11420