### PR TITLE
chore: log a warning in the docker compose script if host.docker.internal does not point to localhost

### DIFF
--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -162,6 +162,11 @@ if [ -n "${DOCKER_USE_ARM64_CONTAINERS:-}" ]; then
   compose_files="$compose_files -f docker-compose.arm64-override.yaml"
 fi
 
+host_docker_internal_ip=$(getent hosts host.docker.internal | awk '{print $1}')
+if [ "$host_docker_internal_ip" != "127.0.0.1" ]; then
+  echo "Error: host.docker.internal is not pointing to localhost. Please check your hosts file as per the instructions. you might not be able to login from the browser."
+fi
+
 op_script=""
 if [ "$disableOnePassword" = "false" ]; then
   if ! command -v op >/dev/null 2>&1; then

--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -162,8 +162,11 @@ if [ -n "${DOCKER_USE_ARM64_CONTAINERS:-}" ]; then
   compose_files="$compose_files -f docker-compose.arm64-override.yaml"
 fi
 
-host_docker_internal_ip=$(getent hosts host.docker.internal | awk '{print $1}')
-if [ "$host_docker_internal_ip" != "127.0.0.1" ]; then
+host_docker_internal_ip=$(
+  command -v getent >/dev/null 2>&1 &&
+  getent hosts host.docker.internal | awk '{print $1}'
+)
+if [ -n "$host_docker_internal_ip" ] && [ "$host_docker_internal_ip" != "127.0.0.1" ]; then
   echo "Error: host.docker.internal is not pointing to localhost. Please check your hosts file as per the instructions. you might not be able to login from the browser."
 fi
 


### PR DESCRIPTION
If the host file is not setup correctly, host.docker.internal will not work in the browser (for instance, when beeing redirected to keycloak). We now check this in the docker compose start up script and inform the user.

Solves PZ-11355