### PR TITLE
fix(documenten): validate document uploads by extension only

### DIFF
--- a/src/main/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadFormValidator.kt
+++ b/src/main/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieFileUploadFormValidator.kt
@@ -17,7 +17,7 @@ class ValidRestEnkelvoudigInformatieFileUploadFormValidator :
         val hasName = !value.bestandsnaam.isNullOrBlank()
         return when {
             !hasFile && !hasName -> true
-            hasFile && hasName -> AllowedFileType.isAllowed(value.bestandsnaam, value.formaat)
+            hasFile && hasName -> AllowedFileType.isAllowed(value.bestandsnaam)
             else -> false
         }
     }

--- a/src/main/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestFileUploadFormValidator.kt
+++ b/src/main/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestFileUploadFormValidator.kt
@@ -17,7 +17,7 @@ class ValidRestFileUploadFormValidator :
         val hasName = !value.filename.isNullOrBlank()
         return when {
             !hasFile && !hasName -> true
-            hasFile && hasName -> AllowedFileType.isAllowed(value.filename, value.type)
+            hasFile && hasName -> AllowedFileType.isAllowed(value.filename)
             else -> false
         }
     }

--- a/src/main/kotlin/nl/info/zac/configuration/AllowedFileType.kt
+++ b/src/main/kotlin/nl/info/zac/configuration/AllowedFileType.kt
@@ -10,13 +10,16 @@ package nl.info.zac.configuration
  *
  * This is the single source of truth for upload validation. Adding a new file type
  * requires extending this enum.
+ *
+ * Only the extension is validated. The media type reported by browsers comes from the
+ * client OS and varies per machine (registry on Windows), so it cannot be validated
+ * against; [mediaType] is the canonical type ZAC associates with the extension.
  */
 enum class AllowedFileType(
     val extension: String,
-    val mediaType: String,
-    val alternativeMediaTypes: Set<String> = emptySet()
+    val mediaType: String
 ) {
-    AVI(".avi", "video/x-msvideo", setOf("video/avi", "video/msvideo", "video/vnd.avi")),
+    AVI(".avi", "video/x-msvideo"),
     BMP(".bmp", "image/bmp"),
     DOC(".doc", "application/msword"),
     DOCX(".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
@@ -25,7 +28,7 @@ enum class AllowedFileType(
     GIF(".gif", "image/gif"),
     JPEG(".jpeg", "image/jpeg"),
     JPG(".jpg", "image/jpeg"),
-    MKV(".mkv", "video/x-matroska", setOf("video/mkv")),
+    MKV(".mkv", "video/x-matroska"),
     MOV(".mov", "video/quicktime"),
     MP4(".mp4", "video/mp4"),
     MPEG(".mpeg", "video/mpeg"),
@@ -36,18 +39,9 @@ enum class AllowedFileType(
     PNG(".png", "image/png"),
     PPT(".ppt", "application/vnd.ms-powerpoint"),
     PPTX(".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"),
-    RTF(".rtf", "application/rtf", setOf("text/rtf", "application/msword")),
+    RTF(".rtf", "application/rtf"),
     TXT(".txt", "text/plain"),
-    VSD(
-        ".vsd",
-        "application/vnd.visio",
-        setOf(
-            "application/x-visio",
-            "application/visio",
-            "application/vnd.ms-visio.drawing",
-            "application/vnd.ms-visio.viewer"
-        )
-    ),
+    VSD(".vsd", "application/vnd.visio"),
     WMV(".wmv", "video/x-ms-wmv"),
     XLS(".xls", "application/vnd.ms-excel"),
     XLSX(".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
@@ -63,15 +57,9 @@ enum class AllowedFileType(
             }
 
         /**
-         * Returns true when [filename]'s extension is on the allowlist and (if [mediaType] is
-         * non-blank) matches the canonical media type registered for that extension or one of
-         * its [alternativeMediaTypes]. Matching is case-insensitive.
+         * Returns true when [filename]'s extension is on the allowlist. Matching is
+         * case-insensitive.
          */
-        fun isAllowed(filename: String?, mediaType: String?): Boolean =
-            fromFilename(filename)?.let { fileType ->
-                mediaType.isNullOrBlank() ||
-                    mediaType.equals(fileType.mediaType, ignoreCase = true) ||
-                    fileType.alternativeMediaTypes.any { it.equals(mediaType, ignoreCase = true) }
-            } ?: false
+        fun isAllowed(filename: String?): Boolean = fromFilename(filename) != null
     }
 }

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieobjectFileUploadFormValidatorTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestEnkelvoudigInformatieobjectFileUploadFormValidatorTest.kt
@@ -14,7 +14,7 @@ class ValidRestEnkelvoudigInformatieobjectFileUploadFormValidatorTest : Behavior
     val validator =
         ValidRestEnkelvoudigInformatieFileUploadFormValidator()
 
-    Given("a REST enkelvoudig informatie object with an allowed extension and matching media type") {
+    Given("a REST enkelvoudig informatie object with an allowed extension") {
         val restEnkelvoudigInformatieobject = RestEnkelvoudigInformatieobject()
             .apply {
                 bestandsnaam = "fakeFileName.txt"
@@ -124,8 +124,8 @@ class ValidRestEnkelvoudigInformatieobjectFileUploadFormValidatorTest : Behavior
         When("validated") {
             val result = validator.isValid(restEnkelvoudigInformatieobject, null)
 
-            Then("it is rejected because the declared media type does not match the extension") {
-                result shouldBe false
+            Then("it is accepted because only the extension is validated; the media type is OS-dependent") {
+                result shouldBe true
             }
         }
     }
@@ -141,7 +141,7 @@ class ValidRestEnkelvoudigInformatieobjectFileUploadFormValidatorTest : Behavior
         When("validated") {
             val result = validator.isValid(restEnkelvoudigInformatieobject, null)
 
-            Then("it is accepted (the extension check is the security gate; media type is optional)") {
+            Then("it is accepted because the extension check is the security gate") {
                 result shouldBe true
             }
         }

--- a/src/test/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestFileUploadFormValidatorTest.kt
+++ b/src/test/kotlin/nl/info/zac/app/informatieobjecten/model/validation/ValidRestFileUploadFormValidatorTest.kt
@@ -16,7 +16,7 @@ class ValidRestFileUploadFormValidatorTest : BehaviorSpec({
     val validator = ValidRestFileUploadFormValidator()
 
     Context("ValidRestFileUploadFormValidator.isValid") {
-        Given("a task file upload with an allowed extension and matching media type") {
+        Given("a task file upload with an allowed extension") {
             val upload = RestFileUpload(
                 file = "fake content".toByteArray(),
                 fileSize = 12,
@@ -28,6 +28,23 @@ class ValidRestFileUploadFormValidatorTest : BehaviorSpec({
                 val result = validator.isValid(upload, null)
 
                 Then("it is accepted") {
+                    result shouldBe true
+                }
+            }
+        }
+
+        Given("a task file upload with an allowed extension and an OS-specific media type") {
+            val upload = RestFileUpload(
+                file = "fake content".toByteArray(),
+                fileSize = 12,
+                filename = "fakeMovie.mkv",
+                type = "video/webm"
+            )
+
+            When("validated") {
+                val result = validator.isValid(upload, null)
+
+                Then("it is accepted because only the extension is validated") {
                     result shouldBe true
                 }
             }

--- a/src/test/kotlin/nl/info/zac/configuration/AllowedFileTypeTest.kt
+++ b/src/test/kotlin/nl/info/zac/configuration/AllowedFileTypeTest.kt
@@ -51,52 +51,31 @@ class AllowedFileTypeTest : BehaviorSpec({
     }
 
     Context("AllowedFileType.isAllowed") {
-        Given("an allowed extension and matching media type") {
+        Given("a filename with an allowed extension") {
             When("isAllowed is called") {
-                Then("it returns true (case-insensitive on media type)") {
-                    AllowedFileType.isAllowed("fakeReport.pdf", "application/pdf") shouldBe true
-                    AllowedFileType.isAllowed("fakeReport.pdf", "APPLICATION/PDF") shouldBe true
+                Then("it returns true (case-insensitive on extension)") {
+                    AllowedFileType.isAllowed("fakeReport.pdf") shouldBe true
+                    AllowedFileType.isAllowed("fakeReport.PDF") shouldBe true
+                    AllowedFileType.isAllowed("fakeMovie.mkv") shouldBe true
                 }
             }
         }
 
-        Given("an allowed extension and an OS- or browser-variant media type") {
-            When("isAllowed is called") {
-                Then("it returns true for any of the extension's additional media types") {
-                    // Windows commonly reports these media types instead of the canonical one
-                    AllowedFileType.isAllowed("fakeMovie.avi", "video/avi") shouldBe true
-                    AllowedFileType.isAllowed("fakeMovie.avi", "VIDEO/AVI") shouldBe true
-                    AllowedFileType.isAllowed("fakeMovie.mkv", "video/mkv") shouldBe true
-                    AllowedFileType.isAllowed("fakeDocument.rtf", "application/msword") shouldBe true
-                    AllowedFileType.isAllowed("fakeDocument.rtf", "text/rtf") shouldBe true
-                    AllowedFileType.isAllowed("fakeDiagram.vsd", "application/x-visio") shouldBe true
-                }
-            }
-        }
-
-        Given("an allowed extension but a mismatching media type") {
+        Given("a filename with a disallowed extension") {
             When("isAllowed is called") {
                 Then("it returns false") {
-                    AllowedFileType.isAllowed("fakeDocument.pdf", "image/png") shouldBe false
-                    AllowedFileType.isAllowed("fakeMovie.avi", "video/mp4") shouldBe false
+                    AllowedFileType.isAllowed("fakeMalware.exe") shouldBe false
+                    AllowedFileType.isAllowed("fakeArchive.zip") shouldBe false
                 }
             }
         }
 
-        Given("an allowed extension and a missing/blank media type") {
+        Given("a null, blank or extensionless filename") {
             When("isAllowed is called") {
-                Then("it returns true (extension is the security gate, media type is optional)") {
-                    AllowedFileType.isAllowed("fakeDocument.pdf", null) shouldBe true
-                    AllowedFileType.isAllowed("fakeDocument.pdf", "") shouldBe true
-                }
-            }
-        }
-
-        Given("a disallowed extension") {
-            When("isAllowed is called") {
-                Then("it returns false regardless of media type") {
-                    AllowedFileType.isAllowed("fakeMalware.exe", "application/x-msdownload") shouldBe false
-                    AllowedFileType.isAllowed("fakeMalware.exe", null) shouldBe false
+                Then("it returns false") {
+                    AllowedFileType.isAllowed(null) shouldBe false
+                    AllowedFileType.isAllowed("") shouldBe false
+                    AllowedFileType.isAllowed("fakeReadme") shouldBe false
                 }
             }
         }


### PR DESCRIPTION
Solves PZ-11474

## Why

Windows users were unable to upload `.mkv` files (and potentially other types). The backend upload validation introduced for PZ-6022/PZ-6023 cross-checked the media type sent by the browser against a fixed list per extension. That browser-reported media type is not determined by the browser itself but by the client OS — on Windows it is read from the registry (`HKCR\.mkv\Content Type`), so the value depends on which media player or codec pack happens to be installed. For `.mkv` there is no IANA-registered media type at all, so machines report anything from an empty string to `video/webm`, while the allowlist only accepted `video/x-matroska` and `video/mkv`.

This made the check a source of false rejections for legitimate users, while adding no security: the media type is fully client-controlled (a forged request can simply send the canonical value, and a blank value was already accepted). The extension allowlist in `AllowedFileType` is the actual security boundary.

Earlier we patched individual variants via `alternativeMediaTypes` (#6167), but the set of possible registry values is unbounded, so that approach guarantees a new ticket for every next OS/app combination.

## What

- `AllowedFileType.isAllowed` now only checks that the file extension is on the allowlist; the media-type parameter and the `alternativeMediaTypes` sets are removed.
- Both upload validators (enkelvoudig informatieobject + Flowable task documents) pass only the filename.
- The canonical `mediaType` per extension is kept, as it is exposed through the configuration REST endpoint.
- Tests updated accordingly, including a regression case for the reported bug: an `.mkv` upload with an OS-specific media type such as `video/webm` is now accepted.
