### PR TITLE
chore: update env example to use host.docker.internal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,14 +29,14 @@ AUTH_SECRET=keycloakZaakafhandelcomponentClientSecret
 # "none" - if HTTPS is not required. This should be set to "all" in production environments.
 AUTH_SSL_REQUIRED=external
 # Keycloak URL
-AUTH_SERVER=http://localhost:8081
+AUTH_SERVER=http://host.docker.internal:8081
 # BAG API REST URL. By default we use the HaalCentraal BAG test environment.
 BAG_API_CLIENT_MP_REST_URL=https://api.bag.kadaster.nl/lvbag/individuelebevragingen/v2/
 # If you want to use the BAG test environment you will need to request an API key.
 # Please see: https://vng-realisatie.github.io/Haal-Centraal-BAG-bevragen/getting-started-IB
 BAG_API_KEY=XXX
 # BRP API REST URL. This assumes you have the BRP Personen mock running locally.
-BRP_API_CLIENT_MP_REST_URL=http://localhost:5010/haalcentraal/api/brp
+BRP_API_CLIENT_MP_REST_URL=http://host.docker.internal:5010/haalcentraal/api/brp
 # Set to true to enable BRP protocollering header injection
 BRP_PROTOCOLLERING_ENABLED=false
 # Set to true to require doelbinding values to be configured per zaaktype in the admin UI
@@ -72,9 +72,9 @@ BRP_LOG_LEVEL=INFO
 # Dit moet een geldig RSIN zijn van 9 nummers en voldoen aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef
 BRON_ORGANISATIE_RSIN=123443210
 # ZAC context URL (take care not to add a trailing slash)
-CONTEXT_URL=http://localhost:8080
+CONTEXT_URL=http://host.docker.internal:8080
 # ZAC PostgreSQL database host and port string
-DB_HOST=localhost:54320
+DB_HOST=host.docker.internal:54320
 # ZAC PostgreSQL database name
 DB_NAME=zac
 # ZAC PostgreSQL database password
@@ -94,7 +94,7 @@ KEYCLOAK_ADMIN_CLIENT_ID=zaakafhandelcomponent-admin-client
 # Keycloak ZAC admin client secret
 KEYCLOAK_ADMIN_CLIENT_SECRET=zaakafhandelcomponentAdminClientSecret
 # Open Klant klanten API REST URL
-KLANTINTERACTIES_API_CLIENT_MP_REST_URL=http://localhost:8002
+KLANTINTERACTIES_API_CLIENT_MP_REST_URL=http://host.docker.internal:8002
 # Open Klant klanten API ZAC token
 KLANTINTERACTIES_API_TOKEN=fakeToken
 # KVK API REST base URL. By default ZAC integrates with the KVK test environment. Please see: https://developers.kvk.nl/nl/documentation/testing on how to use it.
@@ -102,11 +102,11 @@ KVK_API_CLIENT_MP_REST_URL=https://api.kvk.nl/test/
 # The (fixed) API key of the KVK test environment. Note that it should not be surrounded by quotes.
 KVK_API_KEY=l7xx1f2691f2520d487b902f4e0b57a0b197
 # Open Policy Agent API REST URL
-OPA_API_CLIENT_MP_REST_URL=http://localhost:8181
+OPA_API_CLIENT_MP_REST_URL=http://host.docker.internal:8181
 # Open Notifications API secret key
 OPEN_NOTIFICATIONS_API_SECRET_KEY=openNotificatiesApiSecretKey
 # PABC API REST URL
-PABC_API_CLIENT_MP_REST_URL=http://localhost:8006
+PABC_API_CLIENT_MP_REST_URL=http://host.docker.internal:8006
 # PABC API key for local docker container.
 PABC_API_KEY=zac-test-api-key
 # Enables or disables the support for creating a documenta via SmartDocuments.
@@ -135,13 +135,13 @@ SMTP_PASSWORD=XXX
 # Delete any signaleringen older than this number of days when the corresponding admin endpoint is called.
 SIGNALERINGEN_DELETE_OLDER_THAN_DAYS=14
 # Solr URL
-SOLR_URL=http://localhost:8983
+SOLR_URL=http://host.docker.internal:8983
 # Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die eindverantwoordelijk is voor de behandeling van de zaak.
 # Dit moet een geldig RSIN zijn van 9 nummers en voldoen aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef
 VERANTWOORDELIJKE_ORGANISATIE_RSIN=316245124
 ZAC_INTERNAL_ENDPOINTS_API_KEY=xxx
 # Open Zaak API URL
-ZGW_API_CLIENT_MP_REST_URL=http://openzaak.local:8000/
+ZGW_API_CLIENT_MP_REST_URL=http://host.docker.internal:8001/
 # Open Zaak API ZAC client ID
 ZGW_API_CLIENTID=zac_client
 # Open Zaak API ZAC client secret


### PR DESCRIPTION
The env example contains a mixture of localhost and container addresses. If we use docker.host.internal everywhere, it can be used for both running zac from intellij and inside docker

Solves PZ-11497