### PR TITLE
fix(open-notificaties): downgrade open-notificaties docker image to 1.14.0 (reverting earlier renovate PR)

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -26,7 +26,7 @@ This document lists the Docker images and versions that the corresponding versio
 - **objects-api**: 3.3.1
 - **open-klant**: 2.15.0
 - **open-forms**: 3.4.9
-- **open-notificaties**: 1.15.0
+- **open-notificaties**: 1.14.0
 - **open-archiefbeheer**: 1.1.1
 - **pabc-migrations**: 1.1.0
 - **pabc-api**: 1.1.0

--- a/docker-compose.arm64-override.yaml
+++ b/docker-compose.arm64-override.yaml
@@ -44,15 +44,15 @@ services:
     platform: linux/arm64
 
   opennotificaties:
-    image: ghcr.io/infonl/open-notificaties:1.15.0@sha256:2fb36e4f444b6719f292d7ef957444751feb8218a3a68b0d65f860814a7b7387
+    image: ghcr.io/infonl/open-notificaties:1.14.0@sha256:92732eef419f3e4904c71800bbf86eb8f22aa9b3c4e541a92852a25c947deaeb
     platform: linux/arm64
 
   opennotificaties-init:
-    image: ghcr.io/infonl/open-notificaties:1.15.0@sha256:2fb36e4f444b6719f292d7ef957444751feb8218a3a68b0d65f860814a7b7387
+    image: ghcr.io/infonl/open-notificaties:1.14.0@sha256:92732eef419f3e4904c71800bbf86eb8f22aa9b3c4e541a92852a25c947deaeb
     platform: linux/arm64
 
   opennotificaties-celery:
-    image: ghcr.io/infonl/open-notificaties:1.15.0@sha256:2fb36e4f444b6719f292d7ef957444751feb8218a3a68b0d65f860814a7b7387
+    image: ghcr.io/infonl/open-notificaties:1.14.0@sha256:92732eef419f3e4904c71800bbf86eb8f22aa9b3c4e541a92852a25c947deaeb
     platform: linux/arm64
 
   openzaak-database:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -516,7 +516,7 @@ services:
     profiles: [ "opennotificaties", "openformulieren" ]
 
   opennotificaties:
-    image: openzaak/open-notificaties:1.15.0@sha256:5a2f7e04efe6062b71ae9e1b4bef2bf16f2f60c8f1d8b9632fbeab4b90c91c5a
+    image: openzaak/open-notificaties:1.14.0@sha256:fbd0aaaaa8a6e5395510c4d0a28501425b7f9036ece7f99ff70a4465d7d95c38
     # No image for linux/arm64 is available, so we need to run this image with the linux/amd64 platform on Apple Silicon devices using emulation.
     platform: linux/amd64
     environment: &opennotificaties-env
@@ -560,7 +560,7 @@ services:
     profiles: [ "opennotificaties", "openformulieren" ]
 
   opennotificaties-init:
-    image: openzaak/open-notificaties:1.15.0@sha256:5a2f7e04efe6062b71ae9e1b4bef2bf16f2f60c8f1d8b9632fbeab4b90c91c5a
+    image: openzaak/open-notificaties:1.14.0@sha256:fbd0aaaaa8a6e5395510c4d0a28501425b7f9036ece7f99ff70a4465d7d95c38
     # No image for linux/arm64 is available, so we need to run this image with the linux/amd64 platform on Apple Silicon devices using emulation.
     platform: linux/amd64
     environment:
@@ -579,7 +579,7 @@ services:
     profiles: [ "opennotificaties", "openformulieren" ]
 
   opennotificaties-celery:
-    image: openzaak/open-notificaties:1.15.0@sha256:5a2f7e04efe6062b71ae9e1b4bef2bf16f2f60c8f1d8b9632fbeab4b90c91c5a
+    image: openzaak/open-notificaties:1.14.0@sha256:fbd0aaaaa8a6e5395510c4d0a28501425b7f9036ece7f99ff70a4465d7d95c38
     # No image for linux/arm64 is available, so we need to run this image with the linux/amd64 platform on Apple Silicon devices using emulation.
     platform: linux/amd64
     environment: *opennotificaties-env


### PR DESCRIPTION
Reverts #6210, which bumped the `open-notificaties` Docker image from `1.14.0` to `1.15.0`.

The 1.15.0 release introduces breaking changes, so we are reverting to the previously working `1.14.0` image (with its original digests).

Reverted across:
- `docker-compose.yaml`
- `docker-compose.arm64-override.yaml`
- `DEPENDENCIES.md`