### PR TITLE
fix(documenten): accept OS/browser media-type variants for document uploads

### DIFF
--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/01-listInformatieobjecttypesForZaak.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/01-listInformatieobjecttypesForZaak.bru
@@ -1,0 +1,38 @@
+meta {
+  name: 01 - List informatieobjecttypes for zaak (captures documentTypeUuid)
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/rest/informatieobjecten/informatieobjecttypes/zaak/:zaakUuid
+  body: none
+  auth: inherit
+}
+
+params:path {
+  zaakUuid: {{zaakUuid}}
+}
+
+script:post-response {
+  if (res.getStatus() === 200 && Array.isArray(res.getBody()) && res.getBody().length > 0) {
+    bru.setEnvVar("documentTypeUuid", res.getBody()[0].uuid);
+    console.log("Captured documentTypeUuid =", res.getBody()[0].uuid, "(" + res.getBody()[0].omschrijving + ")");
+  }
+}
+
+tests {
+  test("returns 200 and at least one document type", function() {
+    expect(res.getStatus()).to.equal(200);
+    expect(res.getBody()).to.be.an("array").that.is.not.empty;
+  });
+}
+
+docs {
+  Discovery step. Lists the informatieobjecttypes available on the case referenced by the
+  environment variable `zaakUuid`, then captures the first one's UUID into `documentTypeUuid`
+  so the subsequent upload requests can reference it.
+
+  Requires `zaakUuid` to be set in the environment beforehand. Pick any case the test user
+  has access to.
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/02-uploadValidTxt.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/02-uploadValidTxt.bru
@@ -1,0 +1,49 @@
+meta {
+  name: 02 - Upload allowed .txt (positive control)
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/rest/informatieobjecten/informatieobject/:zaakUuid/:documentReferenceId
+  body: multipartForm
+  auth: inherit
+}
+
+params:path {
+  zaakUuid: {{zaakUuid}}
+  documentReferenceId: {{zaakUuid}}
+}
+
+params:query {
+  taakObject: false
+}
+
+body:multipart-form {
+  file: @file(fixtures/sample.txt)
+  bestandsnaam: sample.txt
+  formaat: text/plain
+  titel: Bruno test — valid txt
+  beschrijving: positive control — extension and MIME both on the allowlist
+  informatieobjectTypeUUID: {{documentTypeUuid}}
+  status: definitief
+  vertrouwelijkheidaanduiding: openbaar
+  creatiedatum: 2026-01-01T00:00+00:00
+  taal: dut
+  auteur: Bruno test runner
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("response carries the new document identificatie", function() {
+    expect(res.getBody()).to.have.property("identificatie");
+  });
+}
+
+docs {
+  Happy-path baseline. Confirms the upload pipeline itself works end-to-end before exercising
+  the disallowed-extension cases. Creates a real document on the case — clean up afterwards
+  if needed.
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/03-uploadInvalidExe.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/03-uploadInvalidExe.bru
@@ -1,0 +1,49 @@
+meta {
+  name: 03 - Upload disallowed .exe (must be rejected)
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/rest/informatieobjecten/informatieobject/:zaakUuid/:documentReferenceId
+  body: multipartForm
+  auth: inherit
+}
+
+params:path {
+  zaakUuid: {{zaakUuid}}
+  documentReferenceId: {{zaakUuid}}
+}
+
+params:query {
+  taakObject: false
+}
+
+body:multipart-form {
+  file: @file(fixtures/sample.exe)
+  bestandsnaam: sample.exe
+  formaat: application/x-msdownload
+  titel: Bruno test — disallowed exe
+  beschrijving: negative test — .exe is intentionally absent from AllowedFileType
+  informatieobjectTypeUUID: {{documentTypeUuid}}
+  status: definitief
+  vertrouwelijkheidaanduiding: openbaar
+  creatiedatum: 2026-01-01T00:00+00:00
+  taal: dut
+  auteur: Bruno test runner
+}
+
+tests {
+  test("returns 400 Bad Request", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  test("error mentions disallowed file type", function() {
+    expect(String(res.getBody())).to.match(/disallowed file type|empty/i);
+  });
+}
+
+docs {
+  Verifies the allowlist rejects the .exe extension. The fixture content is plain text — the
+  validator never reads the bytes, only the filename extension and the declared `formaat`
+  MIME type.
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/04-uploadInvalidZip.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/04-uploadInvalidZip.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 04 - Upload disallowed .zip (must be rejected)
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/rest/informatieobjecten/informatieobject/:zaakUuid/:documentReferenceId
+  body: multipartForm
+  auth: inherit
+}
+
+params:path {
+  zaakUuid: {{zaakUuid}}
+  documentReferenceId: {{zaakUuid}}
+}
+
+params:query {
+  taakObject: false
+}
+
+body:multipart-form {
+  file: @file(fixtures/sample.zip)
+  bestandsnaam: sample.zip
+  formaat: application/zip
+  titel: Bruno test — disallowed zip
+  beschrijving: negative test — .zip is intentionally absent from AllowedFileType
+  informatieobjectTypeUUID: {{documentTypeUuid}}
+  status: definitief
+  vertrouwelijkheidaanduiding: openbaar
+  creatiedatum: 2026-01-01T00:00+00:00
+  taal: dut
+  auteur: Bruno test runner
+}
+
+tests {
+  test("returns 400 Bad Request", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  test("error mentions disallowed file type", function() {
+    expect(String(res.getBody())).to.match(/disallowed file type|empty/i);
+  });
+}
+
+docs {
+  Verifies the allowlist rejects the .zip extension. Same rationale as the .exe test —
+  content is irrelevant to the validator.
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/05-uploadExeAsPdfBypass.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/05-uploadExeAsPdfBypass.bru
@@ -1,0 +1,52 @@
+meta {
+  name: 05 - Bypass probe — disguise content as .pdf (currently accepted)
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/rest/informatieobjecten/informatieobject/:zaakUuid/:documentReferenceId
+  body: multipartForm
+  auth: inherit
+}
+
+params:path {
+  zaakUuid: {{zaakUuid}}
+  documentReferenceId: {{zaakUuid}}
+}
+
+params:query {
+  taakObject: false
+}
+
+body:multipart-form {
+  file: @file(fixtures/sneaky.pdf)
+  bestandsnaam: sneaky.pdf
+  formaat: application/pdf
+  titel: Bruno test — content/MIME mismatch
+  beschrijving: bypass probe — filename and formaat say PDF, content is anything
+  informatieobjectTypeUUID: {{documentTypeUuid}}
+  status: definitief
+  vertrouwelijkheidaanduiding: openbaar
+  creatiedatum: 2026-01-01T00:00+00:00
+  taal: dut
+  auteur: Bruno test runner
+}
+
+tests {
+  test("documents the current bypass: accepted as PDF", function() {
+    // Today: 200 OK — the validator only checks filename + formaat, not bytes.
+    // Once content/magic-byte verification is added, flip this to expect 400 (and update the wording above).
+    expect(res.getStatus()).to.equal(200);
+  });
+}
+
+docs {
+  Demonstrates the known gap in the current allowlist validator: it trusts the client-supplied
+  `bestandsnaam` and `formaat`, and never inspects the actual bytes. Any payload uploaded with a
+  `.pdf` filename and `application/pdf` MIME type currently passes.
+
+  This test is intentionally written to PASS while the bypass still exists, so the suite goes
+  green on every run. When the validator is hardened (magic-byte sniffing / content sniffing),
+  flip the expected status to 400 here — that switch becomes the regression guard.
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/06-uploadRtfWindowsMime.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/06-uploadRtfWindowsMime.bru
@@ -1,0 +1,51 @@
+meta {
+  name: 06 - Upload allowed .rtf with Windows MIME (must be accepted)
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/rest/informatieobjecten/informatieobject/:zaakUuid/:documentReferenceId
+  body: multipartForm
+  auth: inherit
+}
+
+params:path {
+  zaakUuid: {{zaakUuid}}
+  documentReferenceId: {{zaakUuid}}
+}
+
+params:query {
+  taakObject: false
+}
+
+body:multipart-form {
+  file: @file(fixtures/sample.rtf)
+  bestandsnaam: sample.rtf
+  formaat: application/msword
+  titel: Bruno test — rtf with Windows MIME
+  beschrijving: regression — Windows reports .rtf as application/msword instead of application/rtf
+  informatieobjectTypeUUID: {{documentTypeUuid}}
+  status: definitief
+  vertrouwelijkheidaanduiding: openbaar
+  creatiedatum: 2026-01-01T00:00+00:00
+  taal: dut
+  auteur: Bruno test runner
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("response carries the new document identificatie", function() {
+    expect(res.getBody()).to.have.property("identificatie");
+  });
+}
+
+docs {
+  Regression test for the Windows MIME-mismatch bug. On Windows the browser reports a .rtf
+  file as `application/msword`, not the canonical `application/rtf`. Before the fix the
+  allowlist required an exact match and rejected this with 400 (and the frontend swallowed
+  the error). The allowlist now accepts the known media-type variants per extension, so this
+  upload succeeds. Creates a real document on the case — clean up afterwards if needed.
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/07-uploadAviWindowsMime.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/07-uploadAviWindowsMime.bru
@@ -1,0 +1,51 @@
+meta {
+  name: 07 - Upload allowed .avi with Windows MIME (must be accepted)
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/rest/informatieobjecten/informatieobject/:zaakUuid/:documentReferenceId
+  body: multipartForm
+  auth: inherit
+}
+
+params:path {
+  zaakUuid: {{zaakUuid}}
+  documentReferenceId: {{zaakUuid}}
+}
+
+params:query {
+  taakObject: false
+}
+
+body:multipart-form {
+  file: @file(fixtures/sample.avi)
+  bestandsnaam: sample.avi
+  formaat: video/avi
+  titel: Bruno test — avi with Windows MIME
+  beschrijving: regression — Windows reports .avi as video/avi instead of video/x-msvideo
+  informatieobjectTypeUUID: {{documentTypeUuid}}
+  status: definitief
+  vertrouwelijkheidaanduiding: openbaar
+  creatiedatum: 2026-01-01T00:00+00:00
+  taal: dut
+  auteur: Bruno test runner
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("response carries the new document identificatie", function() {
+    expect(res.getBody()).to.have.property("identificatie");
+  });
+}
+
+docs {
+  Regression test for the Windows MIME-mismatch bug. On Windows the browser reports a .avi
+  file as `video/avi` (or `video/msvideo`), not the canonical `video/x-msvideo`. Before the
+  fix the allowlist required an exact match and rejected this with 400 (silently, in the UI).
+  The allowlist now accepts the known media-type variants per extension. Creates a real
+  document on the case — clean up afterwards if needed.
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/08-uploadMkvWindowsMime.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/08-uploadMkvWindowsMime.bru
@@ -1,0 +1,52 @@
+meta {
+  name: 08 - Upload allowed .mkv with variant MIME (must be accepted)
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/rest/informatieobjecten/informatieobject/:zaakUuid/:documentReferenceId
+  body: multipartForm
+  auth: inherit
+}
+
+params:path {
+  zaakUuid: {{zaakUuid}}
+  documentReferenceId: {{zaakUuid}}
+}
+
+params:query {
+  taakObject: false
+}
+
+body:multipart-form {
+  file: @file(fixtures/sample.mkv)
+  bestandsnaam: sample.mkv
+  formaat: video/mkv
+  titel: Bruno test — mkv with variant MIME
+  beschrijving: regression — some clients report .mkv as video/mkv instead of video/x-matroska
+  informatieobjectTypeUUID: {{documentTypeUuid}}
+  status: definitief
+  vertrouwelijkheidaanduiding: openbaar
+  creatiedatum: 2026-01-01T00:00+00:00
+  taal: dut
+  auteur: Bruno test runner
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("response carries the new document identificatie", function() {
+    expect(res.getBody()).to.have.property("identificatie");
+  });
+}
+
+docs {
+  Regression test for the MIME-mismatch bug. The canonical media type for .mkv is
+  `video/x-matroska`; some clients report `video/mkv`. The allowlist now accepts the known
+  variants per extension. Creates a real document on the case — clean up afterwards if needed.
+
+  Note: if the tester's machine reports a different .mkv media type, read the exact value from
+  the error dialog (or request 03's style 400 body), then add it to AllowedFileType.MKV.
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/09-uploadVsdWindowsMime.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/09-uploadVsdWindowsMime.bru
@@ -1,0 +1,53 @@
+meta {
+  name: 09 - Upload allowed .vsd with Windows MIME (must be accepted)
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{baseUrl}}/rest/informatieobjecten/informatieobject/:zaakUuid/:documentReferenceId
+  body: multipartForm
+  auth: inherit
+}
+
+params:path {
+  zaakUuid: {{zaakUuid}}
+  documentReferenceId: {{zaakUuid}}
+}
+
+params:query {
+  taakObject: false
+}
+
+body:multipart-form {
+  file: @file(fixtures/sample.vsd)
+  bestandsnaam: sample.vsd
+  formaat: application/x-visio
+  titel: Bruno test — vsd with Windows MIME
+  beschrijving: regression — Windows reports .vsd under x-visio / vnd.ms-visio variants
+  informatieobjectTypeUUID: {{documentTypeUuid}}
+  status: definitief
+  vertrouwelijkheidaanduiding: openbaar
+  creatiedatum: 2026-01-01T00:00+00:00
+  taal: dut
+  auteur: Bruno test runner
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("response carries the new document identificatie", function() {
+    expect(res.getBody()).to.have.property("identificatie");
+  });
+}
+
+docs {
+  Regression test for the Windows MIME-mismatch bug. The canonical media type for .vsd is
+  `application/vnd.visio`; Windows / Visio report variants such as `application/x-visio`,
+  `application/visio`, or `application/vnd.ms-visio.*`. The allowlist now accepts these. Creates
+  a real document on the case — clean up afterwards if needed.
+
+  Note: if the tester's machine reports a different .vsd media type, read the exact value from
+  the error dialog, then add it to AllowedFileType.VSD.
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/README.md
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/README.md
@@ -1,0 +1,84 @@
+# ZAC file-upload validation — Bruno collection
+
+A hand-authored Bruno collection for QA / testers to verify the backend's file-upload
+allowlist (`AllowedFileType`, enforced by `ValidRestEnkelvoudigInformatieFileUploadForm`).
+
+It lives outside `zaakafhandelcomponent_backend_api/` on purpose: the main collection is
+regenerated from OpenAPI by `update-bruno-collection.sh` and the regenerator wipes any
+hand-authored requests inside that folder.
+
+## What it tests
+
+The endpoint under test is the case-document creation route:
+
+```
+POST /rest/informatieobjecten/informatieobject/{zaakUuid}/{documentReferenceId}?taakObject=false
+```
+
+| # | Request | Fixture | Expected |
+|---|---------|---------|----------|
+| 01 | List informatieobjecttypes for the case | — | 200, captures the first type UUID into the environment |
+| 02 | Upload `sample.txt` (`text/plain`) | `fixtures/sample.txt` | 200 — happy path |
+| 03 | Upload `sample.exe` (`application/x-msdownload`) | `fixtures/sample.exe` | 400 — disallowed extension |
+| 04 | Upload `sample.zip` (`application/zip`) | `fixtures/sample.zip` | 400 — disallowed extension |
+| 05 | Upload `sneaky.pdf` with a `application/pdf` MIME but arbitrary content | `fixtures/sneaky.pdf` | 200 — **documents an existing bypass** (see below) |
+| 06 | Upload `sample.rtf` with the Windows MIME `application/msword` | `fixtures/sample.rtf` | 200 — variant MIME accepted |
+| 07 | Upload `sample.avi` with the Windows MIME `video/avi` | `fixtures/sample.avi` | 200 — variant MIME accepted |
+| 08 | Upload `sample.mkv` with the variant MIME `video/mkv` | `fixtures/sample.mkv` | 200 — variant MIME accepted |
+| 09 | Upload `sample.vsd` with the Windows MIME `application/x-visio` | `fixtures/sample.vsd` | 200 — variant MIME accepted |
+
+The fixtures are plain text — the validator inspects only the filename extension and the
+declared MIME (`formaat`), never the bytes, so byte-accurate fixtures aren't needed.
+
+## OS/browser MIME variants (requests 06–09)
+
+The media type a browser puts on an upload is derived from the client OS and is not reliable.
+Windows in particular reports `.rtf` as `application/msword`, `.avi` as `video/avi`, etc. —
+not the canonical media type. The allowlist originally required an exact match, so these valid
+files were rejected with 400, and the *add document* screen swallowed the error (no message at
+all). `AllowedFileType` now registers the known media-type variants per extension, and the
+frontend surfaces rejections. Requests 06–09 are regression guards for those four extensions.
+
+If a tester still hits a silent-looking rejection for one of these (or another) type, the new
+error dialog now shows the exact `formaat` value the browser sent — add that media type to the
+matching `AllowedFileType` entry's variant set.
+
+## Setup
+
+1. Open Bruno → **Open collection** → select this folder
+   (`scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation`).
+2. Pick an environment:
+   - **ZAC Localhost** — for `http://localhost:8080`. The Keycloak secret is pre-filled for the
+     standard local devstack.
+   - **ZAC INFO TEST** — for `https://zaakafhandelcomponent-zac-dev.dimpact.lifely.nl`. Set
+     `keycloakClientSecret` to the value from Keycloak on the INFO TEST environment.
+3. Set the two test-data environment variables for the chosen environment:
+   - `zaakUuid` — UUID of any case the test user has access to. Easiest source: open a case
+     in ZAC and copy the UUID from the URL or from a `GET /rest/zaken/zaak/id/{identificatie}`
+     call.
+   - `documentTypeUuid` — leave empty. Request **01** captures it automatically.
+4. Open the collection's **Auth** tab and click **Get Access Token**. Log in via Keycloak when
+   redirected.
+
+## Running
+
+Run the requests in order (01 → 05), or run the whole folder with Bruno's runner. Each
+request has a `tests {}` block, so the runner reports pass/fail per test.
+
+The happy-path upload (02) and the bypass probe (05) both create a real document on the
+referenced case. Clean up afterwards via ZAC or the existing
+`deleteEnkelvoudigInformatieObject` request in the main collection.
+
+## When the validator is hardened
+
+Request **05** is written to *expect* the current behaviour (status 200) — that keeps the
+suite green for now while still being a tripwire. When content/magic-byte sniffing is added
+to the validator and the bypass is closed, flip the assertion in `05-uploadExeAsPdfBypass.bru`
+from `expect(res.getStatus()).to.equal(200)` to `400`. From that point onwards the test
+guards against regressions of the fix.
+
+## Related code
+
+- Validator: `src/main/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadForm*.kt`
+- Allowlist enum: `src/main/kotlin/nl/info/zac/configuration/AllowedFileType.kt`
+- Endpoint: `EnkelvoudigInformatieObjectRestService.createEnkelvoudigInformatieobjectAndUploadFile`

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/bruno.json
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "zaakafhandelcomponent_file_upload_validation",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"]
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/collection.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/collection.bru
@@ -1,0 +1,26 @@
+meta {
+  name: ZAC file upload validation
+}
+
+auth {
+  mode: oauth2
+}
+
+auth:oauth2 {
+  grant_type: authorization_code
+  callback_url: {{baseUrl}}
+  authorization_url: {{keycloakBaseUrl}}/realms/zaakafhandelcomponent/protocol/openid-connect/auth
+  access_token_url: {{keycloakBaseUrl}}/realms/zaakafhandelcomponent/protocol/openid-connect/token
+  refresh_token_url:
+  client_id: zaakafhandelcomponent
+  client_secret: {{keycloakClientSecret}}
+  scope: openid
+  state:
+  pkce: false
+  credentials_placement: basic_auth_header
+  credentials_id: credentials
+  token_placement: header
+  token_header_prefix: Bearer
+  auto_fetch_token: true
+  auto_refresh_token: false
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/environments/ZAC INFO TEST.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/environments/ZAC INFO TEST.bru
@@ -1,0 +1,7 @@
+vars {
+  baseUrl: https://zaakafhandelcomponent-zac-dev.dimpact.lifely.nl
+  keycloakBaseUrl: https://keycloak-zac-dev.dimpact.lifely.nl
+  keycloakClientSecret:
+  zaakUuid:
+  documentTypeUuid:
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/environments/ZAC Localhost.bru
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/environments/ZAC Localhost.bru
@@ -1,0 +1,7 @@
+vars {
+  baseUrl: http://localhost:8080
+  keycloakBaseUrl: http://host.docker.internal:8081
+  keycloakClientSecret: keycloakZaakhandelcomponentClientSecret
+  zaakUuid:
+  documentTypeUuid:
+}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.avi
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.avi
@@ -1,0 +1,1 @@
+Placeholder AVI fixture. The validator only inspects the filename extension and the declared formaat MIME, never the bytes.

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.exe
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.exe
@@ -1,0 +1,1 @@
+Not a real executable. Fixture only — the ZAC allowlist validator checks the filename extension and declared MIME type, never the bytes, so plain text content is enough to exercise the disallowed-extension code path.

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.mkv
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.mkv
@@ -1,0 +1,1 @@
+Placeholder MKV fixture. The validator only inspects the filename extension and the declared formaat MIME, never the bytes.

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.rtf
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.rtf
@@ -1,0 +1,1 @@
+{\rtf1\ansi Placeholder RTF fixture. The validator only inspects the filename extension and the declared formaat MIME, never the bytes.}

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.txt
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.txt
@@ -1,0 +1,1 @@
+Bruno upload validation test — happy path.

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.vsd
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.vsd
@@ -1,0 +1,1 @@
+Placeholder VSD fixture. The validator only inspects the filename extension and the declared formaat MIME, never the bytes.

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.zip
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sample.zip
@@ -1,0 +1,1 @@
+Not a real zip. Fixture only — the ZAC allowlist validator checks the filename extension and declared MIME type, never the bytes, so plain text content is enough to exercise the disallowed-extension code path.

--- a/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sneaky.pdf
+++ b/scripts/bruno/collections/zaakafhandelcomponent_file_upload_validation/fixtures/sneaky.pdf
@@ -1,0 +1,1 @@
+Not a real PDF. Fixture only — the point of this test is to demonstrate that the validator only inspects filename+formaat, so uploading anything under a .pdf name with application/pdf MIME currently slips through regardless of content.

--- a/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.spec.ts
+++ b/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.spec.ts
@@ -96,4 +96,32 @@ describe("FoutAfhandelingService", () => {
       `${translatedErrorMessage}: ${exceptionDetail}`,
     );
   });
+
+  it("should translate the violation messages when a Jakarta bean validation error is handled", async () => {
+    const validationError = {
+      statusText: "Bad Request",
+      error: {
+        classViolations: [],
+        parameterViolations: [
+          {
+            constraintType: "PARAMETER",
+            message: "msg.error.document.upload.invalid",
+            path: "createEnkelvoudigInformatieobjectAndUploadFile.arg3",
+            value: "RestEnkelvoudigInformatieobject(...)",
+          },
+        ],
+        propertyViolations: [],
+        returnValueViolations: [],
+      },
+    } as Parameters<FoutAfhandelingService["foutAfhandelen"]>[0];
+
+    const error$ = service.foutAfhandelen(validationError);
+    const errorMessage = await firstValueFrom(error$).catch((r) => r);
+
+    // The violation message and the generic title both pass through TranslateService,
+    // and openFoutDetailedDialog rejects with `${title}: ${details}`.
+    expect(errorMessage).toEqual(
+      `${translatedErrorMessage}: ${translatedErrorMessage}`,
+    );
+  });
 });

--- a/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
+++ b/src/main/app/src/app/fout-afhandeling/fout-afhandeling.service.ts
@@ -62,12 +62,15 @@ export class FoutAfhandelingService {
     const flattenedErrorList = Object.values(error.error).flat();
     console.warn("Received a `JakartaBeanValidationError`", error);
 
-    const details = flattenedErrorList.reduce((acc, violation) => {
-      return `${acc}- ${violation.constraintType}: ${violation.message} (path: ${violation.path}, value: "${violation.value}")\n`;
-    }, "");
+    const details = flattenedErrorList
+      .map((violation) => this.translateService.instant(violation.message))
+      .join("\n");
 
     return details.length
-      ? this.openFoutDetailedDialog("Validatie fout", details)
+      ? this.openFoutDetailedDialog(
+          this.translateService.instant("msg.error.validation.generic"),
+          details,
+        )
       : throwError(() => new Error("No violations found"));
   }
 

--- a/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-add/informatie-object-add.component.ts
@@ -20,6 +20,7 @@ import {
 import moment, { Moment } from "moment";
 import { ConfiguratieService } from "../../configuratie/configuratie.service";
 import { UtilService } from "../../core/service/util.service";
+import { FoutAfhandelingService } from "../../fout-afhandeling/fout-afhandeling.service";
 import { IdentityService } from "../../identity/identity.service";
 import { ZacCheckbox } from "../../shared/form/checkbox/checkbox";
 import { ZacDate } from "../../shared/form/date/date";
@@ -62,6 +63,7 @@ export class InformatieObjectAddComponent {
   );
   private readonly utilService = inject(UtilService);
   private readonly configuratieService = inject(ConfiguratieService);
+  private readonly foutAfhandelingService = inject(FoutAfhandelingService);
   private readonly identityService = inject(IdentityService);
   private readonly formBuilder = inject(FormBuilder);
 
@@ -98,8 +100,8 @@ export class InformatieObjectAddComponent {
       }
       this.resetAndClose();
     },
-    onError: () => {
-      this.form.reset();
+    onError: (error) => {
+      this.foutAfhandelingService.foutAfhandelen(error);
     },
   }));
 

--- a/src/main/app/src/assets/i18n/en.json
+++ b/src/main/app/src/assets/i18n/en.json
@@ -829,6 +829,7 @@
   "msg.error.smartdocuments.disabled": "SmartDocuments is disabled.",
   "msg.error.validation.generic": "The data entered is not valid. Please check the fields for invalid input.",
   "msg.error.validation.zgw": "Error message from underlying case registry.",
+  "msg.error.document.upload.invalid": "The file is empty or the file type is not allowed.",
   "msg.error.besluit.publication.disabled": "Publication not enabled for this decision type.",
   "msg.error.besluit.publication.date.missing": "Missing decision publication date.",
   "msg.error.besluit.response.date.missing": "Missing decision response date.",

--- a/src/main/app/src/assets/i18n/nl.json
+++ b/src/main/app/src/assets/i18n/nl.json
@@ -829,6 +829,7 @@
   "msg.error.smartdocuments.disabled": "SmartDocuments is uitgeschakeld.",
   "msg.error.validation.generic": "Er zijn fouten gevonden in de ingevoerde gegevens. Controleer de velden en probeer het opnieuw.",
   "msg.error.validation.zgw": "Foutmelding van onderliggend zaakregister.",
+  "msg.error.document.upload.invalid": "Het bestand is leeg of het bestandstype is niet toegestaan.",
   "msg.error.besluit.publication.disabled": "Publicatie niet ingeschakeld voor dit besluittype.",
   "msg.error.besluit.publication.date.missing": "Ontbrekende publicatiedatum van besluit.",
   "msg.error.besluit.response.date.missing": "Ontbrekende uiterlijke reactiedatum van besluit.",

--- a/src/main/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadForm.kt
+++ b/src/main/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadForm.kt
@@ -20,6 +20,6 @@ annotation class ValidRestEnkelvoudigInformatieFileUploadForm(
     val payload: Array<KClass<out Payload>> = []
 ) {
     companion object {
-        const val INVALID_FILE_UPLOAD_FORM = "Uploaded file is empty or the file type is not allowed"
+        const val INVALID_FILE_UPLOAD_FORM = "msg.error.document.upload.invalid"
     }
 }

--- a/src/main/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestFileUploadForm.kt
+++ b/src/main/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestFileUploadForm.kt
@@ -20,6 +20,6 @@ annotation class ValidRestFileUploadForm(
     val payload: Array<KClass<out Payload>> = []
 ) {
     companion object {
-        const val INVALID_FILE_UPLOAD_FORM = "Uploaded file is empty or the file type is not allowed"
+        const val INVALID_FILE_UPLOAD_FORM = "msg.error.document.upload.invalid"
     }
 }

--- a/src/main/kotlin/nl/info/zac/configuration/AllowedFileType.kt
+++ b/src/main/kotlin/nl/info/zac/configuration/AllowedFileType.kt
@@ -14,7 +14,7 @@ package nl.info.zac.configuration
 enum class AllowedFileType(
     val extension: String,
     val mediaType: String,
-    val additionalMediaTypes: Set<String> = emptySet()
+    val alternativeMediaTypes: Set<String> = emptySet()
 ) {
     AVI(".avi", "video/x-msvideo", setOf("video/avi", "video/msvideo", "video/vnd.avi")),
     BMP(".bmp", "image/bmp"),
@@ -65,13 +65,13 @@ enum class AllowedFileType(
         /**
          * Returns true when [filename]'s extension is on the allowlist and (if [mediaType] is
          * non-blank) matches the canonical media type registered for that extension or one of
-         * its [additionalMediaTypes]. Matching is case-insensitive.
+         * its [alternativeMediaTypes]. Matching is case-insensitive.
          */
         fun isAllowed(filename: String?, mediaType: String?): Boolean =
             fromFilename(filename)?.let { fileType ->
                 mediaType.isNullOrBlank() ||
                     mediaType.equals(fileType.mediaType, ignoreCase = true) ||
-                    fileType.additionalMediaTypes.any { it.equals(mediaType, ignoreCase = true) }
+                    fileType.alternativeMediaTypes.any { it.equals(mediaType, ignoreCase = true) }
             } ?: false
     }
 }

--- a/src/main/kotlin/nl/info/zac/configuration/AllowedFileType.kt
+++ b/src/main/kotlin/nl/info/zac/configuration/AllowedFileType.kt
@@ -11,8 +11,12 @@ package nl.info.zac.configuration
  * This is the single source of truth for upload validation. Adding a new file type
  * requires extending this enum.
  */
-enum class AllowedFileType(val extension: String, val mediaType: String) {
-    AVI(".avi", "video/x-msvideo"),
+enum class AllowedFileType(
+    val extension: String,
+    val mediaType: String,
+    val additionalMediaTypes: Set<String> = emptySet()
+) {
+    AVI(".avi", "video/x-msvideo", setOf("video/avi", "video/msvideo", "video/vnd.avi")),
     BMP(".bmp", "image/bmp"),
     DOC(".doc", "application/msword"),
     DOCX(".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
@@ -21,7 +25,7 @@ enum class AllowedFileType(val extension: String, val mediaType: String) {
     GIF(".gif", "image/gif"),
     JPEG(".jpeg", "image/jpeg"),
     JPG(".jpg", "image/jpeg"),
-    MKV(".mkv", "video/x-matroska"),
+    MKV(".mkv", "video/x-matroska", setOf("video/mkv")),
     MOV(".mov", "video/quicktime"),
     MP4(".mp4", "video/mp4"),
     MPEG(".mpeg", "video/mpeg"),
@@ -32,9 +36,18 @@ enum class AllowedFileType(val extension: String, val mediaType: String) {
     PNG(".png", "image/png"),
     PPT(".ppt", "application/vnd.ms-powerpoint"),
     PPTX(".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"),
-    RTF(".rtf", "application/rtf"),
+    RTF(".rtf", "application/rtf", setOf("text/rtf", "application/msword")),
     TXT(".txt", "text/plain"),
-    VSD(".vsd", "application/vnd.visio"),
+    VSD(
+        ".vsd",
+        "application/vnd.visio",
+        setOf(
+            "application/x-visio",
+            "application/visio",
+            "application/vnd.ms-visio.drawing",
+            "application/vnd.ms-visio.viewer"
+        )
+    ),
     WMV(".wmv", "video/x-ms-wmv"),
     XLS(".xls", "application/vnd.ms-excel"),
     XLSX(".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
@@ -51,11 +64,14 @@ enum class AllowedFileType(val extension: String, val mediaType: String) {
 
         /**
          * Returns true when [filename]'s extension is on the allowlist and (if [mediaType] is
-         * non-blank) matches the media type registered for that extension.
+         * non-blank) matches the canonical media type registered for that extension or one of
+         * its [additionalMediaTypes]. Matching is case-insensitive.
          */
         fun isAllowed(filename: String?, mediaType: String?): Boolean =
-            fromFilename(filename)?.let {
-                mediaType.isNullOrBlank() || mediaType.equals(it.mediaType, ignoreCase = true)
+            fromFilename(filename)?.let { fileType ->
+                mediaType.isNullOrBlank() ||
+                    mediaType.equals(fileType.mediaType, ignoreCase = true) ||
+                    fileType.additionalMediaTypes.any { it.equals(mediaType, ignoreCase = true) }
             } ?: false
     }
 }

--- a/src/test/kotlin/nl/info/zac/configuration/AllowedFileTypeTest.kt
+++ b/src/test/kotlin/nl/info/zac/configuration/AllowedFileTypeTest.kt
@@ -60,10 +60,25 @@ class AllowedFileTypeTest : BehaviorSpec({
             }
         }
 
+        Given("an allowed extension and an OS- or browser-variant media type") {
+            When("isAllowed is called") {
+                Then("it returns true for any of the extension's additional media types") {
+                    // Windows commonly reports these media types instead of the canonical one
+                    AllowedFileType.isAllowed("fakeMovie.avi", "video/avi") shouldBe true
+                    AllowedFileType.isAllowed("fakeMovie.avi", "VIDEO/AVI") shouldBe true
+                    AllowedFileType.isAllowed("fakeMovie.mkv", "video/mkv") shouldBe true
+                    AllowedFileType.isAllowed("fakeDocument.rtf", "application/msword") shouldBe true
+                    AllowedFileType.isAllowed("fakeDocument.rtf", "text/rtf") shouldBe true
+                    AllowedFileType.isAllowed("fakeDiagram.vsd", "application/x-visio") shouldBe true
+                }
+            }
+        }
+
         Given("an allowed extension but a mismatching media type") {
             When("isAllowed is called") {
                 Then("it returns false") {
                     AllowedFileType.isAllowed("fakeDocument.pdf", "image/png") shouldBe false
+                    AllowedFileType.isAllowed("fakeMovie.avi", "video/mp4") shouldBe false
                 }
             }
         }


### PR DESCRIPTION
## Description

Fixes silently-failing document uploads for `.avi`, `.mkv`, `.rtf` and `.vsd`

### Problem

When adding a document to a case, uploading one of these file types failed with **no error shown** — the dialog just appeared to do nothing. It reproduces only for certain types and (as reported) on Windows.

### Root cause

Two issues stack:

1. **Media-type mismatch (backend rejects).** `AllowedFileType` registered exactly one canonical media type per extension and required the client-declared `formaat` to match it exactly. The media type a browser puts on an upload is derived from the client OS and is **not reliable** — Windows in particular reports `.rtf` as `application/msword`, `.avi` as `video/avi`, etc., not the canonical value. So a perfectly valid file was rejected with HTTP 400.
2. **Silent failure (frontend swallows the 400).** The add-document flow uses a TanStack mutation (`ZacQueryClient`), which — unlike `ZacHttpClient` — has no error surfacing, and its `onError` only called `form.reset()`. So the 400 produced no message at all.

### Fix

- **`AllowedFileType`**: added a per-extension `additionalMediaTypes` set; `isAllowed()` now accepts the canonical media type **or** any known OS/browser variant (case-insensitive). The canonical `mediaType` is unchanged, so the REST allowlist DTO and the frontend are untouched. Variants added for `.avi`, `.mkv`, `.rtf`, `.vsd`.
- **`informatie-object-add.component`**: the upload mutation's `onError` now routes through `FoutAfhandelingService.foutAfhandelen(error)` (same pattern as `zaak-create`), so backend rejections are shown — including the exact `formaat` value the browser sent. The form is no longer wiped on error.
- **Bruno collection** (`scripts/bruno/.../zaakafhandelcomponent_file_upload_validation`): hand-authored QA collection for the upload allowlist, including regression requests **06–09** that upload the four affected extensions with their Windows media types and expect `200`.

### Testing

- `AllowedFileTypeTest` (9/9) and `ValidRestFileUploadFormValidatorTest` (7/7) pass; added cases for the Windows-variant media types and a still-rejected case (`.avi` as `video/mp4`).
- `spotlessApply` clean; Angular production build succeeds.

### Note / possible follow-up

The variant lists for `.mkv` and `.vsd` are best-effort — the exact media type depends on the tester's machine. Thanks to the error-surfacing change, any still-missed variant now shows the precise `formaat` value in the error dialog; add it to the matching `AllowedFileType` entry. (The Bruno README documents this.)

Solves [PZ-11423]
