### PR TITLE
feat(deps): group all Angular packages in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -406,6 +406,17 @@
   ],
   "packageRules": [
     {
+      "groupName": "Angular",
+      "matchPackageNames": [
+        "/^@angular\\//",
+        "/^@angular-eslint\\//",
+        "/^@angular-builders\\//"
+      ],
+      "description": [
+        "Group all Angular ecosystem packages (framework, CLI, components, eslint, builders) so the CLI/build packages never upgrade ahead of the framework"
+      ]
+    },
+    {
       "groupName": "Helm CLI",
       "matchPackageNames": [
         "helm",


### PR DESCRIPTION
# Group all Angular packages in renovate config

## What
Groups the entire Angular ecosystem (`@angular/*`, `@angular-eslint/*`,
`@angular-builders/*`) into a single Renovate update PR.

## Why
Renovate groups by source monorepo, and Angular is split across several repos
(`angular/angular`, `angular/angular-cli`, `angular/components`). That made it
propose an isolated PR (#6222) bumping `@angular/build` + `@angular/cli` to v22
while the framework stayed on v19 — unmergeable, since the CLI is version-locked
to the framework major.

Grouping them ensures the CLI never moves ahead of the framework. With the
existing `:separateMultipleMajorReleases`, majors still arrive as one
coordinated PR.

## Notes
- Renovate only bumps versions; `ng update` schematics must still be run manually.
- Closes the need for #6222.

Solves PZ-11495